### PR TITLE
Added version number since when editor model events are supported

### DIFF
--- a/Reference/Events/EditorModel-Events.md
+++ b/Reference/Events/EditorModel-Events.md
@@ -1,5 +1,7 @@
 # EditorModel Events #
 
+**Umbraco 7.4.0+**
+
 The **EditorModelEventManager** class is used to emit events that enable you to manipulate the model used by the backoffice before it is loaded into an editor  (for example the SendingContentModel event fires just before a content item is loaded into the backoffice for editing). It is therefore the perfect event to use to set a default value for a particular property, or perhaps to hide a property/tab from a certain editor.
 
 ## Usage ##

--- a/Reference/Events/EditorModel-Events.md
+++ b/Reference/Events/EditorModel-Events.md
@@ -1,4 +1,9 @@
-# EditorModel Events #
+---
+keywords: EditorModelEventManager
+versionFrom: 7.4.0
+---
+
+# EditorModel Events
 
 **Umbraco 7.4.0+**
 


### PR DESCRIPTION
The editor model events are supported since 7.4 this should be clear from the documentation