### PR TITLE
Added docs about setting notifications badge through content app factory

### DIFF
--- a/Extending/Content-Apps/index.md
+++ b/Extending/Content-Apps/index.md
@@ -269,7 +269,7 @@ $scope.model.badge = {
 };
 ```
 
-From version 8.3.0 and up it is also possible to set a notification badge form a IContentAppFactory. This is done by setting the badge property on the ContentApp model.
+From version 8.3.0 and up it is also possible to set a notification badge from an `IContentAppFactory`. This is achieved by setting the badge property on the ContentApp model.
 
 ```csharp
 using System;

--- a/Extending/Content-Apps/index.md
+++ b/Extending/Content-Apps/index.md
@@ -323,4 +323,4 @@ namespace Umbraco.Web.UI
 }
 ```
 
-Possible values for the ContentAppBadge Type  are Default, Alert and Warning
+Possible values for the `ContentAppBadge` Type are *Default*, *Alert* and *Warning*.

--- a/Extending/Content-Apps/index.md
+++ b/Extending/Content-Apps/index.md
@@ -269,7 +269,7 @@ $scope.model.badge = {
 };
 ```
 
-From version 8.3.0 and up it is also possible to set a notification badge from an `IContentAppFactory`. This is achieved by setting the badge property on the ContentApp model.
+From version 8.4.0 and up it is also possible to set a notification badge from an `IContentAppFactory`. This is achieved by setting the badge property on the ContentApp model.
 
 ```csharp
 using System;

--- a/Extending/Content-Apps/index.md
+++ b/Extending/Content-Apps/index.md
@@ -268,3 +268,59 @@ $scope.model.badge = {
   type: "warning" // optional: determines the badge color - "warning" = dark yellow, "alert" = red, anything else = blue (matching the top-menu background color)
 };
 ```
+
+From version 8.3.0 and up it is also possible to set a notification badge form a IContentAppFactory. This is done by setting the badge property on the ContentApp model.
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core.Composing;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.ContentEditing;
+using Umbraco.Core.Models.Membership;
+
+namespace Umbraco.Web.UI
+{
+
+    public class WordCounterAppComponent : IUserComposer
+    {
+        public void Compose(Composition composition)
+        {
+            // Add our word counter content app into the composition aka into the DI
+            composition.ContentApps().Append<WordCounterApp>();
+        }
+    }
+
+    public class WordCounterApp : IContentAppFactory
+    {
+        public ContentApp GetContentAppFor(object source, IEnumerable<IReadOnlyUserGroup> userGroups)
+        {
+			// Can implement some logic with userGroups if needed
+            // Allowing us to display the content app with some restrictions for certain groups
+            if (userGroups.Any(x => x.Alias.ToLowerInvariant() == "admin") == false)
+                return null;
+			
+
+			// only show app on content items
+			if(content is IContent) 
+			{
+				var wordCounterApp = new ContentApp
+	            {
+	                Alias = "wordCounter",
+	                Name = "Word Counter",
+	                Icon = "icon-calculator",
+	                View = "/App_Plugins/WordCounter/wordcounter.html",
+	                Weight = 0,
+					Badge = new ContentAppBadge { Count = 5 , Type = ContentAppBadgeType.Warning }
+	            };
+	            return wordCounterApp;
+			}
+
+            return null            
+        }
+    }
+}
+```
+
+Possible values for the type are Default, Alert and Warning

--- a/Extending/Content-Apps/index.md
+++ b/Extending/Content-Apps/index.md
@@ -323,4 +323,4 @@ namespace Umbraco.Web.UI
 }
 ```
 
-Possible values for the type are Default, Alert and Warning
+Possible values for the ContentAppBadge Type  are Default, Alert and Warning


### PR DESCRIPTION
I created a PR to make it possible to set content app notification badges through a content app factory. This will be part of 8.3

This PR is the documentation for that functionality.

Dave