### PR TITLE
Fix variable name for content cache

### DIFF
--- a/Getting-Started/Code/Umbraco-Services/index.md
+++ b/Getting-Started/Code/Umbraco-Services/index.md
@@ -153,7 +153,7 @@ namespace Umbraco8.Services
             using (var contextReference = _contextFactory.EnsureUmbracoContext())
             {
                 IPublishedContentCache contentCache = contextReference.UmbracoContext.Content;
-                IPublishedContent newsSection = cache.GetAtRoot().FirstOrDefault().Children.FirstOrDefault(f => f.ContentType.Alias == "newsSection");
+                IPublishedContent newsSection = contentCache.GetAtRoot().FirstOrDefault().Children.FirstOrDefault(f => f.ContentType.Alias == "newsSection");
                 if (newsSection== null)
                 {
                     _logger.Debug<CustomNewsArticleService>("News Section Not Found");


### PR DESCRIPTION
The variable `cache` doesn't exists - it should be `contentCache`.