### PR TITLE
Remove the children part as well here

### DIFF
--- a/Reference/Querying/UmbracoHelper/index.md
+++ b/Reference/Querying/UmbracoHelper/index.md
@@ -145,7 +145,7 @@ Given a node ID, returns a `dynamic` object, representing a single `IPublishedCo
 ### .MediaAtRoot();
 Returns a `dynamic` object, representing the root `IPublishedContent` entity in the Media tree.
 
-    @foreach (var child in Umbraco.MediaAtRoot().Children) {
+    @foreach (var child in Umbraco.MediaAtRoot()) {
         <img src="@child.Url" />
     }
 


### PR DESCRIPTION
I removed the children part for the non-strongly typed version so the example works too