### PR TITLE
New dedicated workers public IP address

### DIFF
--- a/Umbraco-Cloud/Frequently-Asked-Questions/index.md
+++ b/Umbraco-Cloud/Frequently-Asked-Questions/index.md
@@ -188,6 +188,7 @@ The following rule can be added to your web.config (in `system.webServer/rewrite
         <add input="{REMOTE_ADDR}" pattern="13.95.93.29" negate="true" />
         <add input="{REMOTE_ADDR}" pattern="40.68.36.142" negate="true" />
         <add input="{REMOTE_ADDR}" pattern="13.94.247.45" negate="true" />
+        <add input="{REMOTE_ADDR}" pattern="52.157.96.229" negate="true" />
 
         <!-- Don't apply rules on localhost so your local environment still works -->
         <add input="{HTTP_HOST}" pattern="localhost" negate="true" />


### PR DESCRIPTION
**What**
Adding a new outgoing IP address to the the rewrite rules section.

**Why**
This is our only documentation where the end users can potentially find the outgoing IP addresses that websites are reaching out from.

**Suggestion**
We could think about this change as beloning to a a new networking or a security section where it would be much easier to find networking rules, AP addresses, firewall rules for sql, basic authentication and such.
