### PR TITLE
Update egghead link

### DIFF
--- a/Tutorials/Creating-a-Custom-Dashboard/index.md
+++ b/Tutorials/Creating-a-Custom-Dashboard/index.md
@@ -30,7 +30,7 @@ So all the steps we will go through:
 ### Prerequisites
 This tutorial uses AngularJS with Umbraco, so it does not cover AngularJS itself, there are tons of resources on that already here:
 
-- [egghead.io](http://www.egghead.io/)
+- [egghead.io](https://egghead.io/courses/angularjs-fundamentals)
 - [angularjs.org/tutorial](http://docs.angularjs.org/tutorial)
 - [Pluralsight](https://www.pluralsight.com/paths/angular-js)
 


### PR DESCRIPTION
I propose updating the Egghead link to point explicitly at the AngularJS fundamentals course since it's currently only pointing to the egghead homepage. Can be confusing for people to find the AngularJS course instead of the Angular course so it's better to be explicit about it.