### PR TITLE
Removed needsv8Updatefrom DynamicPublishedContent-Collections

### DIFF
--- a/Reference/Querying/DynamicPublishedContent/Collections.md
+++ b/Reference/Querying/DynamicPublishedContent/Collections.md
@@ -1,5 +1,6 @@
 ---
 versionFrom: 7.0.0
+versionRemoved: 8.0.0
 ---
 
 # IPublishedContent Collections

--- a/Reference/Querying/DynamicPublishedContent/Collections.md
+++ b/Reference/Querying/DynamicPublishedContent/Collections.md
@@ -1,6 +1,5 @@
 ---
 versionFrom: 7.0.0
-needsV8Update: "true"
 ---
 
 # IPublishedContent Collections


### PR DESCRIPTION
Helping out with the issue #1875 
v8 does not support DynamicPublishedContent, hence removing.