### PR TITLE
Update "Umbraco Latch" document

### DIFF
--- a/Umbraco-Cloud/Set-Up/Umbraco-Latch/index.md
+++ b/Umbraco-Cloud/Set-Up/Umbraco-Latch/index.md
@@ -29,6 +29,12 @@ In that case you can manually add a TLS certificate to your project instead. Rea
 Umbraco Latch can issue 5 certificates for a single domain per week. If this limit is exceeded, you will have to wait a week in order to regenerate the certificate for the domain.
 :::
 
+:::note
+An error might occur when your DNS provider has both an IPv4 and IPv6 IP address. 
+Unfortunately, Latch doesn't support IPv6 but Lets Encrypt will take that over IPv4 when it's there.
+In order to resolve this, you will need to disable IPv6 for that domain.
+:::
+
 ## Status definitions
 
 When Umbraco Latch is issuing a certificate for one of your hostnames it goes through the following states:

--- a/Umbraco-Cloud/Set-Up/Umbraco-Latch/index.md
+++ b/Umbraco-Cloud/Set-Up/Umbraco-Latch/index.md
@@ -30,7 +30,7 @@ Umbraco Latch can issue 5 certificates for a single domain per week. If this lim
 :::
 
 :::note
-An error might occur when your DNS provider has both an IPv4 and IPv6 IP address. 
+The generation process might freeze (e.g. Initial > DnsApproved > ChallengeFileWritten > Initial) when your DNS provider has both an IPv4 and IPv6 IP address. 
 Unfortunately, Latch doesn't support IPv6 but Lets Encrypt will take that over IPv4 when it's there.
 In order to resolve this, you will need to disable IPv6 for that domain.
 :::


### PR DESCRIPTION
Added note that describes what to do when LATCH isn't able to configure a valid SSL-certificate because of an active IPv6 address.