### PR TITLE
Add tip for injecting a Lazy version of IUmbracoContextFactory

### DIFF
--- a/Implementation/Services/Circular-Dependencies/index.md
+++ b/Implementation/Services/Circular-Dependencies/index.md
@@ -1,0 +1,29 @@
+---
+versionFrom: 8.0.0
+---
+
+# Circurlar Dependencies
+
+In some cases you might experience that a circular dependency is preventing your Umbraco installing from starting up.
+
+An example of this, could be a circular dependency on `IUmbracoContextFactory`, which would happen if your service interacts with third party code that also depends on an `IUmbracoContextFactory` instance.
+
+In this situation, you can request a lazy version of the dependency so it won't evaluate during boot, and would only be evaluated when accessed:
+
+```csharp
+public class SiteService : ISiteService
+{
+    private readonly Lazy<IUmbracoContextFactory> _umbracoContextFactory;
+    public SiteService(Lazy<IUmbracoContextFactory> umbracoContextFactory)
+    {
+        _umbracoContextFactory = umbracoContextFactory;
+    }
+     public IPublishedContent GetNewsSection()
+    {
+         using (UmbracoContextReference umbracoContextReference = _umbracoContextFactory.Value.EnsureUmbracoContext()) 
+         {
+             // Do your thing
+         }
+    }
+}
+```

--- a/Implementation/Services/Circular-Dependencies/index.md
+++ b/Implementation/Services/Circular-Dependencies/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 ---
 
-# Circurlar Dependencies
+# Circular Dependencies
 
 In some cases you might experience that a circular dependency is preventing your Umbraco installing from starting up.
 

--- a/Implementation/Services/index.md
+++ b/Implementation/Services/index.md
@@ -446,27 +446,9 @@ namespace Umbraco8.Services
 The second approach can seem 'different' or more complex at first glance, but it is the syntax and method names that are slightly different... it enables the registering of the service in Singleton Scope, and its use outside of controllers and views.
 
 :::tip
-Occasionally, you may face a situation where Umbraco fails to boot, due to a circular dependency on `IUmbracoContextFactory`.  This can happen if your service interacts with   third party code that also depends on an `IUmbracoContextFactory` instance (e.g. an Umbraco package).  In this situation, you can request a lazy version of the dependency so it won't evaluate during boot, and would only be evaluated when accessed:
+Occasionally, you may face a situation where Umbraco fails to boot, due to a circular dependency on `IUmbracoContextFactory`.  This can happen if your service interacts with   third party code that also depends on an `IUmbracoContextFactory` instance (e.g. an Umbraco package).
 
-```csharp
-public class SiteService : ISiteService
-{
-    private readonly Lazy<IUmbracoContextFactory> _umbracoContextFactory;
-
-    public SiteService(Lazy<IUmbracoContextFactory> umbracoContextFactory)
-    {
-        _umbracoContextFactory = umbracoContextFactory;
-    }
-
-     public IPublishedContent GetNewsSection()
-    {
-         using (UmbracoContextReference umbracoContextReference = _umbracoContextFactory.Value.EnsureUmbracoContext()) 
-         {
-             // Do your thing
-         }
-    }
-}
-```
+See the [Circular Dependencies](Circular-Depndencies) article for an example on how to get around this.
 :::
 
 ###### Aside: What is the IUmbracoContextAccessor then?


### PR DESCRIPTION
This is a gotcha when injecting `IUmbracoContextFactory` into a service which is registered as part of an `IUserComposer` as per the example on this page.  I have found that there are situations, particularly when interacting with third party extension code (e.g. Umbraco Packages), the provided example will fail with a boot error 'Recursive dependency detected: ServiceType:Umbraco.Web.IUmbracoContextFactory'.  

The tip provided fixes this issue, whereas other techniques (such as applying the ComposeBefore/After attribute) have no effect.  I feel like there are many other situations where this could crop up and therefore would be a worthwhile addition to this page.

Ref: forum discussion: https://our.umbraco.com/packages/backoffice-extensions/contentment/contentment-feedback/102944-boot-fail-when-using-an-injected-service-recursive-dependency-iumbracocontextfactory