### PR TITLE
Adds missing parameter to *ModZero IsHelpers

### DIFF
--- a/Reference/Querying/IPublishedContent/IsHelpers.md
+++ b/Reference/Querying/IPublishedContent/IsHelpers.md
@@ -65,11 +65,11 @@ Test if the current node is at the specified index in the collection
 
 Test if the current node is not at the specified index in the collection
 
-### .IsModZero([string valueIfTrue][,string valueIfFalse])
+### .IsModZero(int modulus[,string valueIfTrue][,string valueIfFalse])
 
 Test if the current node's position is evenly divisible by a given number
 
-### .IsNotModZero([string valueIfTrue][,string valueIfFalse])
+### .IsNotModZero(int modulus[,string valueIfTrue][,string valueIfFalse])
 
 Test if the current node's position is not evenly divisible by a given number
 

--- a/Reference/Querying/IPublishedContent/IsHelpers.md
+++ b/Reference/Querying/IPublishedContent/IsHelpers.md
@@ -26,7 +26,10 @@ To use an IsHelper you need to be iterating over a collection of IPublishedConte
 </ul>
 ```
 
-IsHelpers work like ternary operators. The example above uses the `.IsFirst()` IsHelper method. The first parameter is the value we want it to return if the condition returns `true`, and the second, optional value, is the value we want to return if the condition evaluates to `false`.
+IsHelpers work like ternary operators. The example above uses the `.IsFirst()` IsHelper method.
+The first parameter is the value we want it to return if the condition returns `true`, and the second,
+optional value, is the value we want to return if the condition evaluates to `false`. (If you omit the
+second string argument, the returned value will be an empty string if the condition evaluates to `false`).
 
 IsHelpers can also return simple boolean values:
 

--- a/Reference/Querying/IPublishedContent/IsHelpers.md
+++ b/Reference/Querying/IPublishedContent/IsHelpers.md
@@ -9,7 +9,7 @@ The IsHelper methods are a set of extension methods for IPublishedContent to hel
 
 IsHelper methods all work the same, and have 3 overloads. They're basically ternary operators, but work a little nicer in that they're easy to embed in properties and quicker to write as you don't need so many brackets to make Razor understand them.
 
-The general use IsHelper is to allow you to dynamically inject class names and style attributes onto your html elements, based on their position within the collection you are iterating. You can use this for a variety of things such as alternating row colours or fixing the margin/padding on the first/last item etc.
+The general use IsHelper is to allow you to dynamically inject class names and style attributes onto your HTML elements, based on their position within the collection you are iterating. You can use this for a variety of things such as alternating row colours or fixing the margin/padding on the first/last item etc.
 
 ---
 
@@ -26,9 +26,9 @@ To use an IsHelper you need to be iterating over a collection of IPublishedConte
 </ul>
 ```
 
-Is helpers work like ternary operators. The example above uses the `.IsFirst()` Ishelper method. The first parameter is the value we want it to return if the condition returns true, and the second, optional value, is the value we want to return if the condition evaluates to false.
+IsHelpers work like ternary operators. The example above uses the `.IsFirst()` IsHelper method. The first parameter is the value we want it to return if the condition returns `true`, and the second, optional value, is the value we want to return if the condition evaluates to `false`.
 
-IsHelpers can also return simple boolean values.
+IsHelpers can also return simple boolean values:
 
 ```csharp
 @if(item.IsFirst())
@@ -43,61 +43,61 @@ IsHelpers can also return simple boolean values.
 
 ### .IsFirst([string valueIfTrue][,string valueIfFalse])
 
-Test if current node is the first item in the collection
+Test if the current node is the first item in the collection
 
 ### .IsNotFirst([string valueIfTrue][,string valueIfFalse])
 
-Test if current node is not first item in the collection
+Test if the current node is not first item in the collection
 
 ### .IsLast([string valueIfTrue][,string valueIfFalse])
 
-Test if current node is the last item in the collection
+Test if the current node is the last item in the collection
 
 ### .IsNotLast([string valueIfTrue][,string valueIfFalse])
 
-Test if current node is not the last item in the collection
+Test if the current node is not the last item in the collection
 
 ### .IsPosition(int index[,string valueIfTrue][,string valueIfFalse])
 
-Test if current node is at the specified index in the collection
+Test if the current node is at the specified index in the collection
 
 ### .IsNotPosition(int index[,string valueIfTrue][,string valueIfFalse])
 
-Test if current node is not at the specified index in the collection
+Test if the current node is not at the specified index in the collection
 
 ### .IsModZero([string valueIfTrue][,string valueIfFalse])
 
-Test if current node position evenly dividable (modulus) by a given number
+Test if the current node's position is evenly divisible by a given number
 
 ### .IsNotModZero([string valueIfTrue][,string valueIfFalse])
 
-Test if current node position is not evenly dividable (modulus) by a given number
+Test if the current node's position is not evenly divisible by a given number
 
 
 ### .IsEven([string valueIfTrue][,string valueIfFalse])
 
-Test if current node position is even
+Test if the current node's position is even
 
 ### .IsOdd([string valueIfTrue][,string valueIfFalse])
 
-Test if current node position is odd
+Test if the current node's position is odd
 
 ### .IsEqual(IPublishedContent otherNode[,string valueIfTrue][,string valueIfFalse])
 
-Tests if the current node in your iteration is equivalent (by Id) to another node
+Test if the current node is equal (by Id) to another node
 
 ### .IsDescendant(IPublishedContent otherNode[,string valueIfTrue][,string valueIfFalse])
 
-Tests if the current node in your iteration is a descendant of another node
+Test if the current node is a descendant of another node
 
 ### .IsDescendantOrSelf(IPublishedContent otherNode[,string valueIfTrue][,string valueIfFalse])
 
-Tests if the current node in your iteration is a descendant of another node or is the node
+Test if the current node is the same as or a descendant of another node
 
 ### .IsAncestor(IPublishedContent otherNode[,string valueIfTrue][,string valueIfFalse])
 
-Tests if the current node in your iteration is an ancestor of another node
+Test if the current node is an ancestor of another node
 
 ### .IsAncestorOrSelf(IPublishedContent otherNode[,string valueIfTrue][,string valueIfFalse])
 
-Tests if the current node in your iteration is an ancestor of another node or is the node
+Test if the current node is the same as or an ancestor of another node

--- a/Reference/Querying/IPublishedContent/IsHelpers.md
+++ b/Reference/Querying/IPublishedContent/IsHelpers.md
@@ -62,11 +62,11 @@ Test if the current node is not the last item in the collection
 
 ### .IsPosition(int index[,string valueIfTrue][,string valueIfFalse])
 
-Test if the current node is at the specified index in the collection
+Test if the current node is at the specified index (zero-based) in the collection
 
 ### .IsNotPosition(int index[,string valueIfTrue][,string valueIfFalse])
 
-Test if the current node is not at the specified index in the collection
+Test if the current node is not at the specified index (zero-based) in the collection
 
 ### .IsModZero(int modulus[,string valueIfTrue][,string valueIfFalse])
 


### PR DESCRIPTION
This adds the missing `modulus` parameter to the `.IsModZero()` and `.IsNotModZero()` helpers.

Also cleaned up the descriptions a bit and added information about the scenario where you've supplied a single string argument to an IsHelper and the condition evaluates to `false` - where an empty string gets returned.

Closes #1830 