### PR TITLE
- renamed all instances of datatype with data type.

### DIFF
--- a/Add-ons/UmbracoCourier/Architecture/DataResolvers.md
+++ b/Add-ons/UmbracoCourier/Architecture/DataResolvers.md
@@ -1,5 +1,5 @@
 # Dataresolvers
-A dataresolver is a way to add meaning to objects courier doesn't understand. For instance, if you have a document with a custem datatype, and the datatype stores a NodeID reference to another page (like a content picker), Courier doesn't know the number refers to another node, but by adding a dataresolver, you can tell courier that items with the datatype, contains a node ID, and add the needed dependencies and resources to have a succesfull deployment.
+A dataresolver is a way to add meaning to objects courier doesn't understand. For instance, if you have a document with a custem data type, and the data type stores a NodeID reference to another page (like a content picker), Courier doesn't know the number refers to another node, but by adding a dataresolver, you can tell courier that items with the data type, contains a node ID, and add the needed dependencies and resources to have a succesfull deployment.
 
 ### AscxFiles
 * **Full name:** `Umbraco.Courier.DataResolvers.ascxFiles`
@@ -8,7 +8,7 @@ A dataresolver is a way to add meaning to objects courier doesn't understand. Fo
 
 ### ContentPicker
 * **Full name:** `Umbraco.Courier.DataResolvers.ContentPicker`
-* **Triggers on:** Propertydata, which have a contentpicker as datatype (configured in courier.config)
+* **Triggers on:** Propertydata, which have a contentpicker as data type (configured in courier.config)
 * If value is set, and is an int, courier will convert the value to the Node GUID, add the node as a dependency. On extraction the GUID will be converted back to the right ID.
 
 ##### Configuration
@@ -29,12 +29,12 @@ A dataresolver is a way to add meaning to objects courier doesn't understand. Fo
 
 ### DampResolver
 * **Full name:** `Umbraco.Courier.DataResolvers.DampResolver`
-* **Triggers on:** Propertydata, which have a DAMP pick as datatype
+* **Triggers on:** Propertydata, which have a DAMP pick as data type
 * If value is set, and is an int, courier will convert the value to the media GUID, add the media item as a dependency. On extraction the GUID will be converted back to the right ID.
 
 ### EmbeddedContent
 * **Full name:** `Umbraco.Courier.DataResolvers.EmbeddedContent`
-* **Triggers on:** Propertydata, which have a EmbeddedContent type as datatype 
+* **Triggers on:** Propertydata, which have a EmbeddedContent type as data type 
 * Replaces node IDs in the embedded content with corresponding GUIDs and converts them back again on extraction
 
 ### Images
@@ -75,7 +75,7 @@ A dataresolver is a way to add meaning to objects courier doesn't understand. Fo
 * Looks at each property and checks if it contains a node ID reference. If it does, the reference is changed to a GUID, and the node is added as a dependency.
 
 ##### Configuration
-Configuring which datatypes can contain macro elements to resolve
+Configuring which data types can contain macro elements to resolve
 
 	<macros>
 	    <!-- Propertytypes that CAN contain macro mark-up (like the ones inserted with TinyMCE) -->
@@ -101,7 +101,7 @@ Configuring which macro property types contains references to other nodes
 
 ### MediaPicker
 * **Full name:** `Umbraco.Courier.DataResolvers.MediaPicker`
-* **Triggers on:** Propertydata, which have a mediapicker as datatype (configured in courier.config)
+* **Triggers on:** Propertydata, which have a mediapicker as data type (configured in courier.config)
 * If value is set, and is an int, courier will convert the value to the media GUID, add the node as a dependency. On extraction the GUID will be converted back to the right ID.
 
 ##### Configuration:
@@ -115,18 +115,18 @@ Configuring which macro property types contains references to other nodes
 
 ### RelatedLinks
 * **Full name:** `Umbraco.Courier.DataResolvers.RelatedLinks`
-* **Triggers on:** Propertydata, which have a RelatedLinks type as datatype
+* **Triggers on:** Propertydata, which have a RelatedLinks type as data type
 * If values are set, courier will convert the values to the corresponding GUIDs, add the nodes as dependencies. On extraction the GUIDs will be converted back to the right IDs.
 
 
 ### RTEstylesheets
 * **Full name:** `Umbraco.Courier.DataResolvers.RTEstylesheets`
 * **Triggers on:** The Rich text editor DataType
-* If the RTE have any stylesheets associated, these will be added as dependencies to the datatype
+* If the RTE have any stylesheets associated, these will be added as dependencies to the data type
 
 ### Tags
 * **Full name:** `Umbraco.Courier.DataResolvers.Tags`
-* **Triggers on:**  Propertydata, which have a Tags type as datatype
+* **Triggers on:**  Propertydata, which have a Tags type as data type
 * Selected tags are included as separate dependencies and extracted along with the document.
 
 ### TemplateResources
@@ -136,13 +136,13 @@ Configuring which macro property types contains references to other nodes
 
 ### UltimatePicker
 * **Full name:** `Umbraco.Courier.DataResolvers.UltimatePicker`
-* **Triggers on:**  Propertydata, which have a UltimatePicker type as datatype
+* **Triggers on:**  Propertydata, which have a UltimatePicker type as data type
 * Selected node IDs are converted to GUIDs and the linked nodes are added as dependencies
 
 
 ### Upload
 * **Full name:** `Umbraco.Courier.DataResolvers.Upload`
-* **Triggers on:**  Propertydata, which have a Upload type as datatype
+* **Triggers on:**  Propertydata, which have a Upload type as data type
 * If upload field contains a file, the file is added as a resource on the document.
 
 ##### Configuration
@@ -155,5 +155,5 @@ Configuring which macro property types contains references to other nodes
 
 ### UsercontrolWrapper
 * **Full name:** `Umbraco.Courier.DataResolvers.UsercontrolWrapper`
-* **Triggers on:**  The UsercontrolWrapper Datatypes
-*If the datatype has a .ascx file selected as render, the file is added as a resource to ensure it is trasfered with the datatype.
+* **Triggers on:**  The UsercontrolWrapper Data types
+*If the data type has a .ascx file selected as render, the file is added as a resource to ensure it is trasfered with the data type.

--- a/Add-ons/UmbracoCourier/Architecture/Provider-Configuration.md
+++ b/Add-ons/UmbracoCourier/Architecture/Provider-Configuration.md
@@ -31,7 +31,7 @@ Single option to turn of whether allowed/child media types should be added as a 
 
 - Option to include all allowed templates as a dependency
 - option to include all allowed types as a dependency 
-- option filter out certain datatypes.
+- option filter out certain data types.
 
 <!-- -->
 
@@ -41,9 +41,9 @@ Single option to turn of whether allowed/child media types should be added as a 
       <includeAllTemplates>false</includeAllTemplates>
       <includeChildDocumentTypes>true</includeChildDocumentTypes>
       
-      <!-- By default we won't add the built-in datatypes as dependencies, if needed, they can be removed from the list below -->
-      <!-- Only datatypes which are installed as standard, and does not have any settings are ignored -->
-      <!-- to add, find the datatype in the umbracoNode table and copy its uniqueId value to a node below-->
+      <!-- By default we won't add the built-in data types as dependencies, if needed, they can be removed from the list below -->
+      <!-- Only data types which are installed as standard, and does not have any settings are ignored -->
+      <!-- to add, find the data type in the umbracoNode table and copy its uniqueId value to a node below-->
       <ignoredDataTypes>
         <add key="contentPicker">A6857C73-D6E9-480C-B6E6-F15F6AD11125</add>
         <add key="textstring">0CC0EBA1-9960-42C9-BF9B-60E150B429AE</add>

--- a/Add-ons/UmbracoCourier/CommonIssues.md
+++ b/Add-ons/UmbracoCourier/CommonIssues.md
@@ -39,11 +39,11 @@ And copy to /bin
 *Caused by* Courier not able to find a data types assembly or .cs class file which contains the Interface used
 by the data type
 
-*How to spot* Courier returns "cannot package GUID from datatypes provider" 
+*How to spot* Courier returns "cannot package GUID from data types provider" 
 
-*Solution* Make sure you have all your datatype dependencies in place, usually its ucomponents and similar projects
-that are missing dlls, also, if you don't use a datatype, delete it from your site, so you don't accidently 
-transfer a broken datatype. Make sure to clear courier cache and restart application.
+*Solution* Make sure you have all your data type dependencies in place, usually its ucomponents and similar projects
+that are missing dlls, also, if you don't use a data type, delete it from your site, so you don't accidently 
+transfer a broken data type. Make sure to clear courier cache and restart application.
 
 
 ### Courier cannot package items on V4

--- a/Add-ons/UmbracoCourier/Developer/DataResolvers.md
+++ b/Add-ons/UmbracoCourier/Developer/DataResolvers.md
@@ -13,7 +13,7 @@ In short, a Data resolver is simply a .net class, which inherits from a specific
 
 Out of the box, Courier, can understand all standard data-types in Umbraco. This means that Courier knows that a Content picker contains an ID for a document, which then becomes a dependency, and the ID gets translated into a GUID which can safely be deployed to another location. It also knows that a template might contain references to JavaScript files or internal links, using the [locallink:] syntax. Or a lot of other cases where data have a special meaning. 
 
-This is what data resolvers do, add special meaning to specific data that matches certain criteria, for instance properties using a specific datatype, templates containing a certain keyword and so on.
+This is what data resolvers do, add special meaning to specific data that matches certain criteria, for instance properties using a specific data type, templates containing a certain keyword and so on.
 
 ## Sample Data Resolver
 If you need to build your own Data Resolvers for Courier there are some great examples in the [Courier Contrib project](https://github.com/umbraco/Umbraco.Courier.Contrib). The project contains resolvers for both custom [property editors](https://github.com/umbraco/Umbraco.Courier.Contrib/tree/dev/src/Umbraco.Courier.Contrib.Resolvers/PropertyDataResolvers) and custom [grid editors](https://github.com/umbraco/Umbraco.Courier.Contrib/tree/dev/src/Umbraco.Courier.Contrib.Resolvers/GridCellDataResolvers).

--- a/Add-ons/UmbracoCourier/UsingCourier.md
+++ b/Add-ons/UmbracoCourier/UsingCourier.md
@@ -20,7 +20,7 @@ When it has figured this out, it exports the selected item(s) and their dependen
 
 Optionally it can compare the packaged items as it finds them, to figure out if they have actually changed since the last update, and will skip those that have. 
 
-Finally, it will build a graph of the deployment, based on the order of dependencies, this means that Courier knows that for a document to be installed, it needs to have its document type, template, datatypes and so on present on the target website. 
+Finally, it will build a graph of the deployment, based on the order of dependencies, this means that Courier knows that for a document to be installed, it needs to have its document type, template, data types and so on present on the target website. 
 
 So, in short it:
 
@@ -39,8 +39,8 @@ Lets consider the amount of dependencies that goes into moving a document
 - The document data
 - Property Editors used to edit the document data
 - The document type
-- Datatypes used in the document type
-- Dlls, files, settings, content referenced by datatypes, like the RTE, and the content picker
+- Data types used in the document type
+- Dlls, files, settings, content referenced by data types, like the RTE, and the content picker
 - The template
 - Css, js and images referenced in the template
 - macros in the template
@@ -50,7 +50,7 @@ We can sort these things into hard and soft dependencies, the hard ones are docu
 cannot exist in the database, due to ID references. 
 
 The soft ones are all the items that make the page and editor actually work, so if you try to view a page without a template, it breaks, try to edit
-a document with a datatype missing its configuration or a needed dll, it breaks. 
+a document with a data type missing its configuration or a needed dll, it breaks. 
 
 So the short version is, you don't want to miss those dependencies, because your site will not work, and you will have no idea why. 
 
@@ -58,9 +58,9 @@ So the short version is, you don't want to miss those dependencies, because your
 The whole idea of Courier, builds around the idea of dependencies and references, which courier can understand to a certain degree.
 But there are several areas, where Courier have zero chance of understanding what is going an. 
 
-### When a datatype stores node ids
+### When a data type stores node ids
 Common thing, a data type stores a node ID, but courier doesn't know, so it cannot add the document as a dependency, and it cannot convert it into
-a GUID, so it will be transferable, however, you can add the datatype to the courier.config to tell courier to look for ids and convert them
+a GUID, so it will be transferable, however, you can add the data type to the courier.config to tell courier to look for ids and convert them
 
 ### Data in external tables are referenced.
 Courier doesn't know about it, cant deploy it, you can write your own provider for it, but this provides you with overhead, and it would

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout.md
@@ -9,8 +9,8 @@ Gives editors a grid layout editor which allows them to insert different types o
 ## [What are Grid Layouts](Grid-Layout/What-Are-Grid-Layouts.md)
 The basic concept of Grid Layouts
 
-## [Configuring the Grid Layout datatype](Grid-Layout/configuring-the-grid-layout-datatype.md)
-How to setup your Grid Layout datatype
+## [Configuring the Grid Layout data type](Grid-Layout/configuring-the-grid-layout-data type.md)
+How to setup your Grid Layout data type
 
 ## [Settings and styling](Grid-Layout/Settings-and-styles.md)
 Add settings and styles

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Settings-and-styles.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Settings-and-styles.md
@@ -131,7 +131,7 @@ There are many ways to combine these, here are some samples:
     }
 
 ### Multiple settings and styles
-You can add multiple settings and styles configurations on a datatype. This is done by creating a new setting or style object. Remember to separate the objects with a comma.
+You can add multiple settings and styles configurations on a data type. This is done by creating a new setting or style object. Remember to separate the objects with a comma.
 
 **Adding multiple settings**
 

--- a/Getting-Started/Backoffice/index.md
+++ b/Getting-Started/Backoffice/index.md
@@ -43,7 +43,7 @@ Each field has a specific data type e.g. text, number, ...
 Every document type has properties. These are the fields that the content editor is allowed to edit for the node.
 
 ### Data Type
-Each document type property has a data type which defines the type of input of that property. Data types reference a Property Editor and are configured in the Umbraco backoffice in the developer section.  A datatype can be something very simple (textstring, number, true/false,...) or more complex (multi node tree picker, image cropper, ...)
+Each document type property has a data type which defines the type of input of that property. Data types reference a Property Editor and are configured in the Umbraco backoffice in the developer section.  A data type can be something very simple (textstring, number, true/false,...) or more complex (multi node tree picker, image cropper, ...)
 [Read more..](../Data/Data-Types/)
 
 ### [Property Editors](Property-Editors/)

--- a/Getting-Started/Data/Data-Types/default-data-types.md
+++ b/Getting-Started/Data/Data-Types/default-data-types.md
@@ -65,7 +65,7 @@ A simple textbox to input a numeric value.
 This Data type enables editors to choose from list of radiobuttons. 
 
 #### Related Links ####
-This datatype allows an editor to easily add an array of links. These can either be internal Umbraco pages or external URLs.
+This data type allows an editor to easily add an array of links. These can either be internal Umbraco pages or external URLs.
 
 #### Richtext Editor ####
 The TinyMCE based wysiwyg editor. This is the standard editor used to edit any larger amount of text. The editor has a lot of settings, which can be changed under the developer section in "data types" / Richtext editor. The editor also supports TinyMCE plugins which can be controlled in the configuration file located at /config/tinyMce.config
@@ -90,7 +90,7 @@ Stylesheets
 </pre>
 
 #### Tags ####
-A textbox that allows you to use use multiple tags on a docType. You can specify a TAG Group for this datatype, in case you need to use TAGS on different sections of your site (i.e  News, Article, Events).
+A textbox that allows you to use use multiple tags on a docType. You can specify a TAG Group for this data type, in case you need to use TAGS on different sections of your site (i.e  News, Article, Events).
 
 #### Textarea ####
 A simple textarea

--- a/Getting-Started/Setup/Upgrading/version-specific.md
+++ b/Getting-Started/Setup/Upgrading/version-specific.md
@@ -19,17 +19,17 @@ This version also ships with far less client files (i.e. js, css, images) that w
 ## Version 7.6.3
 In short:
 
-In Umbraco version 7.6.2 we made a mistake in the Property Value Converts (PVCs) which was corrected 2 days later in version 7.6.3. If you were having problems with querying the following datatypes in the frontend, then make sure to upgrade to 7.6.3:
+In Umbraco version 7.6.2 we made a mistake in the Property Value Converts (PVCs) which was corrected 2 days later in version 7.6.3. If you were having problems with querying the following data types in the frontend, then make sure to upgrade to 7.6.3:
 
  * Multi Node Tree Picker
  * Related Links
  * Member Picker
 
-Depending on if you tried to fix problem with those datatypes you will might need to fix them again after you upgrade to 7.6.3.
+Depending on if you tried to fix problem with those data types you will might need to fix them again after you upgrade to 7.6.3.
 
 ## Property Value Converters?
 
-Umbraco stores data for datatypes in different ways, for a lot of pickers it will store (for example) 1072 or 1083,1283. These numbers refer to the identifier of the item in Umbraco. In the past, when building your templates you would manually have to take that value and find the content item it belongs to and then get the data you wanted from there, for example:
+Umbraco stores data for data types in different ways, for a lot of pickers it will store (for example) 1072 or 1083,1283. These numbers refer to the identifier of the item in Umbraco. In the past, when building your templates you would manually have to take that value and find the content item it belongs to and then get the data you wanted from there, for example:
 
 		@{
 			IPublishedContent contactPage;
@@ -67,7 +67,7 @@ This issue only affects:
  * Related Links
  * Member Picker
 
-If you have already upgraded to 7.6.2 and fixed some of your queries for those three datatypes then you might have to fix them again in 7.6.3. We promise it's the last time you need to update them! We're sorry for the inconvenience.
+If you have already upgraded to 7.6.2 and fixed some of your queries for those three data types then you might have to fix them again in 7.6.3. We promise it's the last time you need to update them! We're sorry for the inconvenience.
 
 ## Version 7.6.0
 

--- a/Reference/Config/umbracoSettings/index.md
+++ b/Reference/Config/umbracoSettings/index.md
@@ -22,14 +22,14 @@ There is only one supported attribute on the tours element:
 **`enable`**
 By default this is set to true. Set it to false to turn off [backoffice tours](../../../Extending/Backoffice-Tours/index.md)
 
-### Obsolete datatypes
+### Obsolete data types
 
-This section is used for controlling whether or not the datatypes marked as obsolete should be visible in the dropdown when creating new datatypes
+This section is used for controlling whether or not the data types marked as obsolete should be visible in the dropdown when creating new data types
 
     <showDeprecatedPropertyEditors>false</showDeprecatedPropertyEditors>
 
 **`enable`**
-By default this is set to false. To make the obsolete datatypes visible in the dropdown change the value to **true**.
+By default this is set to false. To make the obsolete data types visible in the dropdown change the value to **true**.
 
 ## Content
 

--- a/Reference/Templating/Macros/Xslt/Snippets/Tag-cloud.md
+++ b/Reference/Templating/Macros/Xslt/Snippets/Tag-cloud.md
@@ -1,10 +1,10 @@
 # Tag cloud
 
-If you use the Tag datatype in Umbraco V4, you can easily make an tag-cloud in XSLT:
+If you use the Tag data type in Umbraco V4, you can easily make an tag-cloud in XSLT:
 
 The variable TagFactor is used to calculate the ratio between the tags.
 
-The bold value "Umbraco" is the name of the Tag group used in the datatype.
+The bold value "Umbraco" is the name of the Tag group used in the data type.
 
 The example below has 6 different size of tags, and the style/size of the tags in the cloud is modified through css
 

--- a/Reference/Templating/Masterpages/umbracoimage.md
+++ b/Reference/Templating/Masterpages/umbracoimage.md
@@ -23,7 +23,7 @@ The `field` attribute defines which field of the current page will be used as th
 If a `nodeid` is specified, then that node will be used to get the `field` from.
 
 ## Parameters
-The `parameters` are provider specific. The default provider supports the upload datatypes thumbnails, and the Image Cropper datatypes crops.
+The `parameters` are provider specific. The default provider supports the upload data types thumbnails, and the Image Cropper data types crops.
 
 <table>
 	<tr>

--- a/Tutorials/Creating-a-Property-Editor/index.md
+++ b/Tutorials/Creating-a-Property-Editor/index.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide explains how to set up a simple property editor, how to hook it into Umbraco's datatypes, how to hook it into Angular's modules and its injector, and finally how you can test your property editor.
+This guide explains how to set up a simple property editor, how to hook it into Umbraco's data types, how to hook it into Angular's modules and its injector, and finally how you can test your property editor.
 
 So all the steps we will go through:
 
@@ -91,10 +91,10 @@ Now our basic parts of the editor is done, namely:
 - The HTML view for the editor
 - The controller for wiring up the editor with angular.
 
-## Register the datatype in Umbraco
-After the above edits are done, restart your application. Go to the Developer section, click the 3 dots next to the datatypes folder and create a new data type called "markdown". In the editor you can now select a property editor, where your newly added "markdown editor" will appear.
+## Register the data type in Umbraco
+After the above edits are done, restart your application. Go to the Developer section, click the 3 dots next to the data types folder and create a new data type called "markdown". In the editor you can now select a property editor, where your newly added "markdown editor" will appear.
 
-Save the datatype, and add it to a document type of your choice. Open a document of that type, and you will be greeted with an alert message saying "The controller has landed", which means all is well. You can now edit the assigned property's value with your editor.
+Save the data type, and add it to a document type of your choice. Open a document of that type, and you will be greeted with an alert message saying "The controller has landed", which means all is well. You can now edit the assigned property's value with your editor.
 
 
 ## Add external dependencies

--- a/Tutorials/Creating-a-Property-Editor/part-2.md
+++ b/Tutorials/Creating-a-Property-Editor/part-2.md
@@ -32,13 +32,13 @@ To add configuration options to our markdown editor, open the `package.manifest`
 
 **Remember to:** Separate the editor element and prevalue editor definition with a comma, or you will get a JSON error.
 
-So what did we just add? We added a prevalue editor, with a `fields` collection. This collection contains information about the UI we will render on the datatype configuration for this editor.
+So what did we just add? We added a prevalue editor, with a `fields` collection. This collection contains information about the UI we will render on the data type configuration for this editor.
 
 So the first one gets the label "Preview" and uses the view "boolean", so this will allow us to turn preview on/off and will provide the user with a simple checkbox. The name "boolean" comes from the convention that all preview editors are stored in `/umbraco/views/prevalueeditors/` and then found via `<name>.html`
 
 Same with the next one, only that it will provide the user with a textarea to input a default value for the editor.
 
-Save the manifest, **restart the app pool** and have a look at the markdown datatype in Umbraco now. You should now see that you have 2 configuration options.
+Save the manifest, **restart the app pool** and have a look at the markdown data type in Umbraco now. You should now see that you have 2 configuration options.
 
 ## Using the configuration
 The next step is to gain access to our new configuration options. For this, open the `markdowneditor.controller.js` file.

--- a/Umbraco-Cloud/Deployment/Local-to-Cloud/index.md
+++ b/Umbraco-Cloud/Deployment/Local-to-Cloud/index.md
@@ -7,13 +7,13 @@ Here's a quick step-by-step on how you deploy these changes to your Cloud enviro
   - You’ve cloned a site to your local machine to work on
   - You’ve made some changes to a Document type
   - The corresponding `.uda` file for this Document type is now updated with the changes - the file is located in the `/data/revision` folder
-  - You’ve also created a new datatype that’s used on the document type. This datatype is stored as a new file in the `/data/revision` folder as well
+  - You’ve also created a new data type that’s used on the document type. This data type is stored as a new file in the `/data/revision` folder as well
   - Using Git, commit those two changed files to your local repository and push them to the Cloud environment using `git push`
-  - On the Cloud environment a deployment kicks in and the document type is updated and the new datatype you created locally is now automatically created in the Cloud environment as well
+  - On the Cloud environment a deployment kicks in and the document type is updated and the new data type you created locally is now automatically created in the Cloud environment as well
 
 ![Deploy from Local to Remote](images/stage-commit-deploy.gif)
 
-In the above example, GitKraken is used to stage, commit and deploy changes made to a Document type plus a newly added Datatype from a local environment to a Cloud Development environment.
+In the above example, GitKraken is used to stage, commit and deploy changes made to a Document type plus a newly added data type from a local environment to a Cloud Development environment.
 
 Once you’ve deployed your local changes to your Cloud environment deploying to your remaining Cloud environments (e.g. Staging and/or Live) is literally as simple a pressing the **'Deploy changes to ..'** button in the Umbraco Cloud portal. Learn more about how this is done in our section about [deploying between two Cloud environments](../Cloud-to-Cloud).
 

--- a/Umbraco-Cloud/Troubleshooting/Deployments/Structure-Error/index.md
+++ b/Umbraco-Cloud/Troubleshooting/Deployments/Structure-Error/index.md
@@ -4,7 +4,7 @@
 
 > **NOTE:** If your project is using Umbraco Courier, please refer to this article instead: [Schema Mismatches with Courier](../../Courier/Structure-Errors-Courier)
 
-On some occasions, it's possible that you'll encounter collision errors on your Umbraco Cloud environments. This means that two `.uda` files are created for the same entity type. The `.uda` files contain schema for each of your entity types (e.g Document Types, Templates, Macros, Dictionary Items, Datatypes).
+On some occasions, it's possible that you'll encounter collision errors on your Umbraco Cloud environments. This means that two `.uda` files are created for the same entity type. The `.uda` files contain schema for each of your entity types (e.g Document Types, Templates, Macros, Dictionary Items, Data types).
 
 Example:
 

--- a/Umbraco-Cloud/Troubleshooting/FAQ/index.md
+++ b/Umbraco-Cloud/Troubleshooting/FAQ/index.md
@@ -3,9 +3,9 @@ We have gathered a list of frequently asked questions below that have something 
 
 ## I’m using Archetype, do I need to do anything special?
 
-Yes, as Archetype is third-party created datatype you’ll need to include the appropriate data resolver.  You simply include the data resolver in your site’s `/bin/` folder and make sure you commit and push the file when you deploy your site.  You can find the data resolver for Archetype here: [Archetype.Courier](https://github.com/leekelleher/Archetype.Courier)
+Yes, as Archetype is a third-party created data type you’ll need to include the appropriate data resolver.  You simply include the data resolver in your site’s `/bin/` folder and make sure you commit and push the file when you deploy your site.  You can find the data resolver for Archetype here: [Archetype.Courier](https://github.com/leekelleher/Archetype.Courier)
 
-## I’m using BuzzHybrid / DonutCaching / LatestHotStuff / other custom add-ins or I’ve created my own datatypes - do I need to do anything special?
+## I’m using BuzzHybrid / DonutCaching / LatestHotStuff / other custom add-ins or I’ve created my own data types - do I need to do anything special?
 
 Probably not! In most cases simply including the custom files (and configuration) is enough for Umbraco Cloud to understand how to deploy your site.  In some cases, namely where you’ve created a data type that serializes data or otherwise stores property data in a non-standard format, you’ll need to also create a corresponding data resolver.  Fortunately these are easily created using the guide and samples [here](https://github.com/umbraco/Courier/blob/master/Documentation/Developer%20Documentation/Data%20Resolvers.md)
 


### PR DESCRIPTION
I have replaced all uses of the word 'datatype' with 'data type'.
Microsoft refers to them as data types [https://docs.microsoft.com/en-us/office/vba/language/reference/user-interface-help/data-type-summary](https://docs.microsoft.com/en-us/office/vba/language/reference/user-interface-help/data-type-summary)
And if you [google 'Umbraco datatype'](https://www.google.co.uk/search?q=umbraco+datatype) it says, Did you mean 'Umbraco data type'