### PR TITLE
Removed needv8update tag from 404handler.config

### DIFF
--- a/Reference/Config/404handlers/index-v7.md
+++ b/Reference/Config/404handlers/index-v7.md
@@ -1,0 +1,28 @@
+---
+versionFrom: 7.0.0
+---
+
+# 404handlers.config
+
+**Obsolete.  The concept of *NotFoundHandlers* has been replaced by [Content Finders](../../routing/request-pipeline/IContentFinder)**
+
+_Configuration file for legacy *NotFoundHandlers*. These are used to register custom code within the Umbraco incoming request pipeline, including the legacy way to handle a custom 404 error._
+
+The Default Handlers are listed in this configuration file for 'backwards compatibility':
+
+```xml
+<NotFoundHandlers>
+  <notFound assembly="umbraco" type="SearchForAlias" />
+  <notFound assembly="umbraco" type="SearchForTemplate"/>
+  <notFound assembly="umbraco" type="SearchForProfile"/>
+  <notFound assembly="umbraco" type="handle404"/>
+</NotFoundHandlers>
+```
+
+## Backwards compatibility
+
+If you upgrade from an older version of Umbraco then legacy *NotFoundHandlers* listed here 'should' still work. The request pipeline contains a *ContentFinderByNotFoundHandlers* IContentFinder that will attempt to execute the functionality of any legacy *NotFoundHandlers*, but it's recommended to move your custom request handling logic to IContentFinders.
+
+## Implementing 404 not found properly
+
+Custom 404's are now handled within a custom *IContentFinder* by setting the Is404 property to true for the *PublishedContentRequest* processed by the *IContentFinder* or by registering the *IContentFinder* as a *ContentLastChanceFinder* - [Using an IContentFinder for Custom 404s](../../routing/request-pipeline/IContentFinder#notfoundhandlers)

--- a/Reference/Config/404handlers/index.md
+++ b/Reference/Config/404handlers/index.md
@@ -1,6 +1,5 @@
 ---
 versionFrom: 7.0.0
-needsV8Update: "true"
 ---
 
 # 404handlers.config

--- a/Reference/Config/404handlers/index.md
+++ b/Reference/Config/404handlers/index.md
@@ -1,28 +1,7 @@
 ---
-versionFrom: 7.0.0
+versionFrom: 8.0.0
 ---
 
-# 404handlers.config
+# How to implement a 404 Page
 
-**Obsolete.  The concept of *NotFoundHandlers* has been replaced by [Content Finders](../../routing/request-pipeline/IContentFinder)**
-
-_Configuration file for legacy *NotFoundHandlers*. These are used to register custom code within the Umbraco incoming request pipeline, including the legacy way to handle a custom 404 error._
-
-The Default Handlers are listed in this configuration file for 'backwards compatibility':
-
-```xml
-<NotFoundHandlers>
-  <notFound assembly="umbraco" type="SearchForAlias" />
-  <notFound assembly="umbraco" type="SearchForTemplate"/>
-  <notFound assembly="umbraco" type="SearchForProfile"/>
-  <notFound assembly="umbraco" type="handle404"/>
-</NotFoundHandlers>
-```
-
-## Backwards compatibility
-
-If you upgrade from an older version of Umbraco then legacy *NotFoundHandlers* listed here 'should' still work. The request pipeline contains a *ContentFinderByNotFoundHandlers* IContentFinder that will attempt to execute the functionality of any legacy *NotFoundHandlers*, but it's recommended to move your custom request handling logic to IContentFinders.
-
-## Implementing 404 not found properly
-
-Custom 404's are now handled within a custom *IContentFinder* by setting the Is404 property to true for the *PublishedContentRequest* processed by the *IContentFinder* or by registering the *IContentFinder* as a *ContentLastChanceFinder* - [Using an IContentFinder for Custom 404s](../../routing/request-pipeline/IContentFinder#notfoundhandlers)
+To implement your own 404 finder, create a class which implements the interface *IContentLastChanceFinder* and registering it as the last chance content finder using an *IComposer*. A ContentLastChanceFinder will always return a 404 status code. - [Using an IContentFinder for Custom 404s](../../routing/request-pipeline/IContentFinder#notfoundhandlers)


### PR DESCRIPTION
The `404handlers.config` is obsolete. So it does not need v8 update and hence the tag can be removed