### PR TITLE
Issue around the link to "Configuring grid layout" fixed

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout.md
@@ -9,7 +9,7 @@ Gives editors a grid layout editor which allows them to insert different types o
 ## [What are Grid Layouts](Grid-Layout/What-Are-Grid-Layouts.md)
 The basic concept of Grid Layouts
 
-## [Configuring the Grid Layout data type](Grid-Layout/configuring-the-grid-layout-data type.md)
+## [Configuring the Grid Layout data type](Grid-Layout/Configuring-The-Grid-Layout-Datatype.md)
 How to setup your Grid Layout data type
 
 ## [Settings and styling](Grid-Layout/Settings-and-styles.md)


### PR DESCRIPTION
Fixed issue around Configuring Grid layout  link on the page
https://our.umbraco.com/documentation/getting-started/backoffice/property-editors/built-in-property-editors/grid-layout

![image](https://user-images.githubusercontent.com/3941753/47338620-8cc2a000-d690-11e8-8c38-ed3130d8b264.png)
