### PR TITLE
Update Render-Grid-In-Template.md

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Render-Grid-In-Template.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Render-Grid-In-Template.md
@@ -1,18 +1,19 @@
 #Render grid in template
-To display the grid on a site use:
+To display the grid on a site use using dynamics, you'd should do:
 
-    @CurrentPage.GetGridHtml("propertyAlias")
+    @CurrentPage.GetGridHtml(Html, "propertyAlias")
+
 
 This will by default use the view `/views/partials/grid/bootstrap3.cshtml` you can also use the built-in bootstrap2.cshtml view by overloading the method: 
 
-    @CurrentPage.GetGridHtml("propertyAlias", "bootstrap2")
+    @CurrentPage.GetGridHtml(Html, "propertyAlias", "bootstrap2")
 
 or point it a custom view, which by default looks in `/views/partials/grid/` - or provide the method with a full path 
 
-    @CurrentPage.GetGridHtml("propertyAlias", "mycustomview")
-    @CurrentPage.GetGridHtml("propertyAlias", "/views/mycustomfile.cshtml")
+    @CurrentPage.GetGridHtml(Html, "propertyAlias", "mycustomview")
+    @CurrentPage.GetGridHtml(Html, "propertyAlias", "/views/mycustomfile.cshtml")
 
-If you're working with a strongly typed model simply replace `@CurrentPage` with `@Model.Content`, so:
+If using strongly typed models it's better to use the HtmlHelper extensions, and replace `@CurrentPage` with `@Model.Content` like:
 
-    @Model.Content.GetGridHtml("propertyAlias")
+    @Html.GetGridHtml(Model.Content, "propertyAlias")
 


### PR DESCRIPTION
As of this issue: http://issues.umbraco.org/issue/U4-6209
@Model.Content.GetGridHtml("propertyAlias") is deprecated. Updating the docs to match.