### PR TITLE
Put code in a code block

### DIFF
--- a/Reference/Routing/Request-Pipeline/outbound-pipeline.md
+++ b/Reference/Routing/Request-Pipeline/outbound-pipeline.md
@@ -73,6 +73,7 @@ For our "swibble" product in our example content tree the  `ProductPageUrlSegmen
 
 Register the custom UrlSegmentProvider with Umbraco:
 
+```csharp
 using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco8.Routing;
@@ -87,6 +88,7 @@ namespace Umbraco8.Composers
         }
     }
 }
+```
 
 ### The Default Url Segment Provider
 


### PR DESCRIPTION
There was some code that was missing the code identifier so it was appearing as text rather than code.