### PR TITLE
Incorrect reference in example

### DIFF
--- a/Implementation/Composing/index.md
+++ b/Implementation/Composing/index.md
@@ -107,7 +107,7 @@ namespace My.Website
         {
             // Append our component to the collection of Components
             // It will be the last one to be run
-            composition.Components().Append<MyComponent>();
+            composition.Components().Append<SubscribeToContentServiceSavingComponent>();
         }
     }
 


### PR DESCRIPTION
I followed this guide and saw it had the wrong name for the Custom Component.