### PR TITLE
Start docs for using Modelsbuilder Interfaces

### DIFF
--- a/Reference/Templating/Modelsbuilder/Using-Interfaces.md
+++ b/Reference/Templating/Modelsbuilder/Using-Interfaces.md
@@ -15,17 +15,16 @@ the *ever-so-slightly* clumsier `Model.GetPropertyValue("pageTitle")` syntax to 
 
 If you create a partial and change the first line to use the *interface name* for the model binding, you can call this partial in the Master (or any of the other templates) and rely on Models Builder to handle everything for you, like this:
 
-```csharp
-@inherits Umbraco.Web.Mvc.UmbracoViewPage<ISeocomposition>
-<title>@Model.PageTitle</title>
-<meta name="description" content="@Model.PageDescription">
-```
 
-Called using this in the Master:
+	@inherits Umbraco.Web.Mvc.UmbracoViewPage<ISeocomposition>
+	<title>@Model.PageTitle</title>
+	<meta name="description" content="@Model.PageDescription">
 
-```csharp
-<head>
-	@Html.Partial("Metatags")
-</head>
-```
+
+Called using this in the Master (assuming the partial is named "Metatags.cshtml"):
+
+
+	<head>
+		@Html.Partial("Metatags")
+	</head>
 

--- a/Reference/Templating/Modelsbuilder/Using-Interfaces.md
+++ b/Reference/Templating/Modelsbuilder/Using-Interfaces.md
@@ -1,7 +1,7 @@
 # Using Interfaces
 
 When using compositions, Models Builder generates an interface for the composed model, which enables
-us to not have to switch back to using `GetPropertyValue()` for the composited properties.
+us to not have to switch back to using `GetPropertyValue()` for the composed properties.
 
 A common use-case for this is if you have a separate composition for the "SEO properties" `Page Title` and `Page Description`.
 
@@ -13,7 +13,7 @@ the *ever-so-slightly* clumsier `Model.GetPropertyValue("pageTitle")` syntax to 
 
 ## Render with a partial
 
-If you create a partial and change the first line to use the *interface name* for the model binding, you can call this partial in the Master (or any of the other templates) and rely on Models Builder to handle everything for you, like this:
+If you create a partial and change the first line to use the *interface name* for the model binding, you can use the nice Models Builder syntax when rendering the properties, like this:
 
 
 	@inherits Umbraco.Web.Mvc.UmbracoViewPage<ISeocomposition>
@@ -21,7 +21,7 @@ If you create a partial and change the first line to use the *interface name* fo
 	<meta name="description" content="@Model.PageDescription">
 
 
-Called using this in the Master (assuming the partial is named "Metatags.cshtml"):
+You can then render the partial from your Master Template with something like this (assuming the partial is named "Metatags.cshtml"):
 
 
 	<head>

--- a/Reference/Templating/Modelsbuilder/Using-Interfaces.md
+++ b/Reference/Templating/Modelsbuilder/Using-Interfaces.md
@@ -1,0 +1,31 @@
+# Using Interfaces
+
+When using compositions, Models Builder generates an interface for the composed model, which enables
+us to not have to switch back to using `GetPropertyValue()` for the composited properties.
+
+A common use-case for this is if you have a separate composition for the "SEO properties" `Page Title` and `Page Description`.
+
+You would usually use this composition on both your `Home` and `Textpage` document types, but you won't
+be able to use the simpler Models Builder syntax (e.g. `Model.PageTitle`) to render them on neither the **Home** template nor
+the **Textpage** template, because they would be bound to their respective models. And you won't be able to use it on any Master Template they'd be children of, because that would need to be bound to the generic `IPublishedContent`.
+So you'd have to resort to
+the *ever-so-slightly* clumsier `Model.GetPropertyValue("pageTitle")` syntax to render these properties.
+
+## Render with a partial
+
+If you create a partial and change the first line to use the *interface name* for the model binding, you can call this partial in the Master (or any of the other templates) and rely on Models Builder to handle everything for you, like this:
+
+```csharp
+@inherits Umbraco.Web.Mvc.UmbracoViewPage<ISeocomposition>
+<title>@Model.PageTitle</title>
+<meta name="description" content="@Model.PageDescription">
+```
+
+Called using this in the Master:
+
+```csharp
+<head>
+	@Html.Partial("Metatags")
+</head>
+```
+

--- a/Reference/Templating/Modelsbuilder/index.md
+++ b/Reference/Templating/Modelsbuilder/index.md
@@ -8,7 +8,7 @@ A tool that can generate a complete set of strongly-typed published content mode
 * [Understand And Extend Models](Understand-And-Extend.md)
 * [Control Models Generation](Control-Generation.md)
 * [IPublishedContentModelFactory](IPublishedContentModelFactory.md)
-* [Cool things to do with models](CoolThingsWithModels.md)
 * [Using Interfaces](Using-Interfaces.md)
+* [Cool things to do with models](CoolThingsWithModels.md)
 
 > **Umbraco Models Builder is an open-source project that can be forked on GitHub and gladly accepts pull requests. Don't hesitate to contribute [here](https://github.com/zpqrtbnk/Zbu.ModelsBuilder)!**

--- a/Reference/Templating/Modelsbuilder/index.md
+++ b/Reference/Templating/Modelsbuilder/index.md
@@ -7,7 +7,8 @@ A tool that can generate a complete set of strongly-typed published content mode
 * [Builder Modes](Builder-Modes.md)
 * [Understand And Extend Models](Understand-And-Extend.md)
 * [Control Models Generation](Control-Generation.md)
-* [IPublishedContentModelFactory](IPublishedContentModelFactory.md)  
-* [Cool things to do with models](CoolThingsWithModels.md)  
+* [IPublishedContentModelFactory](IPublishedContentModelFactory.md)
+* [Cool things to do with models](CoolThingsWithModels.md)
+* [Using Interfaces](Using-Interfaces.md)
 
 > **Umbraco Models Builder is an open-source project that can be forked on GitHub and gladly accepts pull requests. Don't hesitate to contribute [here](https://github.com/zpqrtbnk/Zbu.ModelsBuilder)!**


### PR DESCRIPTION
This adds a page to the ModelsBuilder section (in Reference/Templating) about using the interfaces ModelsBuilder creates when rendering content.

Work in progress, but adding the page makes it easy to add even more use-cases and examples :)

Closes #1151 