### PR TITLE
Added missing property to ExamineIndex instructions

### DIFF
--- a/Getting-Started/Setup/Server-Setup/azure-web-apps.md
+++ b/Getting-Started/Setup/Server-Setup/azure-web-apps.md
@@ -67,7 +67,7 @@ The `SyncTempEnvDirectoryFactory` enables Examine to sync indexes between the re
 #### Pre Examine v0.1.80 ####
 
 * If you have a {machinename} token in your `~/Config/ExamineIndex.config` file remove this part of the path. Example, if you have path that looks like: `~/App_Data/TEMP/ExamineIndexes/{machinename}/External/` it should be `~/App_Data/TEMP/ExamineIndexes/External/` 
-* Due to the nature of Lucene files and IO latency, you should update all of your Indexers and Searchers in the `~/Config/ExamineSettings.config` file to have these two properties (see [here](http://issues.umbraco.org/issue/U4-7614) for more details): `useTempStorage="Sync"`
+* Due to the nature of Lucene files and IO latency, you should update all of your Indexers and Searchers in the `~/Config/ExamineSettings.config` file to have these two properties (see [here](http://issues.umbraco.org/issue/U4-7614) for more details): `useTempStorage="Sync"` `tempStorageDirectory="UmbracoExamine.LocalStorage.AzureLocalStorageDirectory, UmbracoExamine"`
 
 ### Umbraco XML cache file and other TEMP files
 


### PR DESCRIPTION
The instructions for using Examine pre v0.1.80 with Azure were missing the second property which is required to use the 'Sync' behaviour.
I have added this missing property in.