### PR TITLE
Umbraco 8: Dictionary items have been moved

### DIFF
--- a/Getting-Started/Backoffice/Sections/index.md
+++ b/Getting-Started/Backoffice/Sections/index.md
@@ -46,6 +46,10 @@ The Settings tree consists of:
 - Stylesheets (`.css` files)
 - Scripts (`.js` files)
 
+:::note
+**Dictionary items** have been moved from the Settings section to the Translation section.
+:::
+
 ## Packages
 In this section you can browse and install packages into your Umbraco solution. You can also get an overview of all installed packages as well as uninstall packages you no longer need.
 

--- a/Getting-Started/Backoffice/Sections/index.md
+++ b/Getting-Started/Backoffice/Sections/index.md
@@ -61,6 +61,12 @@ You can install Umbraco Forms directly from the Backoffice by clicking the insta
 ## Translation
 This is the section where you create and manage your dictionary items.
 
+:::note
+This section is by default not accessible to any User Groups.
+
+Access to the section can be configured under User Groups in the User section.
+:::
+
 ## Help sections
 In the top-right corner you'll find a search tool, which is also accessible by hitting `CTRL + Space` on your keyboard.
 

--- a/Getting-Started/New-in-V8.md
+++ b/Getting-Started/New-in-V8.md
@@ -30,6 +30,7 @@ Giving the Umbraco Backoffice a new look, has given you a bigger workspace when 
 - The **Developer** section has been removed, and merged with the **Settings** sections
 - Templates, Document types, Data Types, Languages, etc. is now all in the same section: **Settings**
 - Health Check, Examine Management and the ModelsBuilder user interfaces have been moved to the **Settings** section
+- **Dictionary items** have been moved from the **Settings** section to the **Translation** section
 - A brand new [Log Viewer interface in the backoffice](Backoffice/LogViewer), that gives you easy access to browse through all your log entries
 - Searching your backoffice has been made even easier: `CTRL + SPACE` opens a search field overlay, which gives you search results as you start typing
 


### PR DESCRIPTION
Added notes about Dictionary Items, which have been moved from Settings to Translation section in Umbraco 8.