### PR TITLE
Fixed broken link

### DIFF
--- a/Reference/Management/Services/TreeService.md
+++ b/Reference/Management/Services/TreeService.md
@@ -4,7 +4,7 @@
 
 The ApplicationTreeService is used to control/query the storage for tree registrations in the ~/Config/trees.config file.
 
-[Browse the API documentation for ApplicationTreeService](https://our.umbraco.org/apidocs/csharp/api/Umbraco.Core.Services.ApplicationTreeService.html).
+[Browse the API documentation for IApplicationTreeService](https://our.umbraco.org/apidocs/csharp/api/Umbraco.Core.Services.IApplicationTreeService.html).
 
  * **Namespace:** `Umbraco.Core.Services` 
  * **Assembly:** `Umbraco.Core.dll`


### PR DESCRIPTION
There is no class called `ApplicationTreeService`, as the `ApplicationTreeService` returns an instance of the `IApplicationTreeService` interface. I've updated the link to reflect that.

I'm not totally sure whether the rest of the text might need some adjustment as well. But now at least the link works ;)