### PR TITLE
Issues 916 + 948

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
+++ b/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
@@ -20,7 +20,7 @@ Here's how to add the three (3) client dependencies below to your template withi
 
 **Example before closing `body` tag**
 
-When adding the script to the bottom of the page, you'll also need to perform an [extra step](../Rendering-Scripts/index.md).
+When adding the script to the bottom of the page, you'll also need to perform an extra step — if you're using Themes (v6.0.0+) have a [look here](../Themes/#rendering-script-content-separately). Otherwise, have a look at [this page](../Rendering-Scripts/index.md) for instructions.
 	
     <body>
         <!-- Page content here -->

--- a/Add-ons/UmbracoForms/Developer/Rendering-Scripts/index.md
+++ b/Add-ons/UmbracoForms/Developer/Rendering-Scripts/index.md
@@ -1,8 +1,8 @@
 # Rendering Forms scripts where you want
-Besides markup Forms will also output some JavaScript, by default this JavaScript is outputted just below the markup. If you wish to change this behaviour follow the next steps (like if all your js is rendered at the bottom of you page)
+Besides markup Forms will also output some JavaScript. By default this is rendered just below the markup. If you wish to change this behaviour (e.g. if all your JS is rendered at the bottom of your page) follow the next steps.
 
 ## Change the Forms partial view macro
-First we'll need to tell the Forms partial macro (that is used to render forms) to only render the markup and not the scripts. Navigate to the developer section and open the > Partial View Macro File > Insert Umbraco Form
+First we'll need to tell the Forms partial macro (that is used to render forms) to only render the markup and not the scripts. Navigate to the Developer section and open the Partial View Macro File > Insert Umbraco Form
 
 It should have the following contents 
 
@@ -16,18 +16,18 @@ It should have the following contents
 		Html.RenderAction("Render", "UmbracoForms", new {formId = g});
 	}
 
-Here we'll make a small change, in the RenderAction call we'll provide an additional argument mode = "form"
+Here we'll make a small change: In the RenderAction call we'll provide an additional argument: `mode = "form"`
 
-so go from
+So change this:
 
 	Html.RenderAction("Render", "UmbracoForms", new {formId = g});	
 
-to
+to this:
 	
 	Html.RenderAction("Render", "UmbracoForms", new {formId = g, mode = "form"});
 
-## Place the Render scripts macro on your template
+## Place the Render Scripts macro on your template
 
-Now we'll need to let Forms know where we want to output the script instead. So Navigate to the settings section and select  your template that should contain the scripts. There simply insert the *Render Umbraco Forms Scripts* macro.
+Now we'll need to let Forms know where we want to output the script instead. So navigate to the Settings section and select the template that should contain the scripts. Insert the *Render Umbraco Forms Scripts* macro where you need the scripts rendered:
 
 	@Umbraco.RenderMacro("FormsRenderScripts")

--- a/Add-ons/UmbracoForms/Developer/Themes/index.md
+++ b/Add-ons/UmbracoForms/Developer/Themes/index.md
@@ -77,7 +77,7 @@ Retrieves all wrapper classes for a given field type, used when rendering form f
 ## Rendering Script content separately
 
 Sometimes when you insert a form into a page you do not wish the JavaScript includes and CSS references to be rendered directly alongside the form itself and more typically you would like to render these before the closing `</body>` tag.
-To do this, when inserting the form using the macro ensure the checkbox for the property `Exclude Scripts` is checked/enabled and then you can use a snippet like below to render the necessary scripts in your main template before the closing `</body>`
+To do this, when inserting the form using the macro, ensure the checkbox for the property `Exclude Scripts` is checked/enabled and then you can use a snippet like below to render the necessary scripts in your main template before the closing `</body>`:
 
 
     @if (TempData["UmbracoForms"] != null)


### PR DESCRIPTION
This addresses the need for an extra link to get the _Themes_ version of the information supplied here about rendering the Forms scripts when dependencies are rendered at the bottom of the page.

I opted for the Themes link first - open to discussions whether that makes sense :)

Closes #916  
Closes #948  