### PR TITLE
Umbraco forms validation update

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Custom-Markup/index.md
+++ b/Add-ons/UmbracoForms/Developer/Custom-Markup/index.md
@@ -52,11 +52,11 @@ Contents of the `FieldType.Textfield.cshtml` view (from the default theme):
     @{if(string.IsNullOrEmpty(Model.PlaceholderText) == false){<text>placeholder="@Model.PlaceholderText"</text>}}
     @{if(Model.Mandatory || Model.Validate){<text>data-val="true"</text>}}
     @{if (Model.Mandatory) {<text> data-val-required="@Model.RequiredErrorMessage"</text>}}
-    @{if (Model.Validate) {<text> data-val-regex="@Model.InvalidErrorMessage" data-regex="@Html.Raw(Model.Regex)"</text>}}
+    @{if (Model.Validate) {<text> data-val-regex="@Model.InvalidErrorMessage" data-val-regex-pattern="@Html.Raw(Model.Regex)"</text>}}
 />
 ```
 
-By default the form makes use of jQuery validate and jQuery validate unobtrusive which is why you see attributes like `data-val` and `data-val-required`.
+Umbraco Forms uses ASP.NET Unobtrusive Validation which is why you see attributes like `data-val` and `data-val-required`.
 
 This can be customized but it's important to keep the ID of the control to `@Model.Id` since that is used to match the value to the form field.  For fields that are conditionally hidden, without an ID of `@Model.Id` the control won't be shown when the conditions to show the field are met.  An ID needs to be added to text controls such as headings and paragraphs.
 

--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Fieldtype.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Fieldtype.md
@@ -58,7 +58,7 @@ Then we will start building the view at `Views\Partials\Forms\Fieldtypes\FieldTy
         @{if (string.IsNullOrEmpty(Model.PlaceholderText) == false) { <text> placeholder="@Model.PlaceholderText" </text> }}
         @{if (Model.Mandatory || Model.Validate) { <text> data-val="true" </text> }}
         @{if (Model.Mandatory) { <text> data-val-required="@Model.RequiredErrorMessage" </text> }}
-        @{if (Model.Validate) { <text> data-val-regex="@Model.InvalidErrorMessage" data-regex="@Html.Raw(Model.Regex)" </text> }} />
+        @{if (Model.Validate) { <text> data-val-regex="@Model.InvalidErrorMessage" data-val-regex-pattern="@Html.Raw(Model.Regex)" </text> }} />
 ```
 
 The view takes care of generating the UI control and setting its value.
@@ -75,7 +75,7 @@ We will also add a file for the default theme of the form at `Views\Partials\For
         @{if (string.IsNullOrEmpty(Model.PlaceholderText) == false) { <text> placeholder="@Model.PlaceholderText" </text> }}
         @{if (Model.Mandatory || Model.Validate) { <text> data-val="true" </text> }}
         @{if (Model.Mandatory) { <text> data-val-required="@Model.RequiredErrorMessage" </text> }}
-        @{if (Model.Validate) { <text> data-val-regex="@Model.InvalidErrorMessage" data-regex="@Html.Raw(Model.Regex)" </text> }} />
+        @{if (Model.Validate) { <text> data-val-regex="@Model.InvalidErrorMessage" data-val-regex-pattern="@Html.Raw(Model.Regex)" </text> }} />
 ```
 
 This will be rendered when the default theme is used. For example purposes, it can be identical to the previous partial view.

--- a/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
+++ b/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
@@ -6,7 +6,7 @@ versionFrom: 7.0.0
 
 In order for Umbraco Forms to work correctly, you need to include some client dependencies.
 
-With latest version of Umbraco Forms, we provide a method that will output the script tags containing the dependencies. Dne with this razor method:
+Use the following Razor method to output script tags containing the dependencies:
 
 ```html
 <head>

--- a/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
+++ b/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
@@ -14,7 +14,7 @@ With latest version of Umbraco Forms, we provide a method that will output the s
 </head>
 ```
 
-All dependencies originates from your UmbracoForms instalation, no external references.
+All dependencies originates from your Umbraco Forms installation, which means that no external references are needed.
 
 If you like to use jQuery instead, you will instead have to manually add those. Without using the above. Jump the the section 'Use jQuery' to learn more.
 

--- a/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
+++ b/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
@@ -4,7 +4,7 @@ versionFrom: 7.0.0
 
 # Preparing your frontend
 
-In order for Umbraco Forms to work correctly, Umbraco Forms need you to include some client dependencies.
+In order for Umbraco Forms to work correctly, you need to include some client dependencies.
 
 With latest version of Umbraco Forms, we provide a method that will output the script tags containing the dependencies. Dne with this razor method:
 

--- a/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
+++ b/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
@@ -4,13 +4,28 @@ versionFrom: 7.0.0
 
 # Preparing your frontend
 
-In order for Umbraco Forms to work correctly, Umbraco Forms needs three (3) client dependencies.
+In order for Umbraco Forms to work correctly, Umbraco Forms need you to include some client dependencies.
+
+With latest version of Umbraco Forms, we provide a method that will output the script tags containing the dependencies. Dne with this razor method:
+
+```html
+<head>
+    @Html.RenderUmbracoFormDependencies()
+</head>
+```
+
+All dependencies originates from your UmbracoForms instalation, no external references.
+
+If you like to use jQuery instead, you will instead have to manually add those. Without using the above. Jump the the section 'Use jQuery' to learn more.
+
+
+## Use jQuery
+
+If you like to use jQuery as your validation framework for Umbraco Forms you will need to manually include three client dependencies:
 
 - `jQuery` (JavaScript library)
 - `jQuery validate` (jQuery plugin that provides client side form validation)
 - `jQuery validate unobtrusive` (Add-on to jQuery Validation that provides unobtrusive validation via data-* attributes)
-
-## Adding the scripts to your template
 
 Easiest way to add the dependencies is to fetch them from a [CDN](https://en.wikipedia.org/wiki/Content_delivery_network). There are various CDN services you can use, we've included references for [Microsoft CDN](https://docs.microsoft.com/en-us/aspnet/ajax/cdn/overview). Other CDN services you might want to look at include https://www.jsdelivr.com/ and https://cdnjs.com/about, which may offer better performance and more reliable service.
 

--- a/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
+++ b/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
@@ -16,7 +16,7 @@ With latest version of Umbraco Forms, we provide a method that will output the s
 
 All dependencies originates from your Umbraco Forms installation, which means that no external references are needed.
 
-If you like to use jQuery instead, you will instead have to manually add those. Without using the above. Jump the the section 'Use jQuery' to learn more.
+If you like to use jQuery instead, you can manually add those. Without using the above, jump to the 'Use jQuery' section below to learn more.
 
 
 ## Use jQuery

--- a/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
+++ b/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index.md
@@ -6,13 +6,15 @@ versionFrom: 7.0.0
 
 In order for Umbraco Forms to work correctly, you need to include some client dependencies.
 
-Use the following Razor method to output script tags containing the dependencies:
+In Umbraco Forms v.8.5.0+ you can use the following Razor method to output script tags containing the dependencies:
 
 ```html
 <head>
     @Html.RenderUmbracoFormDependencies()
 </head>
 ```
+
+For older version of Umbraco Forms you should go for the jQuery option, please read the 'use jQuery' section below.
 
 All dependencies originates from your Umbraco Forms installation, which means that no external references are needed.
 


### PR DESCRIPTION
Made corrections to the validation description to accommodate that we now that a different validation framework default with Umbraco Forms. But jQuery is still an option if you include it manually.
Notice this feature is not released yet, so we need to wait to merge this in until that happens.