### PR TITLE
Adding link to UDI documentation

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Content-Picker2.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Content-Picker2.md
@@ -4,7 +4,7 @@
 
 `Returns: IPublishedContent`
 
-The content picker opens a panel to pick a specific page from the content structure. The value saved is the selected nodes [UDI](/Documentation/Reference/Querying/Udi "Learn more about UDI's")
+The content picker opens a panel to pick a specific page from the content structure. The value saved is the selected nodes [UDI](../../../../Reference/Querying/Udi "Learn more about UDI's")
 
 ## Data Type Definition Example
 

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Content-Picker2.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Content-Picker2.md
@@ -4,7 +4,7 @@
 
 `Returns: IPublishedContent`
 
-The content picker opens a panel to pick a specific page from the content structure. The value saved is the selected nodes [UDI](../../../../Reference/Querying/Udi "Learn more about UDI's")
+The content picker opens a panel to pick a specific page from the content structure. The value saved is the selected nodes [UDI](../../../../Reference/Querying/Udi.md "Learn more about UDI's")
 
 ## Data Type Definition Example
 

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Content-Picker2.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Content-Picker2.md
@@ -4,7 +4,7 @@
 
 `Returns: IPublishedContent`
 
-The content picker opens a panel to pick a specific page from the content structure. The value saved is the selected nodes UDI
+The content picker opens a panel to pick a specific page from the content structure. The value saved is the selected nodes [UDI](https://our.umbraco.com/Documentation/Reference/Querying/Udi "Learn more about UDI's")
 
 ## Data Type Definition Example
 

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Content-Picker2.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Content-Picker2.md
@@ -4,7 +4,7 @@
 
 `Returns: IPublishedContent`
 
-The content picker opens a panel to pick a specific page from the content structure. The value saved is the selected nodes [UDI](https://our.umbraco.com/Documentation/Reference/Querying/Udi "Learn more about UDI's")
+The content picker opens a panel to pick a specific page from the content structure. The value saved is the selected nodes [UDI](/Documentation/Reference/Querying/Udi "Learn more about UDI's")
 
 ## Data Type Definition Example
 


### PR DESCRIPTION
I'm thinking it would make sense to link to the UDI documentation in case people hit this page wondering what UDI is in case they never heard about it before.