### PR TITLE
Checking new entities in ContentService.Saving event

### DIFF
--- a/Documentation/Reference/Events-v6/determining-new-entity.md
+++ b/Documentation/Reference/Events-v6/determining-new-entity.md
@@ -9,7 +9,11 @@ We know that if an entity is new and hasn't been persisted that it will not have
 Here's the snippet of code that does that:
 
     var dirty = (IRememberBeingDirty)entity;
-	var isNew = dirty.WasPropertyDirty("Id");
+    var isNew = dirty.WasPropertyDirty("Id");
+
+To check if an entity is new in the ContentService.Saving event, use the following:
+
+    var isNew = dirty.HasIdentity;
 
 In v6.2+ and 7.1+ you can use the extension method on any implementation of IEntity (which is nearly all models returned by the Umbraco Services):
 


### PR DESCRIPTION
There was no information about checking if an entity is new in the ContentService.Saving event.
Information gathered from: https://twitter.com/Shazwazza/status/496705715306627074
