### PR TITLE
Info on excluding files from publish

### DIFF
--- a/Getting-Started/Setup/Install/install-umbraco-with-nuget.md
+++ b/Getting-Started/Setup/Install/install-umbraco-with-nuget.md
@@ -104,11 +104,12 @@ You should also note that the Umbraco nuget package adds a build step to always 
 You can see these folders in packages/UmbracoCms x.y.z/build/UmbracoCms.targets  
 Should you need to exclude any of these folders or content, you can add a target to your .pubxml files under properties/Publish.
 
+```
   <Target Name="StopUmbracoFromPublishingAppPlugins" AfterTargets="AddUmbracoFilesToOutput">
     <ItemGroup>
       <FilesForPackagingFromProject Remove=".\App_Plugins\**\*.*"/>
     </ItemGroup>
   </Target>
-
+```
 
 [1]: http://youtrack.jetbrains.com/issue/RSRP-419513

--- a/Getting-Started/Setup/Install/install-umbraco-with-nuget.md
+++ b/Getting-Started/Setup/Install/install-umbraco-with-nuget.md
@@ -101,8 +101,8 @@ Follow the installation wizard and after a few easy steps and choices you should
 One important recommendation is to always remove the `install` folder immediately after installing Umbraco and never to upload it to a live server.
 
 You should also note that the Umbraco nuget package adds a build step to always include the Umbraco folders when you deploy using Web One-Click Publish with Visual Studio.  
-You can see these folders in packages/UmbracoCms x.y.z/build/UmbracoCms.targets  
-Should you need to exclude any of these folders or content, you can add a target to your .pubxml files under properties/Publish.
+You can see these folders in `packages/UmbracoCms x.y.z/build/UmbracoCms.targets`  
+Should you need to exclude any of these folders or content, you can add a target to your `.pubxml` files in the `properties/Publish` folder.
 
 ```
   <Target Name="StopUmbracoFromPublishingAppPlugins" AfterTargets="AddUmbracoFilesToOutput">

--- a/Getting-Started/Setup/Install/install-umbraco-with-nuget.md
+++ b/Getting-Started/Setup/Install/install-umbraco-with-nuget.md
@@ -100,4 +100,15 @@ Follow the installation wizard and after a few easy steps and choices you should
 ##Post installation
 One important recommendation is to always remove the `install` folder immediately after installing Umbraco and never to upload it to a live server.
 
+You should also note that the Umbraco nuget package adds a build step to always include the Umbraco folders when you deploy using Web One-Click Publish with Visual Studio.  
+You can see these folders in packages/UmbracoCms x.y.z/build/UmbracoCms.targets  
+Should you need to exclude any of these folders or content, you can add a target to your .pubxml files under properties/Publish.
+
+  <Target Name="StopUmbracoFromPublishingAppPlugins" AfterTargets="AddUmbracoFilesToOutput">
+    <ItemGroup>
+      <FilesForPackagingFromProject Remove=".\App_Plugins\**\*.*"/>
+    </ItemGroup>
+  </Target>
+
+
 [1]: http://youtrack.jetbrains.com/issue/RSRP-419513


### PR DESCRIPTION
I banged my head a few hours today to figure out why the standard ExcludeFilesFromPackage Item Group and siblings didn't work. I'm sure I'm neither first nor last, so I guess it could just as well be in the docs.