### PR TITLE
Should be ".NET" and "C#" (AKA upper case)

### DIFF
--- a/Reference/Management/index.md
+++ b/Reference/Management/index.md
@@ -2,7 +2,7 @@
 
 _Details of CRUD operations within Umbraco and how to interact with the data persisted in the database_
 
-The intended audience for these reference pages are .net developers, it is assumed the reader already has a knowledge of the basics of Umbraco and knows .net & c#.
+The intended audience for these reference pages are .net developers, it is assumed the reader already has a knowledge of the basics of Umbraco and knows .NET & C#.
 
 ## [Models](Models/index.md)
 Here you will find references for the models in the public api including the Content, ContentType, DataTypeDefinition, DictionaryItem, Language, Media, MediaType, Relation, RelationType, Task, TaskType and Template classes. 


### PR DESCRIPTION
They should both use capital letters to match the official spelling.