### PR TITLE
Add minor change to excludedDocumentTypes check

### DIFF
--- a/Tutorials/Creating-an-XML-Site-Map/index.md
+++ b/Tutorials/Creating-an-XML-Site-Map/index.md
@@ -312,10 +312,10 @@ now we can pass this value into our helper
 ```csharp
 @helper RenderSiteMapUrlEntriesForChildren(IPublishedContent parentPage, int maxSiteMapDepth, string[] excludedDocumentTypes)
 {
-    foreach (var page in parentPage.Children.Where(f => !excludedDocumentTypes.Contains(f.Alias) && !f.Value<bool>("hideFromXmlSiteMap")))
+    foreach (var page in parentPage.Children.Where(f => !excludedDocumentTypes.Contains(f.ContentType.Alias) && !f.Value<bool>("hideFromXmlSiteMap")))
     {
         @RenderSiteMapUrlEntry(page)
-        if (page.Level < maxSiteMapDepth && page.Children.Any(f => !excludedDocumentTypes.Contains(f.Alias) && !f.Value<bool>("hideFromXmlSiteMap")))
+        if (page.Level < maxSiteMapDepth && page.Children.Any(f => !excludedDocumentTypes.Contains(f.ContentType.Alias) && !f.Value<bool>("hideFromXmlSiteMap")))
         {
             @RenderSiteMapUrlEntriesForChildren(page, maxSiteMapDepth, excludedDocumentTypes)
         }


### PR DESCRIPTION
To check each page against the excluded document types, the code needs to reference correctly the document's ContentType alias. The correct version is actually already in the final full code sample, but not in this individual step explaining the reasoning. This change makes everything consistent across the entire tutorial and the code can now run correctly. 