### PR TITLE
Removing reference to Web Matrix

### DIFF
--- a/Getting-Started/Setup/Install/index.md
+++ b/Getting-Started/Setup/Install/index.md
@@ -1,18 +1,9 @@
 #Installation
 
-The easiest way to get the latest version of Umbraco up and running is with Webmatrix.
-
-1. **Download and install [Webmatrix](http://webmatrix.com)**
-2. **Download and unzip [Umbraco](http://our.umbraco.org/download)**
-3. **Right click the folder and choose *Open as a Website with Microsoft Webmatrix***
-
-All you have to do is follow the instructions in the installer and that's it, you are now running a local instance of Umbraco. Below you'll find some in-depth tutorials on the different ways to install Umbraco.
+Below you'll find some in-depth tutorials on the different ways to install Umbraco.
 
 ###[Manual installation](install-umbraco-manually.md)
 Goes through the steps to download either a stable release or a nightly version, unzipping, and getting it running on a local webserver.
-
-###[WebMatrix installation](install-umbraco-with-microsoft-webmatrix.md)
-Microsoft WebMatrix is a simple-to use-editor with an embedded webserver. An easy and fast way to get you up and running with Umbraco.
 
 ###[NuGet installation](install-umbraco-with-nuget.md)
 NuGet is the package manager for the Microsoft development platform, including .NET. The NuGet client tools provide the ability to produce and consume packages. NuGet allows you to install Umbraco without ever having to leave Visual Studio.


### PR DESCRIPTION
Removed references to Web Matrix as an option to install Umbraco.
Microsoft has now discontinued Web Matrix and they don't have the installer available via their website.