### PR TITLE
Load balancing updates

### DIFF
--- a/Getting-Started/Setup/Server-Setup/Load-Balancing/azure-web-apps.md
+++ b/Getting-Started/Setup/Server-Setup/Load-Balancing/azure-web-apps.md
@@ -18,19 +18,32 @@ The single instance backoffice Web App should be set to use [SyncTempEnvDirector
 The multi instance front end Web App should be set to use [TempEnvDirectoryFactory](file-system-replication.md#examine-directory-factory-options).
 
 ### Umbraco TEMP files
-When an instance of Umbraco starts up it generates some 'temporary' files on disk... in a normal IIS environment these would be created within the folders of the Web Application. In an Azure Web App we want these to be created in the local storage of the actual server that Azure happens to be using for the Web App. So we set this configuration setting to 'true' and the temporary files will be located in the environment temporary folder. This is great for 'speed' of access for Umbraco operation however, the downside is it's  difficult on Azure to manually browse to this temporary location if you are troubleshooting for any reason.
-			
+
+When an instance of Umbraco starts up it generates some 'temporary' files on disk... in a normal IIS environment these would be created within the folders of the Web Application. In an Azure Web App we want these to be created in the local storage of the actual server that Azure happens to be using for the Web App. So we set this configuration setting to 'true' and the temporary files will be located in the environment temporary folder. This is required for both the performance of the website as well as to prevent file locks from occurring due to the nature of Azure Web Apps shared files system.
+
 ```xml
 <add key="Umbraco.Core.LocalTempStorage" value="EnvironmentTemp" />
 ```
 
-### Umbraco PublishedCache
+### AppDomain synchronization
 
-When Azure Web Apps auto transitions between hosts, you scale the instances or you utilise slot swapping you may experience issues with the Umbraco Published Cache becoming locked unless Umbraco is configured to use SQL for MainDom locking. 
+Each ASP.Net application runs inside an [AppDomain](https://docs.microsoft.com/en-us/dotnet/framework/app-domains/application-domains) which is like a sub process within the web app process. When an ASP.Net application restarts, the current AppDomain 'winds down' while another AppDomain is started meaning there can be more than 1 live AppDomain during a restart. Restarts can occur in many scenarios including when Azure Web Apps auto transitions between hosts, you scale the instances or you utilise slot swapping.
+
+Several file system based services in Umbraco such as the Published Cache and Lucene files can only be accessed by a single AppDomain at once. Umbraco manages this synchronization by an object called `IMainDom`. By default this uses a system-wide locking mechanism but this default mechanism doesn't work in Azure Web Apps so we need to swap it out for a database locking mechanism by using the following appSetting:
 
 ```xml
 <add key="Umbraco.Core.MainDom.Lock" value="SqlMainDomLock" />
 ```
+
+##### v8.6.0 - v8.6.1
+
+TODO: Update this
+
+The `Umbraco.Core.MainDom.Lock` should be applied to your __master__ server only. Your replica servers should be configured with:
+
+##### v8.0 - v8.5.x
+
+TODO: Update this
 
 :::note
 The `Umbraco.Core.MainDom.Lock` setting is for Umbraco v8.6+. Having this setting for versions between v8.0-v8.5 will not have any affect. It is recommended to use 8.6+ when running Umbraco on Azure Web Apps since this setting will prevent file locking issues.

--- a/Getting-Started/Setup/Server-Setup/Load-Balancing/azure-web-apps.md
+++ b/Getting-Started/Setup/Server-Setup/Load-Balancing/azure-web-apps.md
@@ -73,7 +73,7 @@ if (appSettingIgnoreLocalDb == "true")
 
 #### v8.0 - v8.5.x
 
-You should configure both your __MASTER__ and __REPLICA__ servers as if they were all replica servers based on the [v8.6.0 - v8.6.1](#v8_6_0_-_v8_6_1) configuration above.
+You should configure both your __MASTER__ and __REPLICA__ servers as if they were all replica servers based on the [v8.6.0 - v8.6.1](#v860---v861) configuration above.
 
 
 ### Steps to set-up a environment

--- a/Getting-Started/Setup/Server-Setup/Load-Balancing/index.md
+++ b/Getting-Started/Setup/Server-Setup/Load-Balancing/index.md
@@ -17,7 +17,7 @@ This document assumes that you have a fair amount of knowledge about:
 * Umbraco
 * IIS 7+
 * Networking & DNS
-* Windows Server 
+* Windows Server
 * .NET Framework v4.7.2+
 
 :::note
@@ -58,7 +58,7 @@ The process is as follows:
 
 ## Scheduling and master election
 
-Although there is a Master server designated for administration, by default this is not explicitly set as the "Scheduling server". 
+Although there is a Master server designated for administration, by default this is not explicitly set as the "Scheduling server".
 In Umbraco there can only be a single scheduling server which performs the following 3 things:
 
 * Keep alive service - to ensure scheduled publishing occurs
@@ -69,15 +69,15 @@ Umbraco will automatically elect a "Scheduling server" to perform the above serv
 that all of the servers will need to be able to resolve the URL of either: itself, the Master server, the internal load balancer or the public address.
 
 For example, In the following diagram the replica node **f02.mysite.local** is the elected "Scheduling server". In order for scheduling to work it needs to be able to send
-requests to itself, the Master server, the internal load balancer or the public address. The address used by the "Scheduling server" is called the "umbracoApplicationUrl". 
+requests to itself, the Master server, the internal load balancer or the public address. The address used by the "Scheduling server" is called the "umbracoApplicationUrl".
 
 ![Umbraco flexible load balancing diagram](images/flexible-load-balancing-scheduler.png)
 
 By default, Umbraco will set the "umbracoApplicationUrl" to the address made by the first accepted request when the AppDomain starts.
 It is assumed that this address will be a DNS address that the server can resolve.
 
-For example, if a public request reached the load balancer on `www.mysite.com`, the load balancer may send the request on to the servers with the original address: `www.mysite.com`. By default the "umbracoApplicationUrl" will be `www.mysite.com`. However, load balancers may route the request internally under a different DNS name such as "f02.mysite.local" which 
-by default would mean the "umbracoApplicationUrl" is "f02.mysite.local". In any case the elected "Scheduling server" must be able to resolve this address. 
+For example, if a public request reached the load balancer on `www.mysite.com`, the load balancer may send the request on to the servers with the original address: `www.mysite.com`. By default the "umbracoApplicationUrl" will be `www.mysite.com`. However, load balancers may route the request internally under a different DNS name such as "f02.mysite.local" which
+by default would mean the "umbracoApplicationUrl" is "f02.mysite.local". In any case the elected "Scheduling server" must be able to resolve this address.
 
 In many scenarios this is fine, but in case this is not adequate there's a few of options you can use:
 
@@ -86,7 +86,17 @@ In many scenarios this is fine, but in case this is not adequate there's a few o
 
 ## Common load balancing setup information
 
-_The below section applies to all ASP.NET load balancing configurations.
+_The below section applies to all ASP.NET load balancing configurations._
+
+## Server Configuration
+
+This section describes the various configuration options depending on if you are hosting setup:
+
+1. [Azure Web Apps](file-system-replication#mixture-of-standalone--synchronised) - _You use cloud based auto-scaling appliances like [Microsoft's Azure Web Apps](https://azure.microsoft.com/en-us/services/app-service/web/)_
+2. [File Replication](file-system-replication#synchronised-file-system) - _Each server hosts copies of the load balanced website files and a file replication service is running to ensure that all files on all servers are up to date_
+3. [Centralized file share](file-system-replication#standalone-file-system) - _The load balanced website files are located on a centralized file share (SAN/NAS/Clustered File Server/Network Share)_
+
+[Full documentation is available here](file-system-replication.md)
 
 ### Machine Key
 
@@ -109,7 +119,7 @@ _The below section applies to all ASP.NET load balancing configurations.
 ```
 
 ### Session State
-            
+
 * If you use SessionState in your application, or are using the default TempDataProvider in MVC (which uses SessionState) then you will need to configure your application to use the SqlSessionStateStore or an alternative provider (see [https://msdn.microsoft.com/en-us/library/aa478952.aspx](https://msdn.microsoft.com/en-us/library/aa478952.aspx) for more details).
 
 ### Logging
@@ -125,13 +135,6 @@ Your staging environment should also be load balanced so that you can see any is
 You'll need to test this solution **a lot** before going to production. You need to ensure there are no windows security issues, etc... The best way to determine issues is have a lot of people testing this setup and ensuring all errors and warnings in your application/system logs in Windows are fixed.
 
 Ensure to analyze logs from all servers and check for any warnings and errors.
-
-## File system replication
-
-There are various configuration options that need to be considered depending on your infrastructure set-up.
-
-[Full documentation is available here](file-system-replication.md)  
-
 
 ## FAQs
 


### PR DESCRIPTION
* Describes what MainDom is and why it's needed and adds version specific information
* Changes headline `File system replication` to `Server configuration` and moves this section up because it's actually very important and updates this section with explicit links to each type of server design, this makes it much easier to find azure specific docs... these links were extremely hard to find.

We are still missing any docs/links to 'shared' file systems such as NAS/SAN. We don't mention this at all in the new v8 docs since everything now just points to this new `file-system-replication` document. I've linked the 'shared' file system to the file-system-replication#standalone-file-system link because that seems like its correct ... but then reading that it doesn't seem correct since i'm unsure why blob storage would be needed in that case. We basically have deleted this whole section https://our.umbraco.com/Documentation/Getting-Started/Setup/Server-Setup/Load-Balancing/files-shared-v7 for v8. I've left a question for @Jeavon in another PR about that. 
