### PR TITLE
Updating references to our.umbraco.org

### DIFF
--- a/Getting-Started/Code/Source-Control/index-v7.md
+++ b/Getting-Started/Code/Source-Control/index-v7.md
@@ -7,7 +7,7 @@ needsV8Update: "true"
 
 ## Umbraco Cloud
 
-If you are running your site on Umbraco Cloud - and why wouldn't you be? - then source control is very much part of the experience, have a look at the ['Technical overview of an Umbraco Cloud Environment'](https://our.umbraco.org/documentation/Umbraco-Cloud/Getting-Started/Environments/)  and the information on ['Working with your Umbraco Cloud project'](https://our.umbraco.org/documentation/Umbraco-Cloud/Set-Up/#working-with-your-umbraco-cloud-project) for a steer on Source/Version Control good practices.
+If you are running your site on Umbraco Cloud - and why wouldn't you be? - then source control is very much part of the experience, have a look at the ['Technical overview of an Umbraco Cloud Environment'](https://our.umbraco.com/documentation/Umbraco-Cloud/Getting-Started/Environments/)  and the information on ['Working with your Umbraco Cloud project'](https://our.umbraco.com/documentation/Umbraco-Cloud/Set-Up/#working-with-your-umbraco-cloud-project) for a steer on Source/Version Control good practices.
 
 ## Outside of Umbraco Cloud
 
@@ -146,7 +146,7 @@ When you create and edit eg. Document Types, Media Types and Data Types in the U
 
 There are several add-on packages that can help add source control to these structure changes:
 
-- *[The uSync package](https://our.umbraco.org/projects/developer-tools/usync/)* - which can be configured to serialize these changes to files on disk, in a folder called /uSync - enabling you to source/version control these changes too and synchronise them to other environments.
+- *[The uSync package](https://our.umbraco.com/projects/developer-tools/usync/)* - which can be configured to serialize these changes to files on disk, in a folder called /uSync - enabling you to source/version control these changes too and synchronise them to other environments.
 
 - *[uSync Snapshots](https://our.umbraco.com/packages/developer-tools/usyncsnapshots/)* - an extension to uSync, for taking 'before' and 'after' snapshots of an Umbraco site, for managing a release of a 'set of changes' between environments.
 

--- a/Getting-Started/Code/Source-Control/index.md
+++ b/Getting-Started/Code/Source-Control/index.md
@@ -143,7 +143,7 @@ When you create and edit eg. Document Types, Media Types and Data Types in the U
 
 There are several add-on packages that can help add source control to these structure changes:
 
-- *[The uSync package (free)](https://our.umbraco.org/projects/developer-tools/usync/)* - which can be configured to serialize these changes to files on disk, in a folder called /uSync - enabling you to source/version control these changes and synchronise them to other environments.
+- *[The uSync package (free)](https://our.umbraco.com/projects/developer-tools/usync/)* - which can be configured to serialize these changes to files on disk, in a folder called /uSync - enabling you to source/version control these changes and synchronise them to other environments.
 
 - *[uSync Snapshots (licensed)](https://our.umbraco.com/packages/developer-tools/usyncsnapshots/)* - an extension to uSync, for taking 'before' and 'after' snapshots of an Umbraco site, for managing a release of a 'set of changes' between environments.
 

--- a/Reference/Management/Services/LocalizationService/Retrieving-languages.md
+++ b/Reference/Management/Services/LocalizationService/Retrieving-languages.md
@@ -26,7 +26,7 @@ The culture code is the friendly name of the language in Umbraco, which for the 
 
 The ISO code is a combination of the two-letter ISO 639-1 language code (lowercase) and two-letter ISO-3166 country code (uppercase). Eg. `en-US` for English in the United States, `en-GB` for English in the United Kingdom and `da-DK` for Danish in Denmark.
 
-All three methods will return an instance of the [ILanguage](https://our.umbraco.org/apidocs/v7/csharp/api/Umbraco.Core.Models.ILanguage.html) interface, which has traditional properties like `Id` and `Key`, but also properties specific to the language like `CultureName`, `CultureInfo` and `IsoCode`. You can see the API reference for further information on the properties of the interface.
+All three methods will return an instance of the [ILanguage](https://our.umbraco.com/apidocs/v7/csharp/api/Umbraco.Core.Models.ILanguage.html) interface, which has traditional properties like `Id` and `Key`, but also properties specific to the language like `CultureName`, `CultureInfo` and `IsoCode`. You can see the API reference for further information on the properties of the interface.
 
 ### Getting all languages
 

--- a/Reference/Management/Services/UserService/Index.md
+++ b/Reference/Management/Services/UserService/Index.md
@@ -9,7 +9,7 @@ needsV8Update: "true"
 
 The UserService acts as a "gateway" to Umbraco data for operations which are related to Users.
 
-[Browse the API documentation for UserService](https://our.umbraco.org/apidocs/v7/csharp/api/Umbraco.Core.Services.UserService.html).
+[Browse the API documentation for UserService](https://our.umbraco.com/apidocs/v7/csharp/api/Umbraco.Core.Services.UserService.html).
 
  * **Namespace:** `Umbraco.Core.Services`
  * **Assembly:** `Umbraco.Core.dll`


### PR DESCRIPTION
I feel cheap for doing this, but it had to be done!

I've cleaned up the last remaining references to the legacy `our.umbraco.org` links in the source code, and updated them to the new `our.umbraco.com` domain.

I went a little nuts and did this for all the other repos too 🙈(sorry)

* https://github.com/umbraco/OurUmbraco/pull/491
* https://github.com/umbraco/Umbraco-CMS/pull/6695