### PR TITLE
Adding a link to the "new" Related Links data type

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Related-Links.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Related-Links.md
@@ -1,5 +1,7 @@
 # (Obsolete) Related Links
 
+### For the new version of this data type see: [Related-Links2](Related-Links2.md)
+
 `Returns: RelatedLinks` if value converters are enabled (default)
 
 `Returns: JArray` if value converters are disabled


### PR DESCRIPTION
I am not sure who named the new one, but as this is marked as obsolete it would make sense that we highlight clearly what people should now be using instead!