### PR TITLE
Update IContentFinder.md

### DIFF
--- a/Reference/Routing/Request-Pipeline/IContentFinder.md
+++ b/Reference/Routing/Request-Pipeline/IContentFinder.md
@@ -106,15 +106,16 @@ namespace My.Website.ContentFinders
             //find the root node with a matching domain to the incoming request
             var url = contentRequest.Uri.ToString();
             var allDomains = _domainService.GetAll(true);
-            var domain = allDomains.Where(f => f.DomainName == contentRequest.Uri.Authority || f.DomainName == "https://" + contentRequest.Uri.Authority).FirstOrDefault();
-            var siteId = domain != null ? domain.RootContentId : allDomains.FirstOrDefault().RootContentId;
+            var domain = allDomains?.Where(f => f.DomainName == contentRequest.Uri.Authority || f.DomainName == "https://" + contentRequest.Uri.Authority).FirstOrDefault();
+            var siteId = domain != null ? domain.RootContentId : (allDomains.Any() ? allDomains.FirstOrDefault().RootContentId : null);
             var siteRoot = contentRequest.UmbracoContext.Content.GetById(false, siteId ?? -1);
+            if (siteRoot == null) { siteRoot = contentRequest.UmbracoContext.Content.GetAtRoot().FirstOrDefault(); }
             if (siteRoot == null)
             {
                 return false;
             }
             //assuming the 404 page is in the root of the language site with alias fourOhFourPageAlias
-            IPublishedContent notFoundNode = siteRoot.Children().FirstOrDefault(f => f.ContentType.Alias == "fourOhFourPageAlias");
+            IPublishedContent notFoundNode = siteRoot.Children.FirstOrDefault(f => f.ContentType.Alias == "fourOhFourPageAlias");
 
             if (notFoundNode != null)
             {


### PR DESCRIPTION
Corrected `.Children` to be a property rather than a function.

Added null checks in the case that `_domainService.GetAll(true)` returns false (as happened on my project)

Changes are for 8.4.1, I'm not sure how to change for a specific version.  