### PR TITLE
Update inbound request pipeline

### DIFF
--- a/Reference/Routing/Request-Pipeline/inbound-pipeline-v7.md
+++ b/Reference/Routing/Request-Pipeline/inbound-pipeline-v7.md
@@ -1,0 +1,62 @@
+---
+versionFrom: 7.0.0
+---
+
+# Inbound request pipeline
+
+The inbound process is triggered by the Umbraco (http) Module.  The **[published content request preparation](published-content-request-preparation.md)** process kicks in and creates a `PublishedContentRequest`.
+
+The `PublishedContentRequest` object represents the request which Umbraco must handle.  It contains everything that will be needed to render it.  All this happens when the Umbraco modules thinks it's a document to render.
+
+```csharp
+public class PublishedContentRequest
+{
+  public Uri Uri { get; }
+  …
+}
+```
+
+There are 4 important properties, which contains all the information to find back a node:
+
+```csharp
+public bool HasDomain { get; }
+public Domain Domain { get; }
+public Uri DomainUri { get; }
+public CultureInfo Culture { get; }
+```
+
+Domain contains: "example.com", while Uri is "http://example.com".
+
+It contains also the content to render:
+
+```csharp
+public bool HasPublishedContent { get; }
+public IPublishedContent PublishedContent { get; set; }
+public bool IsInitialPublishedContent { get; }
+public IPublishedContent InitialPublishedContent { get; }
+public void SetIsInitialPublishedContent();
+public void SetInternalRedirectPublishedContent(IPublishedContent content);
+public bool IsInternalRedirectPublishedContent { get; }
+```
+
+Contains template information and the corresponding rendering engine:
+
+```csharp
+public bool HasTemplate { get; }
+public string TemplateAlias { get; }
+public RenderingEngine RenderingEngine { get; }
+public bool TrySetTemplate(string alias);
+public void SetTemplate(ITemplate template);
+```
+
+You can subscribe to the event to know when the `PublishedContentRequest` is ready to be processed.  It's up to you to change anything (content, template, ...):
+
+```csharp
+// public static event EventHandler<EventArgs> Prepared;
+
+PublishedContentRequest.Prepared += (sender, args) =>
+{
+  var request = sender as PublishedContentRequest;
+  // do something…
+}
+```

--- a/Reference/Routing/Request-Pipeline/inbound-pipeline.md
+++ b/Reference/Routing/Request-Pipeline/inbound-pipeline.md
@@ -1,13 +1,13 @@
 ---
-versionFrom: 7.0.0
+versionFrom: 8.0.0
 needsV8Update: "true"
 ---
 
 # Inbound request pipeline
 
-The inbound process is triggered by the Umbraco (http) Module.  The **[published content request preparation](published-content-request-preparation.md)** process kicks in and creates a `PublishedContentRequest`.
+The inbound process is triggered by the Umbraco (http) Module.  The **[published content request preparation](published-content-request-preparation.md)** process kicks in and creates a `PublishedRequest`.
 
-The `PublishedContentRequest` object represents the request which Umbraco must handle.  It contains everything that will be needed to render it.  All this happens when the Umbraco modules thinks it's a document to render.
+The `PublishedRequest` object represents the request which Umbraco must handle.  It contains everything that will be needed to render it.  All this happens when the Umbraco modules thinks it's a document to render.
 
 ```csharp
 public class PublishedContentRequest
@@ -21,12 +21,10 @@ There are 4 important properties, which contains all the information to find bac
 
 ```csharp
 public bool HasDomain { get; }
-public Domain Domain { get; }
-public Uri DomainUri { get; }
+public DomainAndUri Domain { get; }
 public CultureInfo Culture { get; }
 ```
-
-Domain contains: "example.com", while Uri is "http://example.com".
+ Is a DomainAndUri object ie a standard Domain plus the fully qualified uri. For example, the Domain may contain "example.com" whereas the Uri will be fully qualified eg "http://example.com/".
 
 It contains also the content to render:
 
@@ -45,19 +43,30 @@ Contains template information and the corresponding rendering engine:
 ```csharp
 public bool HasTemplate { get; }
 public string TemplateAlias { get; }
-public RenderingEngine RenderingEngine { get; }
 public bool TrySetTemplate(string alias);
 public void SetTemplate(ITemplate template);
 ```
 
-You can subscribe to the event to know when the `PublishedContentRequest` is ready to be processed.  It's up to you to change anything (content, template, ...):
+You can subscribe to the event to know when the `PublishedRequest` is ready to be processed.  It's up to you to change anything (content, template, ...):
 
 ```csharp
-// public static event EventHandler<EventArgs> Prepared;
+using Umbraco.Core.Composing;
+using Umbraco.Web.Routing;
 
-PublishedContentRequest.Prepared += (sender, args) =>
+namespace Umbraco8.Components
 {
-  var request = sender as PublishedContentRequest;
-  // do something…
+    public class PublishedRequestComponent : IComponent
+    {
+        public void Initialize()
+        {
+            PublishedRequest.Prepared += (sender, args) =>
+            {
+                var request = sender as PublishedRequest;
+                // do something…
+            };
+        }
+
+        public void Terminate() {}
+    }
 }
 ```

--- a/Reference/Routing/Request-Pipeline/inbound-pipeline.md
+++ b/Reference/Routing/Request-Pipeline/inbound-pipeline.md
@@ -1,6 +1,5 @@
 ---
 versionFrom: 8.0.0
-needsV8Update: "true"
 ---
 
 # Inbound request pipeline

--- a/Reference/Routing/Request-Pipeline/inbound-pipeline.md
+++ b/Reference/Routing/Request-Pipeline/inbound-pipeline.md
@@ -6,7 +6,7 @@ versionFrom: 8.0.0
 
 The inbound process is triggered by the Umbraco (http) Module.  The **[published content request preparation](published-content-request-preparation.md)** process kicks in and creates a `PublishedRequest`.
 
-The `PublishedRequest` object represents the request which Umbraco must handle.  It contains everything that will be needed to render it.  All this happens when the Umbraco modules thinks it's a document to render.
+The `PublishedRequest` object represents the request which Umbraco must handle.  It contains everything that will be needed to render it.  All this occurs when the Umbraco modules consider that an incoming request maps to a document that can be rendered.
 
 ```csharp
 public class PublishedContentRequest

--- a/Reference/Routing/Request-Pipeline/inbound-pipeline.md
+++ b/Reference/Routing/Request-Pipeline/inbound-pipeline.md
@@ -23,7 +23,7 @@ public bool HasDomain { get; }
 public DomainAndUri Domain { get; }
 public CultureInfo Culture { get; }
 ```
-Domain is a DomainAndUri object ie a standard Domain plus the fully qualified uri. For example, the Domain may contain "example.com" whereas the Uri will be fully qualified eg "http://example.com/".
+Domain is a DomainAndUri object ie a standard Domain plus the fully qualified uri. For example, the Domain may contain "example.com" whereas the Uri will be fully qualified eg "https://example.com/".
 
 It contains also the content to render:
 

--- a/Reference/Routing/Request-Pipeline/inbound-pipeline.md
+++ b/Reference/Routing/Request-Pipeline/inbound-pipeline.md
@@ -46,7 +46,7 @@ public bool TrySetTemplate(string alias);
 public void SetTemplate(ITemplate template);
 ```
 
-You can subscribe to the event to know when the `PublishedRequest` is ready to be processed.  It's up to you to change anything (content, template, ...):
+You can subscribe to the 'Prepared' event which is triggered just after the point when the`PublishedRequest` is prepared - (but before it is ready to be processed).  Here modify anything in the request before it is processed!  eg. content, template, etc:
 
 ```csharp
 using Umbraco.Core.Composing;

--- a/Reference/Routing/Request-Pipeline/inbound-pipeline.md
+++ b/Reference/Routing/Request-Pipeline/inbound-pipeline.md
@@ -23,7 +23,7 @@ public bool HasDomain { get; }
 public DomainAndUri Domain { get; }
 public CultureInfo Culture { get; }
 ```
- Is a DomainAndUri object ie a standard Domain plus the fully qualified uri. For example, the Domain may contain "example.com" whereas the Uri will be fully qualified eg "http://example.com/".
+Domain is a DomainAndUri object ie a standard Domain plus the fully qualified uri. For example, the Domain may contain "example.com" whereas the Uri will be fully qualified eg "http://example.com/".
 
 It contains also the content to render:
 

--- a/Reference/Routing/Request-Pipeline/inbound-pipeline.md
+++ b/Reference/Routing/Request-Pipeline/inbound-pipeline.md
@@ -25,7 +25,7 @@ public CultureInfo Culture { get; }
 ```
 Domain is a DomainAndUri object ie a standard Domain plus the fully qualified uri. For example, the Domain may contain "example.com" whereas the Uri will be fully qualified eg "https://example.com/".
 
-It contains also the content to render:
+It contains the content to render:
 
 ```csharp
 public bool HasPublishedContent { get; }


### PR DESCRIPTION
Don't know for sure but think it belongs to: https://github.com/umbraco/UmbracoDocs/issues/1873

Update inbound pipeline for v8

PublishedContentRequest --> PublishedRequest
Domain  --> DomainAndUri (and update description)
Removed RenderingEngine  since it's only MVC
Update how to subscribe 
Removed `needsV8Update`

