### PR TITLE
Added missing example from Property editor tutorial

### DIFF
--- a/Tutorials/Creating-a-Property-Editor/index.md
+++ b/Tutorials/Creating-a-Property-Editor/index.md
@@ -32,6 +32,10 @@ By the end of this guide, we will have a markdown editor running inside of Umbra
 registered as a Data Type in the backoffice, assigned to a Document Type, and the editor can
 create and modify data.
 
+:::note
+This tutorial is a good example of how to create your own property editor from start to finish, however you should know that Umbraco now has a built-in [Markdown editor](https://our.umbraco.com/Documentation/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/#markdown-editor) which is the recommended option for markdown syntax editing.
+:::
+
 ## Setting up a plugin
 
 The first thing we must do is create a new folder inside `/App_Plugins` folder. We will call it

--- a/Tutorials/Creating-a-Property-Editor/part-3.md
+++ b/Tutorials/Creating-a-Property-Editor/part-3.md
@@ -104,6 +104,7 @@ The above is correct markdown code, representing the image, and if preview is tu
 If you wish to render your markdown in a view, you first need to convert you markdown to html format:
 
 ```csharp
+@using HeyRed.MarkdownSharp
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<IPublishedContent>
 @{
     var value = Model.Value<string>("myMarkdownPropertyAlias");

--- a/Tutorials/Creating-a-Property-Editor/part-3.md
+++ b/Tutorials/Creating-a-Property-Editor/part-3.md
@@ -101,7 +101,20 @@ Clicking an image and choosing select returns the image to the editor which then
     [1]: /media/1005/Koala.jpg
 
 The above is correct markdown code, representing the image, and if preview is turned on, you will see the image below the editor.
+If you wish to render your markdown in a view, you first need to convert you markdown to html format:
 
+```csharp
+@inherits Umbraco.Web.Mvc.UmbracoViewPage<IPublishedContent>
+@{
+    var value = Model.Value<string>("myMarkdownPropertyAlias");
+    var html = new Markdown().Transform(value);
+}
+@Html.Raw(html)
+```
+
+:::note
+Umbraco's built-in [Markdown editor](https://our.umbraco.com/Documentation/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/#markdown-editor) will be interpreted by Models Builder, in which case you won't need to do the convertion mentioned above.
+:::
 
 ## Wrap up
 So over the 3 previous steps, we've:
@@ -112,5 +125,6 @@ So over the 3 previous steps, we've:
 - Made the editor configurable
 - Connected the editor with native dialogs and services
 - Looked at koala pictures
+- Converted and rendered our markdown as html format
 
 [Next - Adding server-side data to a property editor](part-4.md)


### PR DESCRIPTION
Issue: https://github.com/umbraco/UmbracoDocs/issues/2285

I added a _:::note_ on the first step of the tutorial, that Umbraco now has a built in markdown editor. As we've discussed @sofietoft, this tutorial is a nice tutorial for how to create your own property editor plugin from start to finish using AngularJs, html, custom configurations, injecting your own or 3rd party JavaScript libraries and using Umbraco’s native dialogs and services etc. but if all you are looking for is a markdown editor, then you don’t need to re-invent the wheel, you can just use the built-in editor. Hence this _:::note_.

I also added an example in step 3 of how to convert the markdown to html format and render it in a view. Aslo included a _:::note_ regarding the built-in Markdown editor and Models Builder.