### PR TITLE
Update code formatting and add version and a warning

### DIFF
--- a/Reference/Config/BaseRestExtensions/index.md
+++ b/Reference/Config/BaseRestExtensions/index.md
@@ -1,15 +1,24 @@
+---
+keywords: base v6 version6
+versionFrom: 6.0.0
+---
+
+:::warning
+If you're using Umbraco 7 you should consider using Umbraco Web API instead of /Base since it's deprecated and only kept for backwards compatibility. Please see the documentation on Umbraco Web API here: https://our.umbraco.com/documentation/Reference/Routing/WebApi/
+:::
+
 # BaseRestExtension.config
 
 BaseRestExtension.config contains the data necessary for the /Base system when exposing the methods in your class library.
 
-	<?xml version="1.0" encoding="utf-8"?>
-	<BaseRestExtensions>
-	  
-	  <extension alias="aliasName" type="the.fully.qualified.name, assemblyName">
-	    <method name="Hello" returnXml="false" allowAll="true"></method>
-	  </extension>
-	  
-	</BaseRestExtensions>
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<BaseRestExtensions>
+    <extension alias="aliasName" type="the.fully.qualified.name, assemblyName">
+        <method name="Hello" returnXml="false" allowAll="true"></method>
+    </extension>
+</BaseRestExtensions>
+```
 
 It contains one extension tag for each class you want the /Base system to expose, and the method tags for each method you want the /Base system to expose.
 
@@ -33,24 +42,26 @@ The user calling the method, will be allowed if she has access through at least 
 
 _BaseRestExtensions.config_
 
-	<?xml version="1.0" encoding="utf-8"?>
-	<BaseRestExtensions>
-	  
-	  <extension alias="test" type="BaseTest.TestClass,basetest">
-	    <method name="Hello" returnXml="false" allowAll="true"></method>
-	  </extension>
-	  
-	</BaseRestExtensions>
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<BaseRestExtensions>
+  <extension alias="test" type="BaseTest.TestClass,basetest">
+    <method name="Hello" returnXml="false" allowAll="true"></method>
+  </extension>
+</BaseRestExtensions>
+```
 
 _BaseTest.cs_  
 
-	namespace BaseTest {
-	    public class TestClass {
-	        public static string Hello() {
-	            return "Hello World";
-	        }
-	    }
-	} 
+```csharp
+namespace BaseTest {
+    public class TestClass {
+        public static string Hello() {
+            return "Hello World";
+        }
+    }
+} 
+```
 
 Visit the /base url. For example: http://example.com/base/test/Hello/.
 


### PR DESCRIPTION
I have added some nicer code formatting for this piece of documentation and I have also added a warning about this piece of documentation only being relevant for Umbraco 6. And I have also added the YAML meta data about the versions.

Even thought the /Base concept has been around since... v3 I think it seems that the way to use /base changed in v6 where the restExtensions.config was renamed to baseRestExtensions.config also containing another syntax, which is the one referenced in this piece of documentation.