### PR TITLE
Add link to reference (more on tags)

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Tags/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Tags/index.md
@@ -98,3 +98,7 @@ namespace Our.Documentation.Examples.Controllers
     }
 }
 ```
+
+### More on working with Tags
+
+More on working with Tags (i.e. query all of them) can be found at the [UmbracoHelper reference page](https://our.umbraco.com/documentation/Reference/Querying/UmbracoHelper/#working-with-tags)

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Tags/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Tags/index.md
@@ -101,4 +101,4 @@ namespace Our.Documentation.Examples.Controllers
 
 ### More on working with Tags
 
-More on working with Tags (i.e. query all of them) can be found at the [UmbracoHelper reference page](https://our.umbraco.com/documentation/Reference/Querying/UmbracoHelper/#working-with-tags)
+More on working with Tags (i.e. query all of them) can be found at the [UmbracoHelper reference page](../../../../../../Reference/Querying/UmbracoHelper/#working-with-tags)


### PR DESCRIPTION
I found the page lacking a link to the UmbracoHelper reference where you can learn more on querying and working with the tags. This makes the current page frustrating because it shows up in search more prominently but misses this information.