### PR TITLE
Remove unused _siteDomainHelper field.

### DIFF
--- a/Reference/Routing/Request-Pipeline/outbound-pipeline.md
+++ b/Reference/Routing/Request-Pipeline/outbound-pipeline.md
@@ -266,11 +266,7 @@ namespace UmbracoV8.Routing.UrlProviders
 
     public class ProductPageUrlProvider : DefaultUrlProvider
     {
-        private readonly ISiteDomainHelper _siteDomainHelper;
-        public ProductPageUrlProvider(IRequestHandlerSection requestSettings, ILogger logger, IGlobalSettings globalSettings, ISiteDomainHelper siteDomainHelper) : base(requestSettings,logger,globalSettings,siteDomainHelper)
-        {
-            _siteDomainHelper = siteDomainHelper;
-        }
+        public ProductPageUrlProvider(IRequestHandlerSection requestSettings, ILogger logger, IGlobalSettings globalSettings, ISiteDomainHelper siteDomainHelper) : base(requestSettings,logger,globalSettings,siteDomainHelper) { }
         public override IEnumerable<UrlInfo> GetOtherUrls(UmbracoContext umbracoContext, int id, Uri current)
         {
             //add custom logic to return 'additional urls' - this method populates a list of additional urls for the node to display in the Umbraco backoffice


### PR DESCRIPTION
In the ProductPageUrlProvider docs the _siteDomainHelper is declared as a local field, for no reason at all (its unused). Maybe its been used in the past?

It should still be injected in the constructor since it is passed down to the DefaultUrlProvider, but it doesnt need to be locally declared in the ProductPageUrlProvider.cs.