### PR TITLE
Title should reflect the file name

### DIFF
--- a/Reference/Management/Services/LocalizationService/Retrieving-languages.md
+++ b/Reference/Management/Services/LocalizationService/Retrieving-languages.md
@@ -1,4 +1,4 @@
-# Referencing languages
+# Retrieving languages
 
 ### Getting a single language
 


### PR DESCRIPTION
Per a discussion I had with @marcemarc a few months back, we decided that we should be using *retrieving* rather than *referencing*. It seems that I back then only renamed the file, but didn't update the title of page **#H5IS**