### PR TITLE
Update plan terminology information in Cloud API docs

### DIFF
--- a/Umbraco-Cloud/Cloud-API/index.md
+++ b/Umbraco-Cloud/Cloud-API/index.md
@@ -49,7 +49,9 @@ To use this endpoint, make a request like this:
         "baselineAlias": "an-alias-of-a-baseline" // Optional. If the project needs to be a child, then you can provide the alias of the baseline
     }
     
-**NOTE** you'll notice the "plan" parameter takes either "Single" or "Studio" as valid options. The terminology used for these plans has since changed. "Single" will create a "Starter" plan whereas "Studio" a "Professional".
+:::note
+you'll notice the "plan" parameter takes either "Single" or "Studio" as valid options. The terminology used for these plans has since changed. "Single" will create a "Starter" plan whereas "Studio" a "Professional".
+:::
 
 If everything went as expected, the endpoint will return a `HTTP 200` status code and a JSON object that looks like this:
 

--- a/Umbraco-Cloud/Cloud-API/index.md
+++ b/Umbraco-Cloud/Cloud-API/index.md
@@ -50,7 +50,7 @@ To use this endpoint, make a request like this:
     }
     
 :::note
-you'll notice the "plan" parameter takes either "Single" or "Studio" as valid options. The terminology used for these plans has since changed. "Single" will create a "Starter" plan whereas "Studio" a "Professional".
+You'll notice the "plan" parameter takes either "Single" or "Studio" as valid options. The terminology used for these plans has since changed. "Single" will create a "Starter" plan whereas "Studio" a "Professional".
 :::
 
 If everything went as expected, the endpoint will return a `HTTP 200` status code and a JSON object that looks like this:

--- a/Umbraco-Cloud/Cloud-API/index.md
+++ b/Umbraco-Cloud/Cloud-API/index.md
@@ -48,6 +48,8 @@ To use this endpoint, make a request like this:
         "ownerId": "c5821a98-ce88-4796-be90-e29f0a05fa39", // Optional. Can be a GUID of an organization or an email. If nothing is provided the owner becomes the user the token is associated with
         "baselineAlias": "an-alias-of-a-baseline" // Optional. If the project needs to be a child, then you can provide the alias of the baseline
     }
+    
+**NOTE** you'll notice the "plan" parameter takes either "Single" or "Studio" as valid options. The terminology used for these plans has since changed. "Single" will create a "Starter" plan whereas "Studio" a "Professional".
 
 If everything went as expected, the endpoint will return a `HTTP 200` status code and a JSON object that looks like this:
 


### PR DESCRIPTION
Plan terminology has since changed yet the accepted variable names still remain. Added a note to the documentation to inform the user