### PR TITLE
index-v7.md Examine Fluent Api example doesn't work

### DIFF
--- a/Reference/Searching/Examine/Quick-Start/index-v7.md
+++ b/Reference/Searching/Examine/Quick-Start/index-v7.md
@@ -87,18 +87,19 @@ var query = Request.QueryString["query"];
 var searcher = Examine.ExamineManager.Instance.SearchProviderCollection["ExternalSearcher"];
 
 var searchCriteria = searcher.CreateSearchCriteria(Examine.SearchCriteria.BooleanOperation.Or);
-var searchQuery = searchCriteria.Field("nodeName", query.Boost(5)).Or().Field("nodeName", query.Fuzzy()).And().OrderByDescending("createDate");
+var searchQuery = searchCriteria.Field("nodeName", query.Boost(5)).Or().Field("nodeName", query.Fuzzy()).And().Field("__IndexType", "content").And().OrderByDescending("createDate");
 var searchResults = searcher.Search(searchQuery.Compile());
 if(searchResults.Any())
 {
-    <ul>
-        @foreach (var result in Umbraco.TypedContent(searchResults.Select(x=>x.Id)))
-        {
-            <li>
-                <a href="@result.Url">@result.Name</a>
-            </li>
-        }
-    </ul>
+<ul>
+    @foreach (var result in searchResults)
+    {
+       var node = Umbraco.TypedContent(result.Id);
+       <li>
+          <a href="@node.Url">@node.Name</a>               
+       </li>
+    }
+</ul>
 }
 ```
 

--- a/Reference/Searching/Examine/Quick-Start/index-v7.md
+++ b/Reference/Searching/Examine/Quick-Start/index-v7.md
@@ -92,7 +92,7 @@ var searchResults = searcher.Search(searchQuery.Compile());
 if(searchResults.Any())
 {
     <ul>
-        @foreach (var result in searchResults)
+        @foreach (var result in Umbraco.TypedContent(searchResults.Select(x=>x.Id)))
         {
             <li>
                 <a href="@result.Url">@result.Name</a>


### PR DESCRIPTION
Amended v7 Fluent API example to convert ISearchResults to IEnumerable<IPublishedContent> so Url and Name are exposed.
Raised on forum https://our.umbraco.com/forum/using-umbraco-and-getting-started/98150-fluent-api-following-documentation-errors