### PR TITLE
Added sub-headlines

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Render-Grid-In-Template.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Render-Grid-In-Template.md
@@ -1,4 +1,7 @@
 # Render grid in template
+
+## Using @Html.GetGridHtml
+
 To render a property based on the grid inside a template you should use the HtmlHelper extension:
 
     @Html.GetGridHtml(Model.Content, "propertyAlias")
@@ -18,7 +21,9 @@ or alternatively you can provide the path to where the file resides:
 
     @Html.GetGridHtml(Model.Content, "propertyAlias", "/views/mycustomrenderer.cshtml")
 
-Finally the Html.GetGridHtml helpers are the recommended approach for rendering grid properties in templates, however you may see in grid examples or discover in your existing site 'legacy code' when using the 'dynamic' CurrentPage approach for working with Umbraco templates and grid properties:
+## Using @CurrentPage.GetGridHtml() or @Model.Content.GetGridHtml() (Obsolete)
+
+Finally the **Html.GetGridHtml()** helpers are the recommended approach for rendering grid properties in templates, however you may see in grid examples or discover in your existing site 'legacy code' when using the 'dynamic' CurrentPage approach for working with Umbraco templates and grid properties:
    
     @CurrentPage.GetGridHtml(Html, "propertyAlias")
     @CurrentPage.GetGridHtml(Html, "propertyAlias", "bootstrap2")
@@ -29,4 +34,4 @@ and similarly
 
     @Model.Content.GetGridHtml(Html, "propertyAlias")
 
-These approaches are considered obsolete. Use @Html.GetGridHtml.
+These approaches are considered obsolete. **Use @Html.GetGridHtml**.


### PR DESCRIPTION
I added some sub-headlines to divide the document into two sections and make it more clear that @CurrentPage.GetGridHtml() and @Model.Content.GetGridHtml() are obsolete and highlighted "Html.GetGridHtml()" and "Use @Html.GetGridHtml" in order to make it easier to quickly distinguish that this is the recommended way of doing things.