### PR TITLE
Update IContentFinder add a note about removal of ContentFinderByUrlAndTemplate in V8

### DIFF
--- a/Reference/Routing/Request-Pipeline/IContentFinder.md
+++ b/Reference/Routing/Request-Pipeline/IContentFinder.md
@@ -75,7 +75,7 @@ namespace My.Website
 :::note
 In Umbraco V7 there existed an IContentFinder that would find content and display it with an 'alternative template' via a convention - (to avoid the ugly ?alttemplate=blogfullstory appearing on the querystring of the url when using the alternative template mechanism). Instead the Url could follow the convention of /urltocontent/altemplatealias 
 
-eg: /blog/my-blog-post/blogfullstory would 'find' the /blog/my-blog-post page and display using the 'blogfullstory' template. 
+Eg: `/blog/my-blog-post/blogfullstory` would 'find' the `/blog/my-blog-post` page and display using the `blogfullstory` template. 
 
 In Umbraco 8 this convention has been removed from the default configuration of Umbraco. You can reintroduce this behaviour by adding the `ContentFinderByUrlAndTemplate` ContentFinder back into the ContentFinderCollection, using an `IUserComposer` (see above example).
 :::

--- a/Reference/Routing/Request-Pipeline/IContentFinder.md
+++ b/Reference/Routing/Request-Pipeline/IContentFinder.md
@@ -73,7 +73,7 @@ namespace My.Website
 
 ```
 :::note
-In Umbraco V7 there existed an IContentFinder that would find content and display it with an 'alternative template' via a convention - (to avoid the ugly ?alttemplate=blogfullstory appearing on the querystring of the url when using the alternative template mechanism). Instead the Url could follow the convention of /urltocontent/altemplatealias 
+In Umbraco7 there existed an IContentFinder that would find content and display it with an 'alternative template' via a convention. This could be to avoid the ugly `?alttemplate=blogfullstory` appearing on the querystring of the url when using the alternative template mechanism. Instead the Url could follow the convention of `/urltocontent/altemplatealias`. 
 
 Eg: `/blog/my-blog-post/blogfullstory` would 'find' the `/blog/my-blog-post` page and display using the `blogfullstory` template. 
 

--- a/Reference/Routing/Request-Pipeline/IContentFinder.md
+++ b/Reference/Routing/Request-Pipeline/IContentFinder.md
@@ -72,6 +72,13 @@ namespace My.Website
 }
 
 ```
+:::note
+In Umbraco V7 there existed an IContentFinder that would find content and display it with an 'alternative template' via a convention - (to avoid the ugly ?alttemplate=blogfullstory appearing on the querystring of the url when using the alternative template mechanism). Instead the Url could follow the convention of /urltocontent/altemplatealias 
+
+eg: /blog/my-blog-post/blogfullstory would 'find' the /blog/my-blog-post page and display using the 'blogfullstory' template. 
+
+In Umbraco V8 this convention has been removed from the default configuration of Umbraco but you can reintroduce this behaviour by adding the `ContentFinderByUrlAndTemplate` ContentFinder back into the ContentFinderCollection, using an `IUserComposer` (see above example)
+:::
 
 # NotFoundHandlers
 

--- a/Reference/Routing/Request-Pipeline/IContentFinder.md
+++ b/Reference/Routing/Request-Pipeline/IContentFinder.md
@@ -77,7 +77,7 @@ In Umbraco V7 there existed an IContentFinder that would find content and displa
 
 eg: /blog/my-blog-post/blogfullstory would 'find' the /blog/my-blog-post page and display using the 'blogfullstory' template. 
 
-In Umbraco V8 this convention has been removed from the default configuration of Umbraco but you can reintroduce this behaviour by adding the `ContentFinderByUrlAndTemplate` ContentFinder back into the ContentFinderCollection, using an `IUserComposer` (see above example)
+In Umbraco 8 this convention has been removed from the default configuration of Umbraco. You can reintroduce this behaviour by adding the `ContentFinderByUrlAndTemplate` ContentFinder back into the ContentFinderCollection, using an `IUserComposer` (see above example).
 :::
 
 # NotFoundHandlers


### PR DESCRIPTION
…

see https://github.com/umbraco/Umbraco-CMS/issues/5290
The convention to find urls via /urltocontent/alttemplatealias has been secretly dropped in V8.. just a note here of how to add it back in, following numerous forum questions!