### PR TITLE
Updated Team Members info

### DIFF
--- a/Umbraco-Cloud/Set-Up/Team-Members/index.md
+++ b/Umbraco-Cloud/Set-Up/Team-Members/index.md
@@ -3,7 +3,7 @@ versionFrom: 7.0.0
 ---
 
 # Team members in the Project Portal
-This article is about team members that are added via the Invite Member button in the Umbraco Cloud Portal. If you are looking for more information about Users in the Backoffice, see [Users](../../../Getting-Started/Data/Users/). Users added through the backoffice do not have access to the project portal.
+This article is about team members that are added via the Invite Member button in the Umbraco Cloud Portal. If you are looking for more information about Users in the Backoffice, see [Users](../../../Getting-Started/Data/Users/). Users added through the backoffice do not have access to the Umbraco Cloud Portal.
 
 Team members are users that you add to your project via the Invite Member button in the Umbraco Cloud Portal. These users are automatically added as users in the backoffice of all environments for the project. These users are able to clone down the project locally and login using the same credentials they use for Umbraco Cloud.
 

--- a/Umbraco-Cloud/Set-Up/Team-Members/index.md
+++ b/Umbraco-Cloud/Set-Up/Team-Members/index.md
@@ -2,24 +2,27 @@
 versionFrom: 7.0.0
 ---
 
-# Team members in the Portal and Umbraco Backoffice users
-You can add team members to your projects from the Umbraco Cloud Portal. These get automatically added as users in the backoffice of all environments for the project. The users will also be created in local clones of your development environment. The same username and password is used to login in all parts of Umbraco Cloud - Portal, backoffice and the KUDU console.
+# Team members in the Project Portal
+This article is about team members that are added via the Invite Member button in the Umbraco Cloud Portal. If you are looking for more information about Users in the Backoffice, see [Users](../../../Getting-Started/Data/Users/). Users added through the backoffice do not have access to the project portal.
+
+Team members are users that you add to your project via the Invite Member button in the Umbraco Cloud Portal. These users are automatically added as users in the backoffice of all environments for the project. These users are able to clone down the project locally and login using the same credentials they use for Cloud.
 
 ![Add team member](images/add-team-member.png)
-When adding a team member the default permission will be *Read*. If the *Admin* checkbox is ticked they will be given Admin rights to the project.
+
+When adding a team member the default permission will be *Write*. If the *Admin* checkbox is ticked they will be given Admin rights to the project.
 
 ## Team member roles
-Roles for each environment can be set on the *Edit Team* page available from the *Settings* dropdown.
+Roles for each environment can be set on the *Edit Team* page available from the *Settings* dropdown. Permissions can be set per environment. For example, a user can have Write access on the Development environment, and Read access on the Live environment.
 
-* Admin: Has access to everything on a Project. An admin can Delete a project, and only admins can edit the Team (adding/removing other team members and changing permissions). An admin can deploy using Portal and has access to git.
+* Read: A team member with Read permissions can only view the project in the portal as well as the backoffices. They are not able to deploy or change anything on the project itself. They can clone down the project, but cannot push changes they have made locally. Since by default they are added as an admin in the backoffice, they can make changes in the backoffice. If you want to change this, see Team Member Permissions in the Umbraco Backoffice below.
 
-* Write: A team member with Write permissions can do everything on a Project except Delete and edit Team. A user with Write permissions is able to Deploy through the Portal and they have access to Development and Staging environments and the git repositories
+* Write: A team member with Write permissions can do everything on a project except delete and edit team. A user with Write permissions is able to deploy changes between environments through the portal. They have access to the git repositories and can push local changes to the environment.
 
-* Read: A team member with Read permissions can only view the Project in the Portal, and is not able to Deploy or change anything on the Project through the Portal.
+* Admin: Has access to everything on a project. An admin can delete a project, and edit the team. An admin can deploy changes between environments in the Project Portal and has access to git, as well as the Power Tools Kudu.
 
 
-## Team Member Permissions in the Umbraco Backoffice 
-By default all team members created through the Portal are created as admin users in the backoffice. This can be overwritten by adding custom rules to the CloudUsers.config file in the /config directory. 
+## Team Member Permissions in the Umbraco Backoffice
+By default all team members created through the Portal are created as admin users in the backoffice. This can be overwritten by adding custom rules to the CloudUsers.config file in the /config directory.
 
 To match a Team Member with a group of permissions in the CloudUsers.config file you'll need to either match by e-mail or by the User Type of the Team Member using the "match" or "matchEmail" attributes.
 

--- a/Umbraco-Cloud/Set-Up/Team-Members/index.md
+++ b/Umbraco-Cloud/Set-Up/Team-Members/index.md
@@ -5,7 +5,7 @@ versionFrom: 7.0.0
 # Team members in the Project Portal
 This article is about team members that are added via the Invite Member button in the Umbraco Cloud Portal. If you are looking for more information about Users in the Backoffice, see [Users](../../../Getting-Started/Data/Users/). Users added through the backoffice do not have access to the project portal.
 
-Team members are users that you add to your project via the Invite Member button in the Umbraco Cloud Portal. These users are automatically added as users in the backoffice of all environments for the project. These users are able to clone down the project locally and login using the same credentials they use for Cloud.
+Team members are users that you add to your project via the Invite Member button in the Umbraco Cloud Portal. These users are automatically added as users in the backoffice of all environments for the project. These users are able to clone down the project locally and login using the same credentials they use for Umbraco Cloud.
 
 ![Add team member](images/add-team-member.png)
 

--- a/Umbraco-Cloud/Set-Up/Team-Members/index.md
+++ b/Umbraco-Cloud/Set-Up/Team-Members/index.md
@@ -16,7 +16,7 @@ Roles for each environment can be set on the *Edit Team* page available from the
 
 * Read: A team member with Read permissions can only view the project in the portal as well as the backoffices. They are not able to deploy or change anything on the project itself. They can clone down the project, but cannot push changes they have made locally. Since by default they are added as an admin in the backoffice, they can make changes in the backoffice. If you want to change this, see Team Member Permissions in the Umbraco Backoffice below.
 
-* Write: A team member with Write permissions can do everything on a project except delete and edit team. A user with Write permissions is able to deploy changes between environments through the portal. They have access to the git repositories and can push local changes to the environment.
+* Write: A team member with Write permissions can do everything on a project except deleting it and editing the team. A user with Write permissions is able to deploy changes between environments through the portal. They have access to the git repositories and can push local changes to the environment.
 
 * Admin: Has access to everything on a project. An admin can delete a project, and edit the team. An admin can deploy changes between environments in the Project Portal and has access to git, as well as the Power Tools Kudu.
 


### PR DESCRIPTION
Clarified and added some info to this page: 
https://our.umbraco.com/documentation/Umbraco-Cloud/Set-Up/Team-Members/#team-member-permissions-in-the-umbraco-backoffice

In order to help better define the difference between Team Members and Backoffice Users, I included a link on the Team Members page to the Users page in the documentation.