### PR TITLE
Adding auth cookie settings for umbracoSettings.config security section

### DIFF
--- a/Reference/Config/umbracoSettings/index.md
+++ b/Reference/Config/umbracoSettings/index.md
@@ -299,17 +299,17 @@ On new installs this set to true. When you are upgrading from a lower version th
 
 ## Security
 
-In the security section you have the following settings which deal with backoffice users.
+In the security section you have the following options: **`<keepUserLoggedIn>`**, **`<usernameIsEmail>`**,  **`<hideDisabledUsersInBackoffice>`**,  **`<allowPasswordReset>`**,  **`<authCookieName>`** and  **`<authCookieDomain>`**. These settings deal with backoffice users and settings for the backoffice authentication cookies.
 
     <security>
         <!-- set to true to auto update login interval (and there by disabling the lock screen -->
         <keepUserLoggedIn>true</keepUserLoggedIn>
 
-        <!-- change in 4.8: Disabled users are now showed dimmed and last in the tree. If you prefer not to display them set this to true -->
-        <hideDisabledUsersInBackoffice>false</hideDisabledUsersInBackoffice>
-
         <!-- by default this is true and if not specified in config will be true. set to false to always show a separate username field in the back office user editor -->
         <usernameIsEmail>true</usernameIsEmail>
+
+        <!-- change in 4.8: Disabled users are now showed dimmed and last in the tree. If you prefer not to display them set this to true -->
+        <hideDisabledUsersInBackoffice>false</hideDisabledUsersInBackoffice>
 
         <!-- set to true to enable the UI and API to allow back-office users to reset their passwords -->
         <allowPasswordReset>true</allowPasswordReset>

--- a/Reference/Config/umbracoSettings/index.md
+++ b/Reference/Config/umbracoSettings/index.md
@@ -299,7 +299,7 @@ On new installs this set to true. When you are upgrading from a lower version th
 
 ## Security
 
-In the security section you have three options: **`<keepUserLoggedIn>`**, **`<allowPasswordReset>`** and **`<hideDisabledUsersInBackoffice>`**. Both settings are dealing with backoffice users.
+In the security section you have the following settings which deal with backoffice users.
 
     <security>
         <!-- set to true to auto update login interval (and there by disabling the lock screen -->
@@ -312,7 +312,13 @@ In the security section you have three options: **`<keepUserLoggedIn>`**, **`<al
         <usernameIsEmail>true</usernameIsEmail>
 
         <!-- set to true to enable the UI and API to allow back-office users to reset their passwords -->
-        <allowPasswordReset>true</allowPasswordReset>  
+        <allowPasswordReset>true</allowPasswordReset>
+
+        <!-- set to a different value if you require the authentication cookie for back-office users to be renamed -->
+        <authCookieName>UMB_UCONTEXT</authCookieName>  
+
+        <!-- set to a different value if you require the authentication cookie for back-office users to be set against a different domain -->
+        <authCookieDomain></authCookieDomain>  
 
     </security>
 
@@ -329,6 +335,12 @@ This setting specifies whether the username and email address are separate field
 
 **`<allowPasswordReset>`**
 The feature to allow users to reset their passwords if they have forgotten them was introduced in 7.5.  The feature is based on [a method provided by ASP.Net Identity](http://www.asp.net/identity/overview/features-api/account-confirmation-and-password-recovery-with-aspnet-identity).  By default this is enabled but if you'd prefer to not allow users to do this it can be disabled at both the UI and API level by setting this value to `false`.
+
+**`<authCookieName>`**
+The authentication cookie which is set in the browser when a back-office user logs in, and defaults to `UMB_UCONTEXT`.  This setting is excluded from the configuration file, but can be added in if a different cookie name needs to be set.
+
+**`<authCookieDomain>`**
+The authentication cookie which is set in the browser when a back-office user logs in is automatically set to the current domain.  This setting is excluded from the configuration file, but can be added in if a different domain is required.
 
 ## RequestHandler
 


### PR DESCRIPTION
From looking at a forum post, I found that the source code for the security section in the umbracoSettings.config file has a couple of undocumented settings which can be set if needed:
Forum post: https://our.umbraco.org/forum/core/general/23192-How-to-have-multiple-Umbraco-instance-login-sessions-without-conflict
SecurityElement source: https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/src/Umbraco.Core/Configuration/UmbracoSettings/SecurityElement.cs

This change is to add these settings into the documentation, and updated the introduction to the security section so that it doesn't mention how many settings there are, as I noticed it was also out of date.