### PR TITLE
Add example of using the colorpicker without modelsbuilder

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Color-Picker/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Color-Picker/index.md
@@ -19,12 +19,27 @@ The Color picker allows you to set some predetermined colors that the editor can
 
 ![Content Picker Content](images/Color-Picker-Content-v8.png)
 
-## Example
+## Example with Modelsbuilder
 
 ```csharp
 @{
     var hexColor = Model.Color;
     String colorLabel = Model.Color.Label;
+
+    if (hexColor != null)
+    {
+        <div style="background-color: #@hexColor">@colorLabel</div>
+    }
+}
+```
+
+## Example without Modelsbuilder
+
+```csharp
+@using Umbraco.Core.PropertyEditors.ValueConverters
+@{
+    var hexColor = Model.Value("Color");
+    var colorLabel = Model.Value<ColorPickerValueConverter.PickedColor>("Color").Label;
 
     if (hexColor != null)
     {


### PR DESCRIPTION
Based on a question on the Community Slack here is an example of how to get a colorpicker label and hex value when not using Modelsbuilder 🙂