### PR TITLE
Fix typo/syntax in Collections.md, ".Where" section

### DIFF
--- a/Reference/Querying/IPublishedContent/Collections.md
+++ b/Reference/Querying/IPublishedContent/Collections.md
@@ -78,7 +78,7 @@ Some examples:
 ###.Where
 
 	@* Returns all items in the collection that have a template assigned and have a name starting with 'S' *@
-	@var nodes = Model.Content.Descendants().Where(x = x.TemplateId > 0 && x.Name.StartsWith("S"))
+	@var nodes = Model.Content.Descendants().Where(x => x.TemplateId > 0 && x.Name.StartsWith("S"))
 
 ###.OrderBy
 


### PR DESCRIPTION
Not a problem for experienced developers, but possibly killing the experience for newbies if they copy and past without further checking.