### PR TITLE
Update load-balancing.md with SSL binding gotcha

### DIFF
--- a/Documentation/Installation/load-balancing.md
+++ b/Documentation/Installation/load-balancing.md
@@ -212,6 +212,8 @@ There are a couple optional elements for the configuration of each server that a
 
 	<server forceProtocol="http|https" forcePortnumber="80|443">server3.mywebsite.com</server>
 
+If you only add https bindings to your site in IIS, then you will need to set umbracoUseSSL="true" in your web.config in order for publish to work.
+
 ### Correct config for scheduled publishing & tasks
 
 As of Umbraco 6.2.1+ and 7.1.5+ there are another couple of options to take into account:


### PR DESCRIPTION
If you don't add http bindings to your IIS site, publish will not work in this configuration unless you set umbracoUseSSL="true" in your web.config. This is somewhat non-obvious, and given the technical level of this document, I think including this information here is appropriate.
