### PR TITLE
Removing the markdown guideslines in readme.md and replacing with a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,62 +27,7 @@ For details on how to contribute, see further down this page.
 Please read our [Contributing Guidelines](CONTRIBUTING.md) to learn how you can get involved and help with the Umbraco Documentation.
 
 # Markdown conventions
-Keep custom HTML to a minimum. All script and style markup are cleaned by default.
-For reference, the [Markdown syntax guide](https://daringfireball.net/projects/markdown/syntax) is available.
-
-## Images
-Images are stored and linked relatively to .md pages, and should by convention always be in an
-`images` folder. So to add an image to `/documentation/reference/partials/renderviewpage.md` you link it like so:
-
-	![My Image Alt Text](images/img.jpg)
-
-And store the image as `/documentation/reference/partials/images/img.jpg`
-
-Images can have a maximum width of **800px**. Please always try to use
-the most efficient compression, `gif`, `png` or `jpg`. No `bmp`, `tiff` or `swf` (Flash), please.
-
-NB: In order to get images to display correctly on GitHub, all image URLs must end with ``.
-
-## External links
-Include either the complete URL, or link using Markdown:
-
-	https://yahoo.com/something
-
-	or
-
-	[yahoo something](https://yahoo.com/something)
-
-
-## Internal links
-If you need to link between pages, always link relatively, and include the .md extension.
-
-	[Umbraco.Helpers](Umbraco.Helpers.md)
-
-	or
-
-	[Umbraco.Helpers](../../Reference/Umbraco.Helpers.md)
-
-## Formatting code
-Indent your sample with a single tab, which will cause it to be rendered as `<pre><code>` tags.
-For inline code, wrap in ` (backtick) chars.
-
-Use # for the headline, ## for sub headers and ### for parameters (on code reference pages).
-
-For optional parameters wrap in _ (underscore) - end result: `###_optionalParameter_`.
-
-## Structure
-For the documentation project, each individual topic is contained in its own folder.
-Each folder must have an `index.md` file which links to the individual sub-pages, if images
-are used, these must be in `images` folders next to the .md file referencing them relatively.
-
-* topic
-	* images
-		* images.jpg
-	* Subtopic
-		* images
-		* index.md
-	* index.md
-	* otherpage.md
+The Umbraco Documentation uses Markdown for all of the documentation, please read about our [Markdown Conventions](Contribute/Markdown-Conventions/).
 
 # Annotating a document
 


### PR DESCRIPTION
to the dedicated page in the 'Contribute' section

As per this issue:
https://github.com/umbraco/UmbracoDocs/issues/1238