### PR TITLE
Cross link to Route Hijacking information

### DIFF
--- a/Implementation/Custom-Routing/index.md
+++ b/Implementation/Custom-Routing/index.md
@@ -100,7 +100,7 @@ namespace Umbraco8.Components
 See: [Custom routing documentation](../../Reference/Routing/custom-routes)
 
 :::note
-This is an approach for mapping a custom route to a custom MVC controller, for existing content page routes you can use a custom MVC controller to handle the request by naming convention: see [Custom Controllers - Route Hijacking](../../Reference/Routing/custom-controllers). 
+This is an approach for mapping a custom route to a custom MVC controller. For creating routes for existing content pages you can use a custom MVC controller to handle the request by naming convention: see [Custom Controllers - Route Hijacking](../../Reference/Routing/custom-controllers). 
 :::
 
 ### PublishedRequest.Prepared event

--- a/Implementation/Custom-Routing/index.md
+++ b/Implementation/Custom-Routing/index.md
@@ -99,6 +99,10 @@ namespace Umbraco8.Components
 
 See: [Custom routing documentation](../../Reference/Routing/custom-routes)
 
+:::note
+This is an approach for mapping a custom route to a custom MVC controller, for existing content page routes you can use a custom MVC controller to handle the request by naming convention: see [Custom Controllers - Route Hijacking](../../Reference/Routing/custom-controllers). 
+:::
+
 ### PublishedRequest.Prepared event
 
 You can subscribe to the 'Prepared' event which is triggered right after the point when the `PublishedRequest` is prepared - (but before it is ready to be processed). Here modify anything in the request before it is processed, eg. content, template, etc: 


### PR DESCRIPTION
I've noticed a pattern where people want to use a custom MVC controller, but follow the scent of 'custom routes', and end up on this page... which then seems to suggest you need to map a route to a custom MVC controller, which if you are coming from MVC background doesn't seem unusual, and you are not going to guess or search for the existence of route hijacking, so I've just added a note underneath mapping a route using a virtual node route handler to point in the direction of the by convention approach... so people can discover it is a thing.