### PR TITLE
Content Apps: added fenced code blocks for syntax highlighting

### DIFF
--- a/Extending/Content-Apps/index-v8.md
+++ b/Extending/Content-Apps/index-v8.md
@@ -49,23 +49,25 @@ Next we need to create a manifest file to describe what this content app does. T
 
 Add the file `/App_Plugins/CakeContentApp/package.manifest` and inside add the JSON to describe the content app. Have a look at the inline comments in the JSON below for details on each bit:
 
-    {
-        // define the content apps you want to create
-        contentApps: [
-            {
-                "name": "Cake", // required - the name that appears under the icon, everyone loves cake, right?
-                "alias": "appCake", // required - unique alias for your app
-                "weight": 0, // optional, default is 0, use values between -99 and +99 to appear between the existing Content (-100) and Info (100) apps
-                "icon": "icon-cupcake", // required - the icon to use
-                "view": "~/App_Plugins/CakeContentApp/cakecontentapp.html" // required - the location of the view file
-            }
-        ]
-        ,
-        // array of files we want to inject into the application on app_start
-        javascript: [
-            '~/App_Plugins/CakeContentApp/cakecontentapp.controller.js'
-        ]
-    }
+```json
+{
+    // define the content apps you want to create
+    contentApps: [
+        {
+            "name": "Cake", // required - the name that appears under the icon, everyone loves cake, right?
+            "alias": "appCake", // required - unique alias for your app
+            "weight": 0, // optional, default is 0, use values between -99 and +99 to appear between the existing Content (-100) and Info (100) apps
+            "icon": "icon-cupcake", // required - the icon to use
+            "view": "~/App_Plugins/CakeContentApp/cakecontentapp.html" // required - the location of the view file
+        }
+    ]
+    ,
+    // array of files we want to inject into the application on app_start
+    javascript: [
+        '~/App_Plugins/CakeContentApp/cakecontentapp.controller.js'
+    ]
+}
+```
 
 ### Creating the View and the Controller
 
@@ -77,35 +79,39 @@ These will be our main files for the app, with the .html file handling the view 
 
 In the .js file we declare our AngularJS controller and inject umbraco's editorState and userService:
 
-    angular.module("umbraco")
-        .controller("My.CakeContentApp", function ($scope, editorState, userService) {
+```javascript
+angular.module("umbraco")
+    .controller("My.CakeContentApp", function ($scope, editorState, userService) {
 
-            var vm = this;
-            vm.CurrentNodeId = editorState.current.id;
-            vm.CurrentNodeAlias = editorState.current.contentTypeAlias;
+        var vm = this;
+        vm.CurrentNodeId = editorState.current.id;
+        vm.CurrentNodeAlias = editorState.current.contentTypeAlias;
 
-            var user = userService.getCurrentUser().then(function (user) {
-                console.log(user);
-                vm.UserName = user.name;
-            });
+        var user = userService.getCurrentUser().then(function (user) {
+            console.log(user);
+            vm.UserName = user.name;
         });
+    });
+```
 
 And in the .html file:
 
-    <div class="umb-box" ng-controller="My.CakeContentApp as vm">
-        <div class="umb-box-header">
-            <div class="umb-box-header-title">
-                Hello cakes are awesome
-            </div>
-        </div>
-        <div class="umb-box-content">
-            <ul>
-                <li>Current node id: <b>{{vm.CurrentNodeId}}</b></li>
-                <li>Current node alias: <b>{{vm.CurrentNodeAlias}}</b></li>
-                <li>Current user: <b>{{vm.UserName}}</b></li>
-            </ul>
+```html
+<div class="umb-box" ng-controller="My.CakeContentApp as vm">
+    <div class="umb-box-header">
+        <div class="umb-box-header-title">
+            Hello cakes are awesome
         </div>
     </div>
+    <div class="umb-box-content">
+        <ul>
+            <li>Current node id: <b>{{vm.CurrentNodeId}}</b></li>
+            <li>Current node alias: <b>{{vm.CurrentNodeAlias}}</b></li>
+            <li>Current user: <b>{{vm.UserName}}</b></li>
+        </ul>
+    </div>
+</div>
+```
 
 ### Checking it works
 
@@ -115,15 +121,17 @@ After the above edits are done, restart your application. Go to any content node
 
 You can set your content app to only show for specific content types by updating your `package.manifest` file and adding a 'show' directive to the content app definition. For example:
 
-     contentApps: [
-        {
-            ...,
-            "show": [ 
-                "-content/homePage", // hide for content type 'homePage'
-                "+content/*", // show for all other content types
-                "+media/*" // show for all media types
-            ]
-        }
+```json
+ contentApps: [
+    {
+        ...,
+        "show": [ 
+            "-content/homePage", // hide for content type 'homePage'
+            "+content/*", // show for all other content types
+            "+media/*" // show for all media types
+        ]
+    }
+```
 
 If the 'show' directive is omitted then the app will be shown for all content types.
 
@@ -131,13 +139,15 @@ If the 'show' directive is omitted then the app will be shown for all content ty
 
 In a similar way, you can limit your content app according to user roles (groups).  For example:
 
-    contentApps: [
-        {
-            ...,
-            "show": [
-                "+role/admin"  // show for 'admin' user group
-            ]
-        }
+```json
+contentApps: [
+    {
+        ...,
+        "show": [
+            "+role/admin"  // show for 'admin' user group
+        ]
+    }
+```
 
 If a role restriction is given in the manifest, it overrides any other restrictions based on type.
 
@@ -145,72 +155,74 @@ If a role restriction is given in the manifest, it overrides any other restricti
 
 This is an example of how to register a content app with C# and perform your own custom logic to show a content app.
 
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using Umbraco.Core.Components;
-    using Umbraco.Core.Models;
-    using Umbraco.Core.Models.ContentEditing;
-    using Umbraco.Core.Models.Membership;
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core.Components;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.ContentEditing;
+using Umbraco.Core.Models.Membership;
 
-    namespace Umbraco.Web.UI
+namespace Umbraco.Web.UI
+{
+    public class CakeContentAppComponent : UmbracoComponentBase, IUmbracoUserComponent
     {
-        public class CakeContentAppComponent : UmbracoComponentBase, IUmbracoUserComponent
+        public override void Compose(Composition composition)
         {
-            public override void Compose(Composition composition)
-            {
-                base.Compose(composition);
+            base.Compose(composition);
 
-                // Add our cake content app into the composition aka into the DI
-                composition.ContentApps().Append<CakeContentApp>();
-            }
-        }
-
-        public class CakeContentApp : IContentAppDefinition
-        {
-            public ContentApp GetContentAppFor(object source, IEnumerable<IReadOnlyUserGroup> userGroups)
-            {
-                // Some logic depending on the object type
-                // To show or hide CakeContentApp
-                switch (source)
-                {
-                    // Do not show content app if doctype/content type is a container
-                    case IContent content when content.ContentType.IsContainer:
-                        return null;
-
-                    // Don't show for media items
-                    case IMedia media:
-                        return null;
-
-                    case IContent content:
-                        break;
-
-                    default:
-                        throw new NotSupportedException($"Object type {source.GetType()} is not supported here.");
-                }
-
-                // Can implement some logic with userGroups if needed
-                // Allowing us to display the content app with some restrictions for certain groups
-                if (userGroups.Any(x=> x.Alias.ToLowerInvariant() == "admin") == false)
-                    return null;
-
-                var cakeApp = new ContentApp
-                {
-                    Alias = "appCake",
-                    Name = "Cake",
-                    Icon = "icon-cupcake",
-                    View = "/App_Plugins/CakeContentApp/cakecontentapp.html",
-                    Weight = 0
-                };
-            
-                return cakeApp;
-            }
+            // Add our cake content app into the composition aka into the DI
+            composition.ContentApps().Append<CakeContentApp>();
         }
     }
+
+    public class CakeContentApp : IContentAppDefinition
+    {
+        public ContentApp GetContentAppFor(object source, IEnumerable<IReadOnlyUserGroup> userGroups)
+        {
+            // Some logic depending on the object type
+            // To show or hide CakeContentApp
+            switch (source)
+            {
+                // Do not show content app if doctype/content type is a container
+                case IContent content when content.ContentType.IsContainer:
+                    return null;
+
+                // Don't show for media items
+                case IMedia media:
+                    return null;
+
+                case IContent content:
+                    break;
+
+                default:
+                    throw new NotSupportedException($"Object type {source.GetType()} is not supported here.");
+            }
+
+            // Can implement some logic with userGroups if needed
+            // Allowing us to display the content app with some restrictions for certain groups
+            if (userGroups.Any(x=> x.Alias.ToLowerInvariant() == "admin") == false)
+                return null;
+
+            var cakeApp = new ContentApp
+            {
+                Alias = "appCake",
+                Name = "Cake",
+                Icon = "icon-cupcake",
+                View = "/App_Plugins/CakeContentApp/cakecontentapp.html",
+                Weight = 0
+            };
+
+            return cakeApp;
+        }
+    }
+}
+```
     
 You will still need to add all of the files you added above but, because your C# code is adding the content app, the package.manifest file can be simplified like this:
 
-```
+```json
 {
     // array of files we want to inject into the application on app_start
     javascript: [

--- a/Extending/Content-Apps/index-v8.md
+++ b/Extending/Content-Apps/index-v8.md
@@ -49,10 +49,10 @@ Next we need to create a manifest file to describe what this content app does. T
 
 Add the file `/App_Plugins/CakeContentApp/package.manifest` and inside add the JSON to describe the content app. Have a look at the inline comments in the JSON below for details on each bit:
 
-```json
+```json5
 {
     // define the content apps you want to create
-    contentApps: [
+    "contentApps": [
         {
             "name": "Cake", // required - the name that appears under the icon, everyone loves cake, right?
             "alias": "appCake", // required - unique alias for your app
@@ -60,11 +60,10 @@ Add the file `/App_Plugins/CakeContentApp/package.manifest` and inside add the J
             "icon": "icon-cupcake", // required - the icon to use
             "view": "~/App_Plugins/CakeContentApp/cakecontentapp.html" // required - the location of the view file
         }
-    ]
-    ,
+    ],
     // array of files we want to inject into the application on app_start
-    javascript: [
-        '~/App_Plugins/CakeContentApp/cakecontentapp.controller.js'
+    "javascript": [
+        "~/App_Plugins/CakeContentApp/cakecontentapp.controller.js"
     ]
 }
 ```
@@ -121,16 +120,18 @@ After the above edits are done, restart your application. Go to any content node
 
 You can set your content app to only show for specific content types by updating your `package.manifest` file and adding a 'show' directive to the content app definition. For example:
 
-```json
- contentApps: [
-    {
-        ...,
-        "show": [ 
-            "-content/homePage", // hide for content type 'homePage'
-            "+content/*", // show for all other content types
-            "+media/*" // show for all media types
-        ]
-    }
+```json5
+{
+    "contentApps": [
+        {
+            "show": [ 
+                "-content/homePage", // hide for content type 'homePage'
+                "+content/*", // show for all other content types
+                "+media/*" // show for all media types
+            ]
+        }
+    ]
+}
 ```
 
 If the 'show' directive is omitted then the app will be shown for all content types.
@@ -139,14 +140,16 @@ If the 'show' directive is omitted then the app will be shown for all content ty
 
 In a similar way, you can limit your content app according to user roles (groups).  For example:
 
-```json
-contentApps: [
-    {
-        ...,
-        "show": [
-            "+role/admin"  // show for 'admin' user group
-        ]
-    }
+```json5
+{
+    "contentApps": [
+        {
+            "show": [ 
+                "+role/admin"  // show for 'admin' user group
+            ]
+        }
+    ]
+}
 ```
 
 If a role restriction is given in the manifest, it overrides any other restrictions based on type.
@@ -222,11 +225,11 @@ namespace Umbraco.Web.UI
     
 You will still need to add all of the files you added above but, because your C# code is adding the content app, the package.manifest file can be simplified like this:
 
-```json
+```json5
 {
     // array of files we want to inject into the application on app_start
-    javascript: [
-        '~/App_Plugins/MyContentApp/mycontentapp.controller.js'
+    "javascript": [
+        "~/App_Plugins/MyContentApp/mycontentapp.controller.js"
     ]
 }
 ```


### PR DESCRIPTION
There is probably a lot of work in updating old documentation pages with fenced code blocks, but there aren't really that many v8 pages yet - so I've now fixed the first one.

With fenced code blocks also comes syntax highlighting, which comes with a number of different issues for the JSON examples in this article. Per the JSON specification:

1. property names should be enclosed with double quotes
2. string values shopuld be enclosed with double quotes
3. comments are not part of the JSON specification

for both 1. and 2., no quotes or single quotes make the JSON invalid. As such, GitHub's syntax highlighting looks like as shown here:

![image](https://user-images.githubusercontent.com/3634580/48800888-4f8f1380-ed0b-11e8-8a9d-2eb2258e48b5.png)

So the big question is now: how much should we actually care about this? While some of the examples are invalid according to the JSON specification, JSON.net is more forgiving, so the examples will work in Umbraco. But editors like Visual Studio and VS Code will complain.

Single quoted strings and comments are also currently not supported by my syntax highlighter package, which is now used on Our - but both will be supported in the next release (the code is already on GitHub, I just haven't pushed a new release yet).

My proposal is that property names and string values always should be enclosed in double quote per the JSON specification, but comments will still be allowed, as they may have a great explanatory effect. I'd be happy to help with that for existing and as well as new pages.

Any thoughts?
