### PR TITLE
Update index.md

### DIFF
--- a/Reference/Routing/URL-Tracking/index.md
+++ b/Reference/Routing/URL-Tracking/index.md
@@ -35,13 +35,4 @@ It is possible to disable the feature entirely (both generating URLs in the data
 
 See: [/Documentation/Reference/Config/umbracoSettings/#web-routing](/Documentation/Reference/Config/umbracoSettings/#web-routing)
 
-In addition, Umbraco will automatically disable the feature if it detects any DLL whose name would contain any of the following strings: 
 
-      "InfoCaster.Umbraco.UrlTracker"
-      "SEOChecker"
-      "Simple301"
-      "Terabyte.Umbraco.Modules.PermanentRedirect"
-      "CMUmbracoTools"
-      "PWUrlRedirect"
-
-These products already implement redirect management and we do not want to interfere.


### PR DESCRIPTION
On inspecting the RedirectTrackingComponent component, which is the v8 equivalent of RedirectTrackingEventHandler I've noticed there no longer is a check for the existence of a 3rd party DLL with redirect functionality in the solution. Changed the documentation accordingly. 

I don't know of this is by design or that the check is simply missing in the v8 codebase, so maybe this should be checked first.