### PR TITLE
Added documentation for healthcheck configuration and scheduler

### DIFF
--- a/Extending/Healthcheck/index.md
+++ b/Extending/Healthcheck/index.md
@@ -34,6 +34,12 @@ Each check returns a message indicating whether or not the issue in question has
 
 Some of them can also be rectified via the dashboard, simply be clicking the **Fix** button and in some cases providing some required information.  These changes usually involve writing to configuration files that will often trigger a restart of the website.  
 
+##Configuring and scheduling checks
+
+As well as viewing the results of health checks via the Developer section dashboard, you can set up the checks to be run on a schedule and be notified of the results by email, Slack and/or log files.  It's also possible to disable certain checks if they aren't applicable in your environment.
+
+For more on this see the [Reference > Config > Health checks page](../Reference/Config/Healthchecks/index.md).
+
 ##Custom checks
 
 You can build your own health checks. There are two types of health checks you can build: **configuration checks** and **general checks**.

--- a/Reference/Config/HealthChecks/index.md
+++ b/Reference/Config/HealthChecks/index.md
@@ -6,20 +6,33 @@ Currently there is no user interface for updating the contents of this file.
 
 The following is an example configuration installed with Umbraco.
 
-	<?xml version ="1.0" encoding="utf-8" ?>
-	<HealthChecks>
-	  <disabledChecks>
-		<!--<check id="1B5D221B-CE99-4193-97CB-5F3261EC73DF" disabledOn="" disabledBy="0" />-->
-	  </disabledChecks>
-	  <notificationSettings enabled="false" firstRunTime="" periodInHours="24" >
-		  <emailSettings recipientEmail="" subject="Umbraco Health Check Notifier" />
-		  <slackSettings webHookUrl="" channel="#test" username="Umbraco Health Check Notifier" />
-		<disabledChecks>
-		  <!--<check id="EB66BB3B-1BCD-4314-9531-9DA2C1D6D9A7" disabledOn="" disabledBy="0" />-->
-		</disabledChecks>    
-	  </notificationSettings>
-	</HealthChecks> 
-	
+    <?xml version ="1.0" encoding="utf-8" ?>
+    <HealthChecks>
+        <disabledChecks>
+        <!--<check id="1B5D221B-CE99-4193-97CB-5F3261EC73DF" disabledOn="" disabledBy="0" />-->
+        </disabledChecks>
+        <notificationSettings enabled="false" firstRunTime="" periodInHours="24" >
+            <notificationMethods>
+                <notificationMethod alias="email" enabled="false" verbosity="Summary">
+                    <settings>
+                        <add key="recipientEmail" value="" />
+                        <add key="subject" value="Umbraco Health Check Status" />
+                    </settings>
+                </notificationMethod>
+                <notificationMethod alias="slack" enabled="false" verbosity="Summary">
+                    <settings>
+                          <add key="webHookUrl" value="" />
+                          <add key="channel" value="#test" />
+                          <add key="username" value="Umbraco Health Check Status" />
+                    </settings>
+                </notificationMethod>
+        </notificationMethods>    
+        <disabledChecks>
+          <!--<check id="EB66BB3B-1BCD-4314-9531-9DA2C1D6D9A7" disabledOn="" disabledBy="0" />-->
+        </disabledChecks>    
+        </notificationSettings>
+    </HealthChecks> 
+    
 In the first `<disabledChecks>` section it's possible to mark certain checks as disabled.  To do so, uncomment one of the examples and update `id` field with the Id of the test to disable (the `disabledOn` and `disabledBy` fields are not required, in place currently just as placeholders for when this information is managed via a user interface).  The Ids for core tests can be found via the [Umbraco GitHub repository](https://github.com/umbraco/Umbraco-CMS/tree/dev-v7/src/Umbraco.Web/HealthCheck/Checks).
 
 To enable notifications set the `enabled` attribute on `<notificationSettings>` to `true`.
@@ -28,8 +41,10 @@ The timing for notifications can be modified by setting the `periodInHours` attr
 
 The results of tests will always be written to the log files.
 
-In addition it's possible to configure notification by email, but supplying the email address as the `recipientEmail` attribute and subject for the email in `subject`, within the `<emailSettings>` tag.  To remove email notifications, just comment out or remove this tag completely.
+Each notification method can separately be enabled or disabled.  The the attribute `verbosity` can be set to `Summary` or `Detailed` to get more or less information in the alerts, and the `failureOnly` can be set to `true` or `false` if you'd prefer to get notifications only if at least one potential problem is detected.
 
-Instead, or in addition, notification via Slack can be confiured by providing the web hook URL, channel and user name in the appropriate attributes within the `<slackSettings>` field.
+Two notification methods are supplied with the core Umbraco product, via email and via [Slack](https://slack.com/).  They each have their own custom configutation.  For the email method, within the `<settings>` section of `<notificationMethod alias="email">`, the email address to send the notification to must be provided as the `recipientEmail` value and a subject for the email within the `subject` one.
 
-Please note that to use healthcheck notifications you must ensure to set the umbracoApplicationUrl value in umbracoSettings.config.  Without this the checks will only work when requested via the developer section dashboard.  For more information on this setting, please see [Config > UmbracoSettings](../config/umbracosettings/index.md#web-routing).
+Similarly, notification via Slack can be confiured by providing the web hook URL, channel and user name in the appropriate fields within the `<settings>` section of the `<notificationMethod alias="slack">` element.
+
+Please note that to use healthcheck notifications you must ensure to set the `umbracoApplicationUrl` value in `umbracoSettings.config`.  Without this the checks will only work when requested via the developer section dashboard.  For more information on this setting, please see [Config > UmbracoSettings](../config/umbracosettings/index.md#web-routing).

--- a/Reference/Config/HealthChecks/index.md
+++ b/Reference/Config/HealthChecks/index.md
@@ -1,0 +1,35 @@
+#HealthChecks.config
+
+The `HealthChecks.config` file contains the configuration for the health checks, allowing you to disable certain checks when not applicable and to manage the notifications.
+
+Currently there is no user interface for updating the contents of this file.
+
+The following is an example configuration installed with Umbraco.
+
+	<?xml version ="1.0" encoding="utf-8" ?>
+	<HealthChecks>
+	  <disabledChecks>
+		<!--<check id="1B5D221B-CE99-4193-97CB-5F3261EC73DF" disabledOn="" disabledBy="0" />-->
+	  </disabledChecks>
+	  <notificationSettings enabled="false" firstRunTime="" periodInHours="24" >
+		  <emailSettings recipientEmail="" subject="Umbraco Health Check Notifier" />
+		  <slackSettings webHookUrl="" channel="#test" username="Umbraco Health Check Notifier" />
+		<disabledChecks>
+		  <!--<check id="EB66BB3B-1BCD-4314-9531-9DA2C1D6D9A7" disabledOn="" disabledBy="0" />-->
+		</disabledChecks>    
+	  </notificationSettings>
+	</HealthChecks> 
+	
+In the first `<disabledChecks>` section it's possible to mark certain checks as disabled.  To do so, uncomment one of the examples and update `id` field with the Id of the test to disable (the `disabledOn` and `disabledBy` fields are not required, in place currently just as placeholders for when this information is managed via a user interface).  The Ids for core tests can be found via the [Umbraco GitHub repository](https://github.com/umbraco/Umbraco-CMS/tree/dev-v7/src/Umbraco.Web/HealthCheck/Checks).
+
+To enable notifications set the `enabled` attribute on `<notificationSettings>` to `true`.
+
+The timing for notifications can be modified by setting the `periodInHours` attribute to the number of hours that should elapse between tests.  If `firstRunTime` is empty, the tests will run for the first time just after the application is started.  To ensure the tests run at a later time - perhaps during low traffic hours, set the time in `hhmm` format (e.g. 2300) and the tests will not run until that time is reached.
+
+The results of tests will always be written to the log files.
+
+In addition it's possible to configure notification by email, but supplying the email address as the `recipientEmail` attribute and subject for the email in `subject`, within the `<emailSettings>` tag.  To remove email notifications, just comment out or remove this tag completely.
+
+Instead, or in addition, notification via Slack can be confiured by providing the web hook URL, channel and user name in the appropriate attributes within the `<slackSettings>` field.
+
+Please note that to use healthcheck notifications you must ensure to set the umbracoApplicationUrl value in umbracoSettings.config.  Without this the checks will only work when requested via the developer section dashboard.  For more information on this setting, please see [Config > UmbracoSettings](../config/umbracosettings/index.md#web-routing).


### PR DESCRIPTION
Obviously only to be applied if and when the health check scheduler work carried out at the retreat is merged into core, perhaps for 7.7.  Which is under [this PR](https://github.com/umbraco/Umbraco-CMS/pull/1983).