### PR TITLE
TreeService

### DIFF
--- a/Reference/Management/Services/TreeService/Index.md
+++ b/Reference/Management/Services/TreeService/Index.md
@@ -1,6 +1,6 @@
 ---
 versionFrom: 7.0.0
-needsV8Update: "true"
+versionRemoved: 8.0.0
 ---
 
 # ApplicationTreeService


### PR DESCRIPTION
needsV8Update  --> versionRemoved

As far as I know the ApplicationTreeService no longer exists in v8. 

Belongs to https://github.com/umbraco/UmbracoDocs/issues/2128