### PR TITLE
Adds link to our.umbraco.ioc package

### DIFF
--- a/Reference/Using-Ioc/index-v7.md
+++ b/Reference/Using-Ioc/index-v7.md
@@ -4,13 +4,15 @@ versionFrom: 7.0.0
 
 # Using IoC with Umbraco
 
-_This section will show you how to setup Ioc/Dependency Injection with your Umbraco installation. The examples will use Autofac but you can use whatever you want_
+_This section will show you how to setup IoC/Dependency Injection with your Umbraco installation. The examples will use Autofac but you can use whatever you want_
 
 ## Overview
 
 We don't use IoC in the Umbraco source code. This isn't because we don't like it or don't want to use it. It's because we want you as a developer to be able to use whatever IoC framework that you would like to use without jumping through any hoops. With that said, it means it is possible to implement whatever IoC engine that you'd like!
 
 ## Implementation
+
+The easiest way to get up and running with IoC/Dependency Injection in Umbraco is to use the [Our.Umbraco.IoC](https://github.com/Shazwazza/Our.Umbraco.IoC) package which contains support for most popular dependency injection frameworks and has all of the boilerplate code and work done for you. The info below describes how you can configure your own framework manually without thsi package.
 
 In most IoC frameworks, you would setup your container in your global.asax class. To do that in Umbraco, you will need to inherit from our global.asax class called: `Umbraco.Web.UmbracoApplication`. You should then override the `OnApplicationStarted` method to build your container, and initialize any of the IoC stuff that you require.
 Alternatively, you can implement the `Umbraco.Web.IApplicationEventHandler` interface.

--- a/Reference/Using-Ioc/index-v7.md
+++ b/Reference/Using-Ioc/index-v7.md
@@ -12,7 +12,7 @@ We don't use IoC in the Umbraco source code. This isn't because we don't like it
 
 ## Implementation
 
-The easiest way to get up and running with IoC/Dependency Injection in Umbraco is to use the [Our.Umbraco.IoC](https://github.com/Shazwazza/Our.Umbraco.IoC) package which contains support for most popular dependency injection frameworks and has all of the boilerplate code and work done for you. The info below describes how you can configure your own framework manually without thsi package.
+The easiest way to get up and running with IoC/Dependency Injection in Umbraco is to use the [Our.Umbraco.IoC](https://github.com/Shazwazza/Our.Umbraco.IoC) package. It contains support for most popular dependency injection frameworks and has all of the boilerplate code and work done for you. The info below describes how you can configure your own framework manually without this package.
 
 In most IoC frameworks, you would setup your container in your global.asax class. To do that in Umbraco, you will need to inherit from our global.asax class called: `Umbraco.Web.UmbracoApplication`. You should then override the `OnApplicationStarted` method to build your container, and initialize any of the IoC stuff that you require.
 Alternatively, you can implement the `Umbraco.Web.IApplicationEventHandler` interface.


### PR DESCRIPTION
This is by far the easiest way to configure IoC in Umbraco v7. I'm not trying to plug the package I created or anything, it's just that all of the hard work is already done for people and it's super easy to use.