### PR TITLE
Added missing key to make imageprocessor work again

### DIFF
--- a/Extending/FileSystemProviders/Azure-Blob-Storage/index.md
+++ b/Extending/FileSystemProviders/Azure-Blob-Storage/index.md
@@ -96,6 +96,7 @@ You have to manually add `prefix="media/"` to the service element, otherwise Ima
     <!--<service name="LocalFileImageService" type="ImageProcessor.Web.Services.LocalFileImageService, ImageProcessor.Web" />-->
     <service prefix="media/" name="CloudImageService" type="ImageProcessor.Web.Services.CloudImageService, ImageProcessor.Web">
     <settings>
+        <setting key="Container" value="[container name]"/>
         <setting key="MaxBytes" value="8194304"/>
         <setting key="Timeout" value="30000"/>
         <setting key="Host" value="https://[your blob account].blob.core.windows.net/media"/>

--- a/Extending/FileSystemProviders/Azure-Blob-Storage/index.md
+++ b/Extending/FileSystemProviders/Azure-Blob-Storage/index.md
@@ -99,7 +99,7 @@ You have to manually add `prefix="media/"` to the service element, otherwise Ima
         <setting key="Container" value="[container name]"/>
         <setting key="MaxBytes" value="8194304"/>
         <setting key="Timeout" value="30000"/>
-        <setting key="Host" value="https://[your blob account].blob.core.windows.net/media"/>
+        <setting key="Host" value="https://[your blob account].blob.core.windows.net/"/>
     </settings>
     </service>
     <service prefix="remote.axd" name="RemoteImageService" type="ImageProcessor.Web.Services.RemoteImageService, ImageProcessor.Web">


### PR DESCRIPTION
The container key was missing from the security.config. Without that imageprocessor won't work with the blobstorage.