### PR TITLE
Forms definitions moved to the database

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
+++ b/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
@@ -6,6 +6,8 @@ versionFrom: 8.0.0
 
 As of Umbraco Forms version 8.5.0 it is possible to persist all forms data in the Umbraco database. This includes definitions for each form and their fields, as well as workflow definitions and prevalues.
 
+In this article you will find instructions on how to migrate your Umbraco Forms data to the database.
+
 :::note
 **Custom file system providers**
 
@@ -18,13 +20,7 @@ Then you need to ensure that your Forms definition files are moved from their pr
 Your configuration is now considered a standard configuration and you are able to perform the steps required for a normal migration.
 :::
 
-In this article you will find instructions on how to migrate your Umbraco Forms data to the database.
-
 ## How to enable storing Forms definitions in the database
-
-:::warning
-Please be aware that enabling the persistance of Umbraco Forms in the database is irreversable. Once you've made the change, reverting to the file approach will not be an option.
-:::
 
 Follow these steps, in order to perstist Umbraco Forms definitions in the database:
 
@@ -37,5 +33,9 @@ Follow these steps, in order to perstist Umbraco Forms definitions in the databa
     ```
 
 4. Save the file
+
+:::warning
+Please be aware that enabling the persistance of Umbraco Forms in the database is irreversable. Once you've made the change, reverting to the file approach will not be an option.
+:::
 
 When you save the file, the site will restart and run a migration step, migrating the files to the Umbraco database.

--- a/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
+++ b/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
@@ -22,7 +22,7 @@ Your configuration is now considered a standard configuration and you are able t
 
 ## How to enable storing Forms definitions in the database
 
-Follow these steps, in order to perstist Umbraco Forms definitions in the database:
+Follow these steps, in order to persist Umbraco Forms definitions in the database:
 
 1. [Upgrade to at least Umbraco Forms version 8.5.2](../../Installation/ManualUpgrade)
 2. Open the configuration file `App_Plugins\UmbracoForms\UmbracoForms.config`

--- a/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
+++ b/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
@@ -1,0 +1,30 @@
+---
+versionFrom: 8.0.0
+---
+
+# Umbraco Forms in the database
+
+As of Umbraco Forms version 8.5.0 all forms meta data is saved to the Umbraco database. This includes definitions for each form and their fields, as well as workflow definitions and prevalues.
+
+If your site has been upgraded to Umbraco Forms 8.5.0+ from an older version, you now have the option to opt-in on making use of persisting Umbraco Forms definitions in the Umbraco database.
+
+In this article you will find instructions on how to switch to persision Umbraco Forms definitions in the database.
+
+## How to enable storing Forms definitions in the database
+
+:::warning
+Please be aware that enabling the persistance of Umbraco Forms in the database is irreversable. Once you've made the change, reverting to the file approach will not be an option.
+:::
+
+Follow these steps, in order to perstist Umbraco Forms definitions in the database:
+
+1. Open the configuration file `App_Plugins\UmbracoForms\UmbracoForms.config`
+2. In the `<settings>` section of the configuration, add
+
+    ```code
+    <setting key=“StoreUmbracoFormsInDb” value=“True” />
+    ```
+
+3. Save the file
+
+When you save the file, the site will restart and run a migration step, migrating the files to the database.

--- a/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
+++ b/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
@@ -9,7 +9,7 @@ As of Umbraco Forms version 8.5.0 it is possible to persist all forms data in th
 :::note
 **Custom file system providers**
 
-If custom fileproviders are used on your project for storing Umbraco Forms data, the migration will not be able to run.
+If custom file system providers are used on your project for storing Umbraco Forms data, the migration will not be able to run.
 
 In order to be able to persist your Umbraco Forms data in the database, you will need to revert back to a **standard Umbraco Forms configuration** using the default provider storing the Forms definition files in the default location.
 

--- a/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
+++ b/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
@@ -6,6 +6,18 @@ versionFrom: 8.0.0
 
 As of Umbraco Forms version 8.5.0 it is possible to persist all forms data in the Umbraco database. This includes definitions for each form and their fields, as well as workflow definitions and prevalues.
 
+:::note
+**Custom file system providers**
+
+If custom fileproviders are used on your project for storing Umbraco Forms data, the migration will not be able to run.
+
+In order to be able to persist your Umbraco Forms data in the database, you will need to revert back to a **standard Umbraco Forms configuration** using the default provider storing the Forms definition files in the default location.
+
+Then you need to ensure that your Forms definition files are moved from their previous location (this being a non-default file path, blob storage or similar) to the default location, `App_Data/UmbracoForms`, that Forms will now be using.
+
+Your configuration is now considered a standard configuration and you are able to perform the steps required for a normal migration.
+:::
+
 In this article you will find instructions on how to migrate your Umbraco Forms data to the database.
 
 ## How to enable storing Forms definitions in the database
@@ -16,13 +28,14 @@ Please be aware that enabling the persistance of Umbraco Forms in the database i
 
 Follow these steps, in order to perstist Umbraco Forms definitions in the database:
 
-1. Open the configuration file `App_Plugins\UmbracoForms\UmbracoForms.config`
-2. Locate the `StoreUmbracoFormsInDb` key in the `<settings>` section, and make sure it has the follow value:
+1. [Upgrade to at least Umbraco Forms version 8.5.2](../../Installation/ManualUpgrade)
+2. Open the configuration file `App_Plugins\UmbracoForms\UmbracoForms.config`
+3. Locate the `StoreUmbracoFormsInDb` key in the `<settings>` section, and make sure it has the follow value:
 
     ```code
     <setting key=“StoreUmbracoFormsInDb” value=“True” />
     ```
 
-3. Save the file
+4. Save the file
 
 When you save the file, the site will restart and run a migration step, migrating the files to the Umbraco database.

--- a/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
+++ b/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
@@ -34,6 +34,8 @@ Follow these steps, in order to persist Umbraco Forms definitions in the databas
 
 4. Save the file
 
+If you are working with an Umbraco Cloud project, make sure you follow the migration steps outlined in the [Umbraco Forms on Cloud](../../../Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud) article.
+
 :::warning
 Please be aware that enabling the persisting of Umbraco Forms in the database is irreversable. Once you've made the change, reverting to the file approach will not be an option.
 :::

--- a/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
+++ b/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
@@ -35,7 +35,7 @@ Follow these steps, in order to persist Umbraco Forms definitions in the databas
 4. Save the file
 
 :::warning
-Please be aware that enabling the persistance of Umbraco Forms in the database is irreversable. Once you've made the change, reverting to the file approach will not be an option.
+Please be aware that enabling the persisting of Umbraco Forms in the database is irreversable. Once you've made the change, reverting to the file approach will not be an option.
 :::
 
 When you save the file, the site will restart and run a migration step, migrating the files to the Umbraco database.

--- a/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
+++ b/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
@@ -11,7 +11,7 @@ In this article you will find instructions on how to migrate your Umbraco Forms 
 :::note
 **Custom file system providers**
 
-If custom file system providers are used on your project for storing Umbraco Forms data, the migration will not be able to run.
+If [custom file system providers are used on your project for storing Umbraco Forms data](../../../Extending/FileSystemProviders/#custom-providers), the migration will not be able to run.
 
 In order to be able to persist your Umbraco Forms data in the database, you will need to revert back to a **standard Umbraco Forms configuration** using the default provider storing the Forms definition files in the default location.
 

--- a/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
+++ b/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
@@ -34,7 +34,7 @@ Follow these steps, in order to persist Umbraco Forms definitions in the databas
 
 4. Save the file
 
-If you are working with an Umbraco Cloud project, make sure you follow the migration steps outlined in the [Umbraco Forms on Cloud](../../../Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud) article.
+If you are working with an Umbraco Cloud project, make sure you follow the migration steps outlined in the [Umbraco Forms on Cloud](../../../../Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud) article.
 
 :::warning
 Please be aware that enabling the persisting of Umbraco Forms in the database is irreversable. Once you've made the change, reverting to the file approach will not be an option.

--- a/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
+++ b/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
@@ -26,7 +26,7 @@ Follow these steps, in order to persist Umbraco Forms definitions in the databas
 
 1. [Upgrade to at least Umbraco Forms version 8.5.2](../../Installation/ManualUpgrade.md)
 2. Open the configuration file `App_Plugins\UmbracoForms\UmbracoForms.config`
-3. Locate the `StoreUmbracoFormsInDb` key in the `<settings>` section, and make sure it has the follow value:
+3. Locate the `StoreUmbracoFormsInDb` key in the `<settings>` section, and make sure it has the following value:
 
     ```code
     <setting key=“StoreUmbracoFormsInDb” value=“True” />

--- a/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
+++ b/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
@@ -4,11 +4,9 @@ versionFrom: 8.0.0
 
 # Umbraco Forms in the database
 
-As of Umbraco Forms version 8.5.0 all forms meta data is saved to the Umbraco database. This includes definitions for each form and their fields, as well as workflow definitions and prevalues.
+As of Umbraco Forms version 8.5.0 it is possible to persist all forms data in the Umbraco database. This includes definitions for each form and their fields, as well as workflow definitions and prevalues.
 
-If your site has been upgraded to Umbraco Forms 8.5.0+ from an older version, you now have the option to opt-in on making use of persisting Umbraco Forms definitions in the Umbraco database.
-
-In this article you will find instructions on how to switch to persision Umbraco Forms definitions in the database.
+In this article you will find instructions on how to migrate your Umbraco Forms data to the database.
 
 ## How to enable storing Forms definitions in the database
 
@@ -19,7 +17,7 @@ Please be aware that enabling the persistance of Umbraco Forms in the database i
 Follow these steps, in order to perstist Umbraco Forms definitions in the database:
 
 1. Open the configuration file `App_Plugins\UmbracoForms\UmbracoForms.config`
-2. In the `<settings>` section of the configuration, add
+2. Locate the `StoreUmbracoFormsInDb` key in the `<settings>` section, and make sure it has the follow value:
 
     ```code
     <setting key=“StoreUmbracoFormsInDb” value=“True” />
@@ -27,4 +25,4 @@ Follow these steps, in order to perstist Umbraco Forms definitions in the databa
 
 3. Save the file
 
-When you save the file, the site will restart and run a migration step, migrating the files to the database.
+When you save the file, the site will restart and run a migration step, migrating the files to the Umbraco database.

--- a/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
+++ b/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
@@ -46,16 +46,16 @@ In this section you can find information about version specific changes that mig
 
 #### Version 8.5.0
 
-Prior to Umbraco 8.5.0 all forms data was saved as `.json` files in the `App_Data/UmbracoForms` directive in the file system.
+Prior to Umbraco 8.5.0 all forms data was saved as `.json` files in the `App_Data/UmbracoForms` directory in the file system.
 
-As of Umbraco 8.5.0 you have the option to persist all Forms data directly in the database. This behavious is default to all new sites created on Umbraco Cloud since September 2020. Was your Cloud project created before, you will need to upgrade the Umbraco Forms version as well as applying a setting in order to perform the migration of the Umbraco Forms data.
+As of Umbraco 8.5.0 you have the option to persist all Forms data directly in the database. This behaviour is default to all new sites created on Umbraco Cloud since September 2020. Was your Cloud project created before, you will need to upgrade the Umbraco Forms version as well as applying a setting in order to perform the migration of the Umbraco Forms data.
 
 In order to switch to persisting all definitions for Umbraco Forms data in the Umbraco database, follow these steps:
 
 1. Make sure all environments are upgraded to **at least Umbraco Forms version 8.5.2 and Deploy 3.5.0**
 2. Make sure your forms are in sync between all your Cloud environments
 3. Clone down you Development environment
-4. Open the configuration file `App_Plugins\UmbracoForms\UmbracoForms.config` from you local clone
+4. Open the configuration file `App_Plugins\UmbracoForms\UmbracoForms.config` from your local clone
 5. Locate the `StoreUmbracoFormsInDb` key in the `<settings>` section, and make sure it has the follow value:
 
     ```code
@@ -71,7 +71,7 @@ Follow the steps outlined below **for each environment** in order for the migrat
 
 1. Access **KUDU**
 2. Navigate to `site/wwwroot/App_Data`
-3. Delete the `UmbracoForms` directive
+3. Delete the `UmbracoForms` directory
 4. Push/Deploy the updated setting to the environment
 5. In order to run the migration, **restart the environment** from the Cloud portal
 6. Repeat steps 1-5 for each of your Cloud environments

--- a/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
+++ b/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
@@ -66,6 +66,7 @@ In order to switch to persisting all definitions for Umbraco Forms data in the U
 7. Spin up your local clone and verify that everything works as expected
 8. Push the change back to the Development evironment
 9. In order to run the migration, **restart the Development environment** from the Cloud portal
+10. After verifying that everythin works as expected, push the setting to the remaining Cloud environment - remember to restart each environment in orderto run the migration.
 
 :::note
 **Did you create your project before June 2018?**

--- a/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
+++ b/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
@@ -38,32 +38,34 @@ Umbraco Forms is part of the [auto-upgrades on Umbraco Cloud](../../Upgrades). W
 
 To avoid having the auto-upgrades overwrite any of your custom settings, we strongly encourage that you use [config transforms](../../Set-Up/Config-Transforms) when you need custom configuration, and [Themes](../../../Add-ons/UmbracoForms/Developer/Themes) when you need to customize your forms.
 
+Whenever a new minor version of Umbraco Forms is ready, eg. 8.x or 7.x, you will get the option to apply the upgrade to your project. When your project is elligible to receive the new version, you will see an "*Upgrade available!*" label on your Development environment.
+
 ### Version specific changes
 
 In this section you can find information about version specific changes that might affect the way Umbraco Forms works on your project.
 
 #### Version 8.5.0
 
-Prior to Umbraco 8.5.0 all forms data was saved to both `.UDA` files in the `data/revision` directive as well as `.json` files in the `App_Data/UmbracoFormsData` directive.
+Prior to Umbraco 8.5.0 all forms data was saved as `.json` files in the `App_Data/UmbracoForms` directive in the file system.
 
-We highly recommend that you switch to persisting all definitions for Umbraco Forms data in the Umbraco database.
+As of Umbraco 8.5.0 you have the option to persist all Forms data directly in the database. This behavious is default to all new sites created on Umbraco Cloud since September 2020. Was your Cloud project created before, you will need to upgrade the Umbraco Forms version as well as applying a setting in order to perform the migration of the Umbraco Forms data.
 
-Follow these steps to make the switch:
+In order to switch to persisting all definitions for Umbraco Forms data in the Umbraco database, follow these steps:
 
-1. Make sure your forms are in sync between all your Cloud environments
-2. Clone down you Development/Live environment
-3. Open the configuration file `App_Plugins\UmbracoForms\UmbracoForms.config` from you local clone
-4. In the `<settings>` section of the configuration, add
+1. Make sure all environments are upgraded to **at least Umbraco Forms version 8.5.2 and Deploy 3.5.0**
+2. Make sure your forms are in sync between all your Cloud environments
+3. Clone down you Development environment
+4. Open the configuration file `App_Plugins\UmbracoForms\UmbracoForms.config` from you local clone
+5. Locate the `StoreUmbracoFormsInDb` key in the `<settings>` section, and make sure it has the follow value:
 
     ```code
     <setting key=“StoreUmbracoFormsInDb” value=“True” />
     ```
 
-5. Save the file
-6. Spin up your local clone and verify that everything works as expected
-7. Push the change back to the Cloud environments
-
-Please note that the change here is made to a config file, which means that the environments will restart as the changes are applied. This can take a few minutes, depending on the scale of your project.
+6. Save the file
+7. Spin up your local clone and verify that everything works as expected
+8. Push the change back to the Development evironment
+9. In order to run the migration, **restart the Development environment** from the Cloud portal
 
 :::note
 **Did you create your project before June 2018?**

--- a/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
+++ b/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
@@ -72,9 +72,10 @@ Follow the steps outlined below **for each environment** in order for the migrat
 1. Access **KUDU**
 2. Navigate to `site/wwwroot/App_Data`
 3. Delete the `UmbracoForms` directory
-4. Push/Deploy the updated setting to the environment
+4. Push the updated setting to the environment
 5. In order to run the migration, **restart the environment** from the Cloud portal
-6. Repeat steps 1-5 for each of your Cloud environments
+6. From the Umbraco Backoffice transfer, queue and transfer the forms to the environment
+7. Repeat steps 1-5 for each of your Cloud environments
 
 :::note
 **Did you create your project before June 2018?**

--- a/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
+++ b/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
@@ -50,19 +50,45 @@ We highly recommend that you switch to persisting all definitions for Umbraco Fo
 
 Follow these steps to make the switch:
 
-1. Clone down you Development/Live environment
-2. Open the configuration file `App_Plugins\UmbracoForms\UmbracoForms.config` from you local clone
-3. In the `<settings>` section of the configuration, add
+1. Make sure your forms are in sync between all your Cloud environments
+2. Clone down you Development/Live environment
+3. Open the configuration file `App_Plugins\UmbracoForms\UmbracoForms.config` from you local clone
+4. In the `<settings>` section of the configuration, add
 
     ```code
     <setting key=“StoreUmbracoFormsInDb” value=“True” />
     ```
 
-4. Save the file
-5. Spin up your local clone and verify that everything works as expected
-6. Push the change back to the Cloud environments
+5. Save the file
+6. Spin up your local clone and verify that everything works as expected
+7. Push the change back to the Cloud environments
 
 Please note that the change here is made to a config file, which means that the environments will restart as the changes are applied. This can take a few minutes, depending on the scale of your project.
+
+:::note
+**Did you create your project before June 2018?**
+
+Then your Umbraco Forms data might still be handled as meta data.
+
+This means that you will need to follow the steps below, in order to persist Umbraco Forms data in the Umbraco database.
+
+1. Find and open `Config\UmbracoDeploy.settings.config` on your local machine
+2. Update the `transferFormsAsContent` value to `true`
+
+   ```xml
+   <?xml version="1.0" encoding="utf-8"?>
+   <settings xmlns="urn:umbracodeploy-settings">
+      <forms transferFormsAsContent="true" />
+   </settings>
+   ```
+
+3. Remove all existing `data\revision\forms-form__*.uda` files, so it's not possible to accidentally revert back to this state (removing `UDA` files won't remove the actual form on deploy)
+4. Push the change back to the Cloud environment
+   * If you have more than 1 Cloud environment, make sure to deploy the change through to all of them
+5. You are now able to queue your forms for transfer between the Cloud environments, like content and media
+
+If you do not have the `transferFormsAsContent` setting in the `UmbracoDeploy.settings.config` file, you do not need to make any further changes.
+:::
 
 ## Common issues with Umbraco Forms on Cloud
 

--- a/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
+++ b/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
@@ -64,9 +64,17 @@ In order to switch to persisting all definitions for Umbraco Forms data in the U
 
 6. Save the file
 7. Spin up your local clone and verify that everything works as expected
-8. Push the change back to the Development evironment
-9. In order to run the migration, **restart the Development environment** from the Cloud portal
-10. After verifying that everythin works as expected, push the setting to the remaining Cloud environment - remember to restart each environment in orderto run the migration.
+
+Now it is time to deploy the setting to your Cloud environments.
+
+Follow the steps outlined below **for each environment** in order for the migration to run on each of them.
+
+1. Access **KUDU**
+2. Navigate to `site/wwwroot/App_Data`
+3. Delete the `UmbracoForms` directive
+4. Push/Deploy the updated setting to the environment
+5. In order to run the migration, **restart the environment** from the Cloud portal
+6. Repeat steps 1-5 for each of your Cloud environments
 
 :::note
 **Did you create your project before June 2018?**

--- a/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
+++ b/Umbraco-Cloud/Deployment/Umbraco-Forms-on-Cloud/index.md
@@ -10,9 +10,11 @@ Umbraco Forms is a package that is included with your Umbraco Cloud project. It 
 
 Read more about the product in the [Umbraco Forms section](../../../Add-ons/UmbracoForms).
 
-## How are forms handled on Cloud?
+## How forms are handled on Umbraco Cloud
 
 Forms are handled like content and media. This means that you can transfer your forms between environments, using the same workflow you use for content and media.
+
+Definitions for each specific form, its fields, workflows and prevalues are all stored in the Umbraco database.
 
 Entries submitted are not transferred to the next environment, as they are *environment specific*. If you need to move entries from one environment to another, you need to run an export/import script on the databases.
 
@@ -30,44 +32,37 @@ For more information on how to handle content transfer/restores on Umbraco Cloud
 * [Transfer content, media and forms](../Content-Transfer)
 * [Restoring content](../Restoring-content)
 
-### Did you create your Cloud project before June 18th 2019?
-
-Then your forms data is handled as metadata. When you create a form, a `UDA` file will be generated. This `UDA` file contains all the metadata from the form and is very similar to the `JSON` file that is also generated when you create a new form (found in `App_Data\UmbracoForms\Data\forms`).
-
-This means that your forms will be deployed along with the rest of your metadata and structure files, e.g. Document Types, Templates and stylesheets.
-
-We strongly recommend that you work with the forms on your local or Development environment, following the [left-to-right deployment model](../../Deployment).
-
-You can configure your project to handle forms data as content by following these steps:
-
-1. Make sure your forms are in sync between all your Cloud environments
-2. Clone down the project to your local machine
-3. Find and open `Config\UmbracoDeploy.settings.config`
-4. Update the `transferFormsAsContent` value to `true`
-   ```xml
-   <?xml version="1.0" encoding="utf-8"?>
-   <settings xmlns="urn:umbracodeploy-settings">
-      <forms transferFormsAsContent="true" />
-   </settings>
-   ```
-5. Remove all existing `data\revision\forms-form__*.uda` files, so it's not possible to accidentally revert back to this state (removing `UDA` files won't remove the actual form on deploy)
-6. Push the change back to the Cloud environment
-   * If you have more than 1 Cloud environment, make sure to deploy the change through to all of them
-7. You are now able to queue your forms for transfer between the Cloud environments, like content and media
-
-:::tip
-Do you want to test this new setting you've configured?
-
-Make a change to a form on your Live environment, and then use the **Restore** option in the Forms section on another environment.
-
-You will see that the changes you made on Live, are now reflected on the current environment.
-:::
-
 ## Upgrades
 
 Umbraco Forms is part of the [auto-upgrades on Umbraco Cloud](../../Upgrades). Whenever a new patch is ready for release, we will automatically apply it to your Cloud project. There will be a message in the Umbraco Cloud Portal at least 5 days before we roll out new versions.
 
 To avoid having the auto-upgrades overwrite any of your custom settings, we strongly encourage that you use [config transforms](../../Set-Up/Config-Transforms) when you need custom configuration, and [Themes](../../../Add-ons/UmbracoForms/Developer/Themes) when you need to customize your forms.
+
+### Version specific changes
+
+In this section you can find information about version specific changes that might affect the way Umbraco Forms works on your project.
+
+#### Version 8.5.0
+
+Prior to Umbraco 8.5.0 all forms data was saved to both `.UDA` files in the `data/revision` directive as well as `.json` files in the `App_Data/UmbracoFormsData` directive.
+
+We highly recommend that you switch to persisting all definitions for Umbraco Forms data in the Umbraco database.
+
+Follow these steps to make the switch:
+
+1. Clone down you Development/Live environment
+2. Open the configuration file `App_Plugins\UmbracoForms\UmbracoForms.config` from you local clone
+3. In the `<settings>` section of the configuration, add
+
+    ```code
+    <setting key=“StoreUmbracoFormsInDb” value=“True” />
+    ```
+
+4. Save the file
+5. Spin up your local clone and verify that everything works as expected
+6. Push the change back to the Cloud environments
+
+Please note that the change here is made to a config file, which means that the environments will restart as the changes are applied. This can take a few minutes, depending on the scale of your project.
 
 ## Common issues with Umbraco Forms on Cloud
 


### PR DESCRIPTION
New article on forms definitions being moved to the database.
Also includes steps on how to enabled this, for older versions.