### PR TITLE
Fixing example in Examine Fluent API

### DIFF
--- a/Reference/Searching/Examine/quick-start.md
+++ b/Reference/Searching/Examine/quick-start.md
@@ -70,8 +70,8 @@ Examine offers a fluent search API which aims to make constructing complex searc
     var searcher = Examine.ExamineManager.Instance.SearchProviderCollection["ExternalSearcher"];
 
     var searchCriteria = searcher.CreateSearchCriteria(Examine.SearchCriteria.BooleanOperation.Or);
-    var searchQuery = searchCriteria.Field("nodeName", query.Boost(5)).Or().Field("nodeName", query.Fuzzy());
-    var searchResults = searcher.Search(searchQuery.Compile()).OrderByDescending("createDate");
+    var searchQuery = searchCriteria.Field("nodeName", query.Boost(5)).Or().Field("nodeName", query.Fuzzy()).And().OrderByDescending("createDate");
+    var searchResults = searcher.Search(searchQuery.Compile());
     if(searchResults.Any())
     {
         <ul>


### PR DESCRIPTION
The recently added example for the fluent API had an error with the ordering. This should be done on the search query, not the results - which doesn't have an OrderBy method or extension.

This was introduced in https://github.com/umbraco/UmbracoDocs/commit/13212de060d35ebbbe98edaa417338083436b636#diff-d142ee10fd27747e8fd653df9b3b0ef1

Reference material: https://github.com/Shazwazza/Examine/wiki/Sorting-results