### PR TITLE
Added VMWare to Running-Umbraco-On-A-Mac help.

### DIFF
--- a/Getting-Started/Setup/Install/Running-Umbraco-On-A-Mac.md
+++ b/Getting-Started/Setup/Install/Running-Umbraco-On-A-Mac.md
@@ -8,3 +8,6 @@ Bootcamp is native vm softvare for Mac OS. See how to install Windows with Bootc
 Parallels is third party and enables integration between Mac OS and Windows ie. running Windows Apps from the dock. Get it [here](https://www.parallels.com). 
 
 When your vm is running windows, follow the instructions for [installing Umbraco](index.md).
+
+###VMWare Fusion
+VMWare Fusion is a third party virtualization software which can be used to run Windows on your Mac.  Get it [here](http://www.vmware.com/products/fusion.html).  Just like with Parallels you should follow these [install instructions for Umbraco](index.md) after you have Windows installed.


### PR DESCRIPTION
I use VMWare so thought it would be helpful to let others know that VMWare Fusion is a viable option to use when developing an Umbraco site as well as Parallels or Bootcamp.  All three options are viable in my opinion.