### PR TITLE
Added some documentation about using Session-variables

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Magic-Strings/index.md
+++ b/Add-ons/UmbracoForms/Developer/Magic-Strings/index.md
@@ -5,7 +5,9 @@ Umbraco Forms has some magic strings that enable you to render values from vario
 `[@SomeRequestItem]` this allows you to display an item from the current HTTPContext.Request with the key of SomeRequestItem
 
 ## Session & Cookies
-`[%SomeSessionOrCookieItem]` this allows you to display an item from the current HTTPContext.Session with the key of SomeSessionOrCookieItem. If it cannot be found in the collection of session keys, it will then try to find the item from the HttpContext.Cookies collection with the same key.
+`[%SomeSessionOrCookieItem]` this allows you to display an item from the current HTTPContext.Session with the key of SomeSessionOrCookieItem. The session key can only contain alphanumeric chars and you cannot use dots for example. `[%Member.Firstname]` cannot be used, but `[MemberFirstname]` can be used. You would have to fill these session keys yourself.
+
+If it cannot be found in the collection of session keys, it will then try to find the item from the HttpContext.Cookies collection with the same key.
 
 ## Umbraco Page Field Item
 `[#myUmbracoField]` this allows you to use the Umbraco document-type property myUmbracoField from the page containing the form.


### PR DESCRIPTION
Discovered the hard way (and after searching a lot) that you cannot use dots in a sessionname for some sort of reason.