### PR TITLE
Mention that installation of NodeJs is assumed

### DIFF
--- a/Umbraco-Cloud/Headless/Headless-Node-Client/index.md
+++ b/Umbraco-Cloud/Headless/Headless-Node-Client/index.md
@@ -1,6 +1,8 @@
 # Umbraco-Headless-Client-NodeJs
 
-Javascript Client Library for working with the Umbraco Headless API
+Javascript Client Library for working with the Umbraco Headless API.
+
+The following assumes that you have already installed [NodeJs](https://nodejs.org/)
 
 ## Getting started
 


### PR DESCRIPTION
Some people who might not be used to playing around with NodeJs might forget or be unaware that installing NodeJs first is a requirement for successfully installing the umbraco-headless package even though it has "NodeJs" written all over it :-)