### PR TITLE
Remove the needsv8Update from the Udi documentation

### DIFF
--- a/Reference/Querying/Udi.md
+++ b/Reference/Querying/Udi.md
@@ -1,6 +1,5 @@
 ---
 versionFrom: 7.6.0
-needsV8Update: "true"
 ---
 
 # UDI Identifiers


### PR DESCRIPTION
Helping out with the issue #1875 

I have removed the v8 update tag from Udi documentation. Verified and its all good for v8.