### PR TITLE
Added paragraph about the depth querystring

### DIFF
--- a/Umbraco-Heartcore/API-Documentation/Content-Delivery/content/index.md
+++ b/Umbraco-Heartcore/API-Documentation/Content-Delivery/content/index.md
@@ -23,6 +23,13 @@ Api-Version: 2
 Umb-Project-Alias: {project-alias}
 ```
 
+## Depth
+
+The `depth` querystring parameter controls how many levels of referenced Content or Media items that is included in the result.
+
+Lets say a Content item have a `Multi Node Tree Picker` and one of the Content items that can be picked have a `Media Picker`, if level is set to `1` the returned data will contain the referenced Content items, but their Media property will be null.
+To include the Media property (which is at level 2) the `depth` parameter should be `2` or higher.
+
 ## Errors
 
 If an error occours you will receive a HTTP status code along with an API error code and an error message in the response body.

--- a/Umbraco-Heartcore/API-Documentation/Content-Delivery/content/index.md
+++ b/Umbraco-Heartcore/API-Documentation/Content-Delivery/content/index.md
@@ -27,7 +27,7 @@ Umb-Project-Alias: {project-alias}
 
 The `depth` querystring parameter controls how many levels of referenced Content or Media items that is included in the result.
 
-Lets say a Content item have a `Multi Node Tree Picker` and one of the Content items that can be picked have a `Media Picker`, if level is set to `1` the returned data will contain the referenced Content items, but their Media property will be null.
+Lets say a Content item have a `Multi Node Tree Picker` and one of the Content items that can be picked have a `Media Picker`. In this case, if the level is set to `1` the returned data will contain the referenced Content items, but their Media property will be null.
 To include the Media property (which is at level 2) the `depth` parameter should be `2` or higher.
 
 ## Errors


### PR DESCRIPTION
Some of the content endpoints in Heartcore have an optional `depth` querystring parameter, I've added a paragraph describing what it does.