### PR TITLE
Update docs regarding renamed UrlMode from UrlProviderMode.

### DIFF
--- a/Implementation/Services/index.md
+++ b/Implementation/Services/index.md
@@ -224,7 +224,7 @@ public bool TryFindContent(PublishedRequest frequest)
 And inside a UrlProvider the GetUrl method has the current UmbracoContext injected:
 
 ```csharp
-public override UrlInfo GetUrl(UmbracoContext umbracoContext, IPublishedContent content, UrlProviderMode mode, string culture, Uri current)
+public override UrlInfo GetUrl(UmbracoContext umbracoContext, IPublishedContent content, UrlMode mode, string culture, Uri current)
 {
     var someContent = umbracoContext.Content.GetById(1234);
 
@@ -234,6 +234,7 @@ public override UrlInfo GetUrl(UmbracoContext umbracoContext, IPublishedContent 
 
 :::Note
 It is still possible to inject services into IContentFinder's. IContentFinders are singletons, but the example is showing you do not 'need to' in order to access the Published Content Cache!
+Also note that UrlMode was renamed from UrlProviderMode in Umbraco v8.1.
 :::
 
 ## Custom Services and Helpers

--- a/Reference/Routing/Request-Pipeline/outbound-pipeline.md
+++ b/Reference/Routing/Request-Pipeline/outbound-pipeline.md
@@ -187,7 +187,7 @@ Umbraco ships with a DefaultUrlProvider, which provides the implementation for t
 // That one is initialized by default
 public class DefaultUrlProvider : IUrlProvider
 {
-    public virtual UrlInfo GetUrl(UmbracoContext umbracoContext, IPublishedContent content, UrlProviderMode mode, string culture, Uri current)
+    public virtual UrlInfo GetUrl(UmbracoContext umbracoContext, IPublishedContent content, UrlMode mode, string culture, Uri current)
     {…}
 
     public virtual IEnumerable<UrlInfo> GetOtherUrls(UmbracoContext umbracoContext, int id, Uri current)
@@ -227,7 +227,7 @@ Create a custom Url Provider by implementing `IUrlProvider` interface
 ```csharp
 public interface IUrlProvider
 {
-    UrlInfo GetUrl(UmbracoContext umbracoContext, IPublishedContent content, UrlProviderMode mode, string culture, Uri current);
+    UrlInfo GetUrl(UmbracoContext umbracoContext, IPublishedContent content, UrlMode mode, string culture, Uri current);
 
     IEnumerable<UrlInfo> GetOtherUrls(UmbracoContext umbracoContext, int id, Uri current);
 }
@@ -335,17 +335,30 @@ Specifies the type of urls that the url provider should produce, eg. absolute vs
 These are the different modes:
 
 ```csharp
-public enum UrlProviderMode
+public enum UrlMode
 {
-  // Produce relative Urls exclusively
+  /// <summary>
+  /// Indicates that the url provider should do what it has been configured to do.
+  /// </summary>
+  Default = 0,
+
+  /// <summary>
+  /// Indicates that the url provider should produce relative urls exclusively.
+  /// </summary>
   Relative,
-  // Produce absolute Urls exclusively
+
+  /// <summary>
+  /// Indicates that the url provider should produce absolute urls exclusively.
+  /// </summary>
   Absolute,
-  // Produce relative Urls when possible, else absolute when required
+
+  /// <summary>
+  /// Indicates that the url provider should determine automatically whether to return relative or absolute urls.
+  /// </summary>
   Auto
 }
 ```
-Auto is the default. The setting can be changed in /config/umbracoSettings.config web.routing section:
+Default setting can be changed in /config/umbracoSettings.config web.routing section:
 
 ```xml
   <web.routing urlProviderMode="Relative">


### PR DESCRIPTION
In Umbraco v.8.1 the UrlProviderMode was renamed to just simply UrlMode. https://our.umbraco.com/documentation/Getting-Started/Setup/Upgrading/v81-ipublishedcontent-changes#url

These two pages in the docs does not seem to been updated with this info.

The **outbound-pipeline** page already had specific index page targeting 8.1.+ but the **services** page did not. I didn't create a specific pre-8.1 page for the services page since it was such a small change, but instead I extended the note with the renamed info. 
Is that fine? 
Or would you like me to update this PR with a specific page for pre-8.1?