### PR TITLE
Added the GetKey() extension method to IPublishedContent

### DIFF
--- a/Reference/Querying/IPublishedContent/ExtensionMethods.md
+++ b/Reference/Querying/IPublishedContent/ExtensionMethods.md
@@ -1,0 +1,4 @@
+# IPublishedContent Extension Methods
+
+### .GetKey() (version 7.6+)
+Returns the Guid Identifier of the IPublishedContent

--- a/Reference/Querying/IPublishedContent/ExtensionMethods.md
+++ b/Reference/Querying/IPublishedContent/ExtensionMethods.md
@@ -1,4 +1,4 @@
 # IPublishedContent Extension Methods
 
-### .GetKey() (version 7.6+)
+### .GetKey()
 Returns the Guid Identifier of the IPublishedContent

--- a/Reference/Querying/IPublishedContent/Properties.md
+++ b/Reference/Querying/IPublishedContent/Properties.md
@@ -111,3 +111,8 @@ Returns a boolean value representing if the IPublishedContent property has had a
 
 ### .IsNull(string propertyAlias)
 Returns a boolean value representing if the IPublishedContent property is Null.
+
+## Extension Methods
+
+### .GetKey()
+Returns the Guid Identifier of the IPublishedContent

--- a/Reference/Querying/IPublishedContent/Properties.md
+++ b/Reference/Querying/IPublishedContent/Properties.md
@@ -111,8 +111,3 @@ Returns a boolean value representing if the IPublishedContent property has had a
 
 ### .IsNull(string propertyAlias)
 Returns a boolean value representing if the IPublishedContent property is Null.
-
-## Extension Methods
-
-### .GetKey()
-Returns the Guid Identifier of the IPublishedContent

--- a/Reference/Querying/IPublishedContent/index.md
+++ b/Reference/Querying/IPublishedContent/index.md
@@ -13,10 +13,13 @@ To access the current page in your macros or templates, copy-paste the below Raz
 	<h1>@pageName</h1>
 
 ## [Properties](Properties.md)
-Listing and explanation of IPublishedContent properties, standard helpers & extension methods for Content and Media.
+Listing and explanation of IPublishedContent properties, standard helpers for Content and Media.
 
 ## [Collections & Filtering](Collections.md)
 Methods for IPublishedContent collections and filtering.
 
 ## [IsHelpers](IsHelpers.md)
 A library of extension methods to simplify working with IPublishedContent in collections to modify your HTML output. Examples of using `IsHelpers` could be injecting CSS classes for alternating rows or to modify margins.
+
+## [Extension Methods](ExtensionMethods.md)
+Extension methods available for IPublishedContent.

--- a/Reference/Querying/IPublishedContent/index.md
+++ b/Reference/Querying/IPublishedContent/index.md
@@ -13,7 +13,7 @@ To access the current page in your macros or templates, copy-paste the below Raz
 	<h1>@pageName</h1>
 
 ## [Properties](Properties.md)
-Listing and explanation of IPublishedContent properties & standard helpers for Content and Media.
+Listing and explanation of IPublishedContent properties, standard helpers & extension methods for Content and Media.
 
 ## [Collections & Filtering](Collections.md)
 Methods for IPublishedContent collections and filtering.

--- a/Reference/Querying/IPublishedContent/index.md
+++ b/Reference/Querying/IPublishedContent/index.md
@@ -13,7 +13,7 @@ To access the current page in your macros or templates, copy-paste the below Raz
 	<h1>@pageName</h1>
 
 ## [Properties](Properties.md)
-Listing and explanation of IPublishedContent properties, standard helpers for Content and Media.
+Listing and explanation of IPublishedContent properties and standard helpers for Content and Media.
 
 ## [Collections & Filtering](Collections.md)
 Methods for IPublishedContent collections and filtering.


### PR DESCRIPTION
I have added the GetKey() extension method to the IPublishedContent page. I was not sure whether we need to create a new .md file for extension methods or just have it alongside properties give the extension method is used to retrieve the Guid of IPublishedContent.

Poornima