### PR TITLE
Added info about Label (Long string).

### DIFF
--- a/Getting-Started/Data/Data-Types/default-data-types.md
+++ b/Getting-Started/Data/Data-Types/default-data-types.md
@@ -40,7 +40,9 @@ Allows for the upload and cropping of images by using a focal point. Specific cr
 Is a non-editable control, can only be used to display a present text (string). It can also be used in the
 media section to load in values related to the node, such as width, height and file size.
 
-If you want to input something other than a string into a Label, you can use one of the five other Label Data Types: Label (bigint), Label (datetime), Label (decimal), Label (integer) or Label (time).
+If you want to input something other than a string into a Label, you can use one of the five other Label Data Types: Label (bigint), Label (datetime), Label (decimal), Label (integer) or Label (time). 
+
+If you want to save a long string value for a Label, there is a Value type: Label (Long string) which can be used for that.
 
 ### List View - Content
 This data type is used by Document Types that are set to display as list views.


### PR DESCRIPTION
If you input a long string value into a "regular" Label (string) then you will get an error when you try to save & publish saying: "Unable to publish - String or binary data would be truncated.". This was easily fixed by changing the value type from Label (String) to Label (Long string). 
![screen](https://user-images.githubusercontent.com/6122154/69517447-08a6b000-0f55-11ea-9b47-07753d10697b.png)

Would have been nice to find information about in the docs, hence this PR. :)

Cheers!