### PR TITLE
Fix link to NodeJS

### DIFF
--- a/Development-Guidelines/building-angular-project.md
+++ b/Development-Guidelines/building-angular-project.md
@@ -14,7 +14,7 @@ The bottom line is the UI project has zero dependencies on asp.net or Windows. H
 Umbraco 7 needs a couple of things to run:
 
 ### Node.js 
-To compile and run the UI project you need Node.js installed, you can get that at [https://nodejs.org](nodejs.org) for both Windows and OSX.
+To compile and run the UI project you need Node.js installed, you can get that at [https://nodejs.org](https://nodejs.org) for both Windows and OSX.
 
 ### gulp
 When you have Node.js installed, you need to install gulp. gulp is a simple JavaScript task runner, basically like NAnt, MSBuild or any traditional build system [more about gulp here](https://gulpjs.com).

--- a/Development-Guidelines/building-angular-project.md
+++ b/Development-Guidelines/building-angular-project.md
@@ -14,7 +14,7 @@ The bottom line is the UI project has zero dependencies on asp.net or Windows. H
 Umbraco 7 needs a couple of things to run:
 
 ### Node.js 
-To compile and run the UI project you need Node.js installed, you can get that at [https://nodejs.org](https://nodejs.org) for both Windows and OSX.
+To compile and run the UI project you need [Node.js](https://nodejs.org) installed, it is needed for both Windows and OSX.
 
 ### gulp
 When you have Node.js installed, you need to install gulp. gulp is a simple JavaScript task runner, basically like NAnt, MSBuild or any traditional build system [more about gulp here](https://gulpjs.com).


### PR DESCRIPTION
See the [Documentation page][docs] for where the link is failing.

-----

Thinking about this, would it be better to use one of the following instead (as per [guidelines])?
- `[nodejs.org](https://nodejs.org)`
- `https://nodejs.org`

[docs]: https://our.umbraco.com/documentation/Development-Guidelines/building-angular-project#nodejs
[guidelines]: https://github.com/umbraco/UmbracoDocs#external-links