### PR TITLE
Add example of @Umbraco.Field() method in partials

### DIFF
--- a/Reference/Templating/Mvc/views.md
+++ b/Reference/Templating/Mvc/views.md
@@ -21,7 +21,7 @@ This is probably the most used method which simply renders the contents of a fie
 	
 If you're using the Field method from within a partial view then be aware that you will need to pass the context so the Field method knows where to get the desired value from. For instance you can pass "CurrentPage" like this:
 
-	@Umbraco.Field(CurrentPage, "bodyContent")
+	@Umbraco.Field(Model.Content, "eventLink")
 
 You will also need to pass the "Context" to the @Umbraco.Field() method if you're looping over a selection like this where we pass the "item" variable.
 

--- a/Reference/Templating/Mvc/views.md
+++ b/Reference/Templating/Mvc/views.md
@@ -23,6 +23,17 @@ If you're using the Field method from within a partial view then be aware that y
 
 	@Umbraco.Field(CurrentPage, "bodyContent")
 
+You will also need to pass the "Context" to the @Umbraco.Field() method if you're looping over a selection like this where we pass the "item" variable.
+
+	@{
+		var selection = Model.Content.Site().FirstChild("events").Children("event").Where(x => x.IsVisible());
+	}
+	<ul>
+		@foreach(var item in selection){
+        		@Umbraco.Field(item, "eventLink")
+		}
+	</ul>
+
 There are several optional parameters. Here is the list with their default values:
 
 * altFieldAlias = ""

--- a/Reference/Templating/Mvc/views.md
+++ b/Reference/Templating/Mvc/views.md
@@ -19,7 +19,7 @@ This is probably the most used method which simply renders the contents of a fie
 
 	@Umbraco.Field("bodyContent")
 	
-If you're using the Field method from within a partial view then be aware that you will need to pass the context so the Field method knows where to get the deisred value from. For instance you can pass "CurrentPage" like this:
+If you're using the Field method from within a partial view then be aware that you will need to pass the context so the Field method knows where to get the desired value from. For instance you can pass "CurrentPage" like this:
 
 	@Umbraco.Field(CurrentPage, "bodyContent")
 

--- a/Reference/Templating/Mvc/views.md
+++ b/Reference/Templating/Mvc/views.md
@@ -18,6 +18,10 @@ All Umbraco views inherit from `Umbraco.Web.Mvc.UmbracoTemplatePage` which expos
 This is probably the most used method which simply renders the contents of a field for the current content item.
 
 	@Umbraco.Field("bodyContent")
+	
+If you're using the Field method from within a partial view then be aware that you will need to pass the context so the Field method knows where to get the deisred value from. For instance you can pass "CurrentPage" like this:
+
+	@Umbraco.Field(CurrentPage, "bodyContent")
 
 There are several optional parameters. Here is the list with their default values:
 
@@ -34,7 +38,7 @@ There are several optional parameters. Here is the list with their default value
 The easiest way to use the Field method is to simply specify the optional parameters you'd like to set. For example, if we want to set the insertBefore and insertAfter parameters we'd do:
 
 	@Umbraco.Field("bodyContent", insertBefore : "<h2>", insertAfter : "</h2>")
-
+	
 
 ## Rendering a field with Model
 


### PR DESCRIPTION
I just discovered that it's not documented anywhere that when you're trying to use @Umbraco.Field() from within a partial you need to pass the context to it otherwise you will not get any value. Therefore I added this information and a basic example.

See my discovery if you have the time to read this reply - At first I actually thought it was not possible so had to correct myself - It's been a while...:-) 

https://our.umbraco.org/forum/using-umbraco-and-getting-started/92301-change-url-on-image#comment-291932