### PR TITLE
Renamed back-office to backoffice.

### DIFF
--- a/Development-Guidelines/Coding-Standards/jquery-guidelines.md
+++ b/Development-Guidelines/Coding-Standards/jquery-guidelines.md
@@ -2,7 +2,7 @@
 
 _Ensure that you have read the [JavaScript Guidelines](js-guidelines.md) document before continuing. As specified in the [JavaScript Guidelines](js-guidelines.md) document, method names are named in "camelCase" and therefore jQuery plugins (since they are methods) are named as "camelCase"._
 
-Just like other JavaScript in the Umbraco back-office, you need to wrap your class in the jQuery self executing function if you want to use the dollar ($) operator.
+Just like other JavaScript in the Umbraco backoffice, you need to wrap your class in the jQuery self executing function if you want to use the dollar ($) operator.
 
 ## Simple jQuery plugins
 Simple jQuery plugins don't require an internal class to perform the functionality and therefore do not expose or return an API. These could be as simple as vertically aligning something:

--- a/Development-Guidelines/Coding-Standards/js-guidelines.md
+++ b/Development-Guidelines/Coding-Standards/js-guidelines.md
@@ -2,7 +2,7 @@
 
 _All JavaScript in the Umbraco core should adhere to these guidelines. The legacy JS code in the core doesn't adhere to these guidelines but should be refactored so that it does._
 
-**All JavaScript in the back-office needs to be in a namespace and defined in a class.**
+**All JavaScript in the backoffice needs to be in a namespace and defined in a class.**
 
 ## Namespaces
 To declare a namespace for your JavaScript class you simply use the following command (as an example to create a namespace called 'Umbraco.Controls'):

--- a/Getting-Started/Setup/Install/install-umbraco-with-microsoft-webmatrix.md
+++ b/Getting-Started/Setup/Install/install-umbraco-with-microsoft-webmatrix.md
@@ -68,7 +68,7 @@ This section continues from where we left off but covers the installation and co
 
 1. After deciding whether to skip or install a starter kit you are finished!
 
-1. Now click the **Set up your new website** to be logged into the Umbraco back-office.
+1. Now click the **Set up your new website** to be logged into the Umbraco backoffice.
 
 	![Web Installer - Install Complete](images/WebMatrix/web-finish.png)
 

--- a/Getting-Started/Setup/Server-Setup/Load-Balancing/flexible.md
+++ b/Getting-Started/Setup/Server-Setup/Load-Balancing/flexible.md
@@ -12,7 +12,7 @@ These instructions make the following assumptions:
 
 * All web servers can communicate with the database where Umbraco data is stored
 * You are running Umbraco 7.3.0 or above
-* _**You will designate a single server to be the back-office server for which your editors will log into for editing content.**_ Umbraco will not work correctly if the back-office is behind the load balancer.
+* _**You will designate a single server to be the backoffice server for which your editors will log into for editing content.**_ Umbraco will not work correctly if the backoffice is behind the load balancer.
 
 There are three design alternatives you can use to effectively load balance servers:
 

--- a/Getting-Started/Setup/Server-Setup/Load-Balancing/traditional.md
+++ b/Getting-Started/Setup/Server-Setup/Load-Balancing/traditional.md
@@ -15,7 +15,7 @@ These instructions make the following assumptions:
 * You have administration access to all servers
 * All servers can communicate via HTTP protocol with each other
 * You should be running in ASP.NET Full Trust (medium trust may cause some issues with load balancing)
-* _**You will designate a single server to be the back-office server for which your editors will log into for editing content.**_ Umbraco will not work if the back-office is behind the load balancer *(see DNS for more information below)*.
+* _**You will designate a single server to be the backoffice server for which your editors will log into for editing content.**_ Umbraco will not work if the backoffice is behind the load balancer *(see DNS for more information below)*.
 
 There are two design alternatives you can use to effectively load balance servers:
 
@@ -51,9 +51,9 @@ Of course you'll have your public website's DNS/address which you'll also need t
 
 ### Backoffice server
 
-You should designate one of these servers to be the back-office server for which your editors will use to log in to and edit content. This can be achieved by creating another public DNS entry/host header that you can assign to your designated server.
+You should designate one of these servers to be the backoffice server for which your editors will use to log in to and edit content. This can be achieved by creating another public DNS entry/host header that you can assign to your designated server.
 
-As an example, you could assign Server 1 as the designated back-office server. In this case you could create a DNS entry such as **admin.mywebsite.com** and add as a host header to Server 1.
+As an example, you could assign Server 1 as the designated backoffice server. In this case you could create a DNS entry such as **admin.mywebsite.com** and add as a host header to Server 1.
 
 You will then need to ensure that any public request going to this DNS entry only goes to Server 1. This can be achieved by assigning a secondary public IP address to the DNS entry and configuring your firewall to NAT this IP address to your Server 1 internal IP address. Other alternatives could possibly be achieved based on your firewall and the configuration that it supports.
 

--- a/Reference/Config/ExamineIndex/index.md
+++ b/Reference/Config/ExamineIndex/index.md
@@ -73,10 +73,10 @@ and if you want to be able to sort search results by this field add EnableSortin
 ## Example Default ExamineIndex.Config file
 
     <ExamineLuceneIndexSets>
-      <!-- The internal index set used by Umbraco back-office - DO NOT REMOVE -->
+      <!-- The internal index set used by Umbraco backoffice - DO NOT REMOVE -->
       <IndexSet SetName="InternalIndexSet" IndexPath="~/App_Data/TEMP/ExamineIndexes/Internal/"/>
 
-      <!-- The internal index set used by Umbraco back-office for indexing members - DO NOT REMOVE -->
+      <!-- The internal index set used by Umbraco backoffice for indexing members - DO NOT REMOVE -->
       <IndexSet SetName="InternalMemberIndexSet" IndexPath="~/App_Data/TEMP/ExamineIndexes/InternalMember/">
         <IndexAttributeFields>
           <add Name="id" />

--- a/Reference/Config/umbracoSettings/index.md
+++ b/Reference/Config/umbracoSettings/index.md
@@ -279,14 +279,14 @@ This setting is used when you're running Umbraco in virtual directories.
         
 **DisallowedUploadFiles**
 
-This setting consists of a "black list" of file extensions that editors shouldn't be allowed to upload via the back-office.
+This setting consists of a "black list" of file extensions that editors shouldn't be allowed to upload via the backoffice.
 
         <!-- These file types will not be allowed to be uploaded via the upload control for media and content -->
         <disallowedUploadFiles>ashx,aspx,ascx,config,cshtml,vbhtml,asmx,air,axd,swf,xml,xhtml,html,htm,svg,php,htaccess</disallowedUploadFiles>
         
 **AllowedUploadFiles (introduced in 7.6.2)**
 
-If greater control is required than available from the above, this setting can be used to store a "white list" of file extensions.  If provided, only files with these extensions can be uploaded via the back-office.
+If greater control is required than available from the above, this setting can be used to store a "white list" of file extensions.  If provided, only files with these extensions can be uploaded via the backoffice.
 
         <!-- If completed, only the file extensions listed below will be allowed to be uploaded.  If empty, disallowedUploadFiles will apply to prevent upload of specific file extensions. -->
         <allowedUploadFiles></allowedUploadFiles>
@@ -320,13 +320,13 @@ In the security section you have the following options: **`<keepUserLoggedIn>`**
         <!-- change in 4.8: Disabled users are now showed dimmed and last in the tree. If you prefer not to display them set this to true -->
         <hideDisabledUsersInBackoffice>false</hideDisabledUsersInBackoffice>
 
-        <!-- set to true to enable the UI and API to allow back-office users to reset their passwords -->
+        <!-- set to true to enable the UI and API to allow backoffice users to reset their passwords -->
         <allowPasswordReset>true</allowPasswordReset>
 
-        <!-- set to a different value if you require the authentication cookie for back-office users to be renamed -->
+        <!-- set to a different value if you require the authentication cookie for backoffice users to be renamed -->
         <authCookieName>UMB_UCONTEXT</authCookieName>  
 
-        <!-- set to a different value if you require the authentication cookie for back-office users to be set against a different domain -->
+        <!-- set to a different value if you require the authentication cookie for backoffice users to be set against a different domain -->
         <authCookieDomain></authCookieDomain>  
 
     </security>
@@ -346,10 +346,10 @@ This setting specifies whether the username and email address are separate field
 The feature to allow users to reset their passwords if they have forgotten them was introduced in 7.5. he feature is based on [a method provided by ASP.Net Identity](https://www.asp.net/identity/overview/features-api/account-confirmation-and-password-recovery-with-aspnet-identity). By default, this is enabled but if you'd prefer to not allow users to do this it can be disabled at both the UI and API level by setting this value to `false`.
 
 **`<authCookieName>`**
-The authentication cookie which is set in the browser when a back-office user logs in, and defaults to `UMB_UCONTEXT`. This setting is excluded from the configuration file but can be added in if a different cookie name needs to be set.
+The authentication cookie which is set in the browser when a backoffice user logs in, and defaults to `UMB_UCONTEXT`. This setting is excluded from the configuration file but can be added in if a different cookie name needs to be set.
 
 **`<authCookieDomain>`**
-The authentication cookie which is set in the browser when a back-office user logs in is automatically set to the current domain.  This setting is excluded from the configuration file but can be added in if a different domain is required.
+The authentication cookie which is set in the browser when a backoffice user logs in is automatically set to the current domain.  This setting is excluded from the configuration file but can be added in if a different domain is required.
 
 ## RequestHandler
 

--- a/Reference/Searching/Examine/index.md
+++ b/Reference/Searching/Examine/index.md
@@ -6,7 +6,7 @@ _Examine uses Lucene as its search and index engine. Searching using Examine wit
 
 Examine allows you to index and search data quickly and easily. It is a library that sits on top of Lucene, a very high performance search engine library written in Java. Examine is built on top of a .NET-implementation of Lucene to provide very efficient APIs to make searching and indexing as straight forward as possible. Umbraco provides a further layer on top, UmbracoExamine, that opens up the Umbraco-specific APIs for indexing and searching content and media out of the box.
 
-Examine is provider based so is very extensible and allows you to configure as many indexes as you like and each may be configured individually. The back-office search in Umbraco also uses this same search engine, so you can trust that you're in good hands.
+Examine is provider based so is very extensible and allows you to configure as many indexes as you like and each may be configured individually. The backoffice search in Umbraco also uses this same search engine, so you can trust that you're in good hands.
 
 ## [Quick start](quick-start.md)
 


### PR DESCRIPTION
Picked up the few remaining areas (from PR #995) where "back-office" is used, it was only those that appear with the hyphen that were left, but now should all be in-line with the CMS, using "backoffice".