### PR TITLE
Change "user group" to "user"

### DIFF
--- a/Reference/Management/Services/UserService/Create-a-new-user.md
+++ b/Reference/Management/Services/UserService/Create-a-new-user.md
@@ -8,7 +8,7 @@ needsV8Update: "true"
 If you want to create a new user, you'd use ASP.NET identity APIs like it is used in core. 
 
 ### Assigning the user to a user group
-As of Umbraco 7.7 permissions aren't administered for the specific user group, but rather for the user group(s) that the user is a part of. So to add our new user to a user group, we first need to get a reference to the user via the `GetUserGroupByAlias` method, and then use the `AddGroup` method for adding the group to our user:
+As of Umbraco 7.7 permissions aren't administered for the specific user, but rather for the user group(s) that the user is a part of. So to add our new user to a user group, we first need to get a reference to the user via the `GetUserGroupByAlias` method, and then use the `AddGroup` method for adding the group to our user:
 
     // Get a reference to the default "Administrators" user group
     UserGroup adminUserGroup = (UserGroup) us.GetUserGroupByAlias("admin");


### PR DESCRIPTION
A colleague of mine pointed out that the text should probably read "...administered for the specific user, but rather for the user group(s)..." rather than "...administered for the specific user group, but rather for the user group(s)..." since permissions are now administered on the group level and not the user level, right? :-)