### PR TITLE
Adding section about ModelsBuilder and IntelliSense

### DIFF
--- a/Umbraco-Cloud/Set-Up/Working-With-Visual-Studio/index.md
+++ b/Umbraco-Cloud/Set-Up/Working-With-Visual-Studio/index.md
@@ -129,6 +129,7 @@ In order to use ModelsBuilder with IntelliSense in Visual Studio, you will need 
 3. Create a directory called "Models" in your App_Code folder in the `*.Web` directory of your site. Then add: `<add key="Umbraco.ModelsBuilder.ModelsDirectory" value="~/App_Code/Models/" />` to Web.config.
 
 This will make the models of your Document Types available with IntelliSense in Visual Studio.
+[You can read more about configuring ModelsBuilder here.](../../../Reference/Templating/Modelsbuilder)
 
 ### Using Umbraco namespaces in your `*.Core` project
 In order to use Umbraco's features in your `*.Core` project, you have to add references to the DLLs in your `*.Web/bin`.

--- a/Umbraco-Cloud/Set-Up/Working-With-Visual-Studio/index.md
+++ b/Umbraco-Cloud/Set-Up/Working-With-Visual-Studio/index.md
@@ -128,7 +128,7 @@ In order to use ModelsBuilder with IntelliSense in Visual Studio, you will need 
 2. Set the Mode to `AppData` or `LiveAppData`. This will ensure you can use ModelsBuilder with Visual Studio. So in your Web.config, you should to have: `<add key="Umbraco.ModelsBuilder.ModelsMode" value="AppData" />`
 3. Create a directory called "Models" in your App_Code folder in the `*.Web` directory of your site. Then add: `<add key="Umbraco.ModelsBuilder.ModelsDirectory" value="~/App_Code/Models/" />` to Web.config.
 
-This will make the models of your document types available with IntelliSense in Visual Studio.
+This will make the models of your Document Types available with IntelliSense in Visual Studio.
 
 ### Using Umbraco namespaces in your `*.Core` project
 In order to use Umbraco's features in your `*.Core` project, you have to add references to the DLLs in your `*.Web/bin`.

--- a/Umbraco-Cloud/Set-Up/Working-With-Visual-Studio/index.md
+++ b/Umbraco-Cloud/Set-Up/Working-With-Visual-Studio/index.md
@@ -122,6 +122,14 @@ We recommend placing all your code in the `*.Core` project (instead of, for exam
 * Data Access (the `*.Core` project references Umbraco so you can use the Umbraco datalayer as needed)
 * Extensions methods
 
+### Using ModelsBuilder and IntelliSense
+In order to use ModelsBuilder with IntelliSense in Visual Studio, you will need to make a couple of configuration changes to the web.config file of your `*.Web` project. This is to ensure that the models produced by ModelsBuilder are stored in the right place for compilation.
+1. Make sure ModelsBuilder.Enable is set to true (default): `<add key="Umbraco.ModelsBuilder.Enable" value="true" />`
+2. Set the Mode to `AppData` or `LiveAppData`. This will ensure you can use ModelsBuilder with Visual Studio. So in your Web.config, you should to have: `<add key="Umbraco.ModelsBuilder.ModelsMode" value="AppData" />`
+3. Create a directory called "Models" in your App_Code folder in the `*.Web` directory of your site. Then add: `<add key="Umbraco.ModelsBuilder.ModelsDirectory" value="~/App_Code/Models/" />` to Web.config.
+
+This will make the models of your document types available with IntelliSense in Visual Studio.
+
 ### Using Umbraco namespaces in your `*.Core` project
 In order to use Umbraco's features in your `*.Core` project, you have to add references to the DLLs in your `*.Web/bin`.
 


### PR DESCRIPTION
I will suggest to have a section about how to work with IntelliSense and ModelsBuilder in the Visual Studio section of the documentation. According to the source below, and my own experiences this should be the way to do it 💪 

Source: https://our.umbraco.com/forum/umbraco-cloud/82156-models-builder-with-umbraco-cloud#comment-281518