### PR TITLE
Spelling and Grammatical Changes To the Documentation

### DIFF
--- a/Add-ons/UmbracoCourier/Architecture/Configuration.md
+++ b/Add-ons/UmbracoCourier/Architecture/Configuration.md
@@ -22,7 +22,7 @@ Milliseconds before a webclient connection times out.
 	<timeout>30000</timeout>
 
 ### Base64 encoding
-Encode all resources and items as bas64 to avoid illegal characters
+Encode all resources and items as base64 to avoid illegal characters
 
 	<disableBase64Encoding>false</disableBase64Encoding >
 
@@ -33,7 +33,7 @@ Strip the raw byte data from .courier files before transferring
 
 ## Path settings
 ### Root folder
-The root folder containing all Couriers data. This folder needs changed, if Courier runs outside of the standard Umbraco webcontext. 
+The root folder containing all Courier's data. This folder needs changed, if Courier runs outside of the standard Umbraco webcontext. 
 	
 	<paths>  
 	    <root>~/path/to/courier</root>
@@ -47,7 +47,7 @@ Specifies the folder within the root folder, which holds each individual revisio
 	</paths>
 
 ### Masterpages folder
-The Sql connection to the SQL database Courier should use. Notice this is not nessary as long as the repository pattern is used, as that will then be handled by the Umbraco website data is pulled/pushed from.
+The Sql connection to the SQL database Courier should use. Notice this is not necessary as long as the repository pattern is used, as that will then be handled by the Umbraco website data is pulled/pushed from.
 
 	<paths>  
 	    <masterPages>/folder</masterPages>
@@ -67,7 +67,7 @@ In case of too long paths, shorten file names
 ## Ignoring providers
 If there is an issue with a specific provider, no matter what type of provider. You can turn it off by ignoring it. 
 
-This is done by adding its full namespace and class to the configuration, you can ignore any item provider, data resolver, repository provider or any other functionality that’s loaded through Couriers provider model.
+This is done by adding its full namespace and class to the configuration, you can ignore any item provider, data resolver, repository provider or any other functionality that’s loaded through Courier's provider model.
 
 	<ignore>
 	    <!-- Ignore the lucene indexer -->

--- a/Add-ons/UmbracoCourier/CommonIssues.md
+++ b/Add-ons/UmbracoCourier/CommonIssues.md
@@ -47,22 +47,22 @@ transfer a broken data type. Make sure to clear courier cache and restart the ap
 
 
 ### Courier cannot package items on V4
-*Caused by:* Missing dlls or dlls from the wrong courier version
+*Caused by:* Missing dlls or dlls from the wrong Courier version
 
 *How to spot:* On v6 sites, it has dlls from V4 distribution, on V4 sites it has V6 dlls, or are missing dlls. To debug,
-put courier in debug mode in /config/courier.config and restart application, it should throw exceptions to 
+put Courier in debug mode in /config/courier.config and restart application, it should throw exceptions to 
 /app_data/courier/logs/log_error.txt about missing dependencies or wrong versions
 
 *Solution:* Uninstall courier, and reinstall 2.7.8.14 from nightly:
 http://nightly.umbraco.org/UmbracoCourier/2.7.8/nightly%20builds/
 
 ### Latest changes aren't deployed / courier can't detect changes
-*Caused by:* When changes are made, courier stores a serialized copy in its cache folder, in some cases, it cannot update
+*Caused by:* When changes are made, Courier stores a serialized copy in its cache folder, in some cases, it cannot update
 the files due to permissions or locks
 
 *How to spot* find the corresponding item in /app_data/courier/cache and see if it changes on save/publish
 
-*Solution:* Clear the /app_data/Courie/cache folder and retry packaging, in some cases caching might need to be turned off
+*Solution:* Clear the /app_data/Courier/cache folder and retry packaging, in some cases caching might need to be turned off
 this will make transfers slower but can be set in /config/courier.config file
 
 
@@ -136,7 +136,7 @@ API
 *How to spot:* Change sorting order on a collection of document, then transfer their parent + children. The sort order will not 
 be correct on the destination site
 
-*Solution:* clear the /app_data/courer/cache folder and re-packge the items
+*Solution:* clear the /app_data/courer/cache folder and re-package the items
 
 
 

--- a/Add-ons/UmbracoCourier/UsingCourier.md
+++ b/Add-ons/UmbracoCourier/UsingCourier.md
@@ -54,34 +54,34 @@ The soft ones are all the items that make the page and editor actually work, so 
 So the short version is, you don't want to miss those dependencies, because your site will not work, and you will have no idea why. 
 
 ## What Courier can and cannot do.
-The whole idea of Courier builds around the idea of dependencies and references, which courier can understand to a certain degree.
-But there are several areas, where Courier has zero chance of understanding what is going an. 
+The whole idea of Courier builds around the idea of dependencies and references, which Courier can understand to a certain degree.
+But there are several areas, where Courier has zero chance of understanding what is going on. 
 
 ### When a data type stores node ids
-Common thing, a data type stores a node ID, but courier doesn't know, so it cannot add the document as a dependency, and it cannot convert it into
-a GUID, so it will be transferable, however, you can add the data type to the courier.config to tell courier to look for ids and convert them
+Common thing, a data type stores a node ID, but Courier doesn't know, so it cannot add the document as a dependency, and it cannot convert it into
+a GUID, so it will be transferable, however, you can add the data type to the courier.config to tell Courier to look for ids and convert them
 
 ### Data in external tables are referenced.
 Courier doesn't know about it, can't deploy it, you can write your own provider for it, but this provides you with overhead, and it would
-be better if you structured your external data so it can be moveable (avoid IDENTITY and so on.)
+be better if you structured your external data so that it can be movable (avoid IDENTITY and so on.)
 
 ### You try to transfer really large files
-Hard to spot, but if a changeset contains large files, and you try to transfer these over a webservice connection
-it will die, you can increase the request limit and so, but it will not ever be 100% solid to do, so better to zip your
-revision files and xcopy them over, when you need to deploy really large things
+It can be hard to spot, but if a changeset contains large files, and you try to transfer these over a webservice connection
+it will die. You can increase the request limit and so, but it will not ever be 100% solid to do, so it's better to zip your
+revision files and xcopy them over, when you need to deploy really large things.
 
 
 ## How to handle the initial deployment
 A common scenario seen, is that people try to transfer their entire site in one go, to do the initial deploy. This is not recommended, and really just adds
 unneeded overhead to your deployment. Courier adds a lot of extra data and overhead, because it needs to convert to a format that be transferred and
 referenced between the 2 sites, it also needs to compare data with this other site and determine which items should transfer, and which should not, finally it
-all happens over http, which is another bottleneck
+all happens over http, which is another bottleneck.
 
-So In short, when you initially want to deploy your site and don't have 2 environments to sync, just deploy your files and database as normal, and let courier handle the ongoing day-to-day changes which you subsequently will have to deploy. 
+So in short, when you initially want to deploy your site and don't have 2 environments to sync, just deploy your files and database as normal, and let Courier handle the ongoing day-to-day changes which you subsequently will have to deploy. 
 
 
 ## Day to day work with Courier
-Due to courier handling pretty much every object of your site, it can quickly create some rather large deployments. Even though your editors just want to deploy a single document, they can all of sudden have a deployment with a lot of documents and files in them, due to the whole dependency setup. There is not many ways around this currently. Courier will check for dependencies, and it will include those that have changed, as it is right now. 
+Due to Courier handling pretty much every object of your site, it can quickly create some rather large deployments. Even though your editors just want to deploy a single document, they can all of sudden have a deployment with a lot of documents and files in them, due to the whole dependency setup. There is not many ways around this currently. Courier will check for dependencies, and it will include those that have changed, as it is right now. 
 
 But for day to day work, let your developers handle deployments of document types, templates and so on, and do these in small batches, as even minor changes do have a great effect on your Umbraco database. F.ex. if you add a property type to a document type, that will add an additional row for each document version on your site to the property data table, so even small things can mean big changes.
 

--- a/Contribute/index.md
+++ b/Contribute/index.md
@@ -42,7 +42,7 @@ You can make an issue for any of the following:
 You can also find a button in the top right corner of every page in the documentation itself that looks like this:
 ![Our issue button](images/report-issue.png)  
 
-We compiled a [list of labels](github-issues.md) which we use regulary to tag issues.
+We compiled a [list of labels](github-issues.md) which we use regularly to tag issues.
 
 ## Annotating a document
 


### PR DESCRIPTION
I have updated pages of the documentation to improve grammatical issues, and also to fix any spelling errors and/or typos. 👍 I have also capitalized instance of Courier throughout the docs, where it was in lowercase initially. 