### PR TITLE
update the link of azure blob storage provider

### DIFF
--- a/Extending/Custom-File-Systems.md
+++ b/Extending/Custom-File-Systems.md
@@ -32,4 +32,4 @@ Both `IFileSystem` and `FileSystemProviderManager` are located in the `Umbraco.C
 
 **Custom providers**
 
-[Azure Blob Storage Provider](http://our.umbraco.org/projects/backoffice-extensions/azure-blob-storage-provider) by Dirk Seefeld
+[Azure Blob Storage Provider](https://our.umbraco.org/projects/collaboration/umbracofilesystemprovidersazure/) by James, Dirk and Jeavon


### PR DESCRIPTION
The referenced azure blob storage provider is superseded by the one from James.