### PR TITLE
Added link to the Constants.Trees.Groups in API documentation and minor readability fixes

### DIFF
--- a/Extending/Section-Trees/trees.md
+++ b/Extending/Section-Trees/trees.md
@@ -31,7 +31,9 @@ public class FavouriteThingsTreeController : TreeController
 The SortOrder controls the order of the custom tree within the Tree Group.
 
 ### Tree Groups
-Tree Groups are a new concept in V8, to enable you to group trees in a section. You provide the alias of the Tree Group name, you wish to add your tree to - see Constants.Trees.Groups for a list of existing group alias. If you add your own alias, you'll need to add a translation key to config/lang/en-US.user.xml to avoid the alias appearing as the header in [square brackets] eg
+Tree Groups are a new concept in V8, to enable you to group trees in a section. You provide the alias of the Tree Group name, you wish to add your tree to - see [Constants.Trees.Groups](https://our.umbraco.com/apidocs/v8/csharp/api/Umbraco.Core.Constants.Trees.Groups.html) for a list of existing group alias. An example of tree groups in the back office would be the *Settings* tree group and the *Templating* tree group in the *Settings* section.
+
+If you add your own alias, you'll need to add a translation key to `config/lang/en-US.user.xml` to avoid the alias appearing as the header in [square brackets] eg
 ```xml
 <language>
   <area alias="treeHeaders">
@@ -42,7 +44,7 @@ Tree Groups are a new concept in V8, to enable you to group trees in a section. 
 
 ### Customising the Root Tree Node
 
-The first node in the tree is referred to as the **Root Node**. You might want to assign a custom icon to the Root Node or specify a custom url route path in the backoffice to use with your custom tree. Perhaps if you had a single page app you customise the Root Tree Node by overriding the abstract CreateRootNode method.
+The first node in the tree is referred to as the **Root Node**. You might want to assign a custom icon to the Root Node or specify a custom url route path in the backoffice to use with your custom tree. Perhaps if you had a single page app you customise the Root Node by overriding the abstract *CreateRootNode* method.
 
 
 :::note
@@ -130,7 +132,7 @@ The actions on items in an Umbraco Tree will trigger a request to load an Angula
 
 For example clicking on one of the 'Favourite Things' in the custom tree example outlined above will trigger the loading of an 'edit.html' view from the folder: */views/favouriteThingsAlias/edit.html*. The 'Delete' menu item would also load a view from: */views/favouriteThingsAlias/delete.html*
 
-If you're creating a custom tree as part of an Umbraco package/plugin, it's recommended to change the location of the default folder to the app_plugins folder. You achieve this by decorating you mvc *TreeController* with the *PluginController* attribute.
+If you're creating a custom tree as part of an Umbraco package/plugin, it's recommended to change the location of the default folder to the `app_plugins` folder. You achieve this by decorating you mvc *TreeController* with the *PluginController* attribute.
 
 ```csharp
 [Tree("developer", "favouriteThingsAlias", "Favourite Things Name")]
@@ -142,7 +144,7 @@ The edit view in the example would now be loaded from the location: */app_plugin
 
 #### Providing functionality in your Tree Action Views
 
-You can instruct the Umbraco backoffice to load additional javascript resources (eg. angularJS controllers) to use in conjunction with your 'tree action views' by adding a package.manifest file in the same folder location as your views.
+You can instruct the Umbraco backoffice to load additional javascript resources (eg. angularJS controllers) to use in conjunction with your 'tree action views' by adding a *package.manifest* file in the same folder location as your views.
 
 **For example**...
 
@@ -184,7 +186,7 @@ Take a look at the [umbEditor directives in the backoffice API Documentation](ht
 It is possible to create 'trees' consisting of only a single node - perhaps to provide an area to control some settings or a placeholder for a single page backoffice app. See the LogViewer in the settings section for a good example.
 (or as in the case of the 'settings/content templates' tree, it's possible to have a custom view for the root node as an 'introduction' page to the tree).
 
-In both scenarios you need to override the 'CreateRootNode' method for the custom tree.
+In both scenarios you need to override the *CreateRootNode* method for the custom tree.
 
 ```csharp
 [Tree("settings", "favouritistThingsAlias", TreeTitle = "Favourite Thing", TreeGroup = "favoritesGroup", SortOrder = 5)]
@@ -192,7 +194,7 @@ In both scenarios you need to override the 'CreateRootNode' method for the custo
 public class FavouritistThingsTreeController : TreeController
 ```
 
-Overriding the CreateRootNode method means it is possible to set the 'RoutePath' to where the single page application will live (or introduction page), setting HasChildren to false will result in a Single Node Tree:
+Overriding the *CreateRootNode* method means it is possible to set the 'RoutePath' to where the single page application will live (or introduction page), setting HasChildren to false will result in a Single Node Tree:
 
 ```csharp
 protected override TreeNode CreateRootNode(FormDataCollection queryStrings)

--- a/Extending/Section-Trees/trees.md
+++ b/Extending/Section-Trees/trees.md
@@ -31,7 +31,7 @@ public class FavouriteThingsTreeController : TreeController
 The SortOrder controls the order of the custom tree within the Tree Group.
 
 ### Tree Groups
-Tree Groups are a new concept in V8, to enable you to group trees in a section. You provide the alias of the Tree Group name, you wish to add your tree to - see [Constants.Trees.Groups](https://our.umbraco.com/apidocs/v8/csharp/api/Umbraco.Core.Constants.Trees.Groups.html) for a list of existing group alias. An example of tree groups in the back office would be the *Settings* tree group and the *Templating* tree group in the *Settings* section.
+Tree Groups are a new concept in V8, to enable you to group trees in a section. You provide the alias of the Tree Group name, you wish to add your tree to - see [Constants.Trees.Groups](https://our.umbraco.com/apidocs/v8/csharp/api/Umbraco.Core.Constants.Trees.Groups.html) for a list of existing group alias. An example of tree groups in the backoffice would be the *Settings* tree group and the *Templating* tree group in the *Settings* section.
 
 If you add your own alias, you'll need to add a translation key to `config/lang/en-US.user.xml` to avoid the alias appearing as the header in [square brackets] eg
 ```xml

--- a/Extending/Section-Trees/trees.md
+++ b/Extending/Section-Trees/trees.md
@@ -132,7 +132,7 @@ The actions on items in an Umbraco Tree will trigger a request to load an Angula
 
 For example clicking on one of the 'Favourite Things' in the custom tree example outlined above will trigger the loading of an 'edit.html' view from the folder: */views/favouriteThingsAlias/edit.html*. The 'Delete' menu item would also load a view from: */views/favouriteThingsAlias/delete.html*
 
-If you're creating a custom tree as part of an Umbraco package/plugin, it's recommended to change the location of the default folder to the `app_plugins` folder. You achieve this by decorating you mvc *TreeController* with the *PluginController* attribute.
+If you're creating a custom tree as part of an Umbraco package/plugin, it's recommended to change the location of the default folder to the `App_Plugins` folder. You achieve this by decorating you mvc *TreeController* with the *PluginController* attribute.
 
 ```csharp
 [Tree("developer", "favouriteThingsAlias", "Favourite Things Name")]


### PR DESCRIPTION
Hi team,

In the [Trees](https://our.umbraco.com/Documentation/Extending/Section-Trees/trees) page I have 
- added a link to the Constants.Trees.Groups API documentation
- Added an example of tree group in the backoffice
- Improved highlighting of some methods 

Poornima