### PR TITLE
Provide a bit more clarity on tutorial for multi-language set up

### DIFF
--- a/Tutorials/Multilanguage-Setup/index.md
+++ b/Tutorials/Multilanguage-Setup/index.md
@@ -6,4 +6,4 @@ product: "CMS"
 
 # Language Variants
 
-In Umbraco 8 you can use **language variants** to setup a multilanguage site. You can read about how to set up and work with language variants [here](../../Getting-Started/Backoffice/Variants).
+In Umbraco 8 you can use **language variants** to setup a multilanguage site. You can read about how to set it up and work with a multilingual site in the [language variants article](../../Getting-Started/Backoffice/Variants).

--- a/Tutorials/Multilanguage-Setup/index.md
+++ b/Tutorials/Multilanguage-Setup/index.md
@@ -4,6 +4,6 @@ meta.Title: "Multilanguage setup in Umbraco"
 product: "CMS"
 ---
 
-# [Language Variants](../../Getting-Started/Backoffice/Variants)
+# Language Variants
 
-In Umbraco 8 you can use **language variants** to setup a multilanguage site.
+In Umbraco 8 you can use **language variants** to setup a multilanguage site. You can read about how to set up and work with language variants [here](../../Getting-Started/Backoffice/Variants).


### PR DESCRIPTION
On the page https://our.umbraco.com/documentation/Tutorials/Multilanguage-Setup/, the title "Language Variants" links off to the variant page and its not very consistent with the rest of the site. I have added more copy to specifically say where one can read more about setting up and working with variants,