### PR TITLE
Update incorrect instructions.

### DIFF
--- a/Umbraco-as-a-Service/Set-Up/Media/index.md
+++ b/Umbraco-as-a-Service/Set-Up/Media/index.md
@@ -34,18 +34,7 @@ Update `~/Config/FileSystemProviders.config` replacing the default provider with
 </FileSystemProviders>
 ```
 
-In order to use Azure Storage for the ImageProcessor cache, you'll also need the following in `~web.config`
-
-```
-<?xml version="1.0"?>
-<configuration>
-  <appSettings>
-    <!--Disables the built in Virtual Path Provider which allows for relative paths-->
-    <add key="AzureBlobFileSystem.DisableVirtualPathProvider" value="true" />
-</configuration>
-```
-
-If you are using IISExpress (as with Visual Studio or WebMatrix) you’ll also need to add a static file handler mapping to `~web.config`
+If you are using IISExpress (as with Visual Studio or WebMatrix) you’ll need to add a static file handler mapping to `~web.config`
 
 ```
 <?xml version="1.0"?>
@@ -135,11 +124,7 @@ Update `~/config/imageprocessor/security.config`
 </security> 
 ```
 
-Update `~/config/imageprocessor/cache.config'
-
-Note that you’ll need to create a container in your Azure Storage account for the cache.  In the below example we have created a container named simply “cache”.
-
-Remove the default “DiskCache” config entry.
+Update `~/config/imageprocessor/cache.config` by removing the default “DiskCache” config entry.
 
 ```
 <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
ImageProcessor.Web does not require disabling the VirtualPathProvider in order for the cache to work. Disabling the provider is strongly discouraged as it will cause Umbraco to persist the media url in absolute format. This causes two issues:

1. ImageProcessor cannot now intercept the image request to the external site without using the /remote.axd prefix.
2. The media cannot now be shared across different urls.

Both the IFileystemProvider implementation and ImageProcessor.Web.Plugins.AzureBlobCache will automatically create containers if they do not exist so you do not have to manually create them.

https://github.com/JimBobSquarePants/ImageProcessor/blob/V2/src/Plugins/ImageProcessor.Web/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs#L100