### PR TITLE
Add index to cache example folder

### DIFF
--- a/Reference/Cache/examples/index.md
+++ b/Reference/Cache/examples/index.md
@@ -1,0 +1,3 @@
+# Examples
+
+- [Setting up caching on the tags property](tags.md).


### PR DESCRIPTION
Adds a list of examples (currently just the one) to the caching folder.

This is to prevent a 404 that will otherwise occur. 