### PR TITLE
Clarifying purpose of core indexes in Examine Quick Start

### DIFF
--- a/Reference/Searching/Examine/Quick-Start/index.md
+++ b/Reference/Searching/Examine/Quick-Start/index.md
@@ -4,7 +4,7 @@ versionFrom: 8.0.0
 
 # Quick start
 
-_This guide will help you get setup quickly using Examine with minimal configuration options. Umbraco ships Examine with 3 internal indexes which should not be used for searching when returning results on a public website because it indexes content that has not been published yet. It also ships with an external index that you can use to get up and running._
+_This guide will help you get setup quickly using Examine with minimal configuration options. Umbraco ships Examine with 3 indexes: internal, external, and members. The internal index should not be used for searching when returning results on a public website because it includes content that has not been published yet. Instead you can use the external index to get up and running._
 
 ## Performing a search
 


### PR DESCRIPTION
As raised by a user on Slack, the existing introduction in the Examine Quick Start is misleading.

Currently it states 3 internal indexes ship with Umbraco and none of them should be used for front-end searches, but later contradicts itself and says to use the external index. Further, there are use cases for searching the member index on a website front-end.

Hopefully this clears things up - I tried to keep things as simple as possible but happy with advice on how the language can be improved!