### PR TITLE
Code snippets does not get syntax highlighting.

### DIFF
--- a/Reference/Searching/Examine/examine-events.md
+++ b/Reference/Searching/Examine/examine-events.md
@@ -16,7 +16,7 @@ In the [Quick Start](Quick-Start/index.md) documentation you can see how to perf
 
 However, what if you want to search through several different node types and search across many different fields, you will typically need to have a query that looks like this:
 
-```cs
+```c#
 var results = searcher.CreateQuery("content").Field("nodeName", searchTerm)
                     Or().Field("bodyText", searchTerm)
                     Or().Field("description", searchTerm)
@@ -35,7 +35,7 @@ This example will build upon the Umbraco Starterkit as it is a good starting poi
 
 So to add a TransformingIndexValues event we will add a controller that inherits from `IComponent`. Something like this:
 
-```cs
+```c#
 public class ExamineEvents : IComponent
 {
     private readonly IExamineManager _examineManager;
@@ -70,7 +70,7 @@ public class ExamineEvents : IComponent
 
 You can read more about this [syntax and Components here](../../../Implementation/Composing/index.md). We can now add the logic to combine fields in the `IndexProviderTransformingIndexValues` method:
 
-```cs
+```c#
 if (e.ValueSet.Category == IndexTypes.Content)
 {
     var combinedFields = new StringBuilder();
@@ -97,7 +97,7 @@ So at this point we have done something along the lines of:
 
 Before this works the component will have to be registered in a composer. If you already have a composer you can add it to that one, but for this example we will make a new composer:
 
-```cs
+```c#
 //This is a composer which automatically appends the ExamineEvents component
 public class ExamineComposer : ComponentComposer<ExamineEvents>, IUserComposer
 {
@@ -111,6 +111,6 @@ We append it so it runs as the last one. Now if you start up your website and [r
 
 At this point you can create a query for only that field:
 
-```cs
+```c#
 var results = searcher.CreateQuery("content").Field("combinedField", searchTerm).Execute();
 ```


### PR DESCRIPTION
This page code does not get syntax highlighting with the ```cs, which also create uncompiling code in the ExamineComposer section, since the type paramter is not rendered on Our.Umbraco.

The code in the docs on Our does not combile, since ComponentComposer requires 1 type argument. 
Currently if you code and paste the ExamineComposer on this page (https://our.umbraco.com/documentation/Reference/Searching/Examine/examine-events) into your code, you will get these two error: 
- Using the generic type 'ComponentComposer<TComponent>' requires 1 type arguments
- 'ExamineComposer' does not implement interface member 'IComposer.Compose(Composition)'

However by using ```c# like all the other pages, we should both get syntax highlighting and hopefully also the missing type paramter.