### PR TITLE
Verified ContentService documentation for v8

### DIFF
--- a/Reference/Management/Services/ContentService/Index-v7.md
+++ b/Reference/Management/Services/ContentService/Index-v7.md
@@ -1,6 +1,6 @@
 ---
 keywords: services content service
-versionFrom: 8.0.0
+versionFrom: 7.0.0
 ---
 
 # ContentService
@@ -11,7 +11,7 @@ Applies to Umbraco 6.0.0+
 
 The ContentService acts as a "gateway" to Umbraco data for operations which are related to Content.
 
-[Browse the v8 API documentation for ContentService](https://our.umbraco.com/apidocs/v8/csharp/api/Umbraco.Core.Services.IContentService.html).
+[Browse the v7 API documentation for ContentService](https://our.umbraco.com/apidocs/v7/csharp/api/Umbraco.Core.Services.ContentService.html).
 
  * **Namespace:** `Umbraco.Core.Services`
  * **Assembly:** `Umbraco.Core.dll`

--- a/Reference/Management/Services/ContentService/Index-v7.md
+++ b/Reference/Management/Services/ContentService/Index-v7.md
@@ -1,6 +1,7 @@
 ---
 keywords: services content service
 versionFrom: 7.0.0
+versionRemoved: 8.0.0
 ---
 
 # ContentService

--- a/Reference/Management/Services/ContentService/Index-v7.md
+++ b/Reference/Management/Services/ContentService/Index-v7.md
@@ -5,10 +5,6 @@ versionFrom: 7.0.0
 
 # ContentService
 
-:::note
-Applies to Umbraco 6.0.0+
-:::
-
 The ContentService acts as a "gateway" to Umbraco data for operations which are related to Content.
 
 [Browse the v7 API documentation for ContentService](https://our.umbraco.com/apidocs/v7/csharp/api/Umbraco.Core.Services.ContentService.html).

--- a/Reference/Management/Services/ContentService/Index.md
+++ b/Reference/Management/Services/ContentService/Index.md
@@ -1,7 +1,6 @@
 ---
 keywords: services content service
 versionFrom: 6.0.0
-needsV8Update: "true"
 ---
 
 # ContentService
@@ -12,7 +11,8 @@ Applies to Umbraco 6.0.0+
 
 The ContentService acts as a "gateway" to Umbraco data for operations which are related to Content.
 
-[Browse the API documentation for ContentService](https://our.umbraco.com/apidocs/v7/csharp/api/Umbraco.Core.Services.ContentService.html).
+[Browse the v7 API documentation for ContentService](https://our.umbraco.com/apidocs/v7/csharp/api/Umbraco.Core.Services.ContentService.html).
+[Browse the v8 API documentation for ContentService](https://our.umbraco.com/apidocs/v8/csharp/api/Umbraco.Core.Services.ContentService.html).
 
  * **Namespace:** `Umbraco.Core.Services`
  * **Assembly:** `Umbraco.Core.dll`

--- a/Reference/Management/Services/ContentService/Index.md
+++ b/Reference/Management/Services/ContentService/Index.md
@@ -5,10 +5,6 @@ versionFrom: 8.0.0
 
 # ContentService
 
-:::note
-Applies to Umbraco 6.0.0+
-:::
-
 The ContentService acts as a "gateway" to Umbraco data for operations which are related to Content.
 
 [Browse the v8 API documentation for ContentService](https://our.umbraco.com/apidocs/v8/csharp/api/Umbraco.Core.Services.IContentService.html).


### PR DESCRIPTION
This is for issue https://github.com/umbraco/UmbracoDocs/issues/2128. I have verified `ContentService` docs for v8. The `ConsentService` has separate docs for v7 and v8. But I have deviated from it as the `ContentService` only needed updated API docs link to v8. I can always make it consistent with `ConsentService` and have separate v7 and v8 pages.