### PR TITLE
Correcting the code example in step three

### DIFF
--- a/Tutorials/Starter-kit/Lessons/2-Add-a-Blog-Post-Publication-Date/part-3.md
+++ b/Tutorials/Starter-kit/Lessons/2-Add-a-Blog-Post-Publication-Date/part-3.md
@@ -11,7 +11,7 @@ Finally in Part Three we shall change the blog listing.
 ```
 3. Scroll further back up the page to where we get the blog posts (as the **Children** of this page).  Change this to:
 ```
-var blogposts = startNode.Children.OrderByDescending(x => x.GetPropertyValue<DateTime>("PublicationDate")).Take(3);
+var blogposts = startNode.Children.OrderByDescending(x => x.GetPropertyValue<DateTime>("PublicationDate")).ToList();
 ```
 Because we are sorting by a custom property we need to use the generic GetPropertyValue method.
 4. Then click *Save*. A confirmation message should appear confirming that the Partial view has saved.  


### PR DESCRIPTION
The current example results in the following error System.Web.HttpCompileException (0x80004005): c:\Git\Sites\Umbraco-7-11-1\Views\MacroPartials\LatestBlogposts.cshtml(21): error CS0428: Cannot convert method group 'Count' to non-delegate type 'double'. Did you intend to invoke the method?

I'm no expert in LINQ but when adding .ToList() it works like it should. The code that should be replaced with the example from step three also converts the output using .ToList() - .Take(3) should also not be necessary to add since paging is already setup, which listes 3 posts pr. page.

I noticed this issue when I tried to re-create the error Nic got here https://our.umbraco.com/forum/using-umbraco-and-getting-started/93182-error-editing-partial-macro-in-the-umbraco-starters-guide - I have not heard from him yet about whether my change works for him or not but I'm 99.99995% certain that it will since it works for me :)