### PR TITLE
Make clearer the need to add using Umbraco.Core when registering depe…

### DIFF
--- a/Reference/Using-Ioc/index.md
+++ b/Reference/Using-Ioc/index.md
@@ -10,11 +10,9 @@ Umbraco `Composition` represents only a minimalist DI abstraction defined by the
 
 ## Registering dependencies
 
-To register your own dependencies to the container you need to do so in a composer ([Read more about composers and components](../../implementation/composing/index.md)). It looks like this:
+To register your own dependencies to the container you need to do so in a composer ([Read more about composers and components](../../implementation/composing/index.md)) using the `Register` extension method from `Umbraco.Core`:
 
 ```csharp
-using Doccers.Core.Services;
-using Doccers.Core.Services.Implement;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
 
@@ -30,7 +28,7 @@ namespace Doccers.Core
 }
 ```
 
-It is not required to have an interface for your dependency. You can also do this:
+It is not required to have an interface for your dependency:
 
 ```csharp
 public void Compose(Composition composition)
@@ -70,12 +68,12 @@ public enum Lifetime
 Once you have registered your services, factories, helpers or whatever you need for you application, you can go ahead and inject them in a class constructor:
 
 ```csharp
-using Doccers.Core.Services;
+using Example.Core.Services;
 using System.Web.Mvc;
 using Umbraco.Web.Models;
 using Umbraco.Web.Mvc;
 
-namespace Doccers.Core.Controllers
+namespace Example.Core.Controllers
 {
     public class HomeController : RenderMvcController
     {
@@ -101,7 +99,7 @@ namespace Doccers.Core.Controllers
 If I place a breakpoint on `var bar = _foobar.Foo()` and inspect the variable in my `Locals` windows of Visual Studio I see that the value is `Bar`, which is what I expect, since all the `Foobar.Foo()` method does is to return `Bar` as a string:
 
 ```csharp
-namespace Doccers.Core
+namespace Example.Core
 {
     public class Foobar
     {
@@ -109,8 +107,11 @@ namespace Doccers.Core
     }
 }
 ```
+:::tip
+Remember to add `Umbraco.Core` and `Umbraco.Core.Composing` as 'using' statements in your Composer to gain access to all the 'Register' extension methods
+:::
 
-Cool! Know you know how to register your own dependencies in your application. :)
+Cool! now you know how to register your own dependencies in your application. :)
 
 ## Other things you can inject
 
@@ -126,7 +127,7 @@ using System.Linq;
 using Umbraco.Web;
 using Umbraco.Web.PublishedModels;
 
-namespace Doccers.Core.Services.Implement
+namespace Example.Core.Services.Implement
 {
     public class SiteService : ISiteService
     {
@@ -160,7 +161,7 @@ using Examine.Providers;
 using System;
 using Umbraco.Core.Composing;
 
-namespace Doccers.Core.Components
+namespace Example.Core.Components
 {
 
     public class ExamineComponent : IComponent
@@ -196,7 +197,7 @@ namespace Doccers.Core.Components
 using System;
 using Umbraco.Core.Logging;
 
-namespace Doccers.Core
+namespace Example.Core
 {
     public class Foobar
     {


### PR DESCRIPTION
…ndencies

From the forum... frustrating if you don't add Umbraco.Core as a using statement, it's not expected that would contain extension methods...
Also updated Doccers namespace to be Example to make it clearer that this isn't part of Umbraco.