### PR TITLE
Remove "Progress"

### DIFF
--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -20,10 +20,6 @@ Documentation on how to extend umbraco with your own editors, trees, sections, a
 ##[Development Guidelines](Development-Guidelines/index.md)
 How to work with the Umbraco codebase.
 
-###Progress
-Consult the Umbraco documentation trello board to see what we are currently working on.
-[See the TrelloBoard here](https://trello.com/board/umbraco-4-documentation/4fdb02df8fc3ef067e809e95)
-
 ###Contribution
 Umbraco is a community powered project and we welcome any contribution, big or small. Even fixing a typo is a valuable contribution.
 [See how to contribute](https://github.com/umbraco/Umbraco4Docs)


### PR DESCRIPTION
The Trello board wasn't updated in almost a year, so we shouldn't link to it anymore. Obviously nobody is using it anymore and if makes the project look "bad".
