### PR TITLE
Updated article about Forms on Umbraco Cloud

### DIFF
--- a/Umbraco-Cloud/Deployment/Content-Transfer/index.md
+++ b/Umbraco-Cloud/Deployment/Content-Transfer/index.md
@@ -41,7 +41,7 @@ Media items are transferred the same way as content:
 
 ### Umbraco Forms
 
-Media items are transferred the same way as content and media:
+Forms are transferred the same way as content and media:
 
 1. In the Forms section *Right-click* the items you want to transfer and choose **Queue for transfer** 
   * or *right-click* the top of the Forms section to transfer all your Forms at once.

--- a/Umbraco-Cloud/Deployment/Content-Transfer/index.md
+++ b/Umbraco-Cloud/Deployment/Content-Transfer/index.md
@@ -2,7 +2,8 @@
 versionFrom: 7.0.0
 ---
 
-# Transferring Content and Media
+# Transferring Content, Media and Forms
+
 After deploying changes to meta data, it's time to transfer your content and media. This is done from the Umbraco backoffice.
 
 Content and media transfers are very flexible which means you have complete control over which content nodes and/or media items you want to transfer - all in one go, a few at a time or just a single node.
@@ -12,6 +13,7 @@ Transferring content will overwrite any existing nodes on the target environment
 **Important**: Content and Media transfers will only work if you've deployed all changes to your meta data before hand. Please refer to our documentation on how to deploy meta data from either [Local to Cloud](../Local-to-Cloud) or [Cloud to Cloud](../Cloud-to-Cloud).
 
 ## Step-by-step
+
 Let’s go through a content transfer step by step. Imagine you’ve finished working on new content for your project locally and you are ready to transfer the changes to the Cloud. 
 
 You want to transfer the whole site so you start from the `Home` node and choose to transfer everything under it:
@@ -35,6 +37,14 @@ Media items are transferred the same way as content:
 
 1. In the Media section *Right-click* the items you want to transfer and choose **Queue for transfer** 
   * or simply *right-click* the top of the Media section to transfer all you media at once.
+2. Go to the Deployment dashboard in the Content section to see the items you've queued for transfer and to transfer your items.
+
+### Umbraco Forms
+
+Media items are transferred the same way as content and media:
+
+1. In the Forms section *Right-click* the items you want to transfer and choose **Queue for transfer** 
+  * or simply *right-click* the top of the Forms section to transfer all your Forms at once.
 2. Go to the Deployment dashboard in the Content section to see the items you've queued for transfer and to transfer your items.
 
 ## Schema Mismatches

--- a/Umbraco-Cloud/Deployment/Content-Transfer/index.md
+++ b/Umbraco-Cloud/Deployment/Content-Transfer/index.md
@@ -36,16 +36,16 @@ You want to transfer the whole site so you start from the `Home` node and choose
 Media items are transferred the same way as content:
 
 1. In the Media section *Right-click* the items you want to transfer and choose **Queue for transfer** 
-  * or simply *right-click* the top of the Media section to transfer all you media at once.
-2. Go to the Deployment dashboard in the Content section to see the items you've queued for transfer and to transfer your items.
+  * or *right-click* the top of the Media section to transfer all you media at once.
+2. Go to the Deployment dashboard in the Content section to see the items you've queued for transfer and to transfer your items
 
 ### Umbraco Forms
 
 Media items are transferred the same way as content and media:
 
 1. In the Forms section *Right-click* the items you want to transfer and choose **Queue for transfer** 
-  * or simply *right-click* the top of the Forms section to transfer all your Forms at once.
-2. Go to the Deployment dashboard in the Content section to see the items you've queued for transfer and to transfer your items.
+  * or *right-click* the top of the Forms section to transfer all your Forms at once.
+2. Go to the Deployment dashboard in the Content section to see the items you've queued for transfer and to transfer your items
 
 ## Schema Mismatches
 

--- a/Umbraco-Cloud/Deployment/Deploy-Settings/index.md
+++ b/Umbraco-Cloud/Deployment/Deploy-Settings/index.md
@@ -65,3 +65,18 @@ These timeout settings default to 8 minutes, but if you are transferring a lot o
    <deploy sessionTimeout="1200" sourceDeployTimeout="1200" httpClientTimeout="1200" databaseCommandTimeout="1200" />
 </settings>
 ```
+
+## Transfer Forms data as content
+
+In order for your Cloud project to handle Forms data as content, you'll need to add the following setting to `UmbracoDeploy.settings.config`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<settings xmlns="urn:umbracodeploy-settings">
+   <forms transferFormsAsContent="true" />
+</settings>
+```
+
+:::note
+This only needs to be done, if your Cloud project was created **before** June 18th 2019.
+:::

--- a/Umbraco-Cloud/Deployment/Restoring-content/index.md
+++ b/Umbraco-Cloud/Deployment/Restoring-content/index.md
@@ -4,7 +4,7 @@ versionFrom: 7.0.0
 
 # Restoring content
 
-When you have already created some content on your Cloud environment and you clone down your Umbraco Cloud project to your local machine, you will need to do an extra step, in order to see your content locally as well.
+When you have created some content on your Cloud environment and you clone down your Umbraco Cloud project to your local machine, you will need to do an extra step, in order to see your content locally as well.
 
 You will also need to use the restore option when setting up new Umbraco Cloud environments. The restore option also comes in really handy if you have content editors creating content on the Live or Staging environments and you want to work with this content when building templates on the Development environment or on your Local clone.
 

--- a/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
+++ b/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
@@ -12,21 +12,38 @@ Read more about the product in the [Umbraco Forms section](../../../Add-ons/Umbr
 
 ## How are Forms handled on Cloud?
 
-Umbraco Forms are currently handled as metadata, and will be deployed along with the rest of your metadata and structure files, e.g. Document Types, Templates and Stylesheets.
+Umbraco Forms are handled as content and media. This means that you can transfer your Forms between environments using the same workflow you use for content and media.
 
-When you create a Form on your Umbraco Cloud project, a UDA file will be generated. This UDA file will contain all the metadata from your form, and be very similar to the `JSON` file that is also generated when you create a new form - this file can be found in `~/App_Data/UmbracoForms/Data/forms`.
+:::note
+**Did you create your Cloud project before June 17th 2019?**
 
-Once you deploy a form, the engine behind Cloud will use the UDA file to extract the form on the next environment in the workflow.
+Then you need to configure your project to handle Umbraco Forms data as content.
+This is done by adding the following to `UmbracoDeploy.settings.config`
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<settings xmlns="urn:umbracodeploy-settings">
+   <forms transferFormsAsContent="true" />
+</settings>
+```
+
+:::
 
 Entries submitted are not transferred to the next environment, as they are *environment specific*. If you need to move entries from one environment to another, you need to run an export/import script on the databases.
 
 ## Recommended workflow
 
-As with all other metadata and structure files, we always recommend that you work with these on your local or Development environment, following the [left-to-right deployment model](../../Deployment).
+You can work with Forms on the environment of your choice. 
 
-:::warning
-When you have more than 1 Cloud environment, you should never make changes to your forms on your Live environment, as these will be overwritten on the next deployment.
-:::
+When you need to test or use your forms on another environment you can
+
+* transfer the forms to the next environment using **Queue for transfer** or
+* **Restore** the forms on an environment lower in the workflow
+
+For more information on how to handle content transfer / restores on Umbraco Cloud, checkout the following articles:
+
+* [Transfer content, media and Forms](../Content-Transfer)
+* [Restoring content](../Restoring-content)
 
 ## Upgrades
 

--- a/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
+++ b/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
@@ -14,21 +14,6 @@ Read more about the product in the [Umbraco Forms section](../../../Add-ons/Umbr
 
 Umbraco Forms are handled as content and media. This means that you can transfer your Forms between environments using the same workflow you use for content and media.
 
-:::note
-**Did you create your Cloud project before June 18th 2019?**
-
-Then you need to configure your project to handle Umbraco Forms data as content.
-This is done by adding the following to `UmbracoDeploy.settings.config`
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<settings xmlns="urn:umbracodeploy-settings">
-   <forms transferFormsAsContent="true" />
-</settings>
-```
-
-:::
-
 Entries submitted are not transferred to the next environment, as they are *environment specific*. If you need to move entries from one environment to another, you need to run an export/import script on the databases.
 
 ## Recommended workflow
@@ -44,6 +29,24 @@ For more information on how to handle content transfer / restores on Umbraco Clo
 
 * [Transfer content, media and Forms](../Content-Transfer)
 * [Restoring content](../Restoring-content)
+
+### Did you create your Cloud project before June 18th 2019?
+
+Then your Forms data are handled as meta data. When you create a Form, a UDA file will be generated. This UDA file will contain all the metadata from your form, and be very similar to the `JSON` file that is also generated when you create a new form - this file can be found in `~/App_Data/UmbracoForms/Data/forms`.
+
+This means that your Forms will be deployed along with the rest of your metadata and structure files, e.g. Document Types, Templates and Stylesheets. 
+
+We strongly recommend that you work with the Forms on your local or Development environment, following the [left-to-right deployment model](../../Deployment).
+
+You can configure your project to handle Umbraco Forms data as content.
+This is done by adding the following to `UmbracoDeploy.settings.config`
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<settings xmlns="urn:umbracodeploy-settings">
+   <forms transferFormsAsContent="true" />
+</settings>
+```
 
 ## Upgrades
 

--- a/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
+++ b/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
@@ -15,7 +15,7 @@ Read more about the product in the [Umbraco Forms section](../../../Add-ons/Umbr
 Umbraco Forms are handled as content and media. This means that you can transfer your Forms between environments using the same workflow you use for content and media.
 
 :::note
-**Did you create your Cloud project before June 17th 2019?**
+**Did you create your Cloud project before June 18th 2019?**
 
 Then you need to configure your project to handle Umbraco Forms data as content.
 This is done by adding the following to `UmbracoDeploy.settings.config`


### PR DESCRIPTION
Forms will on Umbraco Cloud be handled as content / media instead of meta data.
I've updated the article to reflect this.

Also updated the "Content Transfer" article to include Umbraco Forms data.