### PR TITLE
SSL is deprecated and we shouldn't pretend like we support it

### DIFF
--- a/Umbraco-Cloud/Set-Up/Manage-Domains/Security-Certificates/index.md
+++ b/Umbraco-Cloud/Set-Up/Manage-Domains/Security-Certificates/index.md
@@ -2,13 +2,13 @@
 
 ![Manage certificates](images/manage-certificates.png)
 
-On the **Manage domains** page you'll also find the option to upload and configure SSL certificates for your Cloud environments.
+On the **Manage domains** page you'll also find the option to upload and configure certificates for your Cloud environments.
 
 Your certificates need to be **`.pfx`** format and must be set to use a password. Each certificate can then be bound to a hostname you have already added to your site. Make sure you use the hostname you will bind the certificate to as the common name (CN) when generating the certificate.
 
 ### Upload certificate
 
-* Upload your SSL certificate from your local machine
+* Upload your certificate from your local machine
 * Type in the password for your certificate
 * Click **Upload**
 

--- a/Umbraco-Cloud/Set-Up/Manage-Domains/Security-Certificates/index.md
+++ b/Umbraco-Cloud/Set-Up/Manage-Domains/Security-Certificates/index.md
@@ -2,7 +2,7 @@
 
 ![Manage certificates](images/manage-certificates.png)
 
-On the **Manage domains** page you'll also find the option to upload and configure certificates for your Cloud environments.
+On the **Manage domains** page you'll also find the option to upload and configure HTTPS certificates for your Cloud environments.
 
 Your certificates need to be **`.pfx`** format and must be set to use a password. Each certificate can then be bound to a hostname you have already added to your site. Make sure you use the hostname you will bind the certificate to as the common name (CN) when generating the certificate.
 


### PR DESCRIPTION
SSL is not a thing any more, SSL is depracated, at best we could change "SSL" to "TLS" but the technical name for it doesn't matter very much. Let's stick with "certificate" as the regular term to use for this.