### PR TITLE
Update to Color Picker documentation

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Color-Picker/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Color-Picker/index.md
@@ -28,7 +28,7 @@ The Color picker allows you to set some predetermined colors that the editor can
 
     if (hexColor != null)
     {
-        <div style="background-color: @hexColor">@colorLabel</div>
+        <div style="background-color: #@hexColor">@colorLabel</div>
     }
 }
 ```


### PR DESCRIPTION
The div style requires the # symbol in front of @hexColor to display the colour correctly.