### PR TITLE
Updated backoffice rewrite rule

### DIFF
--- a/Umbraco-Cloud/Frequently-Asked-Questions/index.md
+++ b/Umbraco-Cloud/Frequently-Asked-Questions/index.md
@@ -172,7 +172,7 @@ On Cloud it is easy to add an IP filter of your choosing, there's a few things y
 The following rule can be added to your web.config (in `system.webServer/rewrite/rules/`):
 
     <rule name="Backoffice IP Filter" enabled="true">
-        <match url="(^umbraco/backoffice/(.*)|^umbraco)"/>
+        <match url="(^umbraco/backoffice/(.*)|^umbraco($|/$))"/>
         <conditions logicalGrouping="MatchAll">
 
             <!-- Umbraco Cloud to Cloud connections should be allowed -->


### PR DESCRIPTION
The regular expression for blocking access to the backoffice contains an error which makes it easy to get around it.
The problem is that the rule only prevents access to https://site.com/umbraco but not https://site.com/umbraco/#/somerandombackoffice part.
The updated RegEx should be: (^umbraco/backoffice/(.*)|^umbraco($|/$))