### PR TITLE
Remove NotImplementedException from Terminate

### DIFF
--- a/Reference/Events/ContentService-Events.md
+++ b/Reference/Events/ContentService-Events.md
@@ -20,13 +20,14 @@ namespace Umbraco8.Components
 {
     [RuntimeLevel(MinLevel = RuntimeLevel.Run)]
     public class SubscribeToPublishEventComposer : ComponentComposer<SubscribeToPublishEventComponent>
-    {
-    }
+    { }
+    
     public class SubscribeToPublishEventComponent : IComponent
     {
         public void Initialize()
         {
-            ContentService.Publishing += ContentService_Publishing;        }
+            ContentService.Publishing += ContentService_Publishing;
+        }
 
         private void ContentService_Publishing(Umbraco.Core.Services.IContentService sender, Umbraco.Core.Events.ContentPublishingEventArgs e)
         {
@@ -37,18 +38,18 @@ namespace Umbraco8.Components
                     var newsArticleTitle = node.GetValue<string>("newsTitle");
                     if (newsArticleTitle.Equals(newsArticleTitle.ToUpper()))
                     {
-                        //stop putting News Article Titles ALL in Upper Case!!!
-                        //cancel publish
+                        // Stop putting news article titles in upper case, so cancel publish
                         e.Cancel = true;
-                        //explain why publish cancelled.
-                        e.Messages.Add(new Umbraco.Core.Events.EventMessage("Corporate Style Guidelines Infringement", "Don't put news article titles in UpperCase, no need to shout!", Umbraco.Core.Events.EventMessageType.Error));
+                        
+                        // Explain why the publish event is cancelled
+                        e.Messages.Add(new Umbraco.Core.Events.EventMessage("Corporate style guideline infringement", "Don't put the news article title in upper case, no need to shout!", Umbraco.Core.Events.EventMessageType.Error));
                     }
                 }
             }
         }
         public void Terminate()
         {
-            throw new NotImplementedException();
+            // Nothing to terminate
         }
     }
 }


### PR DESCRIPTION
The example component throws a `NotImplementedException` when terminating. This could cause other components to not terminate, as exceptions aren't caught while iterating through the components:
https://github.com/umbraco/Umbraco-CMS/blob/853087a75044b814df458457dc9a1f778cc89749/src/Umbraco.Core/Composing/ComponentCollection.cs#L37-L51