### PR TITLE
Issues/316 content type property conventions filtering

### DIFF
--- a/Reference/Querying/IPublishedContent/Collections.md
+++ b/Reference/Querying/IPublishedContent/Collections.md
@@ -1,11 +1,11 @@
-#IPublishedContent Collections
+# IPublishedContent Collections
 
 All collections of `IPublishedContent` are `IEnumerable<IPublishedContent>`. 
 This means that all c# Linq statements can be used to filter and query the collections.  
 
-##Collections
+## Collections
 
-###.Children
+### .Children
 Returns a collection of items just below the current content item
 
 	<ul>
@@ -16,7 +16,7 @@ Returns a collection of items just below the current content item
 	</ul>
 
 
-###.Ancestors
+### .Ancestors
 Returns all ancestors of the current page (parent page, grandparent and so on)
 
 	<ul>
@@ -27,24 +27,24 @@ Returns all ancestors of the current page (parent page, grandparent and so on)
 		}
 	</ul>
 
-###.Ancestor
+### .Ancestor
 Returns the first ancestor of the current page
 
 	@* return the first ancestor item from the current page *@
-	@var nodes = Model.Content.Ancestor();
+	var nodes = Model.Content.Ancestor();
 	
 	@* return the first item, of a specific type, from the current page *@
-	@var nodes = Model.Content.Ancestor<DocumentTypeAlias>();
+	var nodes = Model.Content.Ancestor<DocumentTypeAlias>();
 
 
 <span id="ancestorsorself"></span>
-###.AncestorsOrSelf
+### .AncestorsOrSelf
 Returns a collection of all ancestors of the current page (parent page, grandparent and so on), and the current page itself
 
 	@* Get the top item in the content tree, this will always be the Last ancestor found *@
 	var websiteRoot = Model.Content.AncestorsOrSelf().Last();
 
-###.Descendants
+### .Descendants
 Returns all descendants of the current page (children, grandchildren etc)
 
 	<ul>
@@ -55,7 +55,7 @@ Returns all descendants of the current page (children, grandchildren etc)
 		}
 	</ul>
 
-###.DescendantsOrSelf
+### .DescendantsOrSelf
 Returns all descendants of the current page (children, grandchildren etc), and the current page itself
 
 	<ul>
@@ -66,7 +66,7 @@ Returns all descendants of the current page (children, grandchildren etc), and t
 		}
 	</ul>
 
-###.OfTypes
+### .OfTypes
 Filters a collection of content by content type alias 
 
 	<ul>
@@ -79,23 +79,23 @@ Filters a collection of content by content type alias
 
 -----
 
-##Filtering, Ordering & Extensions
+## Filtering, Ordering & Extensions
 
 Filtering and Ordering are done simply with Linq.
 
 Some examples:
 	
-###.Where
+### .Where
 
 	@* Returns all items in the collection that have a template assigned and have a name starting with 'S' *@
-	@var nodes = Model.Content.Descendants().Where(x => x.TemplateId > 0 && x.Name.StartsWith("S"))
+	var nodes = Model.Content.Descendants().Where(x => x.TemplateId > 0 && x.Name.StartsWith("S"))
 
-###.OrderBy
+### .OrderBy
 
 	@* Orders a collection by the property name "title" *@
-	@var nodes = Model.Content.Children.OrderBy(x => x.GetPropertyValue<string>("title"))
+	var nodes = Model.Content.Children.OrderBy(x => x.GetPropertyValue<string>("title"))
 	
-###.GroupBy
+### .GroupBy
 Groups collection by content type alias
 
 	@{
@@ -111,25 +111,41 @@ Groups collection by content type alias
 	}
 
 
-###.Take(int)
+### .Take(int)
 Return only the number of items for a collection specified by the integer value.
 	
 	@* return the first 3 items from the child collection *@
-	@var nodes = Model.Content.Children.Take(3);
+	var nodes = Model.Content.Children.Take(3);
 
-###.Skip(int)
+### .Skip(int)
 Return items from the collection after skipping the specified number of items.
 
 	@* Skip the first 3 items in the collection and return the rest *@
-	@var nodes = Model.Content.Children.Skip(3);
+	var nodes = Model.Content.Children.Skip(3);
 
 **HINT:** You can combine Skip and Take when using for paging operations
 
 	@* using skip and take together you can perform paging operations *@
-	@var nodes = Model.Content.Skip(10).Take(10);
+	var nodes = Model.Content.Skip(10).Take(10);
 
-###.Count()
+### .Count()
 Returns the number of items in the collection
 
-	@int numberOfChildren =  Model.Content.Children.Count();
+	int numberOfChildren =  Model.Content.Children.Count();
+
+### .Any()
+Returns a boolean True/False value determined by whether there are any items in the collection
+
+	bool hasChildren =  Model.Content.Children.Any();
 	
+## [Filtering Conventions](#filtering-conventions)
+Some filtering and routing behaviour is dependant upon a set of special naming conventions for certain properties. [See also: Routing Property Conventions](../../Routing/routing-properties.md)
+
+### .IsVisible()
+If you create a checkbox property on a document type with an alias *umbracoNaviHide* then the value of this property is used by the *IsVisible()* extension method when filtering.
+
+   	IEnumerable<IPublishedContent> sectionPages =  Model.Content.Children.Where(x => x.IsVisible());
+
+Use case: When displaying a navigation menu for a section of the site, following this convention gives editors the option to 'hide' certain pages from appearing in the section navigation. (hence the unusual *umbracoNaviHide* property alias!)
+
+

--- a/Reference/Routing/routing-properties.md
+++ b/Reference/Routing/routing-properties.md
@@ -26,3 +26,7 @@ This property when created as a text string lets you provide a comma separated
 list of alternate full URL paths for the node. For example, if your URL was /some-category/some-page/content-node, 
 by adding an umbracoUrlAlias of "flowers", a user can navigate to the node by simply going to /flowers. 
 The URL alias remains in the browser address bar as a 'mask' over the real URL. You can also specify paths like "flowers/roses/red".
+
+## Filtering
+
+[See Filtering Property Conventions](../Querying/IPublishedContent/Collections.md#filtering-conventions)


### PR DESCRIPTION
Add details of IsVisible() helper and convention of umbracoNaviHide to the IPublishedContent Querying and filtering section of the documentation. see issue #316 https://github.com/umbraco/UmbracoDocs/issues/316