### PR TITLE
Incorrent 'don't'-logic in comment in Navigation example.

### DIFF
--- a/Tutorials/Creating-Basic-Site/Master-Template-The-Navigation-Menu/index.md
+++ b/Tutorials/Creating-Basic-Site/Master-Template-The-Navigation-Menu/index.md
@@ -37,7 +37,7 @@ As an example, this has come from the default starter kit.
     var selection = site.Children.Where(x => x.IsVisible()); <!-- see below for explanation of IsVisible helper method -->
 }
 
-<!-- uncomment this line if you don't want the site name to appear in the top navigation -->
+<!-- uncomment this line if you want the site name to appear in the top navigation -->
 <!-- <a class="nav-link @Html.Raw(Model.Id == site.Id ? "navi-link--active" : "")" href="@site.Url">@site.Name</a> -->
 
 @foreach (var item in selection)


### PR DESCRIPTION
Uncommenting this line **WILL** actually show the @site.Name in the top navigation, 
so the word '_don't_' needs to be removed to fit the current logic.

Probably a leftover from a reversed logic in the passed 
(maybe in the past it was '**comment out** this line if you **don't** want...').

Cheers!