### PR TITLE
NetCore: Added documentation on customising the no published content response

### DIFF
--- a/Extending/No-Published-Content/index-v9.md
+++ b/Extending/No-Published-Content/index-v9.md
@@ -1,3 +1,9 @@
+---
+keywords: nonodes
+versionFrom: 9.0.0
+meta.Title: "No Published Content Page"
+meta.Description: "Details the standard page served by Umbraco when no published content is available."
+---
 # No Published Content Page
 
 When Umbraco is first installed, if no starter kit is chosen, there will be no content created in the backoffice, and no published content to display.

--- a/Extending/No-Published-Content/index-v9.md
+++ b/Extending/No-Published-Content/index-v9.md
@@ -1,0 +1,50 @@
+# No Published Content Page
+
+When Umbraco is first installed, if no starter kit is chosen, there will be no content created in the back-office, and no published content to display.
+
+Content can also be created, but be unpublished.
+
+If browsing the front-end of the website, when this situation of no published content is found, a custom page is displayed.
+
+This page is served from `/config/splashes/NoNodes.cshtml`.
+
+## Customising The Page
+
+Whilst the contents of this page can be edited directly, this isn't recommended, as care would need to be taken to avoid the changes getting overwritten in upgrades.
+
+Instead there are two options.
+
+To return the contents of a different Razor file, create this file at your chosen location and configure it's use within the `<appSettings>` section of `web.config` using the following details:
+
+```
+<add key="Umbraco.Core.NoNodesViewPath" value="~/path/to/CustomNoNodes.cshtml" />
+```
+
+*Note: this key/value will likely move to another location once .Net Core configuration is implemented.*
+
+For finer control, you write code to handle the route directly, allowing the implementation of a custom controller, view model and view:
+
+```
+    public class CustomNoNodesComposer: ComponentComposer<CustomNoNodesComponent>, IUserComposer
+    {
+    }
+
+    public class CustomNoNodesComponent : IComponent
+    {
+        public void Initialize()
+        {
+            if (RouteTable.Routes[Constants.Web.NoContentRouteName] is Route route)
+            {
+                route.Defaults = new RouteValueDictionary()
+                {
+                    ["controller"] = "CustomNoNodes",
+                    ["action"] = "Index"
+                };
+            }
+        }
+
+        public void Terminate() { }
+    }
+```
+
+

--- a/Extending/No-Published-Content/index-v9.md
+++ b/Extending/No-Published-Content/index-v9.md
@@ -1,6 +1,6 @@
 # No Published Content Page
 
-When Umbraco is first installed, if no starter kit is chosen, there will be no content created in the back-office, and no published content to display.
+When Umbraco is first installed, if no starter kit is chosen, there will be no content created in the backoffice, and no published content to display.
 
 Content can also be created, but be unpublished.
 

--- a/Extending/No-Published-Content/index.md
+++ b/Extending/No-Published-Content/index.md
@@ -1,3 +1,9 @@
+---
+keywords: nonodes
+versionFrom: 7.0.0
+meta.Title: "No Published Content Page"
+meta.Description: "Details the standard page served by Umbraco when no published content is available."
+---
 # No Published Content Page
 
 When Umbraco is first installed, if no starter kit is chosen, there will be no content created in the backoffice, and no published content to display.

--- a/Extending/No-Published-Content/index.md
+++ b/Extending/No-Published-Content/index.md
@@ -1,0 +1,9 @@
+# No Published Content Page
+
+When Umbraco is first installed, if no starter kit is chosen, there will be no content created in the back-office, and no published content to display.
+
+Content can also be created, but be unpublished.
+
+If browsing the front-end of the website, when this situation of no published content is found, a custom page is displayed.
+
+This page is served from `/config/splashes/noNodes.aspx`.

--- a/Extending/No-Published-Content/index.md
+++ b/Extending/No-Published-Content/index.md
@@ -1,6 +1,6 @@
 # No Published Content Page
 
-When Umbraco is first installed, if no starter kit is chosen, there will be no content created in the back-office, and no published content to display.
+When Umbraco is first installed, if no starter kit is chosen, there will be no content created in the backoffice, and no published content to display.
 
 Content can also be created, but be unpublished.
 

--- a/Extending/index.md
+++ b/Extending/index.md
@@ -62,3 +62,7 @@ Details on implementing virtual file systems for things like media which will al
 ## [Embedded Media Providers](Embedded-Media-Provider/index.md)
 
 Details on how to create a custom Embedded Media Provider to enable editors to embed third party media content into Umbraco via the embed button in the Rich Text Area.
+
+## [No Published Content Page](No-Published-Content/index.md)
+
+Details the standard page served by Umbraco when no published content is available.


### PR DESCRIPTION
Resolves issue #2366 

Explains how to customise the display of the "no nodes" response when no published content is found in an Umbraco installation, in the .Net Core version of Umbraco being developed.