### PR TITLE
Reflect public class requirement for overriding Default Umbraco Forms Providers.

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Type-v7.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Type-v7.md
@@ -95,7 +95,7 @@ needed. Also look in the reference chapter for complete class implementations of
 
 ## Overriding default providers in Umbraco Forms
 
-This is a new feature in **Forms 6.0.3+** that makes it possible to override & inherit the original provider, be it a Field Type or Workflow etc. The only requirement when inheriting a fieldtype that you wish to override is to ensure you do not override/change the Id set for the provider.
+This is a new feature in **Forms 6.0.3+** that makes it possible to override & inherit the original provider, be it a Field Type or Workflow etc. The only requirement when inheriting a fieldtype that you wish to override is to ensure you do not override/change the Id set for the provider, and make sure your class is public.
 
 Here is an example of overriding the Textarea field aka Long Answer that is taken from Per's CodeGarden 17 talk
 

--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Type.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Type.md
@@ -96,7 +96,7 @@ needed. Also look in the reference chapter for complete class implementations of
 
 ## Overriding default providers in Umbraco Forms
 
-This is a new feature in **Forms 6.0.3+** that makes it possible to override & inherit the original provider, be it a Field Type or Workflow etc. The only requirement when inheriting a fieldtype that you wish to override is to ensure you do not override/change the Id set for the provider.
+This is a new feature in **Forms 6.0.3+** that makes it possible to override & inherit the original provider, be it a Field Type or Workflow etc. The only requirement when inheriting a fieldtype that you wish to override is to ensure you do not override/change the Id set for the provider, and make sure your class is public.
 
 Here is an example of overriding the Textarea field aka Long Answer that is taken from Per's CodeGarden 17 talk, which has been updated for Forms 8.
 


### PR DESCRIPTION
When overriding a Umbraco Forms Default Provider it is required that the custom class is public, otherwise the Reflection code won't pick up the overriden class.

For example:
`public class CustomOverridenSendEmail : Umbraco.Forms.Core.Providers.WorkflowTypes.SendEmail`

works, but a internal class does not:

`internal class SendEmailNoFrom : Umbraco.Forms.Core.Providers.WorkflowTypes.SendEmail`

The current documentation states that there is only a requirement that the WorkflowType Id should be the same, which is incorrect.
