### PR TITLE
Removed remaining NotImplementedException from Terminate

### DIFF
--- a/Getting-Started/Code/Umbraco-Services/index.md
+++ b/Getting-Started/Code/Umbraco-Services/index.md
@@ -99,7 +99,7 @@ namespace Umbraco8.Components
 
         public void Terminate()
         {
-            throw new NotImplementedException();
+            // Nothing to terminate
         }
     }
 }

--- a/Reference/Events/MediaService-Events.md
+++ b/Reference/Events/MediaService-Events.md
@@ -44,7 +44,7 @@ namespace Umbraco8.Components
 
         public void Terminate()
         {
-            throw new NotImplementedException();
+            // Nothing to terminate
         }
     }
 }

--- a/Reference/Routing/Authorized/index.md
+++ b/Reference/Routing/Authorized/index.md
@@ -36,10 +36,12 @@ Defining a route is done with the standard ASP.NET MVC routing practices. In Umb
     public class RegisterCustomBackofficeMvcRouteComponent : IComponent
     {
         private readonly IGlobalSettings _globalSettings;
+
         public RegisterCustomBackofficeMvcRouteComponent(IGlobalSettings globalSettings)
         {
             _globalSettings = globalSettings;
         }
+
         public void Initialize()
         {
             RouteTable.Routes.MapRoute("cats", _globalSettings.GetUmbracoMvcArea() + "/backoffice/cats/{action}/{id}", new
@@ -52,7 +54,7 @@ Defining a route is done with the standard ASP.NET MVC routing practices. In Umb
 
         public void Terminate()
         {
-            throw new NotImplementedException();
+            // Nothing to terminate
         }
     }
 ```

--- a/Reference/Routing/custom-routes.md
+++ b/Reference/Routing/custom-routes.md
@@ -36,16 +36,14 @@ namespace Umbraco8.Components
 {
 
     public class RegisterCustomRouteComposer : ComponentComposer<RegisterCustomRouteComponent>
-    {
-
-    }
+    { }
 
     public class RegisterCustomRouteComponent : IComponent
     {
         public void Initialize()
         {
-    // Custom route to MyProductController which will use a node with a specific ID as the
-    // IPublishedContent for the current rendering page
+            // Custom route to MyProductController which will use a node with a specific ID as the
+            // IPublishedContent for the current rendering page
             RouteTable.Routes.MapUmbracoRoute("ProductCustomRoute", "products/{action}/{id}", new
             {
                 controller = "MyProduct",
@@ -55,7 +53,7 @@ namespace Umbraco8.Components
 
         public void Terminate()
         {
-            throw new NotImplementedException();
+            // Nothing to terminate
         }
     }
 }


### PR DESCRIPTION
This removes the remaining `NotImplementedException`s thrown in example components, as described in PR https://github.com/umbraco/UmbracoDocs/pull/1956.