### PR TITLE
Created documentation page for fileSystemProviders.config

### DIFF
--- a/Reference/Config/fileSystemProviders/index.md
+++ b/Reference/Config/fileSystemProviders/index.md
@@ -53,8 +53,4 @@ To store media files in different systems, the type of provider must be changed.
 ##Note
 At the moment when a file is saved, its full url is stored as node property, so a configuration change will not apply to pre-existing media files but only to the ones saved after that.
 
-If you want to move all your media files to a new location [NO IDEA HOW TO DO IT :)]
-
-###Contribution
-Umbraco is a community powered project and we welcome any contribution, big or small, even fixing a typo is a valuable contribution.
-[See how to contribute](https://github.com/umbraco/UmbracoDocs)
+If you want all your media files in the same location you have to copy all pre-existing files to the new path, and update the `path` property of the media item to the new url. This can be either directly inside the database or by using the `MediaService`.

--- a/Reference/Config/fileSystemProviders/index.md
+++ b/Reference/Config/fileSystemProviders/index.md
@@ -1,6 +1,6 @@
-#This section is waiting for content
+#FileSystemProviders.config
 
-TODO: Fill out these docs (https://github.com/umbraco/UmbracoDocs/issues/218)
+The `fileSystemProviders.config` contains the configuration for file system providers that access the actual file system 
 
 ###Contribution
 Umbraco is a community powered project and we welcome any contribution, big or small, even fixing a typo is a valuable contribution.

--- a/Reference/Config/fileSystemProviders/index.md
+++ b/Reference/Config/fileSystemProviders/index.md
@@ -1,6 +1,59 @@
 #FileSystemProviders.config
 
-The `fileSystemProviders.config` contains the configuration for file system providers that access the actual file system 
+The `fileSystemProviders.config` file contains the configuration for the file system providers used by Umbraco to interact with file systems.
+
+Following is the configuration installed with Umbraco.
+
+```
+<?xml version="1.0"?>
+<FileSystemProviders>
+  
+  <!-- Media -->
+  <Provider alias="media" type="Umbraco.Core.IO.PhysicalFileSystem, Umbraco.Core">
+    <Parameters>
+      <add key="virtualRoot" value="~/media/" />
+    </Parameters>
+  </Provider>
+  
+</FileSystemProviders>
+```
+The media provider can be of many types, for example in case you want to store media on Azure, Amazon or even DB. But the provider that comes by default with the installation of Umbraco is the `PhysicalFileSystem` provider.
+
+##PhysicalFileSystem Configuration
+
+The physical file system provider manages the interaction of Umbraco with the local file system. It can be configured for two different scenarios:
+
+ - media files stored inside a virtual folder of the site
+ - media files stored somewhere else outside of the site and accessed via a custom url
+ 
+###Virtual Folder
+To configure the PhysicalFileSystem to work with a virtual folder there not much to do, just change the value of the `virtualRoot` parameter to the virtual folder you want to use. By default it is configured to store media files in  ``~/media`.
+```
+<add key="virtualRoot" value="~/media/" />
+```
+
+###Physical path
+If you want to store the media files in a separate folder, outside of the Umbraco website, maybe on a NAS/SAN you have to remove the `virtualRoot` property and add two new properties:
+
+ - `rootPath` is the full filesystem path where you want media files to be stored. It has to be rooted, must use directory separators (`\`) and must not end with a separator. For example, `Z:` or `C:\path\to\folder` or `\\servername\path`.
+ - `rootUrl` is the url where the files will be accessible from. It must use url separators (`/`) and must not end with a separator. It can either be just a folder, like `/UmbracoMedia`, in which case it will considered as subfolder of the main domain (`example.com/UmbracoMedia`) or can be a fully qualified url, with also domain name and protocol (for ex `http://media.example.com/media`).
+ 
+ ```
+   <Provider alias="media" type="Umbraco.Core.IO.PhysicalFileSystem, Umbraco.Core">
+    <Parameters>
+      <add key="rootPath" value="Z:\Storage\UmbracoMedia" />
+      <add key="rootUrl" value="http://media.example.com/media" />
+    </Parameters>
+  </Provider>
+ ```
+
+##Custom providers
+To store media files in different systems, the type of provider must be changed. You can learn [how to build a custom filesystem provider](/documentation/Extending/Custom-File-Systems) in the Extending Umbraco section.
+
+##Note
+At the moment when a file is saved, its full url is stored as node property, so a configuration change will not apply to pre-existing media files but only to the ones saved after that.
+
+If you want to move all your media files to a new location [NO IDEA HOW TO DO IT :)]
 
 ###Contribution
 Umbraco is a community powered project and we welcome any contribution, big or small, even fixing a typo is a valuable contribution.


### PR DESCRIPTION
I wrote most of the reference for the configuration of the PhysicalFileSystem provider, but despite this being the way it should work, I cannot get it to work on my machine.
After I change the config I can save and edit new files, but I get an exception when trying to update old files.
Also old files are still pointing to the old url, so there must be a way to easily change the path of pre-existing files. But I don't know how to do it.

Addressed issue #218