### PR TITLE
Fixed constructor name in the PVC example

### DIFF
--- a/Extending/Property-Editors/full-examples-value-converters.md
+++ b/Extending/Property-Editors/full-examples-value-converters.md
@@ -18,7 +18,7 @@ namespace MyConverters
         private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
 
         //Injecting the PublishedSnapshotAccessor for fetching content
-        public CpValueConverter(IPublishedSnapshotAccessor publishedSnapshotAccessor)
+        public ContentPickerPropertyConverter(IPublishedSnapshotAccessor publishedSnapshotAccessor)
         {
             _publishedSnapshotAccessor = publishedSnapshotAccessor;
         }


### PR DESCRIPTION
There was a bug in the code, the constructor name is wrong, I have fixed it.