### PR TITLE
Logviewer apps on newline.

### DIFF
--- a/Getting-Started/Code/Debugging/Logging/index.md
+++ b/Getting-Started/Code/Debugging/Logging/index.md
@@ -206,7 +206,8 @@ Learn more about the [logviewer dashboard](../../../Backoffice/LogViewer/) in th
 
 ## The logviewer desktop app
 
-This is a tool for viewing & querying JSON log files from disk in the same way as the built in log viewer dashboard
+This is a tool for viewing & querying JSON log files from disk in the same way as the built in log viewer dashboard.
+
 <a href='//www.microsoft.com/store/apps/9N8RV8LKTXRJ?cid=storebadge&ocid=badge'><img src='https://assets.windowsphone.com/85864462-9c82-451e-9355-a3d5f874397a/English_get-it-from-MS_InvariantCulture_Default.png' alt='English badge' style='height: 38px;' height="38" /></a> <a href="https://itunes.apple.com/gb/app/compact-log-viewer/id1456027499"><img src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-mac-app-store.svg" /></a>
 
 


### PR DESCRIPTION
The last word in the sentence “dashboard” does not end with a dot also there is no new line before the badges, which makes it look wonky on mobile device. See screenshot: https://paste.pics/e0c1c15790f75eaacdfe87392dd94b2d