### PR TITLE
Updated tags default storage type

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Tags.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Tags.md
@@ -15,7 +15,7 @@ The **Tag group** setting provides a way to categorize your tags in groups. So f
 
 ### Storage type
 
-Data can be saved in either CSV format or in JSON format. By default data is saved in CSV format. The difference between using CSV and JSON is that with JSON you can save a tag, which includes comma seperated values.
+Data can be saved in either CSV format or in JSON format. By default data is saved in JSON format, since version [7.12](https://our.umbraco.com/download/releases/7120), but in earlier versions the default format is CSV. The difference between using CSV and JSON is that with JSON you can save a tag, which includes comma separated values.
 
 Since the release of Umbraco 7.6 there are built-in property value converters, which means you don't need to worry about writing them yourself or parse the JSON output when choosing "JSON" in the storage type field. Therefore [the last code example](#mvc-view-example---display-a-list-of-tags) on this page will work out of the box without further ado.
 


### PR DESCRIPTION
Added information about the change to the default storage type for tags since 7.12 and fixed a spelling mistake.