### PR TITLE
Document GetCurrentMemberId method in MemberShipHelper

### DIFF
--- a/Reference/Querying/MemberShipHelper/index.md
+++ b/Reference/Querying/MemberShipHelper/index.md
@@ -44,6 +44,8 @@ Gets the current members login status as a `LoginStatusModel`
 ### .GetCurrentMemberProfileModel()
 Gets the current member profile as a `ProfileModel`
 
+### .GetCurrentMemberId()
+Gets the currently logged in member id, -1 if they are not logged in.
 
 ### .IsLoggedIn()
 Returns a boolean to state whether there is a member currently logged in.


### PR DESCRIPTION
The method `GetCurrentMemberId` wasn't documented.

https://github.com/umbraco/Umbraco-CMS/blob/7ee510ed386495120666a78c61497f58ff05de8f/src/Umbraco.Web/Security/MembershipHelper.cs#L379-L391