### PR TITLE
Aligning code examples

### DIFF
--- a/Reference/Templating/Mvc/views.md
+++ b/Reference/Templating/Mvc/views.md
@@ -19,12 +19,14 @@ All Umbraco views inherit from `Umbraco.Web.Mvc.UmbracoTemplatePage` which expos
 This is probably the most used method which simply renders the contents of a field for the current content item.
 
 ```csharp
-    @Umbraco.Field("bodyContent")
+@Umbraco.Field("bodyContent")
 ```
 
 If you're using the Field method from within a partial view then be aware that you will need to pass the context so the Field method knows where to get the desired value from. For instance you can pass "CurrentPage" like this:
 
-    @Umbraco.Field(Model.Content, "eventLink")
+```csharp
+@Umbraco.Field(Model.Content, "eventLink")
+```
 
 You will also need to pass the "Context" to the @Umbraco.Field() method if you're looping over a selection like this where we pass the "item" variable.
 
@@ -32,6 +34,7 @@ You will also need to pass the "Context" to the @Umbraco.Field() method if you'r
 @{
     var selection = Model.Content.Site().FirstChild("events").Children("event").Where(x => x.IsVisible());
 }
+
 <ul>
     @foreach(var item in selection){
          @Umbraco.Field(item, "eventLink")


### PR DESCRIPTION
The first code example was indented and some of them were not formatted as c# making it inconsistent to look at.