### PR TITLE
typo on version specific page: "revesed"

### DIFF
--- a/Getting-Started/Setup/Upgrading/version-specific.md
+++ b/Getting-Started/Setup/Upgrading/version-specific.md
@@ -46,7 +46,7 @@ Umbraco 7.6.0 also came with new pickers that store their data as a [UDI (Umbrac
 
 Unfortunately we noticed that some new pickers also got their PVCs disabled when the configuration setting was set to false (`<EnablePropertyValueConverters>false</EnablePropertyValueConverters>`) - yet the content picker ignored this setting.
 
-In order to make everything consistent, we made sure that the UDI pickers would always use PVCs in 7.6.2... or so we thought! By accident we actually revesed the behavior. So when PVCs were enabled, the property would NOT be converted and when PVCs were disabled, the property would be converted after all. This is the exact opposite behavior of 7.6.2. Oops!
+In order to make everything consistent, we made sure that the UDI pickers would always use PVCs in 7.6.2... or so we thought! By accident we actually reversed the behavior. So when PVCs were enabled, the property would NOT be converted and when PVCs were disabled, the property would be converted after all. This is the exact opposite behavior of 7.6.2. Oops!
 So we have fixed this now in 7.6.3.
 
 This issue only affects:


### PR DESCRIPTION
should be reversed