### PR TITLE
Introduce gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# General
+.DS_Store
+[Tt]humbs.db
+*.orig


### PR DESCRIPTION
I found a few weird temp files were visible in Git after solving a merge conflict.

I've added a `.gitignore` file to prevent these from showing up in future.

Surprised this wasn't here already!