### PR TITLE
Added information about package.manifest and grid editors

### DIFF
--- a/Extending/Property-Editors/package-manifest.md
+++ b/Extending/Property-Editors/package-manifest.md
@@ -32,7 +32,7 @@ The manifest can contain 4 root colllections, none of them are mandatory
     }
 
 ## Property Editors
-`propertyEditors` returns an array of editor objects, each object specifies an editor to make available to data types as an editor component. These editors are primarily property editors for content, media and members, but can also be made available as a macro parameter editor.
+`propertyEditors` returns an array of property editor definitions, each object specifies an editor to make available to data types as an editor component. These editors are primarily property editors for content, media and members, but can also be made available as a macro parameter editor.
 
 The basic values on any editor is `alias`, `name`, and `editor` these three **must** be set. Furthermore the editor value is an object with additional configuration options on, but must contain a view value.
 
@@ -74,7 +74,7 @@ The basic values on any editor is `alias`, `name`, and `editor` these three **mu
 * `validation` Object describing required validators on the editor
 * `isReadOnly` Disables editing the value
 
-`valueType` sets what kind of data the editor will save in the database. by default this is set to `string`. The available options are:
+`valueType` sets what kind of data the editor will save in the database. By default this is set to `string`. The available options are:
 * `STRING` Stores the value as an nvarchar in the database
 * `DATETIME` Stores the value as datetime in the database
 * `TEXT` Stores the value as ntext in the database
@@ -114,9 +114,9 @@ But it also means that when this property editor is used on a property, then thi
     //this is our specific prevalue with the alias wolf
     $scope.model.config.wolf
 
-`view` config value points the prevalue editor to an editor to use. This follows the same concept as any other editor in umbraco, but with prevalue editors there are a couple of conventions.
+`view` config value points the prevalue editor to an editor to use. This follows the same concept as any other editor in Umbraco, but with prevalue editors there are a couple of conventions.
 
-If you just specify a name like `boolean` then umbraco will look at `/umbraco/views/prevalueeditors/boolean/boolean.html` for the editor view - if you wish to use your own, you specify the path like `~/app_data/package/prevalue-editor.html`.
+If you just specify a name like `boolean` then umbraco will look at `/umbraco/views/prevalueeditors/boolean/boolean.html` for the editor view - if you wish to use your own, you specify the path like `~/App_Data/package/prevalue-editor.html`.
 
 ### Default Config
 The defaultConfig object, provides a collection of default configuration values, in cases the property editor is not configured or is used a parameter editor, which doesnt allow configuration. The object is a key/value collection and must match the prevalue fields keys.

--- a/Extending/Property-Editors/package-manifest.md
+++ b/Extending/Property-Editors/package-manifest.md
@@ -2,22 +2,22 @@
 The package.manifest JSON file format is used to describe one or more custom Umbraco property editors. This page outlines the file format and properties found in the JSON
 
 ## Sample Manifest
-This is a sample manifest, it is always stored in a folder in `/app_plugins/{YourPackageName}`, with the name `package.manifest`
+This is a sample manifest, it is always stored in a folder in `/App_Plugins/{YourPackageName}`, with the name `package.manifest`
 
     {
-        propertyEditors: [
+        "propertyEditors": [
             {
-                alias: "Sir.Trevor",
-                name: "Sir Trevor",
-                editor: {
-                    view: "~/App_Plugins/SirTrevor/SirTrevor.html",
-                    hideLabel: true,
-                    valueType: "JSON"
+                "alias": "Sir.Trevor",
+                "name": "Sir Trevor",
+                "editor": {
+                    "view": "~/App_Plugins/SirTrevor/SirTrevor.html",
+                    "hideLabel": true,
+                    "valueType": "JSON"
                 }
             }
         ],
-        javascript: [
-            '~/App_Plugins/SirTrevor/SirTrevor.controller.js'
+        "javascript": [
+            "~/App_Plugins/SirTrevor/SirTrevor.controller.js"
         ]
     }
 
@@ -25,10 +25,10 @@ This is a sample manifest, it is always stored in a folder in `/app_plugins/{You
 The manifest can contain 4 root colllections, none of them are mandatory
 
     {
-        propertyEditors: [],
-        parameterEditors:[],
-        javascript: [],
-        css: []
+        "propertyEditors": [],
+        "parameterEditors": [],
+        "javascript": [],
+        "css": []
     }
 
 ## Property Editors
@@ -37,12 +37,12 @@ The manifest can contain 4 root colllections, none of them are mandatory
 The basic values on any editor is `alias`, `name`, and `editor` these three **must** be set. Furthermore the editor value is an object with additional configuration options on, but must contain a view value.
 
     {
-        alias: "my.editor.alias",
-        name: "My friendly editor name",
-        editor: {
+        "alias": "my.editor.alias",
+        "name": "My friendly editor name",
+        "editor": {
             view: "~/App_Plugins/SirTrevor/view.html"
         },
-        prevalues:{
+        "prevalues": {
             fields: []
         }
     }
@@ -60,12 +60,12 @@ The basic values on any editor is `alias`, `name`, and `editor` these three **mu
 ### Editor
 `editor` Besides setting a view, the editor can also contain additional information.
 
-    editor: {
-        view: "~/App_Plugins/SirTrevor/view.html",
-        hideLabel: true,
-        valueType: "TEXT",
-        validation: {},
-        isReadOnly: false 
+    "editor": {
+        "view": "~/App_Plugins/SirTrevor/view.html",
+        "hideLabel": true,
+        "valueType": "TEXT",
+        "validation": {},
+        "isReadOnly": false 
     }
 
 * `view` Path to the html file to use for rendering the editor
@@ -84,13 +84,13 @@ The basic values on any editor is `alias`, `name`, and `editor` these three **mu
 ### Pre Values
 `preValues` is a collection of prevalue editors, used for configuring the property editor, the prevalues object must return an array of editors, called `fields`.
 
-    prevalues: {
-        fields:[
+    "prevalues": {
+        "fields": [
             {
-                label: "Enable something",
-                description: "This is a describtion",
-                key: "enableStuff",
-                view: "boolean"
+                "label": "Enable something",
+                "description": "This is a describtion",
+                "key": "enableStuff",
+                "view": "boolean"
             }            
         ]
     }
@@ -121,10 +121,10 @@ If you just specify a name like `boolean` then umbraco will look at `/umbraco/vi
 ### Default Config
 The defaultConfig object, provides a collection of default configuration values, in cases the property editor is not configured or is used a parameter editor, which doesnt allow configuration. The object is a key/value collection and must match the prevalue fields keys.
 
-    defaultConfig: {
-        wolf: "nope",
-        editor: "hello",
-        random: 1234
+    "defaultConfig": {
+        "wolf": "nope",
+        "editor": "hello",
+        "random": 1234
     }
 
 ## Parameter Editors
@@ -135,17 +135,17 @@ The parameter editors array follows the same format as the property editors desc
 ## JavaScript
 `javascript` returns a string[] of javascript files to load on application start
 
-    javascript: [
-            '~/App_Plugins/SirTrevor/SirTrevor.controller.js',
-            '~/App_Plugins/SirTrevor/service.js'
+    "javascript": [
+            "~/App_Plugins/SirTrevor/SirTrevor.controller.js",
+            "~/App_Plugins/SirTrevor/service.js"
     ]
 
 ## CSS
 `css` returns a string[] of css files to load on application start
 
-    css: [
-            '~/App_Plugins/SirTrevor/SirTrevor.css',
-            '~/App_Plugins/SirTrevor/hibba.css'
+    "css": [
+            "~/App_Plugins/SirTrevor/SirTrevor.css",
+            "~/App_Plugins/SirTrevor/hibba.css"
     ]
 
 

--- a/Extending/Property-Editors/package-manifest.md
+++ b/Extending/Property-Editors/package-manifest.md
@@ -1,5 +1,5 @@
 # Package Manifest
-The package.manifest JSON file format is used to describe one or more custom Umbraco property editors. This page outlines the file format and properties found in the JSON
+The package.manifest JSON file format is used to describe one or more custom Umbraco property editors, grid editors or parameter editors. This page outlines the file format and properties found in the JSON.
 
 ## Sample Manifest
 This is a sample manifest, it is always stored in a folder in `/App_Plugins/{YourPackageName}`, with the name `package.manifest`
@@ -22,10 +22,11 @@ This is a sample manifest, it is always stored in a folder in `/App_Plugins/{You
     }
 
 ## Root elements
-The manifest can contain 4 root colllections, none of them are mandatory
+The manifest can contain five root colllections, none of them are mandatory:
 
     {
         "propertyEditors": [],
+        "gridEditors": [],
         "parameterEditors": [],
         "javascript": [],
         "css": []
@@ -126,6 +127,20 @@ The defaultConfig object, provides a collection of default configuration values,
         "editor": "hello",
         "random": 1234
     }
+
+## Grid Editors
+Similar to how the `propertyEditors` array defines one or more property editors, `gridEditors` can be used to define editors specific to the grid. Setting up the default richtext editor in the Umbraco grid could look like:
+
+    "gridEditors": [
+        {
+            "name": "Rich text editor",
+            "alias": "rte",
+            "view": "rte",
+            "icon": "icon-article"
+        }
+    ]
+    
+However the default grid editors are already configured in `/config/grid.editors.config.js` - you can use the file for inspiration, or see the [Grid Editors](../../Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors.md) page for more information on grid editors.
 
 ## Parameter Editors
 `parameterEditors` returns an array of editor objects, each object specifies an editor to make available to macro parameters as an editor component. These editors work solely as parameter editors, and will not show up on the property editors list.

--- a/Extending/Property-Editors/package-manifest.md
+++ b/Extending/Property-Editors/package-manifest.md
@@ -22,7 +22,7 @@ This is a sample manifest, it is always stored in a folder in `/App_Plugins/{You
     }
 
 ## Root elements
-The manifest can contain five root colllections, none of them are mandatory:
+The manifest can contain five root collections, none of them are mandatory:
 
     {
         "propertyEditors": [],

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors.md
@@ -17,7 +17,7 @@ The default editors are specified in `/config/grid.editors.config.js`. They are 
         "icon": "icon-article"
     }
 
-### Custom Grid Editors
+### Custom Grid editors
 You can easily customize the built-in editors to tailor the grid to your need.
 
 ##### package.manifest

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors.md
@@ -17,10 +17,11 @@ The default editors are specified in `/config/grid.editors.config.js`. They are 
         "icon": "icon-article"
     }
 
-### Grid editor configuration
+### Custom Grid Editors
 You can easily customize the built-in editors to tailor the grid to your need.
 
-It is recommended that you define custom editors in a package.manifest file (not in the config file) like so:
+##### package.manifest
+It is recommended that you define custom editors in a `package.manifest` file (not in the config file described above) like so:
 
     {
         "gridEditors": 
@@ -33,10 +34,16 @@ It is recommended that you define custom editors in a package.manifest file (not
             }
         ]
     }
+    
+While the root JSON element of `/config/grid.editors.config.js` is an array of grid editors, `package.manifest` files start with a JSON object with a number of different properties - one of them being `gridEditors`.
 
-The package manifest should be placed in a folder inside the `/App_Plugins/` folder. You can define as many grid editors you want and it can be done over multiple manifests so you can use grid editors from packages etc. 
+The package manifest should be placed in a folder inside the `/App_Plugins/` folder - for instance `/App_Plugins/{YourPackageName}/package.manifest`. You can define as many grid editors you want and it can be done over multiple manifests so you can use grid editors from packages etc. With the `package.manifest` file in place, Umbraco will automatically pick it up during startup.
 
-The required values are:
+You can read more about `package.manifest` files in general at the [Package Manifest](../../../../../Extending/Property-Editors/package-manifest.md) page.
+
+##### Grid editor configuration
+
+For a grid editor, the required values are:
 - **name**: The name of the editor
 - **alias**: Unique alias of the editor
 - **icon**: Icon shown to the editor, uses same icon classes as the rest of 
@@ -87,18 +94,3 @@ The `config.markup` is the string rendered server side in your template. `#value
 
 In this sample `config.size` will resize the the image according to `height` and `width`. The above example will result in a rendered image that is 200x200 pixels no matter the size of the uploaded image. If the ratio of the size differs from the uploaded image it is possible to set a focal point that determines how the image should be cropped.
 ![Resizing](images/grid-resizing.png)
-
-### package.manifest
-
-As an alternative to `/config/grid.editors.config.js`, you can also define grid editors through a `package.manifest` file. If you create a new file at the `/App_Plugins/{YourPackageName}/package.manifest`, Umbraco will automatically pick it up. While the root JSON element of `/config/grid.editors.config.js` is an array of grdi editors, `package.manifest` files start with a JSON object with a number of different properties - one of them being `gridEditors`:
-
-    "gridEditors": [
-        {
-            "name": "Rich text editor",
-            "alias": "rte",
-            "view": "rte",
-            "icon": "icon-article"
-        }
-    ]
-
-You can read more about `package.manifest` files in general at the [Package Manifest](../../../../../Extending/Property-Editors/package-manifest.md) page.

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors.md
@@ -87,3 +87,18 @@ The `config.markup` is the string rendered server side in your template. `#value
 
 In this sample `config.size` will resize the the image according to `height` and `width`. The above example will result in a rendered image that is 200x200 pixels no matter the size of the uploaded image. If the ratio of the size differs from the uploaded image it is possible to set a focal point that determines how the image should be cropped.
 ![Resizing](images/grid-resizing.png)
+
+### package.manifest
+
+As an alternative to `/config/grid.editors.config.js`, you can also define grid editors through a `package.manifest` file. If you create a new file at the `/App_Plugins/{YourPackageName}/package.manifest`, Umbraco will automatically pick it up. While the root JSON element of `/config/grid.editors.config.js` is an array of grdi editors, `package.manifest` files start with a JSON object with a number of different properties - one of them being `gridEditors`:
+
+    "gridEditors": [
+        {
+            "name": "Rich text editor",
+            "alias": "rte",
+            "view": "rte",
+            "icon": "icon-article"
+        }
+    ]
+
+You can read more about `package.manifest` files in general at the [Package Manifest](../../../../../Extending/Property-Editors/package-manifest.md) page.

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors.md
@@ -8,7 +8,7 @@ A grid editor is the component responsible for getting data into the grid - that
 The view is what the editor sees, the controller handles how it acts and the cshtml determines how the entered data is rendered in the template.
 
 ### Default Grid editors
-The default editors are specified in `config/grid.editors.config.js`. They are written in the JSON format and each editor is an object like so:
+The default editors are specified in `/config/grid.editors.config.js`. They are written in the JSON format and each editor is an object like so:
 
     {
         "name": "Rich text editor",
@@ -40,7 +40,7 @@ The required values are:
 - **name**: The name of the editor
 - **alias**: Unique alias of the editor
 - **icon**: Icon shown to the editor, uses same icon classes as the rest of 
-- **view** the view defines the editor used to enter a value. By default Umbraco will look in `umbraco/views/propertyeditors/grid/editors` for a html view to use - but you can pass in your own path
+- **view** the view defines the editor used to enter a value. By default Umbraco will look in `/umbraco/views/propertyeditors/grid/editors` for a html view to use - but you can pass in your own path
 
 The built-in views you can use are: 
 

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors.md
@@ -1,4 +1,4 @@
-#Grid Editors
+# Grid Editors
 A grid editor is the component responsible for getting data into the grid - that could be a simple text field or a media picker. They're built in the same way as a property editor thus consists of 3 parts:
 
 - .html view file
@@ -7,7 +7,7 @@ A grid editor is the component responsible for getting data into the grid - that
 
 The view is what the editor sees, the controller handles how it acts and the cshtml determines how the entered data is rendered in the template.
 
-###Default Grid editors
+### Default Grid editors
 The default editors are specified in `config/grid.editors.config.js`. They are written in the JSON format and each editor is an object like so:
 
     {
@@ -17,7 +17,7 @@ The default editors are specified in `config/grid.editors.config.js`. They are w
         "icon": "icon-article"
     }
 
-###Grid editor configuration
+### Grid editor configuration
 You can easily customize the built-in editors to tailor the grid to your need.
 
 It is recommended that you define custom editors in a package.manifest file (not in the config file) like so:
@@ -33,6 +33,7 @@ It is recommended that you define custom editors in a package.manifest file (not
             }
         ]
     }
+
 The package manifest should be placed in a folder inside the `/App_Plugins/` folder. You can define as many grid editors you want and it can be done over multiple manifests so you can use grid editors from packages etc. 
 
 The required values are:
@@ -52,7 +53,7 @@ The built-in views you can use are:
 
 In most cases you will either use the textstring or media view, or built your own from scratch. The textstring and media editors come with some additional configuration to make it easy and quick to customise these.
 
-#####Sample textstring config
+##### Sample textstring config
 
     {
         "name": "Headline",
@@ -69,7 +70,7 @@ In this sample, the `config.style` value is applied to the editor so users can s
 
 The `config.markup` is the string rendered server side in your template. `#value#`will be replaced with the actual value 
 
-#####Sample media config
+##### Sample media config
 
     {
         "name": "Square Image",


### PR DESCRIPTION
I've primarily added some information about how to define grid editors through `package.manifest` files instead of `/config/grid.editors.config.js`, since this appear to be missing in the current documentation. The pull request also fixes a few typos and similar here and there.

Since the two updated pages have related information, I've added links back and forth at relevant positions. There are tested to be working on GitHub, but I'm not sure whether they will work once uploaded to Our Umbraco. So these probably require a quick review by one of you guys at the HQ ;)