### PR TITLE
Deleting the folder itself causes the next step to fail, so empty it instead.

### DIFF
--- a/Umbraco-Cloud/Deployment/Migrate-Existing-Site/index.md
+++ b/Umbraco-Cloud/Deployment/Migrate-Existing-Site/index.md
@@ -54,7 +54,7 @@ With that in mind, here are the steps to take.
 12. Open a command prompt, cd to the `/data/` folder and add a deploy marker by typing `echo > deploy`.
 13. Now run the local Umbraco Cloud site with the updated files and database. The deploy engine will start when the deploy marker is detected.  This will likely complete relatively quickly. This  adds the users created by Umbraco Cloud to your existing database.
 14. Once complete verify your site has all meta data, content, and media as expected.
-15. Delete the folder `/data/Revision/` from the file system.  
+15. Make sure the folder `/data/Revision/` is empty.  
 16. * If your Umbraco Cloud project uses Umbraco Deploy (it does for Umbraco 7.6.0 and newer) - open a command prompt, cd to the `/data/` folder and add an export marker by typing `echo > deploy-export`.
     * Otherwise, if your Umbraco Cloud project uses Courier (it does for Umbraco versions older than 7.6.0) - in the same browser session as the logged in umbraco user open a new tab at the address:  
         * `http://localhost:port/umbraco/backoffice/api/CourierAdmin/Rebuild`


### PR DESCRIPTION
While I was following the guide during a migration of the existing site, I deleted the `data/Revision/` folder completely as step 15 suggests. However, the next step 16 (`echo > deploy-export`) would then fail.
When I put back an empty `data/Revision/` folder the deploy export would work fine.

So I think the instructions should clarify that the folder needs to stay as an empty folder, rather than deleting it.
