### PR TITLE
Corrected import for Umbraco.Core.Composing

### DIFF
--- a/Extending/Dashboards/index.md
+++ b/Extending/Dashboards/index.md
@@ -258,7 +258,7 @@ In previous versions of Umbraco if you wanted to remove or modify the order of a
 
 ```csharp
 using Umbraco.Core;
-using Umbraco.Core.Components;
+using Umbraco.Core.Composing;
 using Umbraco.Web;
 using Umbraco.Web.Dashboards;
 


### PR DESCRIPTION
Dashboard removal import for `Umbraco.Core.Components` was incorrect and should be `Umbraco.Core.Composing`.