### PR TITLE
Make the index file lighter by splitting information into different files

### DIFF
--- a/Contribute/Markdown-Conventions/index.md
+++ b/Contribute/Markdown-Conventions/index.md
@@ -1,48 +1,53 @@
 # Markdown conventions
-The Umbraco Documentation uses Markdown for all of the documentation - but more precisely we use the CommonMark specification, read more about the difference [here](https://commonmark.org/).
+
+The Umbraco Documentation uses Markdown for all of the documentation - but more precisely we use the CommonMark specification. Read more about the [difference between CommonMark and Markdown](https://commonmark.org/).
 
 ## Structure
+
 For the documentation project, each individual topic is contained in its own folder.
 Each folder must have an `index.md` file which links to the individual sub-pages, if images are used, these must be in `images` folders next to the .md file referencing them relatively.
 
 * topic
-	* images
-		* images.jpg
-	* Subtopic
-		* images
-		* index.md
-	* index.md
-	* otherpage.md
+  * images
+    * images.jpg
+  * Subtopic
+    * images
+    * index.md
+  * index.md
+  * other-page.md
 
 ## Images
+
 Images are stored and linked relatively to .md pages, and should by convention always be in an `images` folder. So to add an image to `/documentation/reference/partials/renderviewpage.md` you link it like so:
 
-	![My Image Alt Text](images/img.jpg)
+    ![My Image Alt Text](images/img.jpg)
 
 And store the image as `/documentation/reference/partials/images/img.jpg`
 
 Images can have a maximum width of **800px**. Please always try to use the most efficient compression, `gif`, `png` or `jpg`. No `bmp`, `tiff` or `swf` (Flash).
 
 ## External links
-Include either the complete URL, or link using Markdown:
 
-	https://yahoo.com/something
+Include either the complete URL, or link using a specific syntax:
 
-	or
+    https://yahoo.com/something
 
-	[yahoo something](https://yahoo.com/something)
+or
 
+    [yahoo something](https://yahoo.com/something)
 
 ## Internal links
+
 If you need to link between pages, always link relatively, and include the .md extension.
 
-	[Umbraco.Helpers](Umbraco.Helpers.md)
+    [Umbraco.Helpers](Umbraco.Helpers.md)
 
-	or
+or
 
-	[Umbraco.Helpers](../../Reference/Umbraco.Helpers.md)
+    [Umbraco.Helpers](../../Reference/Umbraco.Helpers.md)
 
 ## Formatting code
+
 Indent your sample with 4 spaces, which will cause it to be rendered as `<pre><code>` tags.
 For inline code, wrap in ` (backtick) chars.
 
@@ -50,7 +55,8 @@ Use # for the headline, ## for sub headers and ### for parameters (on code refer
 
 For optional parameters wrap in _ (underscore) - end result: `###_optionalParameter_`
 
-## Custom Markdown
+## Adding notes, warnings, tips
+
 The Markdown conversion library used in the documentation is called [Markdig](https://github.com/lunet-io/markdig). It has the possibility of adding classes to markdown that you can then target with CSS. There are a few custom Markdown classes that can be used:
 
 ```

--- a/Contribute/Pull-Requests/pr-through-a-fork.md
+++ b/Contribute/Pull-Requests/pr-through-a-fork.md
@@ -1,5 +1,6 @@
+# Create a pull request using a fork
 
-**Step 1: Creating a fork**
+## Step 1: Creating a fork
 Once you have setup Git you can create a fork of the [Umbraco Documentation repository](https://github.com/umbraco/UmbracoDocs/).
 
 When you make a fork, you get a copy of the whole repository on your own Github profile. You can create a fork by clicking the fork button at the top of the screen:
@@ -10,7 +11,7 @@ Once the fork has been created you will have your own copy of the documentation.
 When you are done and happy with the changes you've made, you can submit a pull request to sync your copy with the "real" repository:
 ![Fork of documentation](images/example-of-fork.png)
 
-**Step 2: Syncing your fork**
+## Step 2: Syncing your fork
 
 Sometimes - like in the example above - you may end up forking and then not working on the documentation for a while. Once you do start, you may find that you no longer have the most recent version. If this happens, before making changes and making a pull request, you should do a rebase. For this you set the main repository as an upstream to sync from, fetch the updates and update your own fork to ensure you are in sync:
 
@@ -20,9 +21,14 @@ git fetch upstream
 git rebase upstream/master
 ```
 
-**Step 3: Creating a PR**
+## Step 3: Creating a PR
 
 If you do this locally and then push it to your fork you will have a synced up fork to start working with! Once you have made some changes and you are happy with the result, you can create a pull request (you may have to rebase again and resolve merged conflicts if a lot of things has been merged in since your last sync).
 ![Creating a PR](images/pull-request.png)
 
 And that is all you need to do to create a fork, sync it and make a pull request to the main repository! 
+
+## Step 4: Wait from an action
+
+Hopefully your work will be merged immediatly.  It might happen that your pull request receives a comment and a *request for changes*. We hope you are able to work with us to update your PR so we can merge it in!
+Sometimes a label is added to a PR.  We have described a [list of different labels we often use](github-issues.md).

--- a/Contribute/Pull-Requests/pr-through-a-fork.md
+++ b/Contribute/Pull-Requests/pr-through-a-fork.md
@@ -1,0 +1,28 @@
+
+**Step 1: Creating a fork**
+Once you have setup Git you can create a fork of the [Umbraco Documentation repository](https://github.com/umbraco/UmbracoDocs/).
+
+When you make a fork, you get a copy of the whole repository on your own Github profile. You can create a fork by clicking the fork button at the top of the screen:
+![Creating a fork](images/fork-repository.png)
+
+Once the fork has been created you will have your own copy of the documentation. If you clone your fork, you will have all the files on your computer which means you can make changes to a lot of files and then push all the changes back up to your fork in one go.
+
+When you are done and happy with the changes you've made, you can submit a pull request to sync your copy with the "real" repository:
+![Fork of documentation](images/example-of-fork.png)
+
+**Step 2: Syncing your fork**
+
+Sometimes - like in the example above - you may end up forking and then not working on the documentation for a while. Once you do start, you may find that you no longer have the most recent version. If this happens, before making changes and making a pull request, you should do a rebase. For this you set the main repository as an upstream to sync from, fetch the updates and update your own fork to ensure you are in sync:
+
+```cmd
+git remote add upstream https://github.com/umbraco/UmbracoDocs/
+git fetch upstream
+git rebase upstream/master
+```
+
+**Step 3: Creating a PR**
+
+If you do this locally and then push it to your fork you will have a synced up fork to start working with! Once you have made some changes and you are happy with the result, you can create a pull request (you may have to rebase again and resolve merged conflicts if a lot of things has been merged in since your last sync).
+![Creating a PR](images/pull-request.png)
+
+And that is all you need to do to create a fork, sync it and make a pull request to the main repository! 

--- a/Contribute/adding-metadata.md
+++ b/Contribute/adding-metadata.md
@@ -1,13 +1,13 @@
 # Annotating a document with meta data
 
-The documentation markdown files are allowed to contain meta data.  This is done by adding (YAML)[https://en.wikipedia.org/wiki/YAML] at the top of the document.
+The documentation markdown files are allowed to contain meta data.  This is done by adding [YAML](https://en.wikipedia.org/wiki/YAML) at the top of the document.
 
 To add meta data, the metadata is between lines with each 3 dashes.  Every line contains a keyword followed by a '`:`' and then the value.
 
     ---
     keywords: content razor v8 version8
     versionTo: 8.0.0
-	versionFrom: 7.3.4
+    versionFrom: 7.3.4
     ---
 
 Currently there are 3 different properties of meta data supported.  
@@ -17,4 +17,5 @@ Currently there are 3 different properties of meta data supported.
 3. **versionTo**: an optional property with semver notation to indicate till which version this page page valid
 
 Related information:
+
 * [Adding multi version files](file-naming-conventions.md)

--- a/Contribute/file-naming-conventions.md
+++ b/Contribute/file-naming-conventions.md
@@ -8,7 +8,7 @@ Naming conventions for documentation files:
 
 The current version of a documentation page will be the normal existing filename format eg `flexible.md` or `index.md`
 
-When creating alternate versions of the documentation page that apply in different Umbraco versions, we will append to the filename portion a -v followed by information which explains roughly to which version the documentation applies.
+When creating alternate versions of the documentation page that apply in different Umbraco versions, we will append to the filename portion a `-v` followed by information which explains roughly to which version the documentation applies.
 
 ### Indicating ranges on file naming
 
@@ -25,12 +25,13 @@ For SEO reasons it is not necessary to change a file name when a feature becomes
 
 ## Adding meta data
 
-It is the YAML meta data in the document itself, that will be used as the point of truth for when a (semver) version applies from and to.
+It is the [YAML meta data](adding-metadata.md) in the document itself, that will be used as the point of truth for when a (semver) version applies from and to.
 The YAML will be added to an examine index, along with the filename and is used later on for searching on (major) version.  Or to show the information to the user.
 
-For versioning we use 2 YAML attributes: 
-1) optional `versionFrom` to indicate a start version
-2) optional `versionTo` to indicate which version the support ended.
+For versioning we use 2 YAML attributes:
+
+1. optional `versionFrom` to indicate a start version
+2. optional `versionTo` to indicate which version the support ended.
 
 Only the current version of the document can have both `versionFrom` and `versionTo` missing.  Otherwise at least one of the should be filled in.
 

--- a/Contribute/github-issues.md
+++ b/Contribute/github-issues.md
@@ -1,0 +1,22 @@
+# Labels
+
+On GitHub our issues and pull requests are marked with labels.  The most common ones are explained below.
+
+## Labels for PRs
+
+- `Dependant On Release` - this label is for documentation pull requests that are made in advance of a new Umbraco release, will be merged in once the changes have been released
+- `need-OUR-update` - this label is used for PR's awaiting some new functionality being added to the Our Umbraco website
+- `D-Team` - this label is usually used when the PR is about something with Umbraco Core that the documentation team is not familiar with, meaning it requires a review from the Umbraco development team
+- `Umbraco Cloud`, `Umbraco Forms`, etc - if the issue is specific to something other than Umbraco CMS it will get the relevant Umbraco product label
+
+## Issue labels
+
+The issue repository has several labels, these are not something you can add yourself but they may be added to your issue and other issues. Here is a quick overview of the commonly used labels and what they mean:
+
+- `discuss` - this label is added to issues that are not a tangible problem or very large, an issue with the discuss label is something everyone is encouraged to give their opinion on!
+- `missing documentation` - for issues about missing information, if you see this and wish to make a pull request on it please write that in a comment
+- `incorrect documentation` - for documentation that is wrong, this can be due to many things, often it is outdated
+- `up-for-grabs` - any issue with an up-for-grabs label is something no-one is actively working on and is open for anyone wishing to contribute
+- `Dependant On Release` - this label is for documentation pull requests that are made in advance of a new Umbraco release, will be merged in once the changes have been released
+- `need-OUR-update` - this label is used for PR's awaiting some new functionality being added to the Our Umbraco website
+- `Umbraco Cloud`, `Umbraco Forms`, etc - if the issue is specific to something other than Umbraco CMS it will get the relevant Umbraco product label

--- a/Contribute/index.md
+++ b/Contribute/index.md
@@ -1,88 +1,69 @@
 # Contribute to Umbraco Documentation
 
-## What is a pull request?
-A pull request (PR) is a way of submitting changes to a project that can then be reviewed by the Documentation Curators. 
+## What is a pull request
+
+A pull request (PR) is a way of submitting changes to a project that can then be reviewed by the Documentation Curators.
 
 Let’s say you’ve found a typing or syntax error in one of the articles on the documentation, and you want to correct it. You can do that with a pull request.
 
 There are two ways to create a pull request.
 
-1. You can either edit a file directly on Github or 
+1. You can either edit a file directly on Github or
 2. You can create a fork of the Github repository
 
-**Note:** It may be helpful for you to read our [Markdown guidelines](Markdown-Conventions) on how to set up Documentation articles before you start writing!
+:::note
+It may be helpful for you to read our [Markdown guidelines](Markdown-Conventions) on how to set up Documentation articles before you start writing!
+:::
 
 ### Option 1. Creating a PR directly in Github
+
 Github has some great functionality that allows you to submit a PR directly from our [repository](https://github.com/umbraco/UmbracoDocs/), and there is also a button on every single documentation article at the top that links you directly to Github in order to edit that specific file:
 ![Our edit button](images/edit-this-page.png)
 
 This is very helpful to fix typing errors or adding small things, but if you are working on a larger update that includes pictures and editing several files in one pull request then it is not the best way to work. You'd be better creating a fork.
 
 ### Options 2. Creating a PR through a fork
-There are a lot of great tutorials available online on how to set up a fork and work with one but we have also created a a quick guide on how to do it. If you want some more information, Github has a [guide here](https://help.github.com/articles/fork-a-repo/).
 
-You should also follow the instructions on how to [setup Git](https://help.github.com/articles/set-up-git/) before you go any futher.
+There are a lot of great tutorials available online on [how to fork a repository (Github)](https://help.github.com/articles/fork-a-repo/) and work with one. But we have also created a quick guide on how to do it.
 
-**Step 1: Creating a fork** 
-Once you have setup Git you can create a fork of the [Umbraco Documentation repository](https://github.com/umbraco/UmbracoDocs/).
+If you do not have installed Git on your computer, you should also follow the [instructions on how to setup Git](https://help.github.com/articles/set-up-git/) before you go any further.
 
-When you make a fork, you get a copy of the whole repository on your own Github profile. You can create a fork by clicking the fork button at the top of the screen:
-![Creating a fork](images/fork-repository.png)
-
-Once the fork has been created you will have your own copy of the documentation. If you clone your fork, you will have all the files on your computer which means you can make changes to a lot of files and then push all the changes back up to your fork in one go.
-
-When you are done and happy with the changes you've made, you can submit a pull request to sync your copy with the "real" repository:
-![Fork of documentation](images/example-of-fork.png)
-
-**Step 2: Syncing your fork**
-
-Sometimes - like in the example above - you may end up forking and then not working on the documentation for a while. Once you do start, you may find that you no longer have the most recent version. If this happens, before making changes and making a pull request, you should do a rebase. For this you set the main repository as an upstream to sync from, fetch the updates and update your own fork to ensure you are in sync:
-
-```cmd
-git remote add upstream https://github.com/umbraco/UmbracoDocs/
-git fetch upstream
-git rebase upstream/master
-```
-
-**Step 3: Creating a PR**
-
-If you do this locally and then push it to your fork you will have a synced up fork to start working with! Once you have made some changes and you are happy with the result, you can create a pull request (you may have to rebase again and resolve merged conflicts if a lot of things has been merged in since your last sync).
-![Creating a PR](images/pull-request.png)
-
-And that is all you need to do to create a fork, sync it and make a pull request to the main repository! 
-
-
-### Labels for PRs
-- `Dependant On Release` - this label is for documentation pull requests that are made in advance of a new Umbraco release, will be merged in once the changes have been released
-- `need-OUR-update` - this label is used for PR's awaiting some new functionality being added to the Our Umbraco website
-- `D-Team` - this label is usually used when the PR is about something with Umbraco Core that the documentation team is not familiar with, meaning it requires a review from the Umbraco development team
-- `Umbraco Cloud`, `Umbraco Forms`, etc - if the issue is specific to something other than Umbraco CMS it will get the relevant Umbraco product label
+If git is installed on your computer, follow the [Create a Pull Request using a fork](Pull-Requests/pr-through-a-fork) guide.
 
 ## Creating an issue
+
 The Umbraco Documentation uses [Github issues](https://github.com/umbraco/UmbracoDocs/issues) to manage issues with the documentation.
 You can make an issue for any of the following:
-* If the issue will need more than one PR.
-* If you feel some documentation is wrong or missing and you do not have time or knowledge to do a PR
-* Open a discussion about possible improvements or ways to deal with something in the documentation
+
+- If the issue will need more than one PR.
+- If you feel some documentation is wrong or missing and you do not have time or knowledge to do a PR
+- Open a discussion about possible improvements or ways to deal with something in the documentation
 
 You can also find a button in the top right corner of every page in the documentation itself that looks like this:
 ![Our issue button](images/report-issue.png)
 
-### Issue labels 
-The issue repository has several labels, these are not something you can add yourself but they may be added to your issue and other issues. Here is a quick overview of the commonly used labels and what they mean:
+## Annotating a document
 
-- `discuss` - this label is added to issues that are not a tangible problem or very large, an issue with the discuss label is something everyone is encouraged to give their opinion on!
-- `missing documentation` - for issues about missing information, if you see this and wish to make a pull request on it please write that in a comment
-- `incorrect documentation` - for documentation that is wrong, this can be due to many things, often it is outdated
-- `up-for-grabs` - any issue with an up-for-grabs label is something noone is actively working on and is open for anyone wishing to contribute
-- `Dependant On Release` - this label is for documentation pull requests that are made in advance of a new Umbraco release, will be merged in once the changes have been released
-- `need-OUR-update` - this label is used for PR's awaiting some new functionality being added to the Our Umbraco website
-- `Umbraco Cloud`, `Umbraco Forms`, etc - if the issue is specific to something other than Umbraco CMS it will get the relevant Umbraco product label
+To add version information and extra keywords, [every document can be annotated using YAML](adding-metadata.md).
+
+## Multi version documentation
+
+With the introduction every new version of Umbraco new features are introduced.  This means that not every document will work for your possibly older version.
+
+Therefor we introduced 2 different mechanisms.
+
+1. the [YAML meta data describing](adding-metadata.md) `versionFrom` and `versionTo`.
+2. the possibility [to add multiple files about the same topic](file-naming-conventions.md)
+
+- [Adding meta data](adding-metadata.md) using YAML
+- [File naming conventions](file-naming-conventions.md)
 
 ## Documentation Curators
+
 All the work of adding labels, going through issues and PR's and managing the Documentation repository is done by the Umbraco Documentation Curators team. If you wish to know more about who they are and how they work there is some information about them here: https://our.umbraco.com/community/the-documentation-curators/
 
 ## Contribution badge
+
 If you make a pull request to any Umbraco repository that gets merged in you will get a Contributor badge on your member profile on [Our](https://our.umbraco.com):
 
 ![Contributor badge on our](images/c-trib-badge.png)

--- a/Contribute/index.md
+++ b/Contribute/index.md
@@ -35,12 +35,14 @@ If git is installed on your computer, follow the [Create a Pull Request using a 
 The Umbraco Documentation uses [Github issues](https://github.com/umbraco/UmbracoDocs/issues) to manage issues with the documentation.
 You can make an issue for any of the following:
 
-- If the issue will need more than one PR.
 - If you feel some documentation is wrong or missing and you do not have time or knowledge to do a PR
+- If the issue will need more than one PR.
 - Open a discussion about possible improvements or ways to deal with something in the documentation
 
 You can also find a button in the top right corner of every page in the documentation itself that looks like this:
-![Our issue button](images/report-issue.png)
+![Our issue button](images/report-issue.png).  
+
+We compiled a [list of labels](github-issues.md) which we use regulary to tag issues.
 
 ## Annotating a document
 


### PR DESCRIPTION
* Move content to different files (PR-through-fork & labels)
* markdown-lint all the things
* move files about YAML & multiverion docs from root to the `Contribute` folder