### PR TITLE
XPATH Examples: Wrong output result

### DIFF
--- a/Reference/Templating/Macros/Xslt/Using-XPATH/XPath-Examples.md
+++ b/Reference/Templating/Macros/Xslt/Using-XPATH/XPath-Examples.md
@@ -69,7 +69,6 @@ Below are some simple examples that demonstrate the use of XPath. All examples a
 	<Track rating="5" length="P2M26S">Calm Like You</Track>
 	<Track rating="4" length="P7M10S">Knocked Up</Track>
 	<Track rating="4" length="P3M09S">McFearless</Track>
-	<Track rating="1" length="P3M59S">Black Thumbnail</Track>
 
 ###//Track/text()
 


### PR DESCRIPTION
Removed the last output row of subject //Track\[@rating >= 4] because the rating is 1 and therefore is not  equal or higher as 4