### PR TITLE
Improve docs (part 1)

### DIFF
--- a/Add-ons/UmbracoCourier/CommonIssues.md
+++ b/Add-ons/UmbracoCourier/CommonIssues.md
@@ -10,7 +10,7 @@ _Here you can find common issues with Courier and possible solutions_
 ## Try this first
 For all issues, always try these steps first:
 
-1. Ensure you have the latest version - [Download the latest version on Nightly Umbraco](http://nightly.umbraco.org/?container=umbraco-courier-release) 
+1. Ensure you have the latest version - [Download the latest version on Nightly Umbraco](http://nightly.umbraco.org/?container=umbraco-courier-release)
 2. Enable debugging in /config/courier.config and restart the app to see if courier has problems with loading dlls.
 3. Clear the cache folder in /app_data/courier/cache.
 
@@ -27,18 +27,18 @@ You can also create your own data resolvers. Read the [Data Resolvers](Developer
 ## Most common issues, and how to solve them
 
 ### Key not found exception
-*Caused by:* Courier not being able to find a specific provider, commonly the datalayer provider. Usually, because Courier didn't load the datalayer dll or one of its dependencies. 
+*Caused by:* Courier not being able to find a specific provider, commonly the datalayer provider. Usually, because Courier didn't load the datalayer dll or one of its dependencies.
 
-*How to spot:* Enable debugging in `/config/courier.config`, restart the app and check the 
-`/app_data/courier/logs/error_log.txt` file for exceptions related to loading providers. Usually, it will say which dll had issues loading. 
+*How to spot:* Enable debugging in `/config/courier.config`, restart the app and check the
+`/app_data/courier/logs/error_log.txt` file for exceptions related to loading providers. Usually, it will say which dll had issues loading.
 
 If no exceptions in the log, it might be missing the dll, or have the dll for the wrong version.
 
-Courier for V6 expects to have `umbraco.courier.persistence.v6.nhibernate.dll` and for V4 it should have 
+Courier for V6 expects to have `umbraco.courier.persistence.v6.nhibernate.dll` and for V4 it should have
 `umbraco.courier.persistence.v4.nhibernate.dll`.
 
 *Solution:* Ensure that all dlls are loaded properly and that it has all the dlls expected. Also, it should only have
-the proper dlls for the specific versions. 
+the proper dlls for the specific versions.
 
 Get the dlls from the latest version [here](http://nightly.umbraco.org/?container=umbraco-courier-release) and copy to `/bin`.
 
@@ -49,7 +49,7 @@ by the data type.
 *How to spot:* Courier returns `Cannot package GUID from data types provider`.
 
 *Solution:* Make sure you have all your data type dependencies in place. Usually its components and similar projects
-that are missing dlls. If you don't use a data type, delete it from your site, so you don't accidentally 
+that are missing dlls. If you don't use a data type, delete it from your site, so you don't accidentally
 transfer a broken data type. Make sure to clear Courier cache and restart the application.
 
 ### Latest changes aren't deployed / courier can't detect changes
@@ -58,7 +58,7 @@ the files due to permissions or locks.
 
 *How to spot:* Find the corresponding item in `/app_data/courier/cache` and see if it changes on save/publish.
 
-*Solution:* Clear the `/app_data/Courier/cache` folder and retry packaging. In some cases caching might need to be turned off.
+*Solution:* Clear the `/app_data/courier/cache` folder and retry packaging. In some cases caching might need to be turned off.
 This will make transfers slower but can be set in `/config/courier.config` file.
 
 ### Properties and tabs are not sorted correctly after transfer
@@ -72,7 +72,7 @@ save item and re-transfer.
 ### Sort order on documents is not transferred
 *Caused by:* Courier not logging sort order changes, due to the way the core does sorting from its API.
 
-*How to spot:* Change sorting order on a collection of document, then transfer their parent + children. The sort order will not 
+*How to spot:* Change sorting order on a collection of document, then transfer their parent + children. The sort order will not
 be correct on the destination site.
 
-*Solution:* Clear the `/app_data/courer/cache` folder and re-package the items.
+*Solution:* Clear the `/app_data/courier/cache` folder and re-package the items.

--- a/Add-ons/UmbracoCourier/Configuration/index.md
+++ b/Add-ons/UmbracoCourier/Configuration/index.md
@@ -9,7 +9,7 @@ Courier comes with sensible defaults, but in special cases, you might need to ad
 
 Core settings are configuration options which covers the entire Courier application, no matter if it runs from Umbraco, or a desktop client, all core settings resides inside the `<settings>` xml node in the `/config/courier.config` file. With the below settings, copy the sample xml inside the `<settings>` node and Courier will register it.
 
-**For provider configuration:** Look under the appropriate provider type in the documentation
+**For provider configuration:** Look under the appropriate provider type in the documentation.
 
 ## [Configure repository providers](RepositoryProviders.md)
 
@@ -32,14 +32,14 @@ Milliseconds before a web client connection times out.
 ```
 
 ### Base64 encoding
-Encode all resources and items as base64 to avoid illegal characters
+Encode all resources and items as base64 to avoid illegal characters.
 
 ```xml
 <disableBase64Encoding>false</disableBase64Encoding >
 ```
 
 ### Strip resources from courier files
-Strip the raw byte data from the courier files before transferring
+Strip the raw byte data from the courier files before transferring.
 
 ```xml
 <stripResourcesFromCourierFiles>false</stripResourcesFromCourierFiles>
@@ -47,10 +47,10 @@ Strip the raw byte data from the courier files before transferring
 
 ## Path settings
 ### Root folder
-The root folder containing all Courier's data. This folder needs changed, if Courier runs outside of the standard Umbraco web context. 
+The root folder containing all Courier's data. This folder needs changed, if Courier runs outside of the standard Umbraco web context.
 
-```xml	
-<paths>  
+```xml
+<paths>
 	<root>~/path/to/courier</root>
 </paths>
 ```
@@ -59,7 +59,7 @@ The root folder containing all Courier's data. This folder needs changed, if Cou
 Specifies the folder within the root folder, which holds each individual revision folder.
 
 ```xml
-<paths>  
+<paths>
 	<revisions>/folder</revisions>
 </paths>
 ```
@@ -68,7 +68,7 @@ Specifies the folder within the root folder, which holds each individual revisio
 The SQL connection to the SQL database Courier should use. Notice this is not necessary as long as the repository pattern is used, as that will then be handled by the Umbraco website data is pulled/pushed from.
 
 ```xml
-<paths>  
+<paths>
 	<masterPages>/folder</masterPages>
 </paths>
 ```
@@ -82,22 +82,22 @@ The SQL connection to the SQL database Courier should use. Notice this is not ne
 ```
 
 ### Use short courier file names
-In case of too long paths, shorten file names
+In case of too long paths, shorten file names.
 
 ```xml
 <enableShortFileNames>false</enableShortFileNames>
 ```
 
 ## Ignoring providers
-If there is an issue with a specific provider, no matter what type of provider. You can turn it off by ignoring it. 
+If there is an issue with a specific provider, no matter what type of provider. You can turn it off by ignoring it.
 
 This is done by adding its full namespace and class to the configuration, you can ignore any item provider, data resolver, repository provider or any other functionality that’s loaded through Courier's provider model.
 
 ```xml
 <ignore>
-    <!-- Ignore the lucene indexer -->
+    <!-- Ignore the Lucene indexer -->
     <add>Umbraco.Courier.DataResolvers.Events.UpdateLuceneIndexes</add>
-    <!-- ignore all ucomponents data resolvers -->
+    <!-- ignore all uComponents data resolvers -->
     <add>Umbraco.Courier.uComponents.*</add>
     <!--<add>my.namespace.*</add>-->
 </ignore>
@@ -106,14 +106,14 @@ This is done by adding its full namespace and class to the configuration, you ca
 ## Settings for debugging
 
 ### Debugmode
-Enables logging to the /app_data/courier/logs folder, by default **false**
+Enables logging to the /app_data/courier/logs folder, by default **false**.
 
 ```xml
 <debugMode>true</debugMode>
 ```
 
 ### Map graphs
-If enabled, Courier will generate a blumind compatible mindmap after each extraction to map dependencies, by default **false**
+If enabled, Courier will generate a Blumind compatible mindmap after each extraction to map dependencies, by default **false**.
 
 ```xml
 <mapGraphs>true</mapGraphs>

--- a/Add-ons/UmbracoCourier/Developer/Provider-Configuration.md
+++ b/Add-ons/UmbracoCourier/Developer/Provider-Configuration.md
@@ -19,7 +19,7 @@ Configuration can expose certain folders and files in the item picker in the Cou
 ```
 
 ## Folders
-Same as above, but only with folders
+Same as above, but only with folders.
 
 ```xml
 <folderItemProvider>
@@ -31,7 +31,7 @@ Same as above, but only with folders
 
 ## Mediatypes
 
-Single option to choose whether allowed/child media types should be added as a dependency or not
+Single option to choose whether allowed/child media types should be added as a dependency or not.
 
 ```xml
 <mediaTypeItemProvider>
@@ -42,7 +42,7 @@ Single option to choose whether allowed/child media types should be added as a d
 ## DocumentTypes
 
 - Option to include all allowed templates as a dependency
-- Option to include all allowed types as a dependency 
+- Option to include all allowed types as a dependency
 - Option to filter out certain data types
 
 ```xml
@@ -50,7 +50,7 @@ Single option to choose whether allowed/child media types should be added as a d
     <!-- Include all available templates as dependencies, if false, only the current standard template is included -->
     <includeAllTemplates>false</includeAllTemplates>
     <includeChildDocumentTypes>true</includeChildDocumentTypes>
-    
+
     <!-- By default we won't add the built-in data types as dependencies, if needed, they can be removed from the list below -->
     <!-- Only data types which are installed as standard, and does not have any settings are ignored -->
     <!-- to add, find the data type in the umbracoNode table and copy its uniqueId value to a node below-->
@@ -69,10 +69,10 @@ Single option to choose whether allowed/child media types should be added as a d
     </ignoredDataTypes>
 </documentTypeItemProvider>
 ```
-    
+
 ## Media
 
-- Option to include parent nodes as a forced dependency 
+- Option to include parent nodes as a forced dependency
 - Option to automatically include all children (in case a folder is transferred)
 
 ```xml
@@ -91,11 +91,11 @@ Single option to choose whether allowed/child media types should be added as a d
     <includeParents>true</includeParents>
 </documentItemProvider>
 ```
-  
+
 ## Templates
 
-- Option to collect macros found in templates as a dependency 
-- Toggle whether Courier should look for files linked in the template(js,css,image files)
+- Option to collect macros found in templates as a dependency
+- Toggle whether Courier should look for files linked in the template (JS/CSS/image files)
 - Collect locallink references and add the documents as dependencies
 - Parse macros and add any NodeIDs passed to the macro as a dependency
 

--- a/Add-ons/UmbracoCourier/Developer/ResourceResolvers.md
+++ b/Add-ons/UmbracoCourier/Developer/ResourceResolvers.md
@@ -4,7 +4,7 @@ versionRemoved: 8.0.0
 ---
 
 # ResourceResolvers
-A resourceresolver is slightly different from dataresolvers, as they only trigger when a resource/file is packaged and extracted. This means it can only modify the file itself, but not call back to the item, which the resource belongs to.
+A resource resolver is slightly different from data resolvers, as they only trigger when a resource/file is packaged and extracted. This means it can only modify the file itself, but not call back to the item, which the resource belongs to.
 
 ### MacroParameters
 * **Full name:** `Umbraco.Courier.ResourceResolvers.MacroParameters`

--- a/Add-ons/UmbracoCourier/Old-Courier-versions/Installation/index.md
+++ b/Add-ons/UmbracoCourier/Old-Courier-versions/Installation/index.md
@@ -19,7 +19,7 @@ If you already have Courier 2.0 installed, follow these steps to upgrade to 2.x:
 1. Backup your /config/courier.config file
 2. Copy the contents of /bin, /config and /umbraco from the manual update zip, to the root of your site
 3. Delete the DLL: Castle.DynamicProxy2.dll and it’s .pdb file from the /bin folder
-4. Update the /config/courier.config file with settings from your backed-up one. 
+4. Update the /config/courier.config file with settings from your backed-up one.
 
  * Ensure your <repositories> node is copied over
  * You resource filters
@@ -32,11 +32,11 @@ If you already have Courier 2.0 installed, follow these steps to upgrade to 2.x:
 ## Manual installation
 If for some reason the package installation fails or due to permissions or other reasons is not an option on your system, we provide a manual installation process.
 
-To manually install, download the manual install package from umbraco.com or one of the hotfix releases from nightly.umbraco.org
+To manually install, download the manual install package from umbraco.com or one of the hotfix releases from nightly.umbraco.org.
 
 The manual process consists of several files:
 
- * **The folders /bin,  /config and /umbraco**  
+ * **The folders /bin,  /config and /umbraco**
 Folders containing the application files for Courier 2
  * **/sql folder**
  Folder containing install and uninstall sql files. For install there are variations for each of the 3 supported databases
@@ -49,15 +49,15 @@ Unzip the /bin, /config and /umbraco folders to the root of your website, the ar
 If you have purchased Umbraco Courier, you can download a license file on umbraco.com. This license file must be placed in the websites /bin directory to be registered.
 
 ### Installing the database
-To install the database, we need to execute a sql script against the database Umbraco is installed on. Courier  currently only supports SQL server 2005 and 2008.
+To install the database, we need to execute a sql script against the database Umbraco is installed on. Courier currently only supports SQL Server 2005 and 2008.
 
-* Open Microsoft Sql Server Management Studio and connect to your database. 
-* Right click your Umbraco database and choose "new query" 
+* Open Microsoft SQL Server Management Studio and connect to your database.
+* Right click your Umbraco database and choose "new query"
 * Open the /sql/install folder and pick the appropriate sql files. If you use MS Sql, you pick “app.sql” and “create.sql” if not, you pick the files with the correct database name in them.
 * Copy the contents of sql files to the query window
 * Execute the script
 
-If any errors are displayed, check your permissions. The install script requires database owner access, as it creates new tables. 
+If any errors are displayed, check your permissions. The install script requires database owner access, as it creates new tables.
 
 ### Uninstalling the database
-In case of error you can use the /sql/uninstall/uninstall.sql file to remove all courier tables. Follow the same procedure as the one describing "installing the database"
+In case of error you can use the /sql/uninstall/uninstall.sql file to remove all courier tables. Follow the same procedure as the one describing "installing the database".

--- a/Add-ons/UmbracoCourier/index.md
+++ b/Add-ons/UmbracoCourier/index.md
@@ -5,7 +5,7 @@ versionRemoved: 8.0.0
 
 # Courier Documentation
 
-Umbraco Courier is a tool that lets you deploy your schema and content from one Umbraco site to another. 
+Umbraco Courier is a tool that lets you deploy your schema and content from one Umbraco site to another.
 
 With Courier installed on your site, you can tell it to deploy an item from one site to another. Courier will then figure out what is needed for that specific item, package everything up, send it and finally extract it on the target site.
 
@@ -29,7 +29,7 @@ Learn about the various ways to configure Courier.
 How Courier is supposed to be used, to deploy content and developer assets from one site to another. Gives insight into how Courier is built.
 
 ## [Developer Documentation](Developer)
-These are the howtos, which describes how you extend courier, and add new providers or hook into existing ones.
+These are the HOWTOs, which describes how you extend courier, and add new providers or hook into existing ones.
 
 ## [Common Issues](CommonIssues.md)
 For developers configuring or troubleshooting Courier.

--- a/Add-ons/UmbracoForms/Developer/Email-Templates/index.md
+++ b/Add-ons/UmbracoForms/Developer/Email-Templates/index.md
@@ -4,7 +4,7 @@ versionFrom: 7.0.0
 
 # Email Templates
 
-From version 6+ we now include a new Workflow 'Send email with template (Razor)' that allows you to pick a Razor view file that will then be used to send out a *pretty HTML email* for form submissions. 
+From version 6+ we now include a new Workflow 'Send email with template (Razor)' that allows you to pick a Razor view file that will then be used to send out a *pretty HTML email* for form submissions.
 
 We include an example email template for you to look at and understand how it works found at `~/Views/Partials/Forms/Emails/`.
 
@@ -42,7 +42,7 @@ Below is an example of an email template:
 
 <h2>Favourite Colors</h2>
 <ul>
-    @foreach(var color in Model.GetValues("favColors")){
+    @foreach (var color in Model.GetValues("favColors")) {
         <li>@color</li>
     }
 </ul>
@@ -64,7 +64,7 @@ Below is an example of an email template:
             @(Convert.ToDateTime(field.GetValue()).ToString("f"))
             break;
 
-        case "FieldType.CheckboxList.cshtml":            
+        case "FieldType.CheckboxList.cshtml":
             foreach (var color in field.GetValues())
             {
                 @color<br/>

--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Workflowtype.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Workflowtype.md
@@ -5,7 +5,7 @@ versionFrom: 7.0.0
 # Adding a workflow type to Umbraco Forms
 *This builds on the "[adding a type to the provider model](Adding-a-Type.md)" chapter*
 
-Add a new class to your project and have it inherit from Umbraco.Forms.Core.WorkflowType, implement the class. For this sample we will focus on the execute method. This method process the current record (the data submitted by the form) and have the ability to change data and state.
+Add a new class to your project and have it inherit from `Umbraco.Forms.Core.WorkflowType`, implement the class. For this sample we will focus on the execute method. This method process the current record (the data submitted by the form) and have the ability to change data and state.
 
 ```csharp
 using System;
@@ -17,7 +17,7 @@ using Umbraco.Forms.Data.Storage;
 using Umbraco.Forms.Web.Services;
 
 /// <summary>
-/// Summary description for Class1
+/// Summary description for TestWorkflow
 /// </summary>
 public class TestWorkflow : WorkflowType
 {
@@ -64,6 +64,6 @@ public class TestWorkflow : WorkflowType
 }
 ```
 
-The Execute() method gets a Record and a RecordEventArgs argument. These 2 arguments contains all information related to the workflow. The record contains all data and meta data submitted by the form. The RecordEventArgs contains references to what form the record is from, what state it is in and a reference to the current HttpContext
+The `Execute()` method gets a `Record` and a `RecordEventArgs` argument. These 2 arguments contains all information related to the workflow. The record contains all data and meta data submitted by the form. The RecordEventArgs contains references to what form the record is from, what state it is in and a reference to the current `HttpContext`.
 
-The sample above uses 2 different areas to work with the record. The first is the RecordStorage class which handles all storage of the record data. The second is the RecordService, this handles record state changes and record events.
+The sample above uses 2 different areas to work with the record. The first is the `RecordStorage` class which handles all storage of the record data. The second is the `RecordService`, this handles record state changes and record events.

--- a/Add-ons/UmbracoForms/Developer/Working-With-Data/index-v7.md
+++ b/Add-ons/UmbracoForms/Developer/Working-With-Data/index-v7.md
@@ -7,7 +7,7 @@ versionFrom: 7.0.0
 Umbraco Forms includes some helper methods that return dynamic objects, which can be used to output records in your templates using razor.
 
 ## Available methods
-The static methods can be found in Umbraco.Forms.Mvc.DynamicObjects.Library
+The static methods can be found in `Umbraco.Forms.Mvc.DynamicObjects.Library`.
 
 ### GetApprovedRecordsFromPage
 
@@ -15,7 +15,7 @@ The static methods can be found in Umbraco.Forms.Mvc.DynamicObjects.Library
 DynamicRecordList GetApprovedRecordsFromPage(int pageId)
 ```
 
-Returns all records with the state set to approved from all forms on the Umbraco page with the id = `pageId` as a DynamicRecordList. 
+Returns all records with the state set to approved from all forms on the Umbraco page with the id = `pageId` as a DynamicRecordList.
 
 ### GetApprovedRecordsFromFormOnPage
 
@@ -77,7 +77,7 @@ DateTime Updated
 
 In order to access custom form fields you can use the dot notation, using the field caption but removing all spaces and non alphanumeric characters.
 
-## Sample razor script 
+## Sample razor script
 
 Sample script that is outputting comments using a form created with the default comment form template.
 
@@ -90,10 +90,12 @@ Sample script that is outputting comments using a form created with the default 
 	{
 		<li>
 			@record.Created.ToString("dd MMMM yyy")
-			@if(string.IsNullOrEmpty(record.Website)){
+			@if (string.IsNullOrEmpty(record.Website))
+            {
 				<strong>@record.Name</strong>
 			}
-			else{
+			else
+            {
 				<strong>
 				<a href="@record.Website" target="_blank">@record.Name</a>
 				</strong>

--- a/Add-ons/UmbracoForms/Editor/Creating-a-Form/Fieldtypes/Date/index.md
+++ b/Add-ons/UmbracoForms/Editor/Creating-a-Form/Fieldtypes/Date/index.md
@@ -4,7 +4,7 @@ versionFrom: 7.0.0
 
 # Date
 
-The date picker uses a front-end library called [PikaDay.js](https://github.com/dbushell/Pikaday) to display a UI to pick dates from.
+The date picker uses a front-end library called [Pikaday](https://github.com/dbushell/Pikaday) to display a UI to pick dates from.
 
 ![Date picker on frontend](images/date-picker.png)
 
@@ -12,9 +12,9 @@ As of Umbraco Forms 4.4.0 we have added the support for the Pikaday date picker 
 
 This displays the picked date in the correct locale. Using JavaScript we update a hidden field with a standard date format to send to the server for storing the record submission in a standard format. This is to avoid locale mixing up dates.
 
-To achieve this, a Razor partial view is included - you can find it here: `/Views/Partials/Forms/DatePicker.cshtml`. 
+To achieve this, a Razor partial view is included - you can find it here: `/Views/Partials/Forms/DatePicker.cshtml`.
 
-This includes the MomentJS library to help with the date locale formatting & the appropriate changes to Pikaday.js to support the locales. If you wish to use a different DatePicker component this is the file that you would customize to your needs.
+This includes the Moment.js library to help with the date locale formatting & the appropriate changes to Pikaday to support the locales. If you wish to use a different DatePicker component this is the file that you would customize to your needs.
 
 ## Configure the Year range
 The Date picker has a configuration setting to control the number of years shown in the picker. The default value is 10 years.

--- a/Add-ons/UmbracoForms/Editor/Creating-a-Form/Fieldtypes/Recaptcha/index.md
+++ b/Add-ons/UmbracoForms/Editor/Creating-a-Form/Fieldtypes/Recaptcha/index.md
@@ -2,9 +2,9 @@
 versionFrom: 7.0.0
 ---
 
-# Recaptcha
+# reCAPTCHA
 
-![Recaptcha2](images/recaptcha2.png)
+![reCAPTCHA v2](images/recaptcha2.png)
 
 You need to configure your site keys adding your public and private keys in the `UmbracoForms.config` file located in `~/App_Plugins/UmbracoForms/`:
 
@@ -13,6 +13,6 @@ You need to configure your site keys adding your public and private keys in the 
 <setting key="RecaptchaPrivateKey" value="sHZZenninFziVUV9TN24FqhwZvc2b4e8BLrG-" />
 ```
 
-You can create your keys by [logging into your Recaptcha account](https://www.google.com/recaptcha/).
+You can create your keys by [logging into your reCAPTCHA account](https://www.google.com/recaptcha/).
 
-**Note**: Don't forget to make the recatpcha field mandatory.
+**Note**: Don't forget to make the **Recaptcha** field mandatory.

--- a/Add-ons/UmbracoForms/Editor/Creating-a-Form/Fieldtypes/index.md
+++ b/Add-ons/UmbracoForms/Editor/Creating-a-Form/Fieldtypes/index.md
@@ -62,13 +62,13 @@ Outputs a title and description that are set as prevalues.
 
 ![Radiobuttonlist](images/titleanddescription.png)
 
-## [Recaptcha](Recaptcha)
+## [reCAPTCHA](Recaptcha)
 The field displays a single checkbox for the user to check in order for the form to be validated
 
-![Recaptcha2](images/recaptcha2.png)
+![reCAPTCHA v2](images/recaptcha2.png)
 
 :::tip
-As ReCaptcha v1 is shut down, we **strongly** recommend that you use the ReCaptcha2 field type.
+As reCAPTCHA v1 is shut down, we **strongly** recommend that you use the reCAPTCHA v2 field type.
 :::
 
 ## Hidden

--- a/Add-ons/UmbracoForms/Editor/Creating-a-Form/index-v7.md
+++ b/Add-ons/UmbracoForms/Editor/Creating-a-Form/index-v7.md
@@ -8,9 +8,9 @@ This will show the basic steps of creating a form and adding them to your Umbrac
 
 ## Navigate to the Forms section
 
-Managing forms happens in the Forms section of the Umbraco backoffice. You need to have access to the section in order to see it. 
+Managing forms happens in the Forms section of the Umbraco backoffice. You need to have access to the section in order to see it.
 
-![Forms Section](images/FormsSection.png) 
+![Forms Section](images/FormsSection.png)
 
 ## Click the forms tree
 
@@ -58,7 +58,7 @@ To add more pages, click **Add new page** at the bottom of the page forms design
 
 As you can give each page a name, you can also name the groups.
 
-![Forms designer page captin](images/FormDesignerPageGroup.png)
+![Forms designer page caption](images/FormDesignerPageGroup.png)
 
 To add another group to your form, click **Add new group** which you can find at the bottom of each page in the form designer.
 

--- a/Add-ons/UmbracoForms/Editor/Creating-a-Form/index.md
+++ b/Add-ons/UmbracoForms/Editor/Creating-a-Form/index.md
@@ -8,9 +8,9 @@ This will show the basic steps of creating a form and adding them to your Umbrac
 
 ## Navigate to the Forms section
 
-Managing forms happens in the Forms section of the Umbraco backoffice. You need to have access to the section in order to see it. 
+Managing forms happens in the Forms section of the Umbraco backoffice. You need to have access to the section in order to see it.
 
-![Forms Section](images/FormsSectionV8.png) 
+![Forms Section](images/FormsSectionV8.png)
 
 ## Click the forms tree
 
@@ -79,7 +79,7 @@ In the dialog you'll also need to choose which type of field or layout element y
 Once the type has been selected, there are a number of additional settings that can be applied to the field:
 
 * Mark whether the field stores **sensitive data**
-    * This will prevent the data from this field from being downloaded and viewed by users who does not have permission to do so. Only members of the sensative data user group will see this option.  
+    * This will prevent the data from this field from being downloaded and viewed by users who does not have permission to do so. Only members of the sensitive data user group will see this option.
 * You can give the field a **default value**
 * Add a **placeholder** to make it easier for the user to fill in the form
 * Mark whether the field is **mandatory**, and customize the message

--- a/Add-ons/UmbracoForms/Installation/ManualUpgrade-v7.md
+++ b/Add-ons/UmbracoForms/Installation/ManualUpgrade-v7.md
@@ -12,10 +12,10 @@ In order to upgrade you will want to [download the version of Forms you wish to 
 Note that this filename ends with `.Files.x.y.z.zip` and contains only the files that get installed when you install Umbraco Forms.
 
 ## Copy
-Unzip the file you downloaded and copy and overwrite (almost) everything into your website. Almost, because you might not want to overwrite `~/App_Plugins/UmbracoForms/UmbracoForms.config` because you might have updated it in the past. Make sure to compare your current version to the version in the zip file you downloaded. If there's any new configuration options in there then copy those into your website's `UmbracoForms.config` file. 
+Unzip the file you downloaded and copy and overwrite (almost) everything into your website. Almost, because you might not want to overwrite `~/App_Plugins/UmbracoForms/UmbracoForms.config` because you might have updated it in the past. Make sure to compare your current version to the version in the zip file you downloaded. If there's any new configuration options in there then copy those into your website's `UmbracoForms.config` file.
 
 ## Upgrade marker
-Finally, you'll need to tell Umbraco Forms to update itself when you start the website next. In order to do that you need to have a `formsupdate` file (an empty text file without extension) in `~/App_Data/TEMP/`. The easiest way to create this file is by going into the root folder of your website and start a command line there. You can then type the following command: `echo > /App_Data/TEMP/formsupdate`
+Finally, you'll need to tell Umbraco Forms to update itself when you start the website next. In order to do that you need to have a `formsupdate` file (an empty text file without extension) in `~/App_Data/TEMP/`. The easiest way to create this file is by going into the root folder of your website and start a command line there. You can then type the following command: `echo > /App_Data/TEMP/formsupdate`.
 
 This command creates the file and you should see it disappear the next time the website recycles (you may want to recycle the website manually after creating this file). If the file isn't automatically removed, it is completely safe to remove it manually.
 

--- a/Add-ons/UmbracoForms/Installation/Version-Specific.md
+++ b/Add-ons/UmbracoForms/Installation/Version-Specific.md
@@ -6,7 +6,7 @@ versionFrom: 7.0.0
 This page covers specific upgrade documentation for specific versions.
 
 ## Version 8
-Version 8 of Umbraco Forms has a minimum dependency on Umbraco CMS core of `8.0.0` & higher. 
+Version 8 of Umbraco Forms has a minimum dependency on Umbraco CMS core of `8.0.0` & higher.
 The reasoning behind this is due to some underlying changes in Umbraco CMS core.
 
 ## Version 4 to Version 6
@@ -37,4 +37,4 @@ The following outlines for `version 6.0.0` what upgrade/migration tasks that are
 * Moves any Form PreValue sources that uses text files that were uploaded to the media section & now stores in the Umbraco Forms IFileSystem
 
 ### Recommendation
-We highly recommend you make the switch away from the legacy macro and swap over to the newer macro that supports the new 6.0.0 feature of themes. The legacy macro is there to ease the transisition over and to avoid entire sites forms to stop working.
+We highly recommend you make the switch away from the legacy macro and swap over to the newer macro that supports the new 6.0.0 feature of themes. The legacy macro is there to ease the transition over and to avoid entire sites forms to stop working.

--- a/Development-Guidelines/breaking-changes.md
+++ b/Development-Guidelines/breaking-changes.md
@@ -33,21 +33,21 @@ As the product evolves and more features are added, there may be rare circumstan
 
 * Changes to class inheritance are not considered breaking if they do not break API usage
 	* Take the following for example, if in v6 a class exists called `MyClass` with the following structure:
-		
+
 		```csharp
-		public class MyClass 
+		public class MyClass
 		{
 			public int Id {get;set;}
 			public string Name {get;set;}
 		}
 		```
-		
+
 	* Then in v6.1 the class structure changes to this:
 
 		```csharp
 		public class MyClass : MySubClass
 		{
-			public string Name {get;set;}    			
+			public string Name {get;set;}
 		}
 
 		public class MySubClass
@@ -55,10 +55,10 @@ As the product evolves and more features are added, there may be rare circumstan
 			public int Id {get;set;}
 		}
 		```
-		
+
 	* With the above change, any API usage of MyClass will not break, however, if a developer is using reflection to target `MyClass` explicitly, in some cases this will break the reflection call. We **do not** consider these types of changes as breaking changes.
 * Changes made to any non-public or non-protected property, methods, interfaces or classes are not considered breaking
-	* Generally these types of changes will never break a developers usage unless they are using reflection to target non-public/non-protected objects. 
+	* Generally these types of changes will never break a developers usage unless they are using reflection to target non-public/non-protected objects.
 
 ### Breaking
 
@@ -84,7 +84,7 @@ As the product evolves and more features are added, there may be rare circumstan
 ### Breaking
 
 * Changing the file location of CSS or Images is a breaking change
- 
+
 _It is advised to use Umbraco's Angular directives if you wish to create backoffice components, this will mean that you are not referencing CSS or Html markup directly_
 
 ## JavaScript
@@ -100,7 +100,7 @@ _It is advised to use Umbraco's Angular directives if you wish to create backoff
 * Changes made to publicly accessible APIs that are documented
 * Changing the location of JavaScript library files
 * Changing the alias of AngularJS controller, service or directive
- 
+
 ## Database
 
 ### Non-breaking

--- a/Development-Guidelines/test-driven-flow.md
+++ b/Development-Guidelines/test-driven-flow.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 ---
 
-# Working with the backoffice UI AngularJS project 
+# Working with the backoffice UI AngularJS project
 
 _This document tries to outline what is required to have a test-driven setup for
 angular development in Umbraco 7. It goes through the setup process as well as how
@@ -22,13 +22,13 @@ To start working on the client files, and have them automatically built and merg
 
 	gulp dev
 
-This will start a webserver on :8080 and tell Karma to run tests every time a .js or .less file is changed. 
+This will start a webserver on :8080 and tell Karma to run tests every time a .js or .less file is changed.
 After linting and tests have passed, all the client files are copied to umbraco.web.ui/umbraco folder, so it also keeps the server project up to date on any client changes. This should all happen in the background.
 
 ## Adding a new service
 The process for adding or modifying a service should always be based on passed tests. So if we need to change the footprint of the contentservice, and the way any controller calls this service, we need to make sure the tests pass with our mocked services.
 
-This ensures 3 things: 
+This ensures 3 things:
 - we test our controllers
 - we test our services
 - we always have mocked data available, if you want to run the client without IIS
@@ -40,7 +40,7 @@ We add a service for fetching macros from the database, the initial implementati
 The macro.resource.js calls `$http` as normal, but no server implementation should be needed at this point.
 
 Next, we describe how the rest service should return data, this is done in /common/mocks/umbraco.httpbackend.js, where we can define what data a certain url
-would return. 
+would return.
 
 So in the case of getting tree items we define:
 
@@ -50,10 +50,10 @@ $httpBackend
 	.respond(returnApplicationTrees);
 ```
 
-The `returnApplicationTrees` function then looks like this: 
+The `returnApplicationTrees` function then looks like this:
 
 ```javascript
-function returnApplicationTrees(status, data, headers){
+function returnApplicationTrees(status, data, headers) {
 	var app = getParameterByName(data, "application");
 	var tree = _backendData.tree.getApplication(app);
 	return [200, tree, null];
@@ -66,7 +66,7 @@ It returns an array of 3 items, the http status code, the expected data and fina
 _backendData.tree.getApplication(app);
 ```
 
-Refers to a helper method in `umbraco.httpbackend.helper.js` which contains all the helper methods we use to return static json. 
+Refers to a helper method in `umbraco.httpbackend.helper.js` which contains all the helper methods we use to return static json.
 
 ### In short
 So to add a service, which requires data from the server we should:
@@ -85,11 +85,11 @@ urlService.url("contentTypes", "GetAllowedChildren");
 // would return /<umbracodir>/<apibaseDir>/contentyTypes/getAllowedChildren
 ```
 
-But for now, they are set in the servervariables file.	
+But for now, they are set in the servervariables file.
 
 =======
 
-# Working with the backoffice UI AngularJS project 
+# Working with the backoffice UI AngularJS project
 
 _This document tries to outline what is required to have a test-driven setup for
 angular development in Umbraco 7. It goes through the setup process as well as how
@@ -109,13 +109,13 @@ To start working on the client files, and have them automatically built and merg
 
 	gulp dev
 
-This will start a webserver on :8080 and tell Karma to run tests every time a .js or .less file is changed. 
+This will start a webserver on :8080 and tell Karma to run tests every time a .js or .less file is changed.
 After linting and tests have passed, all the client files are copied to umbraco.web.ui/umbraco folder, so it also keeps the server project up to date on any client changes. This should all happen in the background.
 
 ## Adding a new service
 The process for adding or modifying a service should always be based on passed tests. So if we need to change the footprint of the `ContentService`, and the way any controller calls this service, we need to make sure the tests pass with our mocked services.
 
-This ensures 3 things: 
+This ensures 3 things:
 - we test our controllers
 - we test our services
 - we always have mocked data available, if you want to run the client without IIS
@@ -127,7 +127,7 @@ We add a service for fetching macros from the database, the initial implementati
 The macro.resource.js calls `$http` as normal, but no server implementation should be needed at this point.
 
 Next, we describe how the rest service should return data, this is done in /common/mocks/umbraco.httpbackend.js, where we can define what data a certain url
-would return. 
+would return.
 
 So in the case of getting tree items we define:
 
@@ -137,10 +137,10 @@ $httpBackend
 	.respond(returnApplicationTrees);
 ```
 
-The `returnApplicationTrees` function then looks like this: 
+The `returnApplicationTrees` function then looks like this:
 
 ```javascript
-function returnApplicationTrees(status, data, headers){
+function returnApplicationTrees(status, data, headers) {
 	var app = getParameterByName(data, "application");
 	var tree = _backendData.tree.getApplication(app);
 	return [200, tree, null];
@@ -153,7 +153,7 @@ It returns an array of 3 items, the http status code, the expected data and fina
 _backendData.tree.getApplication(app);
 ```
 
-Refers to a helper method in `umbraco.httpbackend.helper.js` which contains all the helper methods we use to return static json. 
+Refers to a helper method in `umbraco.httpbackend.helper.js` which contains all the helper methods we use to return static json.
 
 ### In short
 

--- a/Extending/Backoffice-Tours/index.md
+++ b/Extending/Backoffice-Tours/index.md
@@ -5,7 +5,7 @@ versionFrom: 7.8.0
 
 # Backoffice tours
 
-:::note 
+:::note
 This feature has been introduced in Umbraco 7.8.0
 :::
 
@@ -59,27 +59,27 @@ Example tour configuration object :
 
 Below is an explanation of each of the properties on the tour configuration object
 
-### name 
+### name
 
 This is the name that is displayed in the help drawer for the tour.
 
 ![Tour name highlighted](images/tourname.png)
 
-### alias 
+### alias
 
 The unique alias of your tour, this is used to track the progress a user has made while taking a tour. The progress information is stored in the TourData column of the UmbracoUsers table in the database.
 
-### group 
+### group
 
-The group property is used to group related tours in the help drawer under a common subject (e.g. Getting started). 
+The group property is used to group related tours in the help drawer under a common subject (e.g. Getting started).
 
 ![Tour group highlighted](images/tourgroup.png)
 
-### groupOrder 
+### groupOrder
 
 This is used to control the order of the groups in the help drawer. This must be an integer value.
 
-### allowDisable 
+### allowDisable
 
 A boolean value that indicates if the "Don't show this tour again" should be shown on the tour steps. If the user clicks this link the tour will no longer be shown in the help drawer.
 
@@ -118,12 +118,11 @@ Example tour step object:
 },
 ```
 
-Below is an explanation of each of the properties on the tour step object
+Below is an explanation of each of the properties on the tour step object.
 
 ### title
 
 This the title shown on the tour step.
-
 
 ![Tour step highlighted](images/steptitle.png)
 
@@ -141,7 +140,7 @@ The type of step. Currently, only one type is supported : "intro". This will cen
 
 A CSS selector for the element you wish to highlight. The tour step will position itself near the element.
 
-A lot of elements in the Umbraco backoffice have a "data-element" attribute. It's recommended to use that, because "id" and "class" are subject to changes. e.g.
+A lot of elements in the Umbraco backoffice have a "data-element" attribute. It's recommended to use that, because "id" and "class" are subject to changes, e.g.:
 
 	[data-element='section-content']
 
@@ -157,7 +156,7 @@ As an example, it is very useful when you would like to highlight a button, but 
 
 ### event
 
-The JavaScript event that is bound to the highlighted element that should trigger the next tour step e.g. click, hover,...
+The JavaScript event that is bound to the highlighted element that should trigger the next tour step e.g. click, hover, etc.
 
 If not set or omitted a "Next" button will be added to the tour.
 
@@ -170,14 +169,14 @@ The image below shows the entire tree highlighted, but requires the user to clic
 
 ### backdropOpacity
 
-A decimal value between 0 and 1 to indicate the transparency of the background overlay. 
+A decimal value between 0 and 1 to indicate the transparency of the background overlay.
 
 ### view
 
-Here you can enter a path to your own custom angular view that will be used to display the tour step
+Here you can enter a path to your own custom angular view that will be used to display the tour step.
 
 This is useful if you would like to validate input from the user during the tour step.
 
 ### customProperties
 
-A JSON object that is passed to the scope of a custom step view, so you can use this data in your view with $scope.model.currentStep.customProperties
+A JSON object that is passed to the scope of a custom step view, so you can use this data in your view with $scope.model.currentStep.customProperties.

--- a/Extending/Content-Apps/index.md
+++ b/Extending/Content-Apps/index.md
@@ -24,11 +24,11 @@ For example, you could create a Google Analytics integration within a Content Ap
 
 #### Controlling Appearance/Position
 
-You can associate an icon with your custom Content App, control the position (between 'Content' and 'Info') where your custom Content App should appear via a 'weighting' number
+You can associate an icon with your custom Content App, control the position (between 'Content' and 'Info') where your custom Content App should appear via a 'weighting' number.
 
 #### Permissions
 
-Content Apps can be configured to appear dependent on Section, Content Type and User Group Permissions. 
+Content Apps can be configured to appear dependent on Section, Content Type and User Group Permissions.
 
 #### Read-Only?
 
@@ -46,9 +46,9 @@ A basic understanding of how to use AngularJS with Umbraco is required.  If you 
 
 ### Setting up the Plugin
 
-The first thing we do is create a new folder inside `/App_Plugins` folder. We will call it `WordCounter`
+The first thing we do is create a new folder inside `/App_Plugins` folder. We will call it `WordCounter`.
 
-Next we need to create a manifest file to describe what this Content App does. This manifest will tell Umbraco about our new Content App and allows us to inject any needed files into the application.  
+Next we need to create a manifest file to describe what this Content App does. This manifest will tell Umbraco about our new Content App and allows us to inject any needed files into the application.
 
 Create a new file in the `/App_Plugins/WordCounter/` folder and name it `package.manifest`. In this new file, copy the code snippet below and save it. This code describes the Content App. To help you understand the JSON, read the inline comments for details on each bit:
 
@@ -94,7 +94,7 @@ angular.module("umbraco")
             var properties = node.variants[0].tabs[0].properties;
 
             vm.propertyWordCount = {};
-            
+
             var index;
             for (index = 0; index < properties.length; ++index) {
                 var words = properties[index].value;
@@ -148,7 +148,7 @@ You can set your Content App to only show for specific content types by updating
 {
     "contentApps": [
         {
-            "show": [ 
+            "show": [
                 "-content/homePage", // hide for content type 'homePage'
                 "+content/*", // show for all other content types
                 "+media/*" // show for all media types
@@ -159,7 +159,7 @@ You can set your Content App to only show for specific content types by updating
 ```
 
 :::tip
-When the 'show' directive is omitted then the app will be shown for all content types. 
+When the 'show' directive is omitted then the app will be shown for all content types.
 
 Also, when you want to exclude content types, make sure to include all the rest using `"+content/*"`.
 :::
@@ -172,7 +172,7 @@ In a similar way, you can limit your Content App according to user roles (groups
 {
     "contentApps": [
         {
-            "show": [ 
+            "show": [
                 "+role/admin"  // show for 'admin' user group
             ]
         }
@@ -250,7 +250,7 @@ namespace Umbraco.Web.UI
     }
 }
 ```
-    
+
 You will still need to add all of the files you added above but, because your `C#` code is adding the Content App, the `package.manifest` file can be simplified like this:
 
 ```json5

--- a/Extending/Dashboards/index.md
+++ b/Extending/Dashboards/index.md
@@ -203,7 +203,7 @@ If your dashboard is unique to your Umbraco installation then you can modify the
 ```
 
 ### Specifying permissions
-You can configure which applications/sections a dashboard will appear in, in the above examples (package.manifest or c#), you can see the alias of the section is used to control where the dashboard is allowed to appear. 
+You can configure which applications/sections a dashboard will appear in, in the above examples (package.manifest or c#), you can see the alias of the section is used to control where the dashboard is allowed to appear.
 
 Further to this, within this section, you can control which Users can see a particular dashboard based upon the *User Groups* they belong to. This is done by setting the 'access' permissions based on the *User Group* alias, you choose to deny or grant a particular User Group's access to the dashboard.
 
@@ -256,7 +256,7 @@ namespace My.Website
 ```
 
 ## Remove an Umbraco dashboard
-In previous versions of Umbraco if you wanted to remove or modify the order of a default dashboards you would ammend the `config/dashboards.config` file on disk. 
+In previous versions of Umbraco if you wanted to remove or modify the order of a default dashboards you would amend the `config/dashboards.config` file on disk.
 
 In Umbraco 8+ the configuration file approach has been removed and you need to use code to create your own *composer* to remove a dashboard. It could be a c# class that can be used to organise and customise your Umbraco application to your own needs. For example - if you wanted to remove the 'Content Dashboard' you would create a RemoveDashboard composer like this:
 

--- a/Extending/Database/index.md
+++ b/Extending/Database/index.md
@@ -81,7 +81,7 @@ namespace Umbraco.Web.UI
                 Logger.Debug<AddCommentsTable>("The database table {DbTable} already exists, skipping", "BlogComments");
             }
         }
-        
+
         [TableName("BlogComments")]
         [PrimaryKey("Id", AutoIncrement = true)]
         [ExplicitColumns]
@@ -113,7 +113,7 @@ namespace Umbraco.Web.UI
 
 ## Schema class and migrations
 
-**Important!** It is important to note that the `BlogCommentSchema` class is purely used as a database schema representation and should not be used as a DTO to access the table data. Equally, you shouldn't use your DTOs to define the schema used by your migration, instead you should create a duplicate snapshot as demostrated above specifically for the purpose of creating your database table.
+**Important!** It is important to note that the `BlogCommentSchema` class is purely used as a database schema representation and should not be used as a DTO to access the table data. Equally, you shouldn't use your DTOs to define the schema used by your migration, instead you should create a duplicate snapshot as demonstrated above specifically for the purpose of creating your database table.
 
 Whilst this adds a level of duplication, it is important that migrations remain immutable. If the DTO was to be used for both, it could cause unexpected behaviour should you later modify your DTO but you have previous migrations that expect the DTO to be in its unmodified state.
 

--- a/Extending/Embedded-Media-Provider/index-v7.md
+++ b/Extending/Embedded-Media-Provider/index-v7.md
@@ -24,8 +24,8 @@ Umbraco ships with configuration to embed media from the following third-party p
 * Flickr
 * SlideShare
 * Kickstarter
-* GettyImages
-* PollEverywhere
+* Getty Images
+* Poll Everywhere
 * PollDaddy
 * IFTTT
 * Instagram
@@ -33,7 +33,7 @@ Umbraco ships with configuration to embed media from the following third-party p
 * SoundCloud
 * YouTube
 * StreamUmbraco
-* DailyMotion
+* Dailymotion
 * Hulu
 * Vimeo
 * TedTalks
@@ -65,7 +65,7 @@ The configuration would look like this:
 
 Recycle the application pool, the new provider should be available for editors to use:
 
-![Embedding a Media Item from Deviant Art website](images/deviantart-embedded-media.png)
+![Embedding a Media Item from DeviantArt website](images/deviantart-embedded-media.png)
 
 ## Custom Embedded Media Providers
 
@@ -78,7 +78,7 @@ Umbraco provides an AbstractProvider class (or AbstractOEmbedProvider) to get yo
 
 ### Custom Embedded Media Provider Example
 
-Azure Media Services [(https://azure.microsoft.com/en-gb/services/media-services/)](https://azure.microsoft.com/en-gb/services/media-services/) provide 'broadcast-quality' video streaming services. You can embed the Azure Media Player into your site to play a video using an IFrame:  
+Azure Media Services [(https://azure.microsoft.com/en-gb/services/media-services/)](https://azure.microsoft.com/en-gb/services/media-services/) provide 'broadcast-quality' video streaming services. You can embed the Azure Media Player into your site to play a video using an IFrame:
 https://ampdemo.azureedge.net/azuremediaplayer.html
 
 We can create a custom Embedded Media Provider to do the job of taking the Url of the Media asset and writing out the markup required to embed the IFrame in your content.
@@ -97,7 +97,7 @@ namespace Our.Umbraco.Media.EmbedProviders
         {
             // format of markup
             string videoFormat = "<div class=\"iplayer-container\"><iframe src=\"//aka.ms/ampembed?url={0}\" name=\"azuremediaplayer\" scrolling=\"no\" frameborder=\"no\" align=\"center\" autoplay=\"false\" width=\"{1}\" height=\"{2}\" allowfullscreen></iframe></div>";
-            // pass in encoded Url, with and height, and turn off autoplay...                
+            // pass in encoded Url, with and height, and turn off autoplay...
             var videoPlayerMarkup = string.Format(videoFormat, HttpUtility.UrlEncode(url) + "&amp;autoplay=false", maxWidth, maxHeight);
             return videoPlayerMarkup;
         }

--- a/Extending/Embedded-Media-Provider/index.md
+++ b/Extending/Embedded-Media-Provider/index.md
@@ -24,11 +24,11 @@ The list of available default Embed Providers in an Umbraco install are as follo
 * Instagram
 * Twitter
 * Vimeo
-* DailyMotion
+* Dailymotion
 * Flickr
-* Slideshare
+* SlideShare
 * Kickstarter
-* GettyImages
+* Getty Images
 * Ted
 * SoundCloud
 * Issuu
@@ -74,7 +74,7 @@ If the provider to add supports the *OEmbed* format for embedding a representati
 
 ### Adding a new OEmbed Provider Example
 
-Let's allow our editors to embed artwork from the popular DeviantArt website - the world's largest online social community for artists and art enthusiasts. We can see they have information on using OEmbed: https://www.deviantart.com/developers/oembed. The format of their OEmbed implementation returns a JSON format, from a url `https://backend.deviantart.com/oembed?url=[urltoembed]`. We'll need to use the `EmbedProviderBase` and the `base.GetJsonResponse` method. We can see 'links' to media shared on deviantart are in the format: `https://fav.me/[uniquemediaidentifier]` so we'll need a regex to match any urls pasted into the embed panel that start with *fav.me*, achieved by setting the `UrlSchemeRegex` property.
+Let's allow our editors to embed artwork from the popular DeviantArt website - the world's largest online social community for artists and art enthusiasts. We can see they have information on using OEmbed: https://www.deviantart.com/developers/oembed. The format of their OEmbed implementation returns a JSON format, from a url `https://backend.deviantart.com/oembed?url=[urltoembed]`. We'll need to use the `EmbedProviderBase` and the `base.GetJsonResponse` method. We can see 'links' to media shared on DeviantArt are in the format: `https://fav.me/[uniquemediaidentifier]` so we'll need a regex to match any urls pasted into the embed panel that start with *fav.me*, achieved by setting the `UrlSchemeRegex` property.
 
 The Provider would look like this:
 
@@ -108,7 +108,7 @@ namespace Umbraco8.EmbedProviders
 ```
 #### Register the provider with the OEmbedProvidersCollection
 
-Create a new C# class that implments IUserComposer and add append your new provider to the EmbedProvidersCollection:
+Create a new C# class that implements `IUserComposer` and add append your new provider to the EmbedProvidersCollection:
 
 ```csharp
 using Umbraco.Core.Composing;
@@ -127,7 +127,7 @@ namespace Umbraco8.Composing
 ```
 The new provider should be available for editors to use:
 
-![Embedding a Media Item from Deviant Art website](images/deviantart-embedded-media.png)
+![Embedding a Media Item from DeviantArt website](images/deviantart-embedded-media.png)
 
 Notice there isn't really any implementation written here - the regex maps the incoming url to the provider, and the base methods handle the complication of requesting from the third party api, and turning the response into html.
 
@@ -137,7 +137,7 @@ If your third-party media provider does not support OEmbed or there is some quir
 
 ### Custom Embed Provider Example
 
-Azure Media Services [(https://azure.microsoft.com/en-gb/services/media-services/)](https://azure.microsoft.com/en-gb/services/media-services/) provide 'broadcast-quality' video streaming services. You can embed the Azure Media Player into your site to play a video using an IFrame: 
+Azure Media Services [(https://azure.microsoft.com/en-gb/services/media-services/)](https://azure.microsoft.com/en-gb/services/media-services/) provide 'broadcast-quality' video streaming services. You can embed the Azure Media Player into your site to play a video using an IFrame:
 https://ampdemo.azureedge.net/azuremediaplayer.html
 
 This example creates a custom Embed Provider to do the job of taking the Url of the Media asset and writing out the markup required to embed the IFrame video player inside your content.
@@ -152,7 +152,7 @@ namespace Umbraco8.EmbedProviders
 {
     public class AzureVideoEmbedProvider : EmbedProviderBase
     {
-        //no ApiEndpoint!
+        // no ApiEndpoint!
         public override string ApiEndpoint => String.Empty;
         public override string[] UrlSchemeRegex => new string[]
         {
@@ -163,7 +163,7 @@ namespace Umbraco8.EmbedProviders
         {
             // format of markup
             string videoFormat = "<div class=\"iplayer-container\"><iframe src=\"//aka.ms/ampembed?url={0}\" name=\"azuremediaplayer\" scrolling=\"no\" frameborder=\"no\" align=\"center\" autoplay=\"false\" width=\"{1}\" height=\"{2}\" allowfullscreen></iframe></div>";
-            // pass in encoded Url, with and height, and turn off autoplay...                
+            // pass in encoded Url, with and height, and turn off autoplay...
             var videoPlayerMarkup = string.Format(videoFormat, HttpUtility.UrlEncode(url) + "&amp;autoplay=false", maxWidth, maxHeight);
             return videoPlayerMarkup;
         }
@@ -174,7 +174,7 @@ Here the markup to embed has been manually constructed based upon the iframe vid
 
 #### Register the provider with the OEmbedProvidersCollection
 
-Create a new C# class that implments IUserComposer and add append your new provider to the EmbedProvidersCollection:
+Create a new C# class that implements `IUserComposer` and add append your new provider to the EmbedProvidersCollection:
 
 ```csharp
 using Umbraco.Core.Composing;
@@ -191,5 +191,5 @@ namespace Umbraco8.Composing
     }
 }
 ```
-Now editors can embed Azure Media video Urls in the format: //amssamples.streaming.mediaservices.windows.net/3b970ae0-39d5-44bd-b3a3-3136143d6435/AzureMediaServicesPromo.ism/manifest
+Now editors can embed Azure Media video Urls in the format: `//amssamples.streaming.mediaservices.windows.net/3b970ae0-39d5-44bd-b3a3-3136143d6435/AzureMediaServicesPromo.ism/manifest`.
 

--- a/Extending/FileSystemProviders/Azure-Blob-Storage/index-v7.md
+++ b/Extending/FileSystemProviders/Azure-Blob-Storage/index-v7.md
@@ -5,7 +5,7 @@ versionFrom: 7.0.0
 # Setup Your Site to use Azure Blob Storage for Media and Image Processor Cache
 For Umbraco sites there are some scenarios when you may want, or need, to consider using Azure Blob Storage for your media.  Particularly if your site contains large amounts of media.  Having your site’s media in Azure Storage can also help your deployments complete more quickly and has the potential to positively affect site performance as the Image Processor cache is moved to Azure Blob Storage.  It also allows you to serve your media from the Azure CDN.
 
-Setup consists of adding several packages to your site and setting the correct configuration.  Of course, before you begin you’ll need to create an Azure Storage Account and a container for your media and your ImageProcessor cache as well.  In this example we assume your media container is “media” and your cache is “cache”.  You can, optionally, enable an Azure CDN for this storage container and use it in the cache.config below.	
+Setup consists of adding several packages to your site and setting the correct configuration.  Of course, before you begin you’ll need to create an Azure Storage Account and a container for your media and your ImageProcessor cache as well.  In this example we assume your media container is “media” and your cache is “cache”.  You can, optionally, enable an Azure CDN for this storage container and use it in the cache.config below.
 
 ## Packages
 
@@ -39,7 +39,7 @@ Update `~/Config/FileSystemProviders.config` replacing the default provider with
       -->
       <add key="maxDays" value="365"/>
       <!--
-        When true this allows the VirtualPathProvider to use the deafult "media" route prefix regardless 
+        When true this allows the VirtualPathProvider to use the default "media" route prefix regardless
         of the container name.
       -->
       <add key="useDefaultRoute" value="true"/>
@@ -70,7 +70,7 @@ If you are using IISExpress (as with Visual Studio) you’ll need to add a stati
 
 ### ImageProcessor
 
-The ImageProcessor is already a part of Umbraco. 
+The ImageProcessor is already a part of Umbraco.
 
 Are you using a version of Umbraco older than v7.6, installing the FileSystemProvider will give you a warning and you will need to update ImageProcessor.Web and install ImageProcessor.Web.Config from NuGet.
 
@@ -87,7 +87,7 @@ Once the package(s) have been installed you need to set your configuration as be
 
 ```xml
 <configuration>
-  <configSections>  
+  <configSections>
     <sectionGroup name="imageProcessor">
       <section name="security" requirePermission="false" type="ImageProcessor.Web.Configuration.ImageSecuritySection, ImageProcessor.Web" />
       <section name="processing" requirePermission="false" type="ImageProcessor.Web.Configuration.ImageProcessingSection, ImageProcessor.Web" />
@@ -136,7 +136,7 @@ You have to manually add `prefix="media/"` to the service element, otherwise Ima
 </security>
 ```
 
-You have now succesfully setup Azure Blob Storage with your Umbraco site.
+You have now successfully setup Azure Blob Storage with your Umbraco site.
 
 ## Existing Media files
 

--- a/Extending/FileSystemProviders/Azure-Blob-Storage/index.md
+++ b/Extending/FileSystemProviders/Azure-Blob-Storage/index.md
@@ -5,7 +5,7 @@ versionFrom: 8.0.0
 # Setup Your Site to use Azure Blob Storage for Media and Image Processor Cache
 For Umbraco sites there are some scenarios when you may want, or need, to consider using Azure Blob Storage for your media.  Particularly if your site contains large amounts of media.  Having your site's media in Azure Blob Storage can also help your deployments complete more quickly and has the potential to positively affect site performance as the Image Processor cache is moved to Azure Blob Storage.  It also allows you to serve your media from the Azure CDN.
 
-Setup consists of adding several packages to your site and setting the correct configuration.  Of course, before you begin you’ll need to create an Azure Storage Account and a container for your media and your ImageProcessor cache as well.  In this example we assume your media container is "media" and your cache is "cache".  You can, optionally, enable an Azure CDN for this storage container and use it in the cache.config below.	
+Setup consists of adding several packages to your site and setting the correct configuration.  Of course, before you begin you’ll need to create an Azure Storage Account and a container for your media and your ImageProcessor cache as well.  In this example we assume your media container is "media" and your cache is "cache".  You can, optionally, enable an Azure CDN for this storage container and use it in the cache.config below.
 
 ## Packages
 
@@ -32,7 +32,7 @@ The following six keys will have been added to the `<appSettings>` in your `web.
 <appSettings>
   <add key="AzureBlobFileSystem.ContainerName:media" value="media" />
   <add key="AzureBlobFileSystem.RootUrl:media" value="https://[myAccountName].blob.core.windows.net/" />
-  <add key="AzureBlobFileSystem.ConnectionString:media" 
+  <add key="AzureBlobFileSystem.ConnectionString:media"
       value="DefaultEndpointsProtocol=https;AccountName=[myAccountName];AccountKey=[myAccountKey]" />
   <add key="AzureBlobFileSystem.MaxDays:media" value="365" />
   <add key="AzureBlobFileSystem.UseDefaultRoute:media" value="true" />
@@ -55,7 +55,7 @@ If you are using IISExpress (as with Visual Studio) you’ll need to add a stati
     <system.webServer>
       <handlers>
         <remove name="StaticFileHandler" />
-        <add name="StaticFileHandler" path="*" verb="*" 
+        <add name="StaticFileHandler" path="*" verb="*"
              preCondition="integratedMode" type="System.Web.StaticFileHandler" />
       </handlers>
     </system.webServer>
@@ -70,7 +70,7 @@ Once the packages have been installed you need to set your configuration as belo
 
 ```xml
 <configuration>
-  <configSections>  
+  <configSections>
     <sectionGroup name="imageProcessor">
       <section name="security" requirePermission="false" type="ImageProcessor.Web.Configuration.ImageSecuritySection, ImageProcessor.Web" />
       <section name="processing" requirePermission="false" type="ImageProcessor.Web.Configuration.ImageProcessingSection, ImageProcessor.Web" />
@@ -119,7 +119,7 @@ You have to manually add `prefix="media/"` to the service element, otherwise Ima
 </security>
 ```
 
-You have now succesfully setup Azure Blob Storage with your Umbraco site.
+You have now successfully setup Azure Blob Storage with your Umbraco site.
 
 ## Existing Media files
 

--- a/Extending/Macro-Parameter-Editors/index.md
+++ b/Extending/Macro-Parameter-Editors/index.md
@@ -5,7 +5,7 @@ needsV8Update: "true"
 
 # Macro Parameter Editors
 
-Every macro can contain parameters. There are some useful default types.  For example: 
+Every macro can contain parameters. There are some useful default types.  For example:
 
 * True/False
 * TextBox
@@ -57,7 +57,7 @@ We'll create an 'Image Position' Macro Parameter type providing a Radio Button l
 
 ```json
 {
-    "propertyEditors": [ 
+    "propertyEditors": [
         {
             "alias": "tooorangey.ImagePosition",
             "name": "Image Position",
@@ -90,10 +90,11 @@ We'll create an 'Image Position' Macro Parameter type providing a Radio Button l
 ```javascript
 angular.module("umbraco").controller("tooorangey.ImagePositionController", function ($scope) {
 
-        if ($scope.model.value == null) {
+    if ($scope.model.value == null) {
         $scope.model.value = 'FullWidth';
-        }
-        // could read positions from defaultConfig
+    }
+
+    // could read positions from defaultConfig
     $scope.positions = [
         {
             Name: 'FullWidth'
@@ -124,7 +125,7 @@ If you want to create a new macro parameter editor you will need some c# program
 First create a class deriving from a webcontrol and implement the IMacroGuiRendering interface. Afterwards, open your database editor.  Find the **cmsMacroPropertyType** table and add the a new property editor.
 
 ### IMacroGuiRendering Interface
-You can find this interface in the umbraco.interfaces namespace contained in the interfaces dll.  You will need to reference this DLL if you are developing your control in a separate project.
+You can find this interface in the `umbraco.interfaces` namespace contained in the interfaces dll.  You will need to reference this DLL if you are developing your control in a separate project.
 This interface implements 2 properties:  Value and ShowCaption.
 The value stores a string  and the ShowCaption property a bool.
 
@@ -136,21 +137,21 @@ id</th><th>macroPropertyTypeAlias</th><th>macroPropertyTypeRenderAssembly</th><t
 28</td><td>myNewPickerType</td><td>NameOfAssembly</td><td>FullName.OfType.IncludingNamespace</td><td>String</td></tr></table>
 
 ### Example
-A very basic example deriving from a DropDownList ASP.NET server control
+A very basic example deriving from a DropDownList ASP.NET server control.
 
 ```csharp
-public class MyCustomPicker : DropDownList,  IMacroGuiRendering 
+public class MyCustomPicker : DropDownList,  IMacroGuiRendering
 {
     protected override void OnLoad(EventArgs e)
     {
         base.OnLoad(e);
-        if(this.Items.Count == 0)
+        if (this.Items.Count == 0)
         {
             // set properties
-            this.SelectionMode = ListSelectionMode.Multiple;           
+            this.SelectionMode = ListSelectionMode.Multiple;
 
             // load data
-            ...
+            // ...
         }
     }
 

--- a/Extending/Property-Editors/package-manifest.md
+++ b/Extending/Property-Editors/package-manifest.md
@@ -79,7 +79,7 @@ The basic values on any editor are `alias`, `name` and `editor`. These three **m
     "hideLabel": true,
     "valueType": "TEXT",
     "validation": {},
-    "isReadOnly": false 
+    "isReadOnly": false
 }
 ```
 
@@ -107,7 +107,7 @@ The basic values on any editor are `alias`, `name` and `editor`. These three **m
             "description": "This is a description",
             "key": "enableStuff",
             "view": "boolean"
-        }            
+        }
     ]
 }
 ```
@@ -161,7 +161,7 @@ Similar to how the `propertyEditors` array defines one or more property editors,
         "icon": "icon-article"
     }
 ]
-```   
+```
 
 However the default grid editors are already configured in `/config/grid.editors.config.js`. You can use the file for inspiration, or see the [Grid Editors](../../Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors.md) page for more information on grid editors.
 
@@ -224,14 +224,14 @@ To associate the hosted JSON schema file to all package.manifest files you will 
 }
 ```
 
-### adding inline schema
+### Adding inline schema
 
-Editors like visual studio can use the `$schema` notation in your file.  
+Editors like visual studio can use the `$schema` notation in your file.
 
 ```json
 {
     "$schema" : "http://json.schemastore.org/package.manifest",
     "javascript": [],
-    "other properties": ""    
+    "other properties": ""
 }
 ```

--- a/Extending/Section-Trees/Searchable-Trees/index-v7.md
+++ b/Extending/Section-Trees/Searchable-Trees/index-v7.md
@@ -64,34 +64,34 @@ A `SearchResultItem` consists of a Score (a Float value) identifying its relevan
 If we have a custom section Tree with alias 'favouriteThingsAlias' (see the [custom tree example](../trees-v7.md)) then we could implement searchability by creating the following c# class in our site:
 
 ```csharp
-  public class FavouriteThingsSearchableTree : ISearchableTree
+public class FavouriteThingsSearchableTree : ISearchableTree
+{
+    public string TreeAlias => "favouriteThingsAlias";
+
+    public IEnumerable<SearchResultItem> Search(string query, int pageSize, long pageIndex, out long totalFound, string searchFrom = null)
     {
-        public string TreeAlias => "favouriteThingsAlias";
+        // your custom search implementation starts here
+        Dictionary<int, string> favouriteThings = new Dictionary<int, string>();
+        favouriteThings.Add(1, "Raindrops on Roses");
+        favouriteThings.Add(2, "Whiskers on Kittens");
+        favouriteThings.Add(3, "Skys full of Stars");
+        favouriteThings.Add(4, "Warm Woolen Mittens");
+        favouriteThings.Add(5, "Cream coloured Unicorns");
+        favouriteThings.Add(6, "Schnitzel with Noodles");
 
-        public IEnumerable<SearchResultItem> Search(string query, int pageSize, long pageIndex, out long totalFound, string searchFrom = null)
+        var searchResults = new List<SearchResultItem>();
+
+        var matchingItems = favouriteThings.Where(f => f.Value.StartsWith(query, true, System.Globalization.CultureInfo.CurrentCulture));
+        foreach (var matchingItem in matchingItems)
         {
-            // your custom search implementation starts here
-            Dictionary<int, string> favouriteThings = new Dictionary<int, string>();
-            favouriteThings.Add(1, "Raindrops on Roses");
-            favouriteThings.Add(2, "Whiskers on Kittens");
-            favouriteThings.Add(3, "Skys full of Stars");
-            favouriteThings.Add(4, "Warm Woolen Mittens");
-            favouriteThings.Add(5, "Cream coloured Unicorns");
-            favouriteThings.Add(6, "Schnitzel with Noodles");
-
-            var searchResults = new List<SearchResultItem>();
-
-            var matchingItems = favouriteThings.Where(f => f.Value.StartsWith(query, true, System.Globalization.CultureInfo.CurrentCulture));
-            foreach (var matchingItem in matchingItems)
-            {
-                searchResults.Add(new SearchResultItem() { Id = 12345, Alias = "favouriteThingItem", Icon = "icon-favorite", Key = new Guid("325746a0-ec1e-44e8-8f7b-6e7c4aab36d1"), Name = matchingItem.Value, ParentId = -1, Path = "-1,123456", Score = 1.0F, Trashed = false });
-            }
-            // set number of search results found
-            totalFound = matchingItems.Count();
-            // return your IEnumerable of SearchResultItems
-            return searchResults;
+            searchResults.Add(new SearchResultItem() { Id = 12345, Alias = "favouriteThingItem", Icon = "icon-favorite", Key = new Guid("325746a0-ec1e-44e8-8f7b-6e7c4aab36d1"), Name = matchingItem.Value, ParentId = -1, Path = "-1,123456", Score = 1.0F, Trashed = false });
         }
+        // set number of search results found
+        totalFound = matchingItems.Count();
+        // return your IEnumerable of SearchResultItems
+        return searchResults;
     }
+}
 ```
 
 That's all we need, after an application pool recycle, if we now search in the backoffice we'll see matches from our custom 'Favourite Things' tree:

--- a/Extending/Section-Trees/Searchable-Trees/index.md
+++ b/Extending/Section-Trees/Searchable-Trees/index.md
@@ -44,7 +44,7 @@ public interface ISearchableTree
 Your implementation needs to return an IEnumerable of `SearchResultEntity` items:
 
 ```csharp
-public class SearchResultEntiy : EntityBasic
+public class SearchResultEntity : EntityBasic
 {
     public SearchResultEntity();
 
@@ -88,7 +88,7 @@ If we have a custom section Tree with alias 'favouriteThingsAlias' (see the [cus
             }
             // set number of search results found
             totalFound = matchingItems.Count();
-            // return your IEnumerable of SearchResultEntitys
+            // return your IEnumerable of SearchResultEntity
             return searchResults;
         }
     }
@@ -121,7 +121,7 @@ using Umbraco.Web;
 
 namespace My.Website
 {
-[RuntimeLevel(MinLevel = RuntimeLevel.Run)]
+    [RuntimeLevel(MinLevel = RuntimeLevel.Run)]
     public class RemoveCoreMemberSearchableTreeComposer : IUserComposer
     {
         public void Compose(Composition composition)
@@ -130,6 +130,7 @@ namespace My.Website
             composition.SearchableTrees().Exclude<MemberTreeController>();
         }
     }
+}
 ```
 
 This would then allow your custom implementation of ISearchableTree with TreeAlias 'Member' to be used when searching the Member Section Tree.

--- a/Extending/Section-Trees/index.md
+++ b/Extending/Section-Trees/index.md
@@ -4,7 +4,7 @@ versionFrom: 7.0.0
 
 # Sections & Trees
 
-The Umbraco backoffice consists of sections (sometimes referred to as applications) which contain Trees. 
+The Umbraco backoffice consists of sections (sometimes referred to as applications) which contain Trees.
 
 Each section is identified by an icon in the left-hand side navigation ribbon of the Umbraco Backoffice.
 
@@ -14,11 +14,11 @@ You can create your own sections and trees to extend Umbraco.
 
 ## [Sections](sections.md)
 
-Describes Umbraco Sections, configuration and APIs
+Describes Umbraco Sections, configuration and APIs.
 
 ## [Trees](trees.md)
 
-Describes Umbraco Trees, configuration, APIs and events
+Describes Umbraco Trees, configuration, APIs and events.
 
 ## [Searchable Trees (ISearchableTree)](Searchable-Trees)
 

--- a/Extending/Section-Trees/trees.md
+++ b/Extending/Section-Trees/trees.md
@@ -10,7 +10,7 @@ This section describes how to work with and create trees with the v8 APIs.
 
 To Create a Tree in a section of the Umbraco backoffice, you need to take several steps:
 
-Create a 'TreeController' class in C#. A new mvc controller which inherits from the abstract *Umbraco.Web.Trees.TreeController* class and provides an implementation for two abstract methods: 
+Create a 'TreeController' class in C#. A new mvc controller which inherits from the abstract *Umbraco.Web.Trees.TreeController* class and provides an implementation for two abstract methods:
 
 * GetTreeNodes (returns a *TreeNodeCollection*) - Responsible for rendering the content of the tree structure.
 * GetMenuForNode (returns a *MenuItemCollection*) - Responsible for returning the menu structure to use for a particular node within a tree.
@@ -23,7 +23,7 @@ Decorate your '*TreeController*' with the *Tree* Attribute, which is used to def
 ```csharp
 [Tree("settings", "favouriteThingsAlias", TreeTitle = "Favourite Things Name", TreeGroup="favouritesGroup", SortOrder=5)]
 public class FavouriteThingsTreeController : TreeController
-{  
+{
 ```
 
 ...would register a custom tree with a title 'Favourite Things Name' in the Settings section of Umbraco, inside a custom group called 'Favourites'
@@ -49,76 +49,75 @@ The first node in the tree is referred to as the **Root Node**. You might want t
 In V8 the /config/trees.config file has been removed.
 :::
 
-[See Also: How to create your own custom section](../../Extending/Section-Trees/sections.md) 
+[See Also: How to create your own custom section](../../Extending/Section-Trees/sections.md)
 
 ### Implementing the Tree
 
 ```csharp
  protected override TreeNodeCollection GetTreeNodes(string id, FormDataCollection queryStrings)
+{
+    // check if we're rendering the root node's children
+    if (id == Constants.System.Root.ToInvariantString())
+    {
+        // you can get your custom nodes from anywhere, and they can represent anything...
+        Dictionary<int, string> favouriteThings = new Dictionary<int, string>();
+        favouriteThings.Add(1, "Raindrops on Roses");
+        favouriteThings.Add(2, "Whiskers on Kittens");
+        favouriteThings.Add(3, "Skys full of Stars");
+        favouriteThings.Add(4, "Warm Woolen Mittens");
+        favouriteThings.Add(5, "Cream coloured Unicorns");
+        favouriteThings.Add(6, "Schnitzel with Noodles");
+        // create our node collection
+        var nodes = new TreeNodeCollection();
+
+        // loop through our favourite things and create a tree item for each one
+        foreach (var thing in favouriteThings)
         {
-            // check if we're rendering the root node's children
-            if (id == Constants.System.Root.ToInvariantString())
-            {
-                // you can get your custom nodes from anywhere, and they can represent anything... 
-                Dictionary<int, string> favouriteThings = new Dictionary<int, string>();
-                favouriteThings.Add(1, "Raindrops on Roses");
-                favouriteThings.Add(2, "Whiskers on Kittens");
-                favouriteThings.Add(3, "Skys full of Stars");
-                favouriteThings.Add(4, "Warm Woolen Mittens");
-                favouriteThings.Add(5, "Cream coloured Unicorns");
-                favouriteThings.Add(6, "Schnitzel with Noodles");
-                // create our node collection
-                var nodes = new TreeNodeCollection();
+            // add each node to the tree collection using the base CreateTreeNode method
+            // it has several overloads, using here unique Id of tree item, -1 is the Id of the parent node to create, eg the root of this tree is -1 by convention - the querystring collection passed into this route - the name of the tree node -  css class of icon to display for the node - and whether the item has child nodes
+            var node = CreateTreeNode(thing.Key.ToString(), "-1", queryStrings, thing.Value, "icon-presentation", false);
+            nodes.Add(node);
+        }
+        return nodes;
+    }
 
-                // loop through our favourite things and create a tree item for each one
-                foreach (var thing in favouriteThings)
-                {
-                    // add each node to the tree collection using the base CreateTreeNode method
-                    // it has several overloads, using here unique Id of tree item, -1 is the Id of the parent node to create, eg the root of this tree is -1 by convention - the querystring collection passed into this route - the name of the tree node -  css class of icon to display for the node - and whether the item has child nodes
-                    var node = CreateTreeNode(thing.Key.ToString(), "-1", queryStrings, thing.Value, "icon-presentation", false);
-                    nodes.Add(node);
-
-                }
-                return nodes;
-            }
-
-            // this tree doesn't support rendering more than 1 level
-            throw new NotSupportedException();
-        }    
+    // this tree doesn't support rendering more than 1 level
+    throw new NotSupportedException();
+}
 
 protected override MenuItemCollection GetMenuForNode(string id, FormDataCollection queryStrings)
 {
- // create a Menu Item Collection to return so people can interact with the nodes in your tree
-            var menu = new MenuItemCollection();
+    // create a Menu Item Collection to return so people can interact with the nodes in your tree
+    var menu = new MenuItemCollection();
 
-            if (id == Constants.System.Root.ToInvariantString())
-            {
-                // root actions, perhaps users can create new items in this tree, or perhaps it's not a content tree, it might be a read only tree, or each node item might represent something entirely different...
-                // add your menu item actions or custom ActionMenuItems
-                menu.Items.Add(new CreateChildEntity(Services.TextService));
-                // add refresh menu item (note no dialog)            
-                menu.Items.Add(new RefreshNode(Services.TextService, true));
-                return menu;
-            }
-            // add a delete action to each individual item
-            menu.Items.Add<ActionDelete>(Services.TextService, true, opensDialog: true);
+    if (id == Constants.System.Root.ToInvariantString())
+    {
+        // root actions, perhaps users can create new items in this tree, or perhaps it's not a content tree, it might be a read only tree, or each node item might represent something entirely different...
+        // add your menu item actions or custom ActionMenuItems
+        menu.Items.Add(new CreateChildEntity(Services.TextService));
+        // add refresh menu item (note no dialog)
+        menu.Items.Add(new RefreshNode(Services.TextService, true));
+        return menu;
+    }
+    // add a delete action to each individual item
+    menu.Items.Add<ActionDelete>(Services.TextService, true, opensDialog: true);
 
-            return menu;
+    return menu;
 }
 
 protected override TreeNode CreateRootNode(FormDataCollection queryStrings)
-        {
-            var root = base.CreateRootNode(queryStrings);
-          
-            // set the icon
-            root.Icon = "icon-hearts";
-            // could be set to false for a custom tree with a single node.
-            root.HasChildren = true;
-            //url for menu
-            root.MenuUrl = null;
+{
+    var root = base.CreateRootNode(queryStrings);
 
-            return root;
-        }
+    // set the icon
+    root.Icon = "icon-hearts";
+    // could be set to false for a custom tree with a single node.
+    root.HasChildren = true;
+    //url for menu
+    root.MenuUrl = null;
+
+    return root;
+}
 ```
 
 ![Favourite Things Custom Tree](images/favourite-things-custom-tree-v8.png)
@@ -143,16 +142,16 @@ The edit view in the example would now be loaded from the location: */app_plugin
 
 #### Providing functionality in your Tree Action Views
 
-You can instruct the Umbraco backoffice to load additional javascript resources (eg. angularJS controllers) to use in conjunction with your 'tree action views' by adding a package.manifest file in the same folder location as your views. 
+You can instruct the Umbraco backoffice to load additional javascript resources (eg. angularJS controllers) to use in conjunction with your 'tree action views' by adding a package.manifest file in the same folder location as your views.
 
 **For example**...
 
 ```json
 {
     "javascript": [
-    "~/App_Plugins/favouriteThings/favouriteThings.resource.js",
-    "~/App_Plugins/favouriteThings/backoffice/favouriteThingsAlias/edit.controller.js",
-    "~/App_Plugins/favouriteThings/backoffice/favouriteThingsAlias/delete.controller.js"
+        "~/App_Plugins/favouriteThings/favouriteThings.resource.js",
+        "~/App_Plugins/favouriteThings/backoffice/favouriteThingsAlias/edit.controller.js",
+        "~/App_Plugins/favouriteThings/backoffice/favouriteThingsAlias/delete.controller.js"
     ]
 }
 ```
@@ -188,29 +187,29 @@ It is possible to create 'trees' consisting of only a single node - perhaps to p
 In both scenarios you need to override the 'CreateRootNode' method for the custom tree.
 
 ```csharp
-    [Tree("settings", "favouritistThingsAlias", TreeTitle = "Favourite Thing", TreeGroup = "favoritesGroup", SortOrder = 5)]
-    [PluginController("favouriteThing")]
-    public class FavouritistThingsTreeController : TreeController
+[Tree("settings", "favouritistThingsAlias", TreeTitle = "Favourite Thing", TreeGroup = "favoritesGroup", SortOrder = 5)]
+[PluginController("favouriteThing")]
+public class FavouritistThingsTreeController : TreeController
 ```
 
 Overriding the CreateRootNode method means it is possible to set the 'RoutePath' to where the single page application will live (or introduction page), setting HasChildren to false will result in a Single Node Tree:
 
 ```csharp
 protected override TreeNode CreateRootNode(FormDataCollection queryStrings)
-        {
-            var root = base.CreateRootNode(queryStrings);
+{
+    var root = base.CreateRootNode(queryStrings);
 
-            //optionally setting a routepath would allow you to load in a custom UI instead of the usual behaviour for a tree
-             root.RoutePath = string.Format("{0}/{1}/{2}", Constants.Applications.Settings, "favourite", "thing");
-            // set the icon
-            root.Icon = "icon-hearts";
-            // set to false for a custom tree with a single node.
-            root.HasChildren = false;
-            //url for menu
-            root.MenuUrl = null;
+    //optionally setting a routepath would allow you to load in a custom UI instead of the usual behaviour for a tree
+        root.RoutePath = string.Format("{0}/{1}/{2}", Constants.Applications.Settings, "favourite", "thing");
+    // set the icon
+    root.Icon = "icon-hearts";
+    // set to false for a custom tree with a single node.
+    root.HasChildren = false;
+    //url for menu
+    root.MenuUrl = null;
 
-            return root;
-        }
+    return root;
+}
 ```
 The RoutePath should be in the format of: **section/treeAlias/method**. As our example controller uses the PluginController attribute, clicking the root node would now request /App_Plugins/favouriteThings/backoffice/favouriteThingsAlias/overview.html. If you are not using the PluginController attribute, then the request would be to /umbraco/views/favouriteThingsAlias/overview.html
 
@@ -222,9 +221,9 @@ It's possible to make your single node tree app stretch across the full screen o
 To achieve this add an additional attribute `IsSingleNodeTree`, in the Tree attribute for the custom controller.
 
 ```csharp
-    [Tree("settings", "favouritistThingsAlias", IsSingleNodeTree = true, TreeTitle = "Favourite Thing", TreeGroup = "favoritesGroup", SortOrder = 5)]
-    [PluginController("favouriteThing")]
-    public class FavouritistThingsTreeController : TreeController
+[Tree("settings", "favouritistThingsAlias", IsSingleNodeTree = true, TreeTitle = "Favourite Thing", TreeGroup = "favoritesGroup", SortOrder = 5)]
+[PluginController("favouriteThing")]
+public class FavouritistThingsTreeController : TreeController
 ```
 
 ## Tree events
@@ -245,20 +244,21 @@ public static event TypedEventHandler<TreeControllerBase, TreeNodeRenderingEvent
 
 ```csharp
 // register the event listener using a component
-    public void Initialize()
-    {
-        TreeControllerBase.RootNodeRendering += TreeControllerBase_RootNodeRendering;
-    }
+public void Initialize()
+{
+    TreeControllerBase.RootNodeRendering += TreeControllerBase_RootNodeRendering;
+}
+
 // the event listener method:
 void TreeControllerBase_RootNodeRendering(TreeControllerBase sender, TreeNodeRenderingEventArgs e)
 {
-    // normally you will want to target a specific tree, this can be done by checking the 
+    // normally you will want to target a specific tree, this can be done by checking the
     // tree alias of by checking the tree type (casting 'sender')
     if (sender.TreeAlias == "content")
     {
         e.Node.Title = "My new title";
     }
-}	
+}
 ```
 
 ### TreeNodesRendering
@@ -275,21 +275,22 @@ public static event TypedEventHandler<TreeControllerBase, TreeNodesRenderingEven
 
 ```csharp
 // register the event listener with a component:
-    public void Initialize()
-    {
-        TreeControllerBase.TreeNodesRendering += TreeControllerBase_TreeNodesRendering;
-    }
+public void Initialize()
+{
+    TreeControllerBase.TreeNodesRendering += TreeControllerBase_TreeNodesRendering;
+}
 
 // the event listener method:
 void TreeControllerBase_TreeNodesRendering(TreeControllerBase sender, TreeNodesRenderingEventArgs e)
 {
-      // this example will filter any content tree node whose node name starts with
-            // 'Private', for any user that is in the customUserGroup
-            if (sender.TreeAlias == "content"
-                && sender.Security.CurrentUser.Groups.Any(f => f.Alias == "customUserGroupAlias"))
-            {
-                e.Nodes.RemoveAll(node => node.Name.StartsWith("Private"));
-            }
+    // this example will filter any content tree node whose node name starts with
+
+    // 'Private', for any user that is in the customUserGroup
+    if (sender.TreeAlias == "content"
+        && sender.Security.CurrentUser.Groups.Any(f => f.Alias == "customUserGroupAlias"))
+    {
+        e.Nodes.RemoveAll(node => node.Name.StartsWith("Private"));
+    }
 }
 ```
 
@@ -307,41 +308,39 @@ public static event TypedEventHandler<TreeControllerBase, MenuRenderingEventArgs
 
 ```csharp
 // register the event listener with a component:
-    public void Initialize()
-    {
-        TreeControllerBase.MenuRendering += TreeControllerBase_MenuRendering;
-    }
+public void Initialize()
+{
+    TreeControllerBase.MenuRendering += TreeControllerBase_MenuRendering;
+}
 
 // the event listener method:
 void TreeControllerBase_MenuRendering(TreeControllerBase sender, MenuRenderingEventArgs e)
 {
-  // this example will add a custom menu item for all admin users
-            // for all content tree nodes
-            if (sender.TreeAlias == "content"
-                && sender.Security.CurrentUser.Groups.Any(x => x.Alias.InvariantEquals("admin")))
-            {
-                // creates a menu action that will open /umbraco/currentSection/itemAlias.html
-                var i = new Umbraco.Web.Models.Trees.MenuItem("itemAlias", "Item name");
+    // this example will add a custom menu item for all admin users
 
-                // optional, if you want to load a legacy page, otherwise it will follow convention
-                i.AdditionalData.Add("actionUrl", "my/long/url/to/webformshorror.aspx");
+    // for all content tree nodes
+    if (sender.TreeAlias == "content"
+        && sender.Security.CurrentUser.Groups.Any(x => x.Alias.InvariantEquals("admin")))
+    {
+        // creates a menu action that will open /umbraco/currentSection/itemAlias.html
+        var i = new Umbraco.Web.Models.Trees.MenuItem("itemAlias", "Item name");
 
-                // optional, if you don't want to follow the naming conventions, but do want to use a angular view
-                // you can also use a direct path "../App_Plugins/my/long/url/to/view.html"
-                i.AdditionalData.Add("actionView", "my/long/url/to/view.html");
+        // optional, if you want to load a legacy page, otherwise it will follow convention
+        i.AdditionalData.Add("actionUrl", "my/long/url/to/webformshorror.aspx");
 
-                // sets the icon to icon-wine-glass 
-                i.Icon = "wine-glass";
+        // optional, if you don't want to follow the naming conventions, but do want to use a angular view
+        // you can also use a direct path "../App_Plugins/my/long/url/to/view.html"
+        i.AdditionalData.Add("actionView", "my/long/url/to/view.html");
 
-                // insert at index 5
-                e.Menu.Items.Insert(5, i);
-            }
+        // sets the icon to icon-wine-glass
+        i.Icon = "wine-glass";
+
+        // insert at index 5
+        e.Menu.Items.Insert(5, i);
+    }
 }
 ```
 
 ## Tree Actions and User Permissions
 
 [See a list of Tree Actions and User Permission Codes](tree-actions.md)
-
-
- 


### PR DESCRIPTION
There are a lot of changes (fix typos, markup syntax highlight, code style and so on), I hope not too big PR?

An open question: can we use only U.S English in the documentation? for example, instead of "Favorite" we will write "Favorite"? Now both versions of the language are used, which introduces confusion... 