### PR TITLE
Removed unused "the" from docs

### DIFF
--- a/Reference/Management/Services/ContentService.md
+++ b/Reference/Management/Services/ContentService.md
@@ -22,7 +22,7 @@ All samples in this document will require the following usings:
 **Please note that this page will be updated with samples and additional information about the methods listed below**
 
 ##Getting the service
-The ContentService is available through the `ApplicationContext`, but the if you are using a `SurfaceController` or the `UmbracoUserControl` then the ContentService is available through a local `Services` property.
+The ContentService is available through the `ApplicationContext`, but if you are using a `SurfaceController` or the `UmbracoUserControl` then the ContentService is available through a local `Services` property.
 
 	Services.ContentService
 


### PR DESCRIPTION
This line had an additional "the" in the docs. This has now been removed.