### PR TITLE
Bringing consistency to App_Plugins folder wording

### DIFF
--- a/Extending/Dashboards/index.md
+++ b/Extending/Dashboards/index.md
@@ -12,7 +12,7 @@ The dashboard area of Umbraco is used to display an 'editor' for the selected it
 There are two approaches to registering a custom dashboard to appear in the Umbraco Backoffice:
 
 ### Registering with package.manifest
-Add a file named 'package.manifest' to the app_plugins folder, containing the following json configuration pointing to your dashboard view:
+Add a file named 'package.manifest' to the 'App_Plugins' folder, containing the following json configuration pointing to your dashboard view:
 
 ```json
 {


### PR DESCRIPTION
Hi,

The folder was worded 'app_plugins' and 'App_Plugins' in the same document. I have made it uniform to 'App_Plugins' 

There are at least 40 places in the whole documentation. I can do a replace wherever sensible but I think it will be worth having the lint check for the word like 'backoffice' long term. What do you think?

Poornima

