### PR TITLE
Updated Debug and CustomErrors section.

### DIFF
--- a/Umbraco-Cloud/Set-Up/Config-Transforms/index.md
+++ b/Umbraco-Cloud/Set-Up/Config-Transforms/index.md
@@ -84,7 +84,7 @@ On live environments only:
 - We set `debug="false"` on the `compilation` node in `system.web` 
 - We set `mode="RemoteOnly"` on the `customErrors` node in `system.web`
 
-On all other environments:
+On all other Cloud environments:
 
 - We set `debug="true"` on the `compilation` node in `system.web` 
 - We set `mode="Off"` on the `customErrors` node in `system.web`


### PR DESCRIPTION
We set `debug` to `true` and `CustomErrors` to `Off` only on Cloud environments. 
If you clone it down locally, you'll have Debug set to RemoteOnly and Compilation to False.