### PR TITLE
Update wording around implementation of rewriting rules

### DIFF
--- a/Reference/Routing/URL-Tracking/index.md
+++ b/Reference/Routing/URL-Tracking/index.md
@@ -2,9 +2,9 @@
 
 ## User Overview
 
-Whenever a document is published, and this causes changes to its URL (and any of its descendants' URLs), Umbraco saves the old URLs. Whenever an incoming request is served and the default content finders cannot find a matching document, Umbraco checks whether the URL matches one of these saved URLs. If a match is found, Umbraco returns a "301 Redirect" answer pointing to the new URL of the document.
+Whenever a document is published, and this causes changes to its URL (and any of its descendants' URLs), Umbraco makes a note of the old URLs. Whenever an incoming request is served and the default content finders cannot find a matching published document, Umbraco checks whether the URL matches one of these saved URLs. If a match is found, Umbraco returns a "301 Redirect" response pointing to the new URL of the document.
 
-Umbraco does not support rewriting "rules" (e.g. regular expressions) nor complex scenarios (e.g. changing the culture and hostnames configuration). There already are powerful solutions to deal what that type of situations, such as Microsoft's own [Url Rewrite](http://www.iis.net/downloads/microsoft/url-rewrite) module for IIS.
+The URL Redirect Management functionality does not support rewriting "rules" (e.g. regular expressions), nor complex scenarios (e.g. changing the culture and hostnames configuration). There are already powerful solutions to deal with these types of situations, such as Microsoft's own [Url Rewrite](http://www.iis.net/downloads/microsoft/url-rewrite) module for IIS. [Creating IIS Rewrite Rules](../IISRewriteRules)
 
 ## Dashboard
 


### PR DESCRIPTION
Make it clear that the Redirect Url Management dashboard doesn't implement rewriting rules, but IIS Rewrites do, and point people to the information on configuring them.