### PR TITLE
Fixing the issue with latest release for tutorial Article Item

### DIFF
--- a/Tutorials/Creating-Basic-Site/Articles-Parent-and-Article-Items/index.md
+++ b/Tutorials/Creating-Basic-Site/Articles-Parent-and-Article-Items/index.md
@@ -88,9 +88,9 @@ This code will output a list of all the **_Article Items_** as links using the n
 
 ```csharp
 <article class="special">
-    <div class="articletitle"><a href="@item.Url">@item.Name</a></div>
-    <div class="articlepreview">@item.Value("articleContent").ToString().Truncate(100) <a href="@item.Url">Read More..</a></div>
-</article>
+        <div class="articletitle"><a href="@item.Url">@item.Name</a></div>
+        <div class="articlepreview">@Html.Truncate(item.Value("articleContent").ToString(), 20, true)<a href="@item.Url">Read More..</a></div>
+    </article>
 <hr/>
 ```
 


### PR DESCRIPTION
Fixing the issue with the Truncate Method. It prints out the <p> tags to the frontend view when using the Rich Text Box Editor. It is not supposed to do that. It has now been fixed so the tutorial is up to date with the latest releases. 