### PR TITLE
Add details of Application Pool Identity Account

### DIFF
--- a/Getting-Started/Setup/Install/permissions.md
+++ b/Getting-Started/Setup/Install/permissions.md
@@ -1,6 +1,6 @@
 # File and folder permissions
 
-_To ensure a stable and smoothly running Umbraco installation, these permissions need to be set correctly. These permissions should be setup before or during the installation of Umbraco. The user with the permissions set are the user used by the Application Pool used by the IIS website (usually Network Service or the IIS\_IUSRS group). If in doubt, ask your server admin / hosting company. Generally if you are using WebMatrix, permissions don't need to be strictly applied_
+_To ensure a stable and smoothly running Umbraco installation, these permissions need to be set correctly. These permissions should be setup before or during the installation of Umbraco. The main account that requires 'modify' file permissions to be set on the folders below, is the account used by the Application Pool Identity for the IIS website (usually IIS APPPOOL\appPoolName or a specific local account or in some circumstances Network Service - If in doubt, ask your server admin / hosting company). Additionally the IUSR account and IIS_IUSRS account only require 'read only' access to the site's folders. Generally when developing locally with Visual Studio or WebMatrix, permissions do not need to be strictly applied_
 
 <table border="0">
 <thead>


### PR DESCRIPTION
Common question over what is the Application Pool Identity account, which is the default now rather than Network Service in IIS