### PR TITLE
Re-added information about URL Tracking disabling if some packages detected.

### DIFF
--- a/Reference/Routing/URL-Tracking/index.md
+++ b/Reference/Routing/URL-Tracking/index.md
@@ -34,3 +34,18 @@ It is possible to disable the feature entirely (both generating URLs in the data
 ```
 
 See: [/Documentation/Reference/Config/umbracoSettings/#web-routing](/Documentation/Reference/Config/umbracoSettings/#web-routing)
+
+## Note 
+
+**The following applies only to v7 sites.**
+
+In addition, Umbraco will automatically disable the feature if it detects any DLL whose name would contain any of the following strings: 
+
+      "InfoCaster.Umbraco.UrlTracker"	
+      "SEOChecker"	
+      "Simple301"	
+      "Terabyte.Umbraco.Modules.PermanentRedirect"	
+      "CMUmbracoTools"	
+      "PWUrlRedirect"	
+
+These products already implement redirect management and we do not want to interfere.


### PR DESCRIPTION
The change made in this [commit](https://github.com/umbraco/UmbracoDocs/commit/f745095f476fdc266454483b676225dcc068cdc6) removed important information that applies to v7 sites without creating multi-versions of the page. Adding this back in with a note that this doesn't apply to v8 sites.