### PR TITLE
Add clear example for @section usage

### DIFF
--- a/Getting-Started/Design/Templates/index.md
+++ b/Getting-Started/Design/Templates/index.md
@@ -85,8 +85,15 @@ By default, when defining a section it is required. To make the section optional
 
     @RenderSection("Head", required: false)
 
- On your child page call `@section Head {}` and then type your markup that will be pushed into the Master Template.  
+On your child page call `@section Head {}` and then type your markup that will be pushed into the Master Template:
 
+    @section Head {
+        <style>
+            body {
+                background: #ff0000;
+            }
+        </style>
+    }
 
 ## Injecting partial template
 Another way to reuse html is to use partials - which are small reusable views which can be injected into another view.

--- a/Getting-Started/Design/Templates/index.md
+++ b/Getting-Started/Design/Templates/index.md
@@ -85,7 +85,7 @@ By default, when defining a section it is required. To make the section optional
 
     @RenderSection("Head", required: false)
 
-On your child page call `@section Head {}` and then type your markup that will be pushed into the Master Template:
+On your child page template call `@section Head {}` and then type your markup that will be pushed into the Master Template:
 
     @section Head {
         <style>


### PR DESCRIPTION
As @RenderSection has a code example, I feel that @section should have
one too.
https://our.umbraco.org/documentation/Getting-Started/Design/Templates/#template-sections