### PR TITLE
Change Relate to original warning

### DIFF
--- a/Tutorials/Editors-Manual/Getting-Started-With-Umbraco/Copying-a-Page/index.md
+++ b/Tutorials/Editors-Manual/Getting-Started-With-Umbraco/Copying-a-Page/index.md
@@ -20,7 +20,6 @@ If you want to re-use a page or structure you have created previously you can co
 6. Click ***Move***.
 
 
-:::warning
-When you select **Relate to original** every change you make to the copied page will also be made to the original. So if you want the original and duplicated pages to be separate then do not select the **Relate to original** tick box.
-:::
+:::info
+When you select **Relate to original** Umbraco will create a relationship between the original and copies page. This relationship can be used to programmatically link the pages: For example linking between pages in a multilingual setup. It is important to note that this relationship **does not** keep the content between the master original and copied page in sync.:::
 


### PR DESCRIPTION
Update Warning box: as this is not how relate to original works :( - it creates a relation in a table, so the two pages can be linked (e.g languages) but no coping goes on between them, after the first time.