### PR TITLE
Increase the visibility of the existence of the API documentation

### DIFF
--- a/Extending/Backoffice-UI-API-Documentation/index.md
+++ b/Extending/Backoffice-UI-API-Documentation/index.md
@@ -1,0 +1,14 @@
+# Backoffice UI API Documentation
+
+A library of API Reference documentation is auto-generated from the comments within the Umbraco Source Code.
+
+## [Backoffice UI](https://our.umbraco.org/apidocs/ui/#/api/)
+
+Angular, JS, CSS & Less UI API references for building Umbraco backoffice components.
+
+- umbraco.directives
+- umbraco.services
+- umbraco.resources
+
+__Note: opens a documentation browser that is different from the documentation section you're viewing now, we're planning to integrate both.__
+

--- a/Extending/Backoffice-UI-API-Documentation/index.md
+++ b/Extending/Backoffice-UI-API-Documentation/index.md
@@ -10,5 +10,5 @@ Angular, JS, CSS & Less UI API references for building Umbraco backoffice compon
 - umbraco.services
 - umbraco.resources
 
-__Note: opens a documentation browser that is different from the documentation section you're viewing now, we're planning to integrate both.__
+__Note: opens a documentation browser that is different from the documentation section you're viewing now.__
 

--- a/Reference/API-Documentation/index.md
+++ b/Reference/API-Documentation/index.md
@@ -1,0 +1,25 @@
+# API Documentation
+
+A library of API Reference documentation is auto-generated from the comments within the Umbraco Source Code.
+
+## C# API Documentation
+
+C# API references for the Umbraco Core and Web libraries.
+
+### [Umbraco.Core](https://our.umbraco.org/apidocs/csharp/api/Umbraco.Core.html)
+### [Umbraco.Web](https://our.umbraco.org/apidocs/csharp/api/Umbraco.Web.html)
+
+__Note: opens a documentation browser that is different from the documentation section you're viewing now, we're planning to integrate both.__
+
+## Backoffice UI API Documentation
+
+Angular, JS, CSS & Less UI API references for building Umbraco backoffice components.
+
+- umbraco.directives
+- umbraco.services
+- umbraco.resources
+
+### [Backoffice UI](https://our.umbraco.org/apidocs/ui/#/api/)
+
+__Note: opens a documentation browser that is different from the documentation section you're viewing now, we're planning to integrate both.__
+

--- a/Reference/API-Documentation/index.md
+++ b/Reference/API-Documentation/index.md
@@ -9,7 +9,7 @@ C# API references for the Umbraco Core and Web libraries.
 ### [Umbraco.Core](https://our.umbraco.org/apidocs/csharp/api/Umbraco.Core.html)
 ### [Umbraco.Web](https://our.umbraco.org/apidocs/csharp/api/Umbraco.Web.html)
 
-__Note: opens a documentation browser that is different from the documentation section you're viewing now, we're planning to integrate both.__
+__Note: opens a documentation browser that is different from the documentation section you're viewing now.__
 
 ## Backoffice UI API Documentation
 
@@ -21,5 +21,5 @@ Angular, JS, CSS & Less UI API references for building Umbraco backoffice compon
 
 ### [Backoffice UI](https://our.umbraco.org/apidocs/ui/#/api/)
 
-__Note: opens a documentation browser that is different from the documentation section you're viewing now, we're planning to integrate both.__
+__Note: opens a documentation browser that is different from the documentation section you're viewing now.__
 

--- a/Reference/index.md
+++ b/Reference/index.md
@@ -10,13 +10,13 @@ This section is ultra important! It describes many common pitfalls that develope
 
 #### [C# API Documentation](https://our.umbraco.org/apidocs/csharp/)
 
-__Note: opens a documentation browser that is different from the documentation section you're viewing now, we're planning to integrate both.__
+__Note: opens a documentation browser that is different from the documentation section you're viewing now.__
 
 C# API references for the Umbraco Core and Web libraries.
 
 #### [Backoffice UI API documentation](https://our.umbraco.org/apidocs/ui/)
 
-__Note: opens a documentation browser that is different from the documentation section you're viewing now, we're planning to integrate both.__
+__Note: opens a documentation browser that is different from the documentation section you're viewing now.__
 
 Angular, JS, CSS & Less UI API references for building Umbraco backoffice components.
 


### PR DESCRIPTION
See issue: https://github.com/umbraco/UmbracoDocs/issues/845 #845 

Essentially if you are within the documentation pages, and using the navigation there isn't any scent that would lead you to the auto generated / API documentation for C# or Backoffice UI

So this PR adds a couple of 'Landing Pages' that sign post the existence of the documentation to the reference and to the extending sections...