### PR TITLE
Flag that the Redirect URL Management dashboard is in the Content Sec…

### DIFF
--- a/Reference/Routing/URL-Tracking/index.md
+++ b/Reference/Routing/URL-Tracking/index.md
@@ -8,7 +8,7 @@ Umbraco does not support rewriting "rules" (e.g. regular expressions) nor comple
 
 ## Dashboard
 
-It is possible to list the redirect URLs via the *Redirect Url Management* dashboard in the *Developer* section. This dashboard lists the original URL, new URL, and date. It allows you to delete a URL, and to directly edit the corresponding document.
+It is possible to list the redirect URLs via the *Redirect Url Management* dashboard in the *Content* section. This dashboard lists the original URL, new URL, and date. It allows you to delete a URL, and to directly edit the corresponding document.
 
 In addition, the dashboard can be used to disable or enable the 301 Redirect Management (via the `web.routing` configuration attribute described below - note that this causes an application restart).
 


### PR DESCRIPTION
…tion

Installing 7.5.3 and spent some time debugging why the *Redirect Url Management* dashboard was not in the *Developer* section. Finally noticed that the dashboard.config file says 

```
 <section alias="RedirectUrlManagement">
    <areas>
      <area>content</area>
    </areas>
    <tab caption="Redirect URL Management">
      <control>
        views/dashboard/developer/redirecturls.html
      </control>
    </tab>
  </section>
```

The URL is in Developer but the tab is in Content