### PR TITLE
Security config prefix change

### DIFF
--- a/Extending/FileSystemProviders/Azure-Blob-Storage/index-v7.md
+++ b/Extending/FileSystemProviders/Azure-Blob-Storage/index-v7.md
@@ -111,7 +111,7 @@ You have to manually add `prefix="media/"` to the service element, otherwise Ima
 <security>
   <services>
     <!--<service name="LocalFileImageService" type="ImageProcessor.Web.Services.LocalFileImageService, ImageProcessor.Web" />-->
-    <service prefix="media/" name="CloudImageService" type="ImageProcessor.Web.Services.CloudImageService, ImageProcessor.Web">
+    <service prefix="/media" name="CloudImageService" type="ImageProcessor.Web.Services.CloudImageService, ImageProcessor.Web">
     <settings>
         <setting key="Container" value="[container name]"/>
         <setting key="MaxBytes" value="8194304"/>


### PR DESCRIPTION
Without the slash being added before 'media', I get the following error in the logs when image are trying to be served,
"ERROR ImageProcessor.Web.HttpModules.ImageProcessingModule - 
ImageProcessor.Common.Exceptions.ImageProcessingException: ProcessImageAsync 610 : No image exists at ..."

The images are still served but adding the slash at the beginning removes the error.