### PR TITLE
MembershipHelper Tests

### DIFF
--- a/Implementation/Unit-Testing/index.md
+++ b/Implementation/Unit-Testing/index.md
@@ -365,9 +365,9 @@ public class MyCustomControllerTests : UmbracoBaseTest
 }
 ```
 
-## Testing GetCurrentMember using the UmbracoHelper
+## Testing GetCurrentMember using the MembershipHelper
 In this example we have a controller which renders a profile page, by using ```Umbraco.MembershipHelper.GetCurrentMember()```.
-This involves a lot of different dependencies working together behind the scenes such as the ```MembershipHelper```, ```IMemberService```, ```IPublishedMemberCache``` and the ```HttpContext``` which needs to be mocked in order for our tests to run smoothly.
+This involves a lot of different dependencies working together behind the scenes such as the ```MembershipHelper```, ```IMemberService```, ```IPublishedMemberCache``` and the ```HttpContext``` which needs to be mocked for our tests to run smoothly.
 
 ```csharp
 public class MemberController : RenderMvcController

--- a/Implementation/Unit-Testing/index.md
+++ b/Implementation/Unit-Testing/index.md
@@ -370,9 +370,9 @@ In this example we have a controller which renders a profile page, by using ```U
 This involves a lot of different dependencies working together behind the scenes such as the ```MembershipHelper```, ```IMemberService```, ```IPublishedMemberCache``` and the ```HttpContext``` which needs to be mocked for our tests to run smoothly.
 
 ```csharp
-public class MemberController : RenderMvcController
+public class MemberProfileController : RenderMvcController
 {
-    public MemberController(IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ServiceContext serviceContext, AppCaches appCaches, IProfilingLogger profilingLogger, UmbracoHelper umbracoHelper) : base(globalSettings, umbracoContextAccessor, serviceContext, appCaches, profilingLogger, umbracoHelper) { }
+    public MemberProfileController(IGlobalSettings globalSettings, IUmbracoContextAccessor umbracoContextAccessor, ServiceContext serviceContext, AppCaches appCaches, IProfilingLogger profilingLogger, UmbracoHelper umbracoHelper) : base(globalSettings, umbracoContextAccessor, serviceContext, appCaches, profilingLogger, umbracoHelper) { }
 
     public override ActionResult Index(ContentModel model)
     {
@@ -391,15 +391,15 @@ public class MemberProfile : ContentModel
 }
 
 [TestFixture]
-public class MemberControllerTests : UmbracoBaseTest 
+public class MemberProfileControllerTests : UmbracoBaseTest 
 {
-    private MemberController controller;
+    private MemberProfileController controller;
     
     [SetUp]
     public override void SetUp()
     {
         base.SetUp();
-        this.controller = new MemberController(Mock.Of<IGlobalSettings>(), Mock.Of<IUmbracoContextAccessor>(), base.ServiceContext, AppCaches.NoCache, Mock.Of<IProfilingLogger>(), base.UmbracoHelper);
+        this.controller = new MemberProfileController(Mock.Of<IGlobalSettings>(), Mock.Of<IUmbracoContextAccessor>(), base.ServiceContext, AppCaches.NoCache, Mock.Of<IProfilingLogger>(), base.UmbracoHelper);
     }
 
     [Test]

--- a/Implementation/Unit-Testing/index.md
+++ b/Implementation/Unit-Testing/index.md
@@ -302,7 +302,7 @@ public class HomeControllerTests : UmbracoBaseTest
 
     [Test]
     [TestCase("myDictionaryKey", "myDictionaryValue")]
-    public void GivenMyDictionaryKey_WhenIndex_ThenReturnViewModelWithMyPropertyDictionaryValue(string key, string expected)
+    public void GivenMyDictionaryKey_WhenIndexAction_ThenReturnViewModelWithMyPropertyDictionaryValue(string key, string expected)
     {
         var model = new ContentModel(new Mock<IPublishedContent>().Object);
         base.CultureDictionary.Setup(x => x[key]).Returns(expected);
@@ -352,7 +352,7 @@ public class MyCustomControllerTests : UmbracoBaseTest
     }
 
     [Test]
-    public void GivenContentQueryReturnsOtherContent_WhenIndex_ThenReturnViewModelWithOtherContent()
+    public void GivenContentQueryReturnsOtherContent_WhenIndexAction_ThenReturnViewModelWithOtherContent()
     {
         var currentContent = new ContentModel(new Mock<IPublishedContent>().Object);
         var otherContent = Mock.Of<IPublishedContent>();
@@ -405,7 +405,7 @@ public class MemberControllerTests : UmbracoBaseTest
     [Test]
     [TestCase("member1")]
     [TestCase("member2")]
-    public void GivenMemberIsAuthenticated_WhenIndexAction_ThenReturnViewModelWithCurrentMember(string username)
+    public void GivenExistingMemberIsAuthenticated_WhenIndexAction_ThenReturnViewModelWithCurrentMember(string username)
     {
         var member = new Mock<IMember>();
         member.Setup(x => x.Username).Returns(username);
@@ -427,6 +427,21 @@ public class MemberControllerTests : UmbracoBaseTest
         var actual = (MemberProfile)((ViewResult)this.controller.Index(new ContentModel(Mock.Of<IPublishedContent>()))).Model;
 
         Assert.AreEqual(expected, actual.Member);
+    }
+
+    [Test]
+    [TestCase("member1")]
+    [TestCase("member2")]
+    public void GivenExistingMemberIsNotAuthenticated_WhenIndexAction_ThenReturnViewModelWithNullMember(string username)
+    {
+        var member = new Mock<IMember>();
+        member.Setup(x => x.Username).Returns(username);
+        base.memberService.Setup(x => x.GetByUsername(username)).Returns(member.Object);
+        base.memberCache.Setup(x => x.GetByMember(member.Object)).Returns(Mock.Of<IPublishedContent>());
+        
+        var actual = (MemberProfile)((ViewResult)this.controller.Index(new Umbraco.Web.Models.ContentModel(Mock.Of<IPublishedContent>()))).Model;
+
+        Assert.Null(actual.Member);
     }
 }
 ```


### PR DESCRIPTION
Added some test sample for the MembershipHelper.GetCurrentMember();

A bit more complexity than the previous tests, but I think it can be useful since it involves mocking a lot of different dependencies. 

The idea the the documentation page is to start of low level at the top and the further down you get on the documentation page the more complex test samples. Hope you like this approach.

Cheers! 🎉 