### PR TITLE
Variable 'content' does not exist in this context.

### DIFF
--- a/Extending/Content-Apps/index.md
+++ b/Extending/Content-Apps/index.md
@@ -222,7 +222,7 @@ namespace Umbraco.Web.UI
 			
 
 			// only show app on content items
-			if(content is IContent) 
+			if(source is IContent) 
 			{
 				var wordCounterApp = new ContentApp
 	            {
@@ -303,7 +303,7 @@ namespace Umbraco.Web.UI
 			
 
 			// only show app on content items
-			if(content is IContent) 
+			if(source is IContent) 
 			{
 				var wordCounterApp = new ContentApp
 	            {


### PR DESCRIPTION
`if(content is IContent)` is not compiling, since variable '_content_' does not exist.
The variable we want to use is the passed in object parameter '**source**'.