### PR TITLE
Removed default member props no longer present in 7.4.2

### DIFF
--- a/Getting-Started/Data/Members/index.md
+++ b/Getting-Started/Data/Members/index.md
@@ -12,11 +12,9 @@ There is also a number of default properties on the __Membership__ tab:
 - umbracoMemberFailedPasswordAttempts
 - umbracoMemberApproved
 - umbracoMemberLockedOut
-- umbracoMemberLastLockOutDate
+- umbracoMemberLastLockoutDate
 - umbracoMemberLastLogin
 - umbracoMemberLastPasswordChangeDate
-- umbracoMemberPassWordRetrievalAnswer
-- umbracoMemberPasswordRetrivalQuestion
 
 Once the member is created and saved you can access it by expanding the members tree and click __All Members__ to get a list view (with real time search) or select the member type to filter by, by selecting it in the Members tree.
 


### PR DESCRIPTION
These default member properties:

* umbracoMemberPassWordRetrievalAnswer
* umbracoMemberPasswordRetrivalQuestion

Have typos and are no longer present for default members in my version of Umbraco (v7.4.2)

![capture](https://cloud.githubusercontent.com/assets/17275652/15430523/9b5da964-1e9d-11e6-8e00-16856ac23e01.PNG)
