### PR TITLE
Mark Dynamic as obsolete

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Date-Time.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Date-Time.md
@@ -22,7 +22,7 @@ The only setting that is available for manipulating the DateTime property is to 
 
 ### Dynamic (Obsolete):
 
-The below example is using Dynamic access content access, which is considered obsolete and is not recommended to use. However the example is included for historical reasons if for instance a developer has overtaken a project where this approach is being used. This approach will be obsolete when Umbraco 8 is released and therefore is best to use the strongly typed example listed above.
+See [Common pitfalls](https://our.umbraco.org/documentation/reference/Common-Pitfalls/#dynamics) for more information about why the dynamic approach is obsolete.
 
 	@{
 		@CurrentPage.datePicker.ToString("dd-MM-yyyy HH:mm:ss")

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Date-Time.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Date-Time.md
@@ -20,7 +20,9 @@ The only setting that is available for manipulating the DateTime property is to 
 
 	@(Model.Content.GetPropertyValue<DateTime>("datePicker").ToString("dd MM yyyy HH:mm:ss"))
 
-### Dynamic: 
+### Dynamic (Obsolete):
+
+The below example is using Dynamic access content access, which is considered obsolete and is not recommended to use. However the example is included for historical reasons if for instance a developer has overtaken a project where this approach is being used. This approach will be obsolete when Umbraco 8 is released and therefore is best to use the strongly typed example listed above.
 
 	@{
 		@CurrentPage.datePicker.ToString("dd-MM-yyyy HH:mm:ss")


### PR DESCRIPTION
Marked the dynamic example as being obsolete and added a text explaining that the dynamic approach is not the recommended one.