### PR TITLE
Reorder items on reference page

### DIFF
--- a/Documentation/Reference/index.md
+++ b/Documentation/Reference/index.md
@@ -3,19 +3,9 @@ _Developers reference primarily consists of API references of the different core
 
 ##[Templating](Templating/index.md)
 
-How to use templates and macros. Covers the basic definitions of templates/macros to advanced techniques and API usage.
+How to use **templates** and **macros**. Covers the basic definitions of templates/macros to advanced techniques and API usage.
 
 *This section contains all of the details about both templates types: MVC & WebForms* 
-
-##[Web API](WebApi/index.md) 
-Introduced in **Umbraco 6.1.0+**
-How to use Web API in Umbraco to easily create REST services.
-
-##[Management APIs](Management-v6/index.md)
-Specific to version 6.x or later: Create, update, delete all build-in system objects like content, media, templates, content types and so on. 
-
-##[Legacy Management APIs](Management/index.md)
-Specific to version 4.x or earlier: Create, update, delete all build-in system objects like documents, media, templates, document types and so on.
 
 ##[Querying](Querying/index.md)
 Umbraco comes with several ways of querying, filtering and searching contnet, through the APIs: uQuery, DynamicNode and NodeFactory
@@ -23,28 +13,32 @@ Umbraco comes with several ways of querying, filtering and searching contnet, th
 ##[Searching](Searching/index.md)
 Details on how to implement search capabilities for your Umbraco website using Examine, which is a Lucene based search engine for umbraco.
 
-##[Events](Events-v6/index.md)
-Umbraco 6.x or later: event model covering all mayor aspects of the system for triggering custom code or automation.  
-
-##[Legacy Events](Events/index.md)
-Umbraco 4 and earlier, comes with a complete event model, covering all mayor aspects of the system for triggering custom code or automation.
-
-##[/Base](Api/Base/Index.md)
-/Base is a extendable system for creating raw feeds directly from Umbraco using very basic Url's. This enables developers to access umbraco data through javascript, flash or any other client. It even allows you to modify umbraco data directly via simple url's.
-
 ##[Umbraco.Library](Api/UmbracoLibrary/index.md)
 Umbraco.Library is a Xslt extension library, built specifically for xslt macros in umbraco 4. It contains many utility methods which are strictly for use in Xslt, but also has a number of more general purpous methods, which can used more broadly.
+
+##Events
+###[Events](Events-v6/index.md) (v6+)
+Umbraco 6.x or later: event model covering all mayor aspects of the system for triggering custom code or automation.  
+
+###[Legacy Events](Events/index.md) (v4)
+Umbraco 4 and earlier, comes with a complete event model, covering all mayor aspects of the system for triggering custom code or automation.
+
+## Rest Apis
+
+###[Web API](WebApi/index.md) 
+Introduced in **Umbraco 6.1.0+**
+How to use Web API in Umbraco to easily create REST services.
+###[/Base](Api/Base/Index.md)
+/Base is a extendable system for creating raw feeds directly from Umbraco using very basic Url's. This enables developers to access umbraco data through javascript, flash or any other client. It even allows you to modify umbraco data directly via simple url's.
+
+## Management Api's
+Api's around create, update and deleting  
+###[Management APIs](Management-v6/index.md) (V6+)
+Specific to version 6.x or later: Create, update, delete all build-in system objects like content, media, templates, content types and so on. 
+
+###[Legacy Management APIs](Management/index.md)  (v4)
+Specific to version 4.x or earlier: Create, update, delete all build-in system objects like documents, media, templates, document types and so on.
 
 ##[Plugins](Plugins/index.md) 
 Introduced in **Umbraco 4.10.0+**
 The term 'Plugins' is refering to any types in Umbraco that are found in assemblies that are used to extend and/or enhance the Umbraco application.
-
----
-
-###Progress
-Consult the Umbraco 4 documentation trello board to see what we are currently working on.
-[See the TrelloBoard here](https://trello.com/board/umbraco-4-documentation/4fdb02df8fc3ef067e809e95)
-
-###Contribution
-Umbraco is a community powered project and we welcome any contribution, big or small, even fixing a typo is a valuable contribution.
-[See how to contribute](https://github.com/umbraco/Umbraco4Docs) 


### PR DESCRIPTION
There were to many topic, so bundeld a few under one heading.  
New order is (approx) simple to more advanced topic from Template, querying over events, management apis to plugins.
