### PR TITLE
Fixes compiler error CS0103 in RuntimeLevel

### DIFF
--- a/Extending/Database/index.md
+++ b/Extending/Database/index.md
@@ -11,6 +11,7 @@ In Umbraco it is possible to add custom database tables to your site if you want
 ![Database result of a migration](images/db-table.png)
 
 ```csharp
+using Umbraco.Core
 using Umbraco.Core.Logging;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Migrations;

--- a/Extending/Database/index.md
+++ b/Extending/Database/index.md
@@ -11,7 +11,7 @@ In Umbraco it is possible to add custom database tables to your site if you want
 ![Database result of a migration](images/db-table.png)
 
 ```csharp
-using Umbraco.Core
+using Umbraco.Core;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Migrations;


### PR DESCRIPTION
Fixes...

The name 'RuntimeLevel' does not exist in the current context (Compiler Error CS0103)

... in line...

[RuntimeLevel(MinLevel = RuntimeLevel.Run)]

... when using Umbraco version 8.6.3.