### PR TITLE
Update 'Too much querying' examples

### DIFF
--- a/Reference/Common-Pitfalls/index.md
+++ b/Reference/Common-Pitfalls/index.md
@@ -165,13 +165,13 @@ using the current page's root node::
         }
     </ul>
 
-The syntax `@Model.Content.Site()` is actually shorthand for doing this:
+The syntax `@Model.Site()` is actually shorthand for doing this:
 `Model.Content.AncestorsOrSelf(1)` which means it is going to traverse up the tree until it reaches an ancestor node
 with a level of one. As mentioned above, traversing costs resources and in this example there is 3x traversals being done
 for the same value. Instead this can be rewritten as:
 
     @{
-        var site = @Model.Content.Site();
+        var site = @Model.Site();
     }
     <ul>
         <li><a href="@site.Url">@site.Name</a></li>


### PR DESCRIPTION
Was using `@Model.Content.Site()` instead of `@Model.Site()`