### PR TITLE
Add docs for Umbraco.MemberPicker2

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/index.md
@@ -127,7 +127,7 @@ Made obsolete with the release of Umbraco v7.6 the media picker displays the cur
 ## [(Obsolete)Member Picker](Member-Picker.md)
 `Alias: Umbraco.MemberPicker`
 
-## [Member Picker]
+## Member Picker
 `Alias: Umbraco.MemberPicker2`
 
 ## [Multinode Treepicker](Multinode-Treepicker2.md)

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/index.md
@@ -124,8 +124,11 @@ Made obsolete with the release of Umbraco v7.6 the media picker displays the cur
 ## Member Group Picker
 `Alias: Umbraco.MemberGroupPicker`
 
-## [Member Picker](Member-Picker.md)
+## [(Obsolete)Member Picker](Member-Picker.md)
 `Alias: Umbraco.MemberPicker`
+
+## [Member Picker]
+`Alias: Umbraco.MemberPicker2`
 
 ## [Multinode Treepicker](Multinode-Treepicker2.md)
 `Alias: Umbraco.MultiNodeTreePicker2`


### PR DESCRIPTION
I have added `Umbraco.MemberPicker2` to the list, which is the default Member Picker in new Umbraco projects.

![image](https://user-images.githubusercontent.com/2919859/46109965-68cf8400-c1e2-11e8-8309-92844aa954c2.png)