### PR TITLE
fix(umbraco-services): fix broken paths in Reference links

### DIFF
--- a/Getting-Started/Code/Umbraco-Services/index-v7.md
+++ b/Getting-Started/Code/Umbraco-Services/index-v7.md
@@ -42,19 +42,19 @@ public class EventHandler : Umbraco.Core.ApplicationEventHandler
 ## Services available
 There is full API coverage of all Umbraco core entities:
 
-- [ConsentService](../../../Reference/Management/Services/ConsentService/index.md)
-- [ContentService](../../../Reference/Management/Services/ContentService/index.md)
-- [ApplicationTreeService](../../../Reference/Management/Services/TreeService/index.md)
-- [DataTypeService](../../../Reference/Management/Services/DataTypeService/index.md)
+- [ConsentService](../../../Reference/Management/Services/ConsentService/Index.md)
+- [ContentService](../../../Reference/Management/Services/ContentService/Index.md)
+- [ApplicationTreeService](../../../Reference/Management/Services/TreeService/Index.md)
+- [DataTypeService](../../../Reference/Management/Services/DataTypeService/Index.md)
 - EntityService
-- [FileService](../../../Reference/Management/Services/FileService/index.md)
-- [LocalizationService](../../../Reference/Management/Services/LocalizationService/index.md)
+- [FileService](../../../Reference/Management/Services/FileService/Index.md)
+- [LocalizationService](../../../Reference/Management/Services/LocalizationService/Index.md)
 - MacroService
-- [MediaService](../../../Reference/Management/Services/MediaService/index.md)
-- [MemberService](../../../Reference/Management/Services/MemberService/index.md)
-- [MemberTypeService](../../../Reference/Management/Services/MemberTypeService/index.md)
-- [MemberGroupService](../../../Reference/Management/Services/MemberGroupService/index.md)
-- [ContentTypeService](../../../Reference/Management/Services/ContentTypeService/index.md)
+- [MediaService](../../../Reference/Management/Services/MediaService/Index.md)
+- [MemberService](../../../Reference/Management/Services/MemberService/Index.md)
+- [MemberTypeService](../../../Reference/Management/Services/MemberTypeService/Index.md)
+- [MemberGroupService](../../../Reference/Management/Services/MemberGroupService/Index.md)
+- [ContentTypeService](../../../Reference/Management/Services/ContentTypeService/Index.md)
 
 
 ### More information

--- a/Getting-Started/Code/Umbraco-Services/index.md
+++ b/Getting-Started/Code/Umbraco-Services/index.md
@@ -168,19 +168,19 @@ namespace Umbraco8.Services
 ## Services available
 There is full API coverage of all Umbraco core entities:
 
-- [ConsentService](../../../Reference/Management/Services/ConsentService/index.md)
-- [ContentService](../../../Reference/Management/Services/ContentService/index.md)
-- [ApplicationTreeService](../../../Reference/Management/Services/TreeService/index.md)
-- [DataTypeService](../../../Reference/Management/Services/DataTypeService/index.md)
+- [ConsentService](../../../Reference/Management/Services/ConsentService/Index.md)
+- [ContentService](../../../Reference/Management/Services/ContentService/Index.md)
+- [ApplicationTreeService](../../../Reference/Management/Services/TreeService/Index.md)
+- [DataTypeService](../../../Reference/Management/Services/DataTypeService/Index.md)
 - EntityService
-- [FileService](../../../Reference/Management/Services/FileService/index.md)
-- [LocalizationService](../../../Reference/Management/Services/LocalizationService/index.md)
+- [FileService](../../../Reference/Management/Services/FileService/Index.md)
+- [LocalizationService](../../../Reference/Management/Services/LocalizationService/Index.md)
 - MacroService
-- [MediaService](../../../Reference/Management/Services/MediaService/index.md)
-- [MemberService](../../../Reference/Management/Services/MemberService/index.md)
-- [MemberTypeService](../../../Reference/Management/Services/MemberTypeService/index.md)
-- [MemberGroupService](../../../Reference/Management/Services/MemberGroupService/index.md)
-- [ContentTypeService](../../../Reference/Management/Services/ContentTypeService/index.md)
+- [MediaService](../../../Reference/Management/Services/MediaService/Index.md)
+- [MemberService](../../../Reference/Management/Services/MemberService/Index.md)
+- [MemberTypeService](../../../Reference/Management/Services/MemberTypeService/Index.md)
+- [MemberGroupService](../../../Reference/Management/Services/MemberGroupService/Index.md)
+- [ContentTypeService](../../../Reference/Management/Services/ContentTypeService/Index.md)
 
 
 ### More information


### PR DESCRIPTION
These links work well on https://our.umbraco.com/documentation/Getting-Started/Code/Umbraco-Services/ , but,  broken in .md files

This PR fixed it

P.S. Feel free to decline this PR, if it's not a meaningful/important change  : )