### PR TITLE
Add some documentation for the EditorModelEventManager SendingContent…

### DIFF
--- a/Reference/Events/EditorModel-Events.md
+++ b/Reference/Events/EditorModel-Events.md
@@ -49,45 +49,27 @@ Example usage of the **EditorModelEventManager** '*SendingContentModel*' event -
         <td>SendingContentModel</td>
         <td>(HttpActionExecutedContext sender,  EditorModelEventArgs&ltContentItemDisplay&gt; e)</td>
         <td>
-        Raised when ContentService.Save is called in the API.<br />
-        NOTE: It can be skipped completely if the parameter "raiseEvents" is set to false during the Save method call (true by default).<br />
-        "sender" will be the current IContentService object.<br />
-        "e" will provide:<br/>
-		<em>NOTE: If the entity is brand new then HasIdentity will equal false.</em>
-            <ol>
-                <li>SavedEntities: Gets the collection of IContent objects being saved.</li>
-            </ol>
+        Raised just before the editor model is sent for editing in the content section <br />
+        NOTE: 'e' contains a model property of *Umbraco.Web.Models.ContentEditing.ContentItemDisplay* type which in turn contains the tabs and properties of the elements about to be loaded for editing
         </td>
     </tr>
     <tr>
             <td>SendingMediaModel</td>
         <td>(HttpActionExecutedContext sender,  EditorModelEventArgs&ltMediaItemDisplay&gt; e)</td>
         <td>
-        Raised when ContentService.Save is called in the API and after data has been persisted.<br />
-        NOTE: It can be skipped completely if the parameter "raiseEvents" is set to false during the Save method call (true by default). <br />
-        "sender" will be the current IContentService object.<br />
-        "e" will provide:<br/>
-		<em>NOTE: <a href="determining-new-entity">See here on how to determine if the entity is brand new</a></em>
-            <ol>
-                <li>SavedEntities: Gets the saved collection of IContent objects.</li>
-            </ol>
+        Raised just before the editor model is sent for editing in the media section <br />
+        NOTE: 'e' contains a model property of *Umbraco.Web.Models.ContentEditing.MediaItemDisplay* type which in turn contains the tabs and properties of the elements about to be loaded for editing
         </td>
     </tr>
     <tr>
      <td>SendingMemberModel</td>
         <td>(HttpActionExecutedContext sender,  EditorModelEventArgs&ltMemberDisplay&gt; e)</td>
         <td>
-        Raised when ContentService.Publishing is called in the API.<br />
-        NOTE: It can be skipped completely if the parameter "raiseEvents" is set to false during the Publish method call (true by default).<br />
-        "sender" will be the current IPublishingStrategy object.<br />
-        "e" will provide:<br/>
-		<em>NOTE: If the entity is brand new then HasIdentity will equal false.</em>
-            <ol>
-                <li>PublishedEntities: Gets the collection of IContent objects being published.</li>
-            </ol>
+          Raised just before the editor model is sent for editing in the member section.<br />
+        NOTE: 'e' contains a model property of *Umbraco.Web.Models.ContentEditing.MemberDisplay* type which in turn contains the tabs and properties of the elements about to be loaded for editing 
         </td>
     </tr>   
-</table>
+   </table>
 
 ### EditorModelEventArgs ###
 

--- a/Reference/Events/EditorModel-Events.md
+++ b/Reference/Events/EditorModel-Events.md
@@ -1,0 +1,122 @@
+# EditorModel Events #
+
+The **EditorModelEventManager** class is used to emit events that enable you to manipulate the model used by the backoffice before it is loaded into an editor  (for example the SendingContentModel event fires just before a content item is loaded into the backoffice for editing). It is therefore the perfect event to use to set a default value for a particular property, or perhaps to hide a property/tab from a certain editor.
+
+## Usage ##
+
+Example usage of the **EditorModelEventManager** '*SendingContentModel*' event - eg set the default PublishDate for a new NewsArticle to be today's date:
+
+    using Umbraco.Core;
+    using Umbraco.Core.Events;
+    using Umbraco.Core.Models;
+    using Umbraco.Web.Editors;
+	using Umbraco.Web.Models.ContentEditing;
+    
+    namespace My.Namespace
+    {
+        public class MyEventHandler : ApplicationEventHandler
+        {
+
+			protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
+            {
+				EditorModelEventManager.SendingContentModel += EditorModelEventManager_SendingContentModel;   
+            }            
+    
+             private void EditorModelEventManager_SendingContentModel(System.Web.Http.Filters.HttpActionExecutedContext sender, EditorModelEventArgs<Umbraco.Web.Models.ContentEditing.ContentItemDisplay> e)
+			{
+
+            //set a default value for NewsArticle PublishDate property, the editor can override this, but we will suggest it should be todays date
+            if (e.Model.ContentTypeAlias == "newsArticle")
+            {
+               var pubDateProperty = e.Model.Properties.FirstOrDefault(f => f.Alias == "publishDate");
+                if (pubDateProperty.Value == null || String.IsNullOrEmpty(pubDateProperty.Value.ToString())){
+				//set default value if the date property is null or empty
+                    pubDateProperty.Value = DateTime.UtcNow;
+                }
+            }
+        }
+        }
+    }
+
+## Events ##
+
+<table>
+    <tr>
+        <th>Event</th>
+        <th>Signature</th>
+        <th>Description</th>
+    </tr>    
+    <tr>
+        <td>SendingContentModel</td>
+        <td>(HttpActionExecutedContext sender,  EditorModelEventArgs&ltContentItemDisplay&gt; e)</td>
+        <td>
+        Raised when ContentService.Save is called in the API.<br />
+        NOTE: It can be skipped completely if the parameter "raiseEvents" is set to false during the Save method call (true by default).<br />
+        "sender" will be the current IContentService object.<br />
+        "e" will provide:<br/>
+		<em>NOTE: If the entity is brand new then HasIdentity will equal false.</em>
+            <ol>
+                <li>SavedEntities: Gets the collection of IContent objects being saved.</li>
+            </ol>
+        </td>
+    </tr>
+    <tr>
+            <td>SendingMediaModel</td>
+        <td>(HttpActionExecutedContext sender,  EditorModelEventArgs&ltMediaItemDisplay&gt; e)</td>
+        <td>
+        Raised when ContentService.Save is called in the API and after data has been persisted.<br />
+        NOTE: It can be skipped completely if the parameter "raiseEvents" is set to false during the Save method call (true by default). <br />
+        "sender" will be the current IContentService object.<br />
+        "e" will provide:<br/>
+		<em>NOTE: <a href="determining-new-entity">See here on how to determine if the entity is brand new</a></em>
+            <ol>
+                <li>SavedEntities: Gets the saved collection of IContent objects.</li>
+            </ol>
+        </td>
+    </tr>
+    <tr>
+     <td>SendingMemberModel</td>
+        <td>(HttpActionExecutedContext sender,  EditorModelEventArgs&ltMemberDisplay&gt; e)</td>
+        <td>
+        Raised when ContentService.Publishing is called in the API.<br />
+        NOTE: It can be skipped completely if the parameter "raiseEvents" is set to false during the Publish method call (true by default).<br />
+        "sender" will be the current IPublishingStrategy object.<br />
+        "e" will provide:<br/>
+		<em>NOTE: If the entity is brand new then HasIdentity will equal false.</em>
+            <ol>
+                <li>PublishedEntities: Gets the collection of IContent objects being published.</li>
+            </ol>
+        </td>
+    </tr>   
+</table>
+
+### EditorModelEventArgs ###
+
+The EditorModelEventArgs class has two properties, one 'Model' representing the type of Model being sent, eg 'ContentItemDisplay' and an 'UmbracoContext' property representing the current context.
+
+#### ContentItemDisplay ####
+
+A model representing a content item to be displayed in the backoffice
+* TemplateAlias
+* Urls
+* AllowPreview - Determines whether previewing is allowed for this node, By default this is true but by using events developers can toggle this off for certain documents if there is nothing to preview
+* AllowedActions - The allowed 'actions' based on the user's permissions - Create, Update, Publish, Send to publish
+* IsBlueprint
+* Tabs - Defines the tabs containing display properties
+* Properties - properties based on the properties in the tabs collection
+
+#### MediaItemDisplay ####
+
+A model representing a media item to be displayed in the backoffice
+* Tabs - Defines the tabs containing display properties
+* Properties - properties based on the properties in the tabs collection
+
+#### MemberDisplay ####
+
+A model representing a member to be displayed in the backoffice
+* Username
+* Email
+* MembershipScenario
+* MemberProviderFieldMapping - This is used to indicate how to map the membership provider properties to the save model, this mapping will change if a developer has opted to have custom member property aliases specified in their membership provider config, or if we are editing a member that is not an Umbraco member (custom provider)
+* Tabs - Defines the tabs containing display properties
+* Properties - properties based on the properties in the tabs collection

--- a/Reference/Events/EditorModel-Events.md
+++ b/Reference/Events/EditorModel-Events.md
@@ -16,25 +16,24 @@ Example usage of the **EditorModelEventManager** '*SendingContentModel*' event -
     {
         public class MyEventHandler : ApplicationEventHandler
         {
-
-			protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
+            protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
             {
-				EditorModelEventManager.SendingContentModel += EditorModelEventManager_SendingContentModel;   
+                EditorModelEventManager.SendingContentModel += EditorModelEventManager_SendingContentModel;   
             }            
     
-             private void EditorModelEventManager_SendingContentModel(System.Web.Http.Filters.HttpActionExecutedContext sender, EditorModelEventArgs<Umbraco.Web.Models.ContentEditing.ContentItemDisplay> e)
-			{
-
-            //set a default value for NewsArticle PublishDate property, the editor can override this, but we will suggest it should be todays date
-            if (e.Model.ContentTypeAlias == "newsArticle")
-            {
-               var pubDateProperty = e.Model.Properties.FirstOrDefault(f => f.Alias == "publishDate");
-                if (pubDateProperty.Value == null || String.IsNullOrEmpty(pubDateProperty.Value.ToString())){
-				//set default value if the date property is null or empty
-                    pubDateProperty.Value = DateTime.UtcNow;
+            private void EditorModelEventManager_SendingContentModel(System.Web.Http.Filters.HttpActionExecutedContext sender, EditorModelEventArgs<Umbraco.Web.Models.ContentEditing.ContentItemDisplay> e)
+            {            
+                //set a default value for NewsArticle PublishDate property, the editor can override this, but we will suggest it should be todays date
+                if (e.Model.ContentTypeAlias == "newsArticle")
+                {
+                    var pubDateProperty = e.Model.Properties.FirstOrDefault(f => f.Alias == "publishDate");
+                    if (pubDateProperty.Value == null || String.IsNullOrEmpty(pubDateProperty.Value.ToString()))
+                    {
+                        //set default value if the date property is null or empty
+                        pubDateProperty.Value = DateTime.UtcNow;
+                    }
                 }
             }
-        }
         }
     }
 

--- a/Reference/Events/index.md
+++ b/Reference/Events/index.md
@@ -1,4 +1,4 @@
-#Using events
+# Using events
 
 Umbraco uses .Net events to allow you to hook into the workflow processes for the backoffice. For example you might want to execute some code every time a page is published. Events allow you to do that.
 
@@ -26,3 +26,7 @@ Which one you want to use depends on what you want to achieve. If you want to be
 ## Tree events
 
 * See [Tree Events](../../Extending-Umbraco/Section-Trees/trees.md) for a listing of the tree events.  
+
+## Editor Model events
+See [EditorModelEventManager Events](EditorModel-Events.md) for a listing of the EditorModel events 
+<small>*(hint: useful for manipulating the model before it is sent to an editor in the backoffice - eg. perhaps to set a default value of a property on a new document)*</small>


### PR DESCRIPTION
…Model event

Think this might be a really useful event for people to be aware of, but it's not really mentioned on any of the official Umbraco Training courses nor in the documentation that I can find, other than the generated API reference, but if you didn't know it existed, you probably wouldn't look for it, and if you did think something might exist, you might not guess/remember it's called the EditorModelEventManager... (When I forget what it's called - I actually remember it because Lee Kelleher tweeted it about once as his 'new favourite #Umbraco thing' - so I google that phrase, and then find the name of it!

Anyway, I've added this amongst the general Events documentation, but part of me thinks it's hidden here, and there should be perhaps something under the heading of 'How to set a default value', as that's probably the angle people will benefit from discovering this extension point from ... perhaps linking through to this page?