### PR TITLE
The three first tutorials on making a new property editor all linked to ...

### DIFF
--- a/Documentation/Extending-Umbraco/Property-Editors/creating-tutorial1-v7.md
+++ b/Documentation/Extending-Umbraco/Property-Editors/creating-tutorial1-v7.md
@@ -147,9 +147,3 @@ and add that id to the text area in the html, for more info on the html structur
 Now, clear the cache, reload the document and see the pagedown editor running. 
 
 When you save or publish the value of the editor is automaticly synced to the current content object and sent to the server, all through the power of angular and the `ng-model`attribute.
-
-##Get the source
-The full source, including manifest and dependencies, can be found on the umbraco-cms project 
-[here](https://github.com/umbraco/Umbraco-CMS/tree/7.0.0/src/Umbraco.Web.UI.Client/src/packages/MarkdownEditor)
-
-Simply copy the MarkdownEditor folder to /app_plugins and restart your website, and it will be up and running.

--- a/Documentation/Extending-Umbraco/Property-Editors/creating-tutorial2-v7.md
+++ b/Documentation/Extending-Umbraco/Property-Editors/creating-tutorial2-v7.md
@@ -56,10 +56,3 @@ However, you can also use these values without any javascript, so open the `mark
 Because we can also use the configuration directly in our html like here, where we use it to toggle the preview `<div>`, using the ng-hide attribute: 
 
 	<div ng-show="model.config.preview" class="wmd-panel wmd-preview"></div>
-
-
-##Get the codes
-The latest update to the markdowneditor project is on github where you can see all the files and the manifest [here](https://github.com/umbraco/Umbraco-CMS/tree/7.0.0/src/Umbraco.Web.UI.Client/src/packages/MarkdownEditor).
-	 
-
-

--- a/Documentation/Extending-Umbraco/Property-Editors/creating-tutorial3-v7.md
+++ b/Documentation/Extending-Umbraco/Property-Editors/creating-tutorial3-v7.md
@@ -72,5 +72,3 @@ So over the 3 previous steps, we've:
 - made the editor configurable
 - connected the editor with native dialogs and services
 - looked at koala pictures.
-
-The complete project can be found [here](https://github.com/umbraco/Umbraco-CMS/tree/7.0.0/src/Umbraco.Web.UI.Client/src/packages/MarkdownEditor).


### PR DESCRIPTION
..."Get the source", which was linked to the following location

https://github.com/umbraco/Umbraco-CMS/tree/7.0.0/src/Umbraco.Web.UI.Client/src/packages/MarkdownEditor

This location doesnt exist any more, and the package seems to have been moved from the project at some point in time.
"Fixed" by removing the part that links to the missing package. Another fix could be to restore the package
