### PR TITLE
Update egghead link

### DIFF
--- a/Tutorials/Creating-a-Property-Editor/index.md
+++ b/Tutorials/Creating-a-Property-Editor/index.md
@@ -15,7 +15,7 @@ So all the steps we will go through:
 ## Prerequisites
 This is about how to use AngularJS with Umbraco, so it does not cover AngularJS itself, as there are tons of resources on that already here:
 
-- [egghead.io](http://www.egghead.io/)
+- [egghead.io](https://egghead.io/courses/angularjs-fundamentals)
 - [angularjs.org/tutorial](http://docs.angularjs.org/tutorial)
 - [Pluralsight](https://www.pluralsight.com/paths/angular-js)
 


### PR DESCRIPTION
I propose updating the Egghead link to point explicitly at the AngularJS fundamentals course since it's currently only pointing to the egghead homepage. Can be confusing for people to find the AngularJS course instead of the Angular course so it's better to be explicit about it.

Don't know if perhaps we should consider creating a page with angularJs information in the documentation, which can be referenced instead? Like the "common pitfalls" page? Does it make sense what I'm trying to say? :) - Don't know if there are more places where these 3 links are mentioned though...Just spotted these today browsing through the documentation randomly.