### PR TITLE
* Search and replace ```cs to ```csharp for better syntax highlightning.

### DIFF
--- a/Extending/Packages/Package-Actions/custom-package-actions.md
+++ b/Extending/Packages/Package-Actions/custom-package-actions.md
@@ -24,7 +24,7 @@ If the package files are deployed between environments then the package action w
 
 To create a custom package action you need to create a new class and implement the `IPackageAction` interface. The empty package action would then look like this:
 
-```cs
+```csharp
 using System.Xml.Linq;
 using Umbraco.Core.PackageActions;
 
@@ -69,7 +69,7 @@ However if you want it to be more configurable you can add extra parameters to i
 </actions>
 ```
 
-```cs
+```csharp
 using System.Xml.Linq;
 using Umbraco.Core.PackageActions;
 using Umbraco.Core.Composing;

--- a/Reference/Language-Variation/index.md
+++ b/Reference/Language-Variation/index.md
@@ -11,7 +11,7 @@ Introduced in Umbraco 8, Language Variation allows you to have several different
 
 [`IPublishedContent`](../Querying/IPublishedContent/index.md) contains all language variations of a node, and when rendering it out it will then use the Culture you are currently on. This can then be overridden on an individual property level if you want like this:
 
-```cs
+``csharp
 @Model.Value("pageTitle", "fr", fallback: Fallback.ToLanguage)
 ```
 
@@ -21,7 +21,7 @@ The problem here comes if you want to output all values of an IPublishedContent 
 
 If you do something like this:
 
-```cs
+```csharp
 using System.Linq;
 using System.Web.Mvc;
 using Umbraco.Web.Mvc;
@@ -43,7 +43,7 @@ namespace TestStuff
 
 You will get the root node in the default culture. However you can set a new `VariationContext` like this:
 
-```cs
+```csharp
 using System.Linq;
 using System.Web.Mvc;
 using Umbraco.Web.Mvc;

--- a/Reference/Searching/Examine/pdf-index.md
+++ b/Reference/Searching/Examine/pdf-index.md
@@ -17,7 +17,7 @@ You will then have a new Examine index called "PDFIndex" available.
 
 To use the multisearcher in Umbraco 8, you can instantiate it when needed like:
 
-```cs
+```csharp
 using(var multiSearcher = new MultiIndexSearcher("MultiSearcher", new IIndex[] {
     externalIndex,
     pdfIndex
@@ -29,7 +29,7 @@ using(var multiSearcher = new MultiIndexSearcher("MultiSearcher", new IIndex[] {
 
 Or you can register a multi index searcher with the ExamineManager on startup like:
 
-```cs
+```csharp
 using Examine;
 using Examine.LuceneEngine.Providers;
 using Umbraco.Core.Composing;
@@ -67,7 +67,7 @@ public class MyComponent : IComponent
 
 With this approach, the multisearcher will show up in the Examine dashboard and it can be resolved from the ExamineManager like:
 
-```cs
+```csharp
 if (_examineManager.TryGetSearcher("MultiSearcher", out var searcher))
 {
     //TODO: use the `searcher` to search


### PR DESCRIPTION
**csharp** 
gives better C# syntax highlighting that 
**cs**.
I did a search through the docs project and I think this is the only once.

Affected pages:
- https://our.umbraco.com/Documentation/Extending/Packages/Package-Actions/custom-package-actions
- https://our.umbraco.com/Documentation/Reference/Language-Variation/
- https://our.umbraco.com/Documentation/Reference/Searching/Examine/pdf-index/