### PR TITLE
Document ncNodeName filter

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Nested-Content.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Nested-Content.md
@@ -17,7 +17,7 @@ You should then be presented with the **Nested Content** property editors data-t
 
 The data-type editor allows you to configure the following properties:
 
-- **Doc Types** - Defines a list of document-types to use as data blue prints for this **Nested Content** instance. For each document-type you can provide the alias of the tab you wish to render (first tab is used by default if not set) as well as a template for generating list item labels using the syntax `{{propertyAlias}}`. If you would like to include the index position in the label, you can use `{{$index}}`.
+- **Doc Types** - Defines a list of document-types to use as data blue prints for this **Nested Content** instance. For each document-type you can provide the alias of the tab you wish to render (first tab is used by default if not set) as well as a template for generating list item labels using the syntax `{{propertyAlias}}`. If you would like to include the index position in the label, you can use `{{$index}}`. If your property links to a content node, you can use the Angular filter `{{ pickerAlias | ncNodeName }}` to show the node name rather than the node ID.
 - **Min Items** - Sets the minimum number of items that should be allowed in the list. If greater than `0`, **Nested Content** will pre-populate your list with the minimum amount of allowed items and prevent deleting items below this level. Defaults to `0`.
 - **Max Items** - Sets the maximum number of items that should be allowed in the list. If greater than `0`, **Nested Content** will prevent new items being added to the list above this threshold. Defaults to `0`.
 - **Confirm Deletes** - Enabling this will require item deletions to require a confirmation before being deleted. Defaults to `true`.


### PR DESCRIPTION
This angular filter allows to get the name of  item picked with a content picker as name template. This was also in original docs and the filter is present in the current core version

https://github.com/umco/umbraco-nested-content/blob/develop/docs/developers-guide.md#name-template