### PR TITLE
Updating contribution link

### DIFF
--- a/index.md
+++ b/index.md
@@ -71,6 +71,6 @@ How to use Umbraco Cloud: Get started, set up your Umbraco Cloud project, deploy
 ---
 
 ### Contributing
-*The documentation project is open source and hosted on GitHub. If you have any corrections or additions to the documentation clone the project and make a pull request. [Guidelines](https://github.com/umbraco/UmbracoDocs) on how to contribute to the documentation.*
+*The documentation project is open source and hosted on GitHub. If you have any corrections or additions to the documentation clone the project and make a pull request. [Guidelines](https://github.com/umbraco/UmbracoDocs/blob/master/CONTRIBUTING.md) on how to contribute to the documentation.*
 
 ----------------


### PR DESCRIPTION
Hello,

I was getting some links to contribution info for our Glasgow meetup tomorrow and realised this link on docs index page just links to the repo and not contributing info. I have updated it to link to contribution guidelines.

Thanks,
Carole