### PR TITLE
 Updated the documentation for the content type service

### DIFF
--- a/Reference/Management/Services/ContentTypeService/Index.md
+++ b/Reference/Management/Services/ContentTypeService/Index.md
@@ -1,6 +1,8 @@
-# ContentTypeService
+---
+versionFrom: 6.0.0
+---
 
-**Applies to Umbraco 6.x and newer**
+# ContentTypeService
 
 The content type service acts as a "gateway" to Umbraco data for operations which are related to both content types and media types.
 

--- a/Reference/Management/Services/ContentTypeService/Index.md
+++ b/Reference/Management/Services/ContentTypeService/Index.md
@@ -15,23 +15,31 @@ All samples in this document will require references to the following dll:
 
 All samples in this document will require the following using statements:
 	
-	using Umbraco.Core;
-	using Umbraco.Core.Models;
-	using Umbraco.Core.Services;
+```C#
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+```
 
 ## Getting the service
 
 If you wish to use use the content type service in a class that inherits from one of the Umbraco base classes (eg. `SurfaceController`, `UmbracoApiController` or `UmbracoAuthorizedApiController`), you can access the content type service through a local `Services` property:
 
-	IContentTypeService contentTypeService = Services.ContentTypeService;
+```C#
+IContentTypeService contentTypeService = Services.ContentTypeService;
+```
 
 In Razor views, you can access the content type service through the `ApplicationContext` property:
 
-    IContentTypeService contentTypeService = ApplicationContext.Services.ContentTypeService;
+```C#
+IContentTypeService contentTypeService = ApplicationContext.Services.ContentTypeService;
+```
 
 If neither a `Services` property or a `ApplicationContext` property is available, you can also reference the `ApplicationContext` class directly and using the static `Current` property:
 
-	IContentTypeService contentTypeService = ApplicationContext.Current.Services.ContentTypeService;
+```C#
+IContentTypeService contentTypeService = ApplicationContext.Current.Services.ContentTypeService;
+```
 
 ## Samples
 

--- a/Reference/Management/Services/ContentTypeService/Index.md
+++ b/Reference/Management/Services/ContentTypeService/Index.md
@@ -2,7 +2,7 @@
 
 **Applies to Umbraco 6.x and newer**
 
-The ContentTypeService acts as a "gateway" to Umbraco data for operations which are related to ContentTypes and MediaTypes.
+The content type service acts as a "gateway" to Umbraco data for operations which are related to both content types and media types.
 
 [Browse the API documentation for ContentTypeService](https://our.umbraco.com/apidocs/csharp/api/Umbraco.Core.Services.ContentTypeService.html).
 
@@ -32,3 +32,9 @@ In Razor views, you can access the content type service through the `Application
 If neither a `Services` property or a `ApplicationContext` property is available, you can also reference the `ApplicationContext` class directly and using the static `Current` property:
 
 	IContentTypeService contentTypeService = ApplicationContext.Current.Services.ContentTypeService;
+
+## Samples
+
+* [**Retrieving content types**](Retrieving-content-types.md)<br />See examples on how to retrieve content types via the service - either individually or as a collection.
+
+* [**Retrieving content type containers**](Retrieving-content-type-containers.md)<br />See examples on how to retrieve content type containers (folders) via the service - either individually or as a collection.

--- a/Reference/Management/Services/ContentTypeService/Retrieving-content-type-containers.md
+++ b/Reference/Management/Services/ContentTypeService/Retrieving-content-type-containers.md
@@ -1,0 +1,42 @@
+# Retrieving content types
+
+## Getting a single content type container
+
+Content types can be added either at the root level, under another content type or under a content type container (or folders as they're called in the Umbraco backoffice). The approach for getting a single container is similar to getting a single content type, meaning that you can look up a container - either by it's numeric ID:
+
+```C#
+// Get a container by its numeric ID
+EntityContainer container = contentTypeService.GetContentTypeContainer(1090);
+```
+
+or it's GUID conterpart:
+
+```C#
+// Declare the GUID ID
+Guid guid = new Guid("d3b9cc9a-d471-4465-a89a-112c6bc1e5b4");
+
+// Get a container by its GUID ID
+EntityContainer container = contentTypeService.GetContentTypeContainer(guid);
+```
+
+## Getting a list of content type containers
+
+In the same way as you can get the content types of a container, you can get the child containers of another container. This is done by calling the `GetContentTypeContainers` method with an array of numeric IDs:
+
+```C#
+// Declare the array of IDs to lookup
+int[] ids = new[] {1090};
+
+// Get the child containers via the content type service
+IEnumerable<EntityContainer> containers = contentTypeService.GetContentTypeContainers(ids);
+```
+
+Also, if the array is empty, all containers will be returned:
+
+```C#
+// Declare the array of IDs to lookup
+int[] ids = new int[0];
+
+// Get all content type containers
+IEnumerable<EntityContainer> containers = contentTypeService.GetContentTypeContainers(ids);
+```

--- a/Reference/Management/Services/ContentTypeService/Retrieving-content-types.md
+++ b/Reference/Management/Services/ContentTypeService/Retrieving-content-types.md
@@ -1,0 +1,65 @@
+# Retrieving content types
+
+## Getting a single content type
+
+A given content type has a few different unique identifier that we can use to look it up via the content type service. For instance, if we know the numeric ID of the content type, we can look it up like this:
+
+```C#
+// Get a reference to the content type by its numeric ID
+IContentType contentType = contentTypeService.GetContentType(1234);
+```
+
+As Umbraco is shifting to use GUIDs instead of numeric IDs, you can also lookup a content type if you already know its GUID ID:
+
+```C#
+// Declare the GUID ID
+Guid guid = new Guid("796a8d5c-b7bb-46d9-bc57-ab834d0d1248");
+
+// Get a reference to the content type by its GUID ID
+IContentType contentType = contentTypeService.GetContentType(guid);
+```
+
+Finally, you can also look up a content type by its alias:
+
+```C#
+// Get a reference to the content type by its alias
+IContentType contentType = contentTypeService.GetContentType("home");
+```
+
+## Getting a list of content types
+
+As content types are stored in a hierarchical list with folders (containers), there is also multiple ways to can get content types. If you are looking for a flat list of all content types, you can use the `GetAllContentTypes` method:
+
+```C#
+// Get a collection of all content types
+IEnumerable<IContentType> contentTypes = contentTypeService.GetAllContentTypes();
+```
+
+In the example above, the method was called without any parameters. The method also has two overloads, which lets you look up a collection fo content types by either specifying their numeric or GUID IDs:
+
+```C#
+// Get a collection of two specific content types by their numeric IDs
+IEnumerable<IContentType> contentTypes = contentTypeService.GetAllContentTypes(1234, 1235);
+```
+
+```C#
+// Get a collection of two specific content types by their GUIDs IDs
+IEnumerable<IContentType> contentTypes = contentTypeService.GetAllContentTypes(new[] {
+    new Guid("2b54088e-d355-4b9e-aa4b-5aec4b3f87eb"),
+    new Guid("859c5916-19d8-4a72-9bd0-5641ad503aa9")
+});
+```
+
+To get a list of all content types of a another content type (or container), you can instead use the `GetContentTypeChildren` method - either by specyfing the numeric ID of the folder:
+
+```C#
+// Get a collection of content types of a specific content type
+IEnumerable<IContentType> contentTypes = contentTypeService.GetContentTypeChildren(1232);
+```
+
+or by the GUID ID of the folder:
+
+```C#
+// Get a collection of content types of a specific content type
+IEnumerable<IContentType> contentTypes = contentTypeService.GetContentTypeChildren(new Guid("d3b9cc9a-d471-4465-a89a-112c6bc1e5b4"));
+```


### PR DESCRIPTION
Added some information about retrieving content types and content type containers.

I have a general question about headlines. Should it be something like **Getting a single content type** or **Getting a Single Content Type**? Or something else?

Anyways - I've used fenced code blocks as these is now supported by Our (YAY :tada:). Also, with https://github.com/umbraco/OurUmbraco/pull/332 the documentation should look something like below:

![image](https://user-images.githubusercontent.com/3634580/47609542-0e278300-da41-11e8-8dc8-0a3c234dc2cc.png)