### PR TITLE
Update /Reference/Searching/index.md

### DIFF
--- a/Reference/Searching/index.md
+++ b/Reference/Searching/index.md
@@ -1,6 +1,5 @@
 ---
 versionFrom: 7.0.0
-needsV8Update: "true"
 ---
 
 # Searching


### PR DESCRIPTION
I think the [Examine introduction page](https://our.umbraco.com/documentation/Reference/Searching/) fits to both v7 and v8. 
- Remove needsV8Update