### PR TITLE
Document GetCurrentMember method in MemberShipHelper

### DIFF
--- a/Reference/Querying/MemberShipHelper/index.md
+++ b/Reference/Querying/MemberShipHelper/index.md
@@ -40,10 +40,11 @@ Looks for a member with a given username, if found, returns a member profile as 
 ### .GetCurrentLoginStatus()
 Gets the current members login status as a `LoginStatusModel`
 
+### .GetCurrentMember()
+Get the currently logged in member as `IPublishedContent`
 
 ### .GetCurrentMemberProfileModel()
 Gets the current member profile as a `ProfileModel`
-
 
 ### .IsLoggedIn()
 Returns a boolean to state whether there is a member currently logged in.


### PR DESCRIPTION
The `GetCurrentMember` method in MemberShipHelper wasn't documented.
https://github.com/umbraco/Umbraco-CMS/blob/7ee510ed386495120666a78c61497f58ff05de8f/src/Umbraco.Web/Security/MembershipHelper.cs#L365-L377