### PR TITLE
Add missing xml keyword to code formatting

### DIFF
--- a/Umbraco-Cloud/Set-Up/Config-Transforms/index.md
+++ b/Umbraco-Cloud/Set-Up/Config-Transforms/index.md
@@ -46,7 +46,7 @@ Rewrite rules are often something you only want to apply to your Live environmen
 
 Here is an example of how that config transform would look:
 
-```
+```xml
 <?xml version="1.0" encoding="utf-8"?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
     <system.webServer>


### PR DESCRIPTION
The code sample currently just appears as a black box where it's not possible to see the code. Adding the xml keyword should fix this.