### PR TITLE
Email clash when adding cloud user

### DIFF
--- a/Umbraco-Cloud/Getting-Started/Migrate-Existing-Site/index.md
+++ b/Umbraco-Cloud/Getting-Started/Migrate-Existing-Site/index.md
@@ -197,7 +197,7 @@ As Umbraco Forms comes with an Umbraco Cloud project, there are a few things you
 * The existing site uses Umbraco Forms
     * No extra steps needed, as you will have upgraded Umbraco Forms to the latest version before starting the migration
 
-The final thing to do before moving on, is to make sure your Umbraco Cloud user will be added to the new database you've just merged into the project.
+The final thing to do before moving on, is to make sure your Umbraco Cloud user will be added to the new database you've just merged into the project. First you need to check if any Umbraco user uses the same email address as your Umbraco Cloud account. If this is the case you need to change the email address of the existing user to something else otherwise your Cloud user will be stuck in a inactive state. If you have confirmed there is no user with the same email address you can add the cloud by following these steps.
 
 * Go to the `data/backoffice/users` folder in your Umbraco Cloud project files
 * Rename your user file by removing the leading underscore


### PR DESCRIPTION
I added info on changing the existing user email addresses if they are the same as a cloud user. This prevents a situation of confusion of what user someone is using. Happened to me yesterday and also locked out my colleague today.

If the wording isn't clear please let me know what you'd like to see different.