### PR TITLE
Updated UmbracoAuthorizeAttribute information

### DIFF
--- a/Reference/Routing/WebApi/authorization.md
+++ b/Reference/Routing/WebApi/authorization.md
@@ -10,7 +10,9 @@ Probably the easiest way to ensure your controller is secured for only back offi
 
 The `UmbracoAuthorizedApiController` is automatically routed.  Check out the [routing documentation](../Authorized/index.md) for more information on this topic.
 
-###Using UmbracoAuthorizeAttribute
+###Using UmbracoAuthorizeAttribute (<7.2.2)
+
+**Please note, this attribute [will not work](http://issues.umbraco.org/issue/U4-6352) in Umbraco from version 7.2.2. Please get your controller to inherit from the `UmbracoAuthorizedApiController` as is shown above.**
 
 To secure your controller based on back offce membership use the attribute: `Umbraco.Web.WebApi.UmbracoAuthorizeAttribute`. 
 


### PR DESCRIPTION
Added information about how UmbracoAuthorizeAttribute doens't work after Umbraco 7.2.2 onwards.

Honestly, I'm not even sure what the point of this attribute is. I keep accidentally using it only to find that it stops anyone from being able to access the method even if they're logged in to Umbraco!