### PR TITLE
Add RuntimeLevel attribute to the Composer snippet

### DIFF
--- a/Extending/Database/index.md
+++ b/Extending/Database/index.md
@@ -22,6 +22,7 @@ using Umbraco.Core.Persistence.DatabaseAnnotations;
 
 namespace Umbraco.Web.UI
 {
+    [RuntimeLevel(MinLevel = RuntimeLevel.Run)]
     public class BlogCommentsComposer : ComponentComposer<BlogCommentsComponent>
     {
     }


### PR DESCRIPTION
When you want to deploy a new website to the server, you need to clear the connection string from the Web.config file, in order to trigger the Umbraco installation. However, without the RuntimeLevel attribute, the composer will try to run even before the Umbraco installation. Since no connection string has been configured yet, the code in the composer that tries to execute the migration will fail. Adding this attribute prevents the composer from running too soon.

See also the discussion at https://github.com/umbraco/UmbracoDocs/issues/2350