### PR TITLE
Fixed broken link to UmbracoDocs labels

### DIFF
--- a/Contribute/Pull-Requests/index.md
+++ b/Contribute/Pull-Requests/index.md
@@ -58,4 +58,4 @@ And that is all you need to do to create a fork, sync it and make a pull request
 ### Step 4: Wait for an action
 
 Hopefully your work will be merged immediately.  It might happen that your pull request receives a comment and a *request for changes*. We hope you are able to work with us to update your PR so we can merge it in!
-Sometimes a label is added to a PR.  We have described a [list of different labels we often use](https://github.com/umbraco/UmbracoDocs/labels).
+Sometimes a label is added to a PR.  We have described a [list of different labels we often use](../index.md#labels).

--- a/Contribute/Pull-Requests/index.md
+++ b/Contribute/Pull-Requests/index.md
@@ -58,4 +58,4 @@ And that is all you need to do to create a fork, sync it and make a pull request
 ### Step 4: Wait for an action
 
 Hopefully your work will be merged immediately.  It might happen that your pull request receives a comment and a *request for changes*. We hope you are able to work with us to update your PR so we can merge it in!
-Sometimes a label is added to a PR.  We have described a [list of different labels we often use](../github-issues.md).
+Sometimes a label is added to a PR.  We have described a [list of different labels we often use](https://github.com/umbraco/UmbracoDocs/labels).


### PR DESCRIPTION
I was originally thrown by the term 'often use' implied it was a blog like tutorial like 
https://umbraco.com/blog/the-umbraco-issue-tracker-process/
But I realised that was for CMS and not docs specifically :)

Let me know if I can improve this.