### PR TITLE
Update IContentFinder.md

### DIFF
--- a/Reference/Routing/Request-Pipeline/IContentFinder.md
+++ b/Reference/Routing/Request-Pipeline/IContentFinder.md
@@ -149,3 +149,7 @@ namespace My.Website
 }
 
 ```
+
+:::note
+To make sure your custom 404 page is served remove the `<error404>1</error404>` from `umbracoSettings.config` as this will override any custom node.
+:::

--- a/Reference/Routing/Request-Pipeline/IContentFinder.md
+++ b/Reference/Routing/Request-Pipeline/IContentFinder.md
@@ -151,5 +151,5 @@ namespace My.Website
 ```
 
 :::note
-To make sure your custom 404 page is served remove the `<error404>1</error404>` from `umbracoSettings.config` as this will override any custom node.
+To make sure your custom 404 page is served set the `error404` in `umbracoSettings.config` to 0.  
 :::


### PR DESCRIPTION
When implementing my own `IContentLastChanceFinder` I noticed that the ugly 404 page was still served to the browser, this seems to occur due to the 404 page defined in umbracoSettings.config. Removing that setting shows the correct 404 page.