### PR TITLE
Clarifiying that UrlSegmentProvider docs

### DIFF
--- a/Reference/Routing/Request-Pipeline/outbound-pipeline.md
+++ b/Reference/Routing/Request-Pipeline/outbound-pipeline.md
@@ -27,7 +27,7 @@ To create a new Url segment provider, implement the following interface:
       string GetUrlSegment(IContentBase content);
     }
 
-The returned string will be your URL segment for this node.  You are free to return whatever string you like.
+The returned string will be your URL segment for this node.  You are free to return whatever string you like, but it cannot contain url segment separators `/` characters as this would create additional "segments". So something like `5678/swibble` is not allowed.
 
 #### Example
 


### PR DESCRIPTION
Clarifying that a UrlSegmentProvider cannot create new segments, so `/` characters are forbidden.

I discussed this with @zpqrtbnk on [a forum post on Our](https://our.umbraco.org/forum/extending-umbraco-and-using-the-api/81741-urlsegmentprovider-giving-this-document-is-published-but-its-url-would-collide-with-content-error)