### PR TITLE
Fixed links to NodeJS and Grunt

### DIFF
--- a/Development-Guidelines/building-angular-project.md
+++ b/Development-Guidelines/building-angular-project.md
@@ -14,10 +14,10 @@ The bottom line is the UI project has zero dependencies on asp.net or Windows. H
 Umbraco 7 needs a couple of things to run:
 
 ### Node.js 
-To compile and run the UI project you need node.js installed, you can get that at [http://nodejs.org](nodejs.org) for both Windows and OSX.
+To compile and run the UI project you need node.js installed, you can get that at [nodejs.org](http://nodejs.org) for both Windows and OSX.
 
 ### Grunt
-When you have node.js installed, you need to install Grunt. Grunt is a simple JavaScript task runner, basically like Nant, Msbuild or any traditional build system [http://gruntjs.com](more about grunt here).
+When you have node.js installed, you need to install Grunt. Grunt is a simple JavaScript task runner, basically like Nant, Msbuild or any traditional build system. You can [read more about grunt here](http://gruntjs.com).
 
 To install, open a terminal and run: 
 	

--- a/Development-Guidelines/building-angular-project.md
+++ b/Development-Guidelines/building-angular-project.md
@@ -14,10 +14,14 @@ The bottom line is the UI project has zero dependencies on asp.net or Windows. H
 Umbraco 7 needs a couple of things to run:
 
 ### Node.js 
-To compile and run the UI project you need node.js installed, you can get that at [nodejs.org](http://nodejs.org) for both Windows and OSX.
+To compile and run the UI project you need Node.js installed, which is available for both Windows and OSX.
+
+[Read more at the official **Node.js** website](https://nodejs.org/)
 
 ### Grunt
-When you have node.js installed, you need to install Grunt. Grunt is a simple JavaScript task runner, basically like Nant, Msbuild or any traditional build system. You can [read more about grunt here](http://gruntjs.com).
+When you have node.js installed, you need to install Grunt. Grunt is a simple JavaScript task runner, basically like Nant, Msbuild or any traditional build system.
+
+[Read more at the official **Grunt** website](https://gruntjs.com/)
 
 To install, open a terminal and run: 
 	


### PR DESCRIPTION
Figured I'd write a link scanner for the Our documentation. While still in development, this is the first page that it discovered with broken links ;)