### PR TITLE
Added documentation for eventsService

### DIFF
--- a/Reference/Angular/Services/eventsService/index.md
+++ b/Reference/Angular/Services/eventsService/index.md
@@ -1,0 +1,471 @@
+# Events Service
+
+The events service allows different components in Umbraco to broadcast and listen for global events.
+
+https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/common/services/events.service.js
+
+### Broadcasting an event
+
+To broadcast an event, you can use the `emit` function. It takes two arguments, where the first is the name of the event - eg. `featured.updated`, and the second argument is an object or similar describing the event.
+
+The second argument is optional, so if your use case doesn't need this, feel free to skip this argument.
+
+The illustrate this function, you could have a controller with an `updated` function that is triggered by the view. In this dummy example, the function will increment the value of a property editor, and then use the events service to broadcast that the value was updated:
+
+```javascript
+angular.module('umbraco').controller("MyController", function($scope, eventsService) {
+
+    $scope.updated = function() {
+        $scope.model.value++;
+        eventsService.emit("feature.updated", { value: $scope.model.value });
+	};
+
+});
+```
+
+### Listening for an event
+
+Another controller could then listen for broadcasts of your `feature.updated` event via the events service's `on` function, which takes the name of the event as the first argument, and a callback function as the second argument.
+
+Then in the callback function, the first argument is the event it self, and the second argument is the object we pass on to the `emit` function when we're broadcasting:
+
+```javascript
+angular.module('umbraco').controller("MyOtherController", function($scope, eventsService) {
+
+    $scope.count = 0;
+    
+    // Subscribe to the event
+    var unsubscribe = eventsService.on("feature.updated", function(event, args) {
+        $scope.count = args.value;
+    });
+    
+    // When the scope is destroyed we need to unsubscribe
+    $scope.$on("$destroy", function () {
+        unsubscribe();
+    });
+
+});
+```
+
+### Unsubscribing from an event
+
+Notice how the result of the `on` function is saved in an `unsubscribe` variable. When we add a listener via the `on` function, it's important to clean up after our selves when our component (here a controller) no longer exists - eg. when removed from the DOM.
+
+In Angular, we can listen for the `$destroy` event in the current scope, and then unsubscribe from the events service by calling the `unsubscribe` variable as a function.
+
+Alternatively, we could replace `unsubscribe()` with `eventsService.unsubscribe(unsubscribe)`, but it does the same thing - so calling the variable as a function directly may be preferred as it's shorter.
+
+
+
+
+
+
+
+## Events in Umbraco
+
+Below you'll find a list of events broadcasted by the Umbraco codebase. The list may not be complete, so please help updating the list should you find an event that isn't listed.
+
+### Umbraco application
+
+#### Init
+
+**When the Umbraco application is ready**
+
+```javascript
+eventsService.emit("app.ready", data);
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/release-8.6.3/src/Umbraco.Web.UI.Client/src/init.js#L65
+
+#### Security interceptor
+
+When Umbraco our your custom code makes a request to the server via the `$http` service, Umbraco listens for the `x-umb-user-modified` header in the response. In can be used to tell the Umbraco backoffice that the current user has been modified, in which case Umbraco knows that it should refetch the user data.
+
+```javascript
+if (headers["x-umb-user-modified"]) {
+    eventsService.emit("app.userRefresh");
+}
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/release-8.6.3/src/Umbraco.Web.UI.Client/src/common/interceptors/security.interceptor.js#L31
+
+
+### Services
+
+#### Clipboard service
+
+**When the clipboard in local storage is updated**
+
+```js
+eventsService.emit("clipboardService.storageUpdate");
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/9829d4abef248a15ba5fed4118f6c75751bf6919/src/Umbraco.Web.UI.Client/src/common/services/clipboard.service.js#L49
+
+#### Editor service
+
+**When an editor is opened**
+
+```javascript
+var args = {
+    editors: editors,
+    editor: editor
+};
+
+eventsService.emit("appState.editors.open", args);
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/0bd9e3ca9955844389556ce512fa0aab181703fb/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js#L281
+
+**When an editor is closed**
+
+```javascript
+var args = {
+    editors: editors,
+    editor: closedEditor
+};
+
+// emit event to let components know an editor has been removed
+eventsService.emit("appState.editors.close", args);
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/0bd9e3ca9955844389556ce512fa0aab181703fb/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js#L304
+
+**When all editors are closed**
+
+```javascript
+var args = {
+    editors: editors,
+    editor: null
+};
+
+eventsService.emit("appState.editors.close", args);
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/0bd9e3ca9955844389556ce512fa0aab181703fb/src/Umbraco.Web.UI.Client/src/common/services/editor.service.js#L336
+
+#### Editor State service
+
+```javascript
+eventsService.emit("editorState.changed", { entity: entity });
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/eed94d8cd03b04385c244a8f593e01e95f349218/src/Umbraco.Web.UI.Client/src/common/services/editorstate.service.js#L33
+
+#### Localization service
+
+**When the language resource file is loaded from the server**
+
+````javascript
+eventsService.emit("localizationService.updated", response.data);
+````
+
+https://github.com/umbraco/Umbraco-CMS/blob/12dff9bca31aa1486aa418a0d8b66d42154896c9/src/Umbraco.Web.UI.Client/src/common/services/localization.service.js#L95
+
+#### Overlay service
+
+**When an overlay is opened**
+
+```javascript
+eventsService.emit("appState.overlay", overlay);
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/c95a7f2ef468f5f338edb0ee0d5c2df3d5718fc0/src/Umbraco.Web.UI.Client/src/common/services/overlay.service.js#L49
+
+**When an overlay is closed**
+
+```javascript
+eventsService.emit("appState.overlay", null);
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/c95a7f2ef468f5f338edb0ee0d5c2df3d5718fc0/src/Umbraco.Web.UI.Client/src/common/services/overlay.service.js#L56
+
+#### TinyMCE service
+
+**When upload of a file starts**
+
+```javascript
+eventsService.emit("rte.file.uploading");
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/511a7f1371a62bf7b77ef80177b4f89cf30cde70/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js#L232
+
+**When upload of a file ends**
+
+```js
+eventsService.emit("rte.file.uploaded");
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/511a7f1371a62bf7b77ef80177b4f89cf30cde70/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js#L238
+
+**When the user presses CTRL + S**
+
+```js
+eventsService.emit("rte.shortcut.save");
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/511a7f1371a62bf7b77ef80177b4f89cf30cde70/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js#L1217
+
+#### Tours
+
+**When tours are loaded**
+
+```javascript
+eventsService.emit("appState.tour.updatedTours", tours);
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/7634b376769b1965f5425129f3f3865bab23d301/src/Umbraco.Web.UI.Client/src/common/services/tour.service.js#L31
+
+**When user starts a tour**
+
+```javascript
+eventsService.emit("appState.tour.start", tour);
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/7634b376769b1965f5425129f3f3865bab23d301/src/Umbraco.Web.UI.Client/src/common/services/tour.service.js#L53
+
+**When user ends a tour**
+
+```javascript
+eventsService.emit("appState.tour.end", tour);
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/7634b376769b1965f5425129f3f3865bab23d301/src/Umbraco.Web.UI.Client/src/common/services/tour.service.js#L66
+
+**When a tour is disabled**
+
+```javascript
+eventsService.emit("appState.tour.end", tour);
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/7634b376769b1965f5425129f3f3865bab23d301/src/Umbraco.Web.UI.Client/src/common/services/tour.service.js#L80
+
+**When user completes a tour**
+
+```javascript
+eventsService.emit("appState.tour.complete", tour);
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/7634b376769b1965f5425129f3f3865bab23d301/src/Umbraco.Web.UI.Client/src/common/services/tour.service.js#L102
+
+#### Tree service
+
+**When loading a tree node fails**
+
+```javascript
+eventsService.emit("treeService.treeNodeLoadError", { error: reason });
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/b5b319f9176e06f797c8aa5b314f5478c54e1259/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js#L328
+
+**When a tree node is removed**
+
+```javascript
+eventsService.emit("treeService.removeNode", { node: treeNode });
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/b5b319f9176e06f797c8aa5b314f5478c54e1259/src/Umbraco.Web.UI.Client/src/common/services/tree.service.js#L366
+
+#### User service
+
+**When the user is logged out**
+
+```javascript
+const args = { isTimedOut: isTimedOut };
+eventsService.emit("app.notAuthenticated", args);
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/d65041c2503fc85ac4619a4abcd703dcc20f067d/src/Umbraco.Web.UI.Client/src/common/services/user.service.js#L13,L14
+
+**When user is trying to log in, but have not start nodes**
+
+```javascript
+var result = { errorMsg: errorMsg, user: data, authenticated: false, lastUserId: lastUserId, loginType: "credentials" };
+eventsService.emit("app.notAuthenticated", result);
+```
+
+**When user is successfully authenticated**
+
+```javascript
+var result = { user: data, authenticated: true, lastUserId: lastUserId, loginType: "credentials" };
+eventsService.emit("app.authenticated", result);
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/d65041c2503fc85ac4619a4abcd703dcc20f067d/src/Umbraco.Web.UI.Client/src/common/services/user.service.js#L207,L210
+
+**When user data is refetched from the server**
+
+```javascript
+if (args && args.broadcastEvent) {
+    //broadcast a global event, will inform listening controllers to load in the user specific data
+    eventsService.emit("app.authenticated", result);
+}
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/d65041c2503fc85ac4619a4abcd703dcc20f067d/src/Umbraco.Web.UI.Client/src/common/services/user.service.js#L255,L257
+
+#### Util service
+
+**When the app is initialized**
+
+```javascript
+eventsService.emit("app.reInitialize");
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/7634b376769b1965f5425129f3f3865bab23d301/src/Umbraco.Web.UI.Client/src/common/services/util.service.js#L137
+
+
+
+
+
+
+
+
+### Directives
+
+#### Toggle directive
+
+**When the toggle is initialized**
+
+```javascript
+eventsService.emit("toggleValue", { value: scope.checked });
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/7b8ef85541b993e375c98cc969c41f029e7c3142/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js#L85
+
+**When the toggle is clicked**
+
+```javascript
+eventsService.emit("toggleValue", { value: !scope.checked });
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/7b8ef85541b993e375c98cc969c41f029e7c3142/src/Umbraco.Web.UI.Client/src/common/directives/components/buttons/umbtoggle.directive.js#L113
+
+#### Other directives
+
+https://github.com/umbraco/Umbraco-CMS/blob/b81bd6645634e8fc99eb6ced403b7de3dac73108/src/Umbraco.Web.UI.Client/src/common/directives/components/tabs/umbtabsnav.directive.js
+
+https://github.com/umbraco/Umbraco-CMS/blob/11e82f26000ffe10c7cca260503e5d05f734bfd2/src/Umbraco.Web.UI.Client/src/common/directives/validation/valformmanager.directive.js#L210
+
+https://github.com/umbraco/Umbraco-CMS/blob/5541d130207b8a32dfb361bc4d7143c85143c645/src/Umbraco.Web.UI.Client/src/common/directives/components/editor/umbeditorheader.directive.js#L343
+
+https://github.com/umbraco/Umbraco-CMS/blob/34749ec2339731fb3d81101a9720cbcc1dbd04b2/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js#L381
+
+https://github.com/umbraco/Umbraco-CMS/blob/34749ec2339731fb3d81101a9720cbcc1dbd04b2/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js#L637
+
+https://github.com/umbraco/Umbraco-CMS/blob/34749ec2339731fb3d81101a9720cbcc1dbd04b2/src/Umbraco.Web.UI.Client/src/common/directives/components/umbgroupsbuilder.directive.js#L725
+
+https://github.com/umbraco/Umbraco-CMS/blob/99a3dec4bac7d98ab9424ad6a70019fd5f62d56a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontenteditors.directive.js#L113
+
+https://github.com/umbraco/Umbraco-CMS/blob/7634b376769b1965f5425129f3f3865bab23d301/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbcontentnodeinfo.directive.js#L191
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+### Controllers
+
+#### Grid controller
+
+**When a new row is added**
+
+```javascript
+eventsService.emit("grid.rowAdded", { scope: $scope, element: $element, row: row });
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/fda7251aedba177bf0add71ad8bdc1ddc0c1910c/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js#L406
+
+**When a new control is added**
+
+```javascript
+eventsService.emit("grid.itemAdded", { scope: $scope, element: $element, cell: cell, item: newControl });
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/fda7251aedba177bf0add71ad8bdc1ddc0c1910c/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js#L666
+
+**When the grid is initializing**
+
+```javascript
+eventsService.emit("grid.initializing", { scope: $scope, element: $element });
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/fda7251aedba177bf0add71ad8bdc1ddc0c1910c/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js#L974
+
+**When the grid is initialized**
+
+```javascript
+eventsService.emit("grid.initialized", { scope: $scope, element: $element });
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/fda7251aedba177bf0add71ad8bdc1ddc0c1910c/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/grid.controller.js#L978
+
+#### Languages overview controller
+
+**When a language is deleted**
+
+```c#
+eventsService.emit("editors.languages.languageDeleted", args);
+```
+
+https://github.com/umbraco/Umbraco-CMS/blob/bd4e66e0c6ef2d0d47c1630ee13b1ac3778ab001/src/Umbraco.Web.UI.Client/src/views/languages/overview.controller.js#L99
+
+#### content - edit.controller.js
+
+https://github.com/umbraco/Umbraco-CMS/blob/b67d56804c08e92b70bb4a48ca0fd9a3c034bdfa/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js#L235
+
+https://github.com/umbraco/Umbraco-CMS/blob/b67d56804c08e92b70bb4a48ca0fd9a3c034bdfa/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js#L260
+
+https://github.com/umbraco/Umbraco-CMS/blob/b67d56804c08e92b70bb4a48ca0fd9a3c034bdfa/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js#L449
+
+https://github.com/umbraco/Umbraco-CMS/blob/b67d56804c08e92b70bb4a48ca0fd9a3c034bdfa/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js#L468
+
+https://github.com/umbraco/Umbraco-CMS/blob/b67d56804c08e92b70bb4a48ca0fd9a3c034bdfa/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js#L580
+
+#### Other controllers
+
+https://github.com/umbraco/Umbraco-CMS/blob/bd26cb36ecce2bbe86f11b61dd1a01c314378c89/src/Umbraco.Web.UI.Client/src/views/languages/edit.controller.js#L158
+
+https://github.com/umbraco/Umbraco-CMS/blob/227a0ec0d8fef6c5ae528935cf887df6cce97329/src/Umbraco.Web.UI.Client/src/views/dashboard/content/redirecturls.controller.js#L149
+
+https://github.com/umbraco/Umbraco-CMS/blob/ecb6f93e54de1f37e83f4c85bffe81d32c86d917/src/Umbraco.Web.UI.Client/src/views/prevalueeditors/treesource.controller.js#L71
+
+https://github.com/umbraco/Umbraco-CMS/blob/b55fdd60e5397f3b9d95160d78d2a34a85ba2a7f/src/Umbraco.Web.UI.Client/src/views/media/media.sort.controller.js#L53
+
+https://github.com/umbraco/Umbraco-CMS/blob/463128734c3fda8c7ed740332688c7356153fd0b/src/Umbraco.Web.UI.Client/src/views/content/content.sort.controller.js#L55
+
+https://github.com/umbraco/Umbraco-CMS/blob/0bd9e3ca9955844389556ce512fa0aab181703fb/src/Umbraco.Web.UI.Client/src/views/membertypes/edit.controller.js#L260
+
+https://github.com/umbraco/Umbraco-CMS/blob/fdfcb75a7198b2267a230663ff62c7bdac67d5ef/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/datatypesettings/datatypesettings.controller.js#L116
+
+https://github.com/umbraco/Umbraco-CMS/blob/41d1e33fc452c955ebfbdd3d85931dad8b06da42/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/userpicker/userpicker.controller.js#L71
+
+https://github.com/umbraco/Umbraco-CMS/blob/0bd9e3ca9955844389556ce512fa0aab181703fb/src/Umbraco.Web.UI.Client/src/views/mediatypes/edit.controller.js#L340
+
+https://github.com/umbraco/Umbraco-CMS/blob/591575b47de87ce64c963ac85066ed6572660171/src/Umbraco.Web.UI.Client/src/views/documenttypes/edit.controller.js#L356
+
+https://github.com/umbraco/Umbraco-CMS/blob/bd26cb36ecce2bbe86f11b61dd1a01c314378c89/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/linkpicker/linkpicker.controller.js#L127
+
+https://github.com/umbraco/Umbraco-CMS/blob/7634b376769b1965f5425129f3f3865bab23d301/src/Umbraco.Web.UI.Client/src/navigation.controller.js#L434
+
+https://github.com/umbraco/Umbraco-CMS/blob/1347b973f1c8617d372592236eab101507dd4179/src/Umbraco.Web.UI.Client/src/common/directives/components/application/umblogin.directive.js#L464
+
+https://github.com/umbraco/Umbraco-CMS/blob/dc39faeb5ecc51992eeb1dcdf901b7ffc11be486/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js#L344
+
+https://github.com/umbraco/Umbraco-CMS/blob/e8bb3b01aacc50fc096d726a83d3bd6a914749bd/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js#L287
+

--- a/Reference/Angular/Services/eventsService/index.md
+++ b/Reference/Angular/Services/eventsService/index.md
@@ -1,3 +1,7 @@
+---
+versionFrom: 8.0.0
+---
+
 # Events Service
 
 The events service allows different components in Umbraco to broadcast and listen for global events.

--- a/Reference/Angular/Services/eventsService/index.md
+++ b/Reference/Angular/Services/eventsService/index.md
@@ -4,6 +4,8 @@ The events service allows different components in Umbraco to broadcast and liste
 
 https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/common/services/events.service.js
 
+## Using the events service in your custom code
+
 ### Broadcasting an event
 
 To broadcast an event, you can use the `emit` function. It takes two arguments, where the first is the name of the event - eg. `featured.updated`, and the second argument is an object or similar describing the event.
@@ -18,7 +20,7 @@ angular.module('umbraco').controller("MyController", function($scope, eventsServ
     $scope.updated = function() {
         $scope.model.value++;
         eventsService.emit("feature.updated", { value: $scope.model.value });
-	};
+    };
 
 });
 ```
@@ -33,12 +35,12 @@ Then in the callback function, the first argument is the event it self, and the 
 angular.module('umbraco').controller("MyOtherController", function($scope, eventsService) {
 
     $scope.count = 0;
-    
+
     // Subscribe to the event
     var unsubscribe = eventsService.on("feature.updated", function(event, args) {
         $scope.count = args.value;
     });
-    
+
     // When the scope is destroyed we need to unsubscribe
     $scope.$on("$destroy", function () {
         unsubscribe();
@@ -468,4 +470,3 @@ https://github.com/umbraco/Umbraco-CMS/blob/1347b973f1c8617d372592236eab101507dd
 https://github.com/umbraco/Umbraco-CMS/blob/dc39faeb5ecc51992eeb1dcdf901b7ffc11be486/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/treepicker/treepicker.controller.js#L344
 
 https://github.com/umbraco/Umbraco-CMS/blob/e8bb3b01aacc50fc096d726a83d3bd6a914749bd/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js#L287
-


### PR DESCRIPTION
This PR is still work in progress. I haven't marked it as a draft as I'm not sure whether those are reviewed, and I may need some feedback in order to continue.

The events service is currently not documented - not even in the main Angular documentation - so this PR is an attempt to do at least something about that.

The first part of the page describes the three functions of the events service with both some text and some examples. This should be good to go - unless of course the docs team has some feedback for any changes.

The second part attempts to list all events currently used and broadcasted by Umbraco. This is where I need some feedback 😄 

My idea was to have a quick example of how each event is broadcasted, but also a link to the source code. For one, this could let developers get a better overview of how the event is broadcasted. And second, linking to a specific tag - eg. `release-8.6.3` - may make it easier to maintaining the list going forward.

I'm not sure whether having the links to the source code there adds too much noise, but if so we could add the links as HTML comments so they're still there for reference.

Currently the links refer to a mix of mix of files at at specific commit and files from a specific release/tag. Ideally they should all link to a specific release, so if we decide that their is a need to show/include the links, I will go through them and make sure they all refer to the tag of the most recent release.

Some of the events may also need a bit more description or better examples than what I have so far - eg. so it's better explained which arguments an given event has. But at least this should serve as a start 😉 