### PR TITLE
Correct initialization of custom model

### DIFF
--- a/Reference/Routing/custom-controllers.md
+++ b/Reference/Routing/custom-controllers.md
@@ -104,7 +104,7 @@ public class HomeController : Umbraco.Web.Mvc.RenderMvcController
     public ActionResult MobileHomePage(RenderModel model)
     {
         // we will create a custom model
-        var myCustomModel = new MyCustomModel();
+        var myCustomModel = new MyCustomModel(model.Content);
 
         // TODO: assign some values to the custom model...
 


### PR DESCRIPTION
The previous snippet has an example of a custom model, with a constructor that takes an IPublishedContent. This snippet utilized a custom model, but without using the constructor that was made in the previous example.

The proposed change will make the code more copy-pasteable.