### PR TITLE
fixed typos in v4 Documents documentation

### DIFF
--- a/Documentation/Reference/Management/Documents/index.md
+++ b/Documentation/Reference/Management/Documents/index.md
@@ -53,7 +53,7 @@ To create and store a `Document` you need a `DocumentType`, calling `MakeNew()` 
 	
 	Document d = Document.MakeNew("name of document", dt, u, parentId); 
 	//set a string
-	d.getProperty("bodyText").Value = "Hello");
+	d.getProperty("bodyText").Value = "Hello";
 	//set a date
 	d.getProperty("date").Value = DateTime.Now;
 	//set a HttpPostedFile 
@@ -66,10 +66,10 @@ To create and store a `Document` you need a `DocumentType`, calling `MakeNew()` 
 	d.Publish(user);
 	
 	//Inform the cache it should update
-	umbraco.librarh.UpdateDocumentCache(d.Id);
+	umbraco.library.UpdateDocumentCache(d.Id);
 	
 ##[Document methods and properties](document.md) 
-The `Document` class itself has a big collection of methods and properties, please see the seperate [Document](document.md) page for this.
+The `Document` class itself has a big collection of methods and properties, please see the separate [Document](document.md) page for this.
 
 
 ##Static methods


### PR DESCRIPTION
Hi, I noticed a couple of typos on the Documents page of the documentation and they are fixed in this pull request.

Dallas
