### PR TITLE
Updates description for umbracoDisableElectionForSingleServer since it is currently incorrect

### DIFF
--- a/Reference/Config/webconfig/index.md
+++ b/Reference/Config/webconfig/index.md
@@ -136,4 +136,6 @@ When this value is set above 0, the backoffice will check for a new version of U
 
 The default value is: `false`
 
-When this value is set to true your Umbraco installation will be treated as a single server, so no [master election](https://our.umbraco.org/documentation/Getting-Started/Setup/Server-Setup/load-balancing/flexible#scheduling-and-master-election) will happen, which is needed for a load balanced setup.
+This is not a setting that commonly needs to be configured.
+
+This value is primarily used on Umbraco Cloud for a small startup performance optimization. When this is true, the website instance will automatically be configured to not support load balancing and the website instance will be configured to be the 'master' server for scheduling so no [master election](https://our.umbraco.org/documentation/Getting-Started/Setup/Server-Setup/load-balancing/flexible#scheduling-and-master-election) occurs. This will save 1 database call during startup. 


### PR DESCRIPTION
The current description for umbracoDisableElectionForSingleServer isn't correct since it is not required for load balancing at all. In fact it's not required for anything at all, and if it is set it will disable load balancing from working. It is not a setting that generally should be configured.