### PR TITLE
Make C# app factory sample non breaking 

### DIFF
--- a/Extending/Content-Apps/index.md
+++ b/Extending/Content-Apps/index.md
@@ -215,39 +215,27 @@ namespace Umbraco.Web.UI
     {
         public ContentApp GetContentAppFor(object source, IEnumerable<IReadOnlyUserGroup> userGroups)
         {
-            // Some logic depending on the object type
-            // To show or hide WordCounterApp
-            switch (source)
-            {
-                // Do not show content app if doctype/content type is a container
-                case IContent content when content.ContentType.IsContainer:
-                    return null;
-
-                // Don't show for media items
-                case IMedia media:
-                    return null;
-
-                case IContent content:
-                    break;
-
-                default:
-                   	return null;
-            }
-
-            // Can implement some logic with userGroups if needed
+			// Can implement some logic with userGroups if needed
             // Allowing us to display the content app with some restrictions for certain groups
             if (userGroups.Any(x => x.Alias.ToLowerInvariant() == "admin") == false)
                 return null;
+			
 
-            var wordCounterApp = new ContentApp
-            {
-                Alias = "wordCounter",
-                Name = "Word Counter",
-                Icon = "icon-calculator",
-                View = "/App_Plugins/WordCounter/wordcounter.html",
-                Weight = 0
-            };
-            return wordCounterApp;
+			// only show app on content items
+			if(content is IContent) 
+			{
+				var wordCounterApp = new ContentApp
+	            {
+	                Alias = "wordCounter",
+	                Name = "Word Counter",
+	                Icon = "icon-calculator",
+	                View = "/App_Plugins/WordCounter/wordcounter.html",
+	                Weight = 0
+	            };
+	            return wordCounterApp;
+			}
+
+            return null            
         }
     }
 }

--- a/Extending/Content-Apps/index.md
+++ b/Extending/Content-Apps/index.md
@@ -8,7 +8,7 @@ meta.Description: "A guide to Umbraco Content Apps in the backoffice"
 
 ## What are Content Apps?
 
-Content Apps are **companions** to the editing experience when working with content in the Umbraco backoffice.
+Content Apps are **companions** to the editing experience when working with content or media in the Umbraco backoffice.
 
 Content Apps are a new concept in v8. Editors can switch from editing 'Content' to accessing contextual information related to the item they are editing.
 

--- a/Extending/Content-Apps/index.md
+++ b/Extending/Content-Apps/index.md
@@ -231,7 +231,7 @@ namespace Umbraco.Web.UI
                     break;
 
                 default:
-                    throw new NotSupportedException($"Object type {source.GetType()} is not supported here.");
+                   	return null;
             }
 
             // Can implement some logic with userGroups if needed


### PR DESCRIPTION
There is a PR open at core for introducing content apps on members as well. There is discussion going on how big this breaking change is. 

The discussion is mainly sparked because this will break the C# Content app factory code example. Because this throws a exception when the item is not a media or content item. It would have been better to return null. 
But that would make the entire switch statement look strange. So I changed the example a bit to only show the app when on content items.

I also made clear from the description that content apps can be used on media as well