### PR TITLE
Rename Slave to Replica i v8 Load Balancing docs.

### DIFF
--- a/Getting-Started/Setup/Server-Setup/Load-Balancing/index.md
+++ b/Getting-Started/Setup/Server-Setup/Load-Balancing/index.md
@@ -62,11 +62,11 @@ In Umbraco there can only be a single scheduling server which performs the follo
 * Keep alive service - to ensure scheduled publishing occurs
 * Scheduled tasks - to initiate any configured scheduled tasks
 * Scheduled publishing - to initiate any scheduled publishing for documents
-* 
+
 Umbraco will automatically elect a "Scheduling server" to perform the above services. This means
 that all of the servers will need to be able to resolve the URL of either: itself, the Master server, the internal load balancer or the public address.
 
-For example, In the following diagram the slave node **f02.mysite.local** is the elected "Scheduling server". In order for scheduling to work it needs to be able to send
+For example, In the following diagram the replica node **f02.mysite.local** is the elected "Scheduling server". In order for scheduling to work it needs to be able to send
 requests to itself, the Master server, the internal load balancer or the public address. The address used by the "Scheduling server" is called the "umbracoApplicationUrl". 
 
 ![Umbraco flexible load balancing diagram](images/flexible-load-balancing-scheduler.png)


### PR DESCRIPTION
* In v8, Slave is no longer a thing. It has been renamed to Replica, so we should not be using the term Slave anymore.
* Removed empty list-item in Scheduling and master election list