### PR TITLE
Add details about configurating LocalDB

### DIFF
--- a/Umbraco-Cloud/Databases/index.md
+++ b/Umbraco-Cloud/Databases/index.md
@@ -23,7 +23,6 @@ If you're using Visual Studio 2015+ check this path:
 `$(solutionDir)\.vs\config\applicationhost.config`
 
 In Visual Studio 2015+ you can also configure which applicationhost.config file is used by altering the `<UseGlobalApplicationHostFile>true|false</UseGlobalApplicationHostFile>` setting in the project file (eg: MyProject.csproj). (source: MSDN forum)
-```
 
 ## Using Custom Tables with Umbraco Cloud
 Umbraco Cloud will ensure that your Umbraco related data is always up to date, but it won't know anything about data in custom tables unless told. Nothing new here, it's basically just like any other host when it comes to non-Umbraco data.

--- a/Umbraco-Cloud/Databases/index.md
+++ b/Umbraco-Cloud/Databases/index.md
@@ -3,6 +3,28 @@ When working with Umbraco Cloud, the way you work with databases might differ fr
 
 So when you clone a site locally, Umbraco Cloud automatically creates a local database and populates it with data from your website running on the Cloud. If you don't specify anything before starting up your site locally, it'll be a SQL CE database that lives in the /App_Data folder. If you wish to use a local SQL Server instead, you can update the connection string in the web.config, but it's important that you do so before your site start up the first time.
 
+## LocalDB
+By default when Umbraco Cloud restores a local database it will be an Umbraco.sdf file in `/App_Data` folder. However if LocalDB is installed and configurated, the restore will create a Umbraco.mdf file. To use LocalDB ensure `applicationHost.config` is configurated with `loadUserProfile="true"` and `setProfileEnvironment="true"`: https://blogs.msdn.microsoft.com/sqlexpress/2011/12/08/using-localdb-with-full-iis-part-1-user-profile/
+
+```
+<add name="ASP.NET v4.0" autoStart="true" managedRuntimeVersion="v4.0" managedPipelineMode="Integrated">
+   <processModel identityType="ApplicationPoolIdentity" loadUserProfile="true" setProfileEnvironment="true" />
+</add>
+```
+
+Usually `applicationHost.config` is located in this folder for IIS:
+`C:\Windows\System32\inetsrv\config`
+
+and in one of thes folders for IIS Express:
+
+`C:\Users\<user>\Documents\IISExpress\config\`
+
+If you're using Visual Studio 2015+ check this path:
+`$(solutionDir)\.vs\config\applicationhost.config`
+
+In Visual Studio 2015+ you can also configure which applicationhost.config file is used by altering the `<UseGlobalApplicationHostFile>true|false</UseGlobalApplicationHostFile>` setting in the project file (eg: MyProject.csproj). (source: MSDN forum)
+```
+
 ## Using Custom Tables with Umbraco Cloud
 Umbraco Cloud will ensure that your Umbraco related data is always up to date, but it won't know anything about data in custom tables unless told. Nothing new here, it's basically just like any other host when it comes to non-Umbraco data.
 


### PR DESCRIPTION
I couldn't find this mentioned elsewhere in the docs, so I have added some basic details about this.

I have usually used this approach:
---------
Restore using LocalDB on Umbraco Cloud (.mdf instead of .sdf local db file):

C:\Windows\System32\inetsrv\config

Ensure loadUserProfile="true" and setProfileEnvironment="true".

https://blogs.msdn.microsoft.com/sqlexpress/2011/12/08/using-localdb-with-full-iis-part-1-user-profile/