### PR TITLE
Updated code examples

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Nested-Content.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Nested-Content.md
@@ -79,7 +79,7 @@ Example:
 
     @inherits Umbraco.Web.Mvc.UmbracoViewPage
     @{
-        var items = Model.GetPropertyValue<IEnumerable<IPublishedContent>>("myPropertyAlias");
+        var items = Model.Content.GetPropertyValue<IEnumerable<IPublishedContent>>("myPropertyAlias");
     
         foreach(var item in items)
         {
@@ -93,7 +93,7 @@ Example:
 
     @inherits Umbraco.Web.Mvc.UmbracoViewPage
     @{
-        var items = Model.GetPropertyValue<IEnumerable<IPublishedContent>>("myPropertyAlias");
+        var items = Model.Content.GetPropertyValue<IEnumerable<IPublishedContent>>("myPropertyAlias");
     
         foreach(var item in items)
         {
@@ -110,7 +110,7 @@ Example:
 
     @inherits Umbraco.Web.Mvc.UmbracoViewPage
     @{
-        var item = Model.GetPropertyValue<IPublishedContent>("myPropertyAlias");
+        var item = Model.Content.GetPropertyValue<IPublishedContent>("myPropertyAlias");
     }
         <h3>@item.GetPropertyValue("heading")</h3>
         @Umbraco.Field(item, "bodyText")


### PR DESCRIPTION
I believe the examples are wrong, unless I misunderstand something (which is highly likely):  Whenever I use nested content, I need to use "Model.**Content**.GetPropertyValue".  

Model.GetPropertyValue always raises an error.

So I believe this will fix the examples.  If I am wrong then please discard this.

Thanks, Darren