### PR TITLE
Fix typo in package.manifest definition

### DIFF
--- a/Extending/Macro-Parameter-Editors/index.md
+++ b/Extending/Macro-Parameter-Editors/index.md
@@ -19,13 +19,14 @@ You can create your own custom macro parameter types.
 All you need to do to create a macro parameter type in Umbraco 7, is to create a custom 'Property Editor' (or copy someone else's), see [Property Editors documentation](../../Extending/Property-Editors.md)
 and in the [Package Manifest file](../../Extending/Property-Editors/package-manifest.md) for the editor, set the isParameterEditor property to be true.
 
-    propertyEditors: [      
+    propertyEditors: [
         {
-        alias: "My.ParameterEditorAlias",
-        name: "Parameter Editor Name",
-        isParameterEditor: true,         
-        editor: {               
-            view: "~/App_Plugins/My.ParameterEditor/ParameterEditorView.html"           
+            alias: "My.ParameterEditorAlias",
+            name: "Parameter Editor Name",
+            isParameterEditor: true,
+            editor: {
+                view: "~/App_Plugins/My.ParameterEditor/ParameterEditorView.html"
+            }
         }
     ]
 ### PreValues/Configuration/DefaultValues ###

--- a/Extending/Property-Editors/package-manifest.md
+++ b/Extending/Property-Editors/package-manifest.md
@@ -4,15 +4,16 @@ The package.manifest JSON file format is used to describe one or more custom Umb
 ## Sample Manifest
 This is a sample manifest, it is always stored in a folder in `/app_plugins/{YourPackageName}`, with the name `package.manifest`
 
-    {       
-        propertyEditors: [      
+    {
+        propertyEditors: [
             {
-            alias: "Sir.Trevor",
-            name: "Sir Trevor",         
-            editor: {               
-                view: "~/App_Plugins/SirTrevor/SirTrevor.html",
-                hideLabel: true,
-                valueType: "JSON"
+                alias: "Sir.Trevor",
+                name: "Sir Trevor",
+                editor: {
+                    view: "~/App_Plugins/SirTrevor/SirTrevor.html",
+                    hideLabel: true,
+                    valueType: "JSON"
+                }
             }
         ],
         javascript: [


### PR DESCRIPTION
There was a missing `}` brace in the package.manifest definitions under the property editor and macro parameter sections:

```
propertyEditors: [
    {
    alias: "My.ParameterEditorAlias",
    name: "Parameter Editor Name",
    isParameterEditor: true,
    editor: {
        view: "~/App_Plugins/My.ParameterEditor/ParameterEditorView.html"           
    }
]
```
Should be:
```
propertyEditors: [
    {
        alias: "My.ParameterEditorAlias",
        name: "Parameter Editor Name",
        isParameterEditor: true,
        editor: {
            view: "~/App_Plugins/My.ParameterEditor/ParameterEditorView.html"
        }
    }
]
```

I've also updated the indenting to make this clearer, and match with the rest of the examples.

Thanks!