### PR TITLE
Note regarding smtp settings

### DIFF
--- a/Reference/Config/webconfig/index.md
+++ b/Reference/Config/webconfig/index.md
@@ -78,6 +78,7 @@ By adding this settings to the web.config you will be able to send out emails fr
         </mailSettings>
       </system.net>
 
+Note, that since version 7.13, if you keep the `from` attribute set to noreply@example.com, Umbraco won't be able to send user invitations, or password recovery emails.
 
 ## Optional settings
 


### PR DESCRIPTION
Since 7.13, Umbraco won't send mails regarding user invitations or forgotten passwords if the from attribute of the smtp settings is set to noreply@example.com.

https://github.com/umbraco/Umbraco-CMS/pull/3308