### PR TITLE
Update Sections article

### DIFF
--- a/Getting-Started/Backoffice/Sections/index.md
+++ b/Getting-Started/Backoffice/Sections/index.md
@@ -46,10 +46,6 @@ The Settings tree consists of:
 - Stylesheets (`.css` files)
 - Scripts (`.js` files)
 
-:::note
-**Dictionary items** have been moved from the Settings section to the Translation section.
-:::
-
 ## Packages
 In this section you can browse and install packages into your Umbraco solution. You can also get an overview of all installed packages as well as uninstall packages you no longer need.
 
@@ -65,12 +61,6 @@ You can install Umbraco Forms directly from the Backoffice by clicking the insta
 ## Translation
 This is the section where you create and manage your dictionary items.
 
-:::note
-This section is by default not accessible to any User Groups.
-
-Access to the section can be configured under User Groups in the User section.
-:::
-
 ## Help sections
 In the top-right corner you'll find a search tool, which is also accessible by hitting `CTRL + Space` on your keyboard.
 
@@ -80,3 +70,8 @@ There's also a small user section with shortcuts to edit the user that's current
 
 ## Custom Sections
 As well as the default sections that come with Umbraco, you can create your own [Custom Sections](../../../Extending/Section-Trees/index.md)
+
+## Access based on User Group
+Access to the section is based on which User Group a user is added to.
+
+Learn more about how to configure the permissions in the the article about [backoffice users](../../Data/Users).


### PR DESCRIPTION
In Umbraco 8.2 the Translation section is by default accessible by users with admin access - https://github.com/umbraco/Umbraco-CMS/issues/6359

I've removed notes about both dictionary items and the Translation section.
Also added a link to the "Users" article, where permission on access to the sections is set.