### PR TITLE
updates a link with `//` to `/`

### DIFF
--- a/Getting-Started/Design/Rendering-Content/index.md
+++ b/Getting-Started/Design/Rendering-Content/index.md
@@ -105,7 +105,7 @@ You can use the Query Builder in the template editor to build more advanced quer
 
 ### More information
 - [Razor examples](../../../Reference/Templating/Mvc/examples.md)
-- [Querying](../../..//Reference/Templating/Mvc/querying.md)
+- [Querying](../../../Reference/Templating/Mvc/querying.md)
 
 <!--
 ### Umbraco TV


### PR DESCRIPTION
A tiny typo fix on the more `info -> querying` link