### PR TITLE
Update index.md on key umbracoVersionCheckPeriod 

### DIFF
--- a/Reference/Config/webconfig/index.md
+++ b/Reference/Config/webconfig/index.md
@@ -95,4 +95,4 @@ If you are not running a load balanced environment on a central SAN based file s
 The default value is:
 `7`
 
-When this value is set above 0, the backoffice will check for a new version of Umbraco every 'x' number of days where 'x' is the value defined for this setting. By default Umbraco ships with a value of '7'.
+When this value is set above 0, the backoffice will check for a new version of Umbraco every 'x' number of days where 'x' is the value defined for this setting. Set this value to `0` to never check for a new version.


### PR DESCRIPTION
Added information about how to set the umbracoVersionCheckPeriod key to never let the backoffice check for updates. By default Umbraco ships with a value of '7' is not true because this key is not present in the default installation.