### PR TITLE
Update jQuery version

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
+++ b/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
@@ -20,7 +20,7 @@ Here's how to add the three (3) client dependencies below to your template withi
 
 ```html
 <head>
-    <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-2.2.4.min.js"></script>
+    <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.4.1.min.js"></script>
     <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.15.0/jquery.validate.min.js"></script>
     <script src="https://ajax.aspnetcdn.com/ajax/mvc/5.1/jquery.validate.unobtrusive.min.js"></script>
 </head>
@@ -34,7 +34,7 @@ When adding the script to the bottom of the page, you'll also need to perform an
 <body>
     <!-- Page content here -->
 
-    <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-2.2.4.min.js"></script>
+    <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.4.1.min.js"></script>
     <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.15.0/jquery.validate.min.js"></script>
     <script src="https://ajax.aspnetcdn.com/ajax/mvc/5.1/jquery.validate.unobtrusive.min.js"></script>
 </body>


### PR DESCRIPTION
Some of the frontend functionality for Forms requires jQuery.

I did some quick testing with an up to date version and things that use jQuery still work with a later version. So we should recommend people to use that.

Tested the following:
- Conditional fields
- Validation
- Datepicker field (pickaday has a jQuery dependency)
- Mandatory messages