### PR TITLE
Clarifying Umbraco version settings

### DIFF
--- a/Getting-Started/Setup/Server-Setup/azure-web-apps.md
+++ b/Getting-Started/Setup/Server-Setup/azure-web-apps.md
@@ -83,7 +83,7 @@ For Umbraco installations that are hosted by Azure Web Apps it is recommend that
 
 This will set Umbraco to store `umbraco.config` and the other Umbraco TEMP files in the environment temporary folder. More info on this setting is available [here](../../../Reference/Config/webconfig/index.md#umbracolocaltempstorage-umbraco-v773)
 
-For **Umbraco v7.6+**
+For **Umbraco v7.6 - v7.7.2**
 
 ```xml
 <add key="umbracoContentXMLStorage" value="EnvironmentTemp" />


### PR DESCRIPTION
Config settings for Umbraco XML cache file and other TEMP files differ depending on Umbraco version used. Proposed change clarifies only one entry is required if on version 7.7.3+