### PR TITLE
Suggestion: The fallback handling for changefreq can give invalid output

### DIFF
--- a/Tutorials/Creating-an-XML-Site-Map/index.md
+++ b/Tutorials/Creating-an-XML-Site-Map/index.md
@@ -118,7 +118,7 @@ This is a great candidate for a [Razor Helper](https://weblogs.asp.net/scottgu/a
 ```csharp
 @helper RenderSiteMapUrlEntry(IPublishedContent node)
 {
-    var changeFreq = node.Value("searchEngineChangeFrequency", fallback: Fallback.To(Fallback.Ancestors, Fallback.DefaultValue),defaultValue:"monthly");
+    var changeFreq = node.HasValue("searchEngineChangeFrequency") && node.Value<string>("searchEngineChangeFrequency") != "" ? node.Value<string>("searchEngineChangeFrequency") : "monthly";
     // with the relative priority, this is a per page setting only, so we're not using recursion, so we won't set Fallback.ToAncestors here and we'll default to 0.5 if no value is set
     var priority = node.HasValue("searchEngineRelativePriority") ? node.Value<string>("searchEngineRelativePriority") : "0.5";
     
@@ -341,7 +341,7 @@ string[] excludedDocumentTypes = (!String.IsNullOrEmpty(excludedDocumentTypeList
 
 @helper RenderSiteMapUrlEntry(IPublishedContent node)
 {
-    var changeFreq = node.Value("searchEngineChangeFrequency", fallback: Fallback.To(Fallback.Ancestors, Fallback.DefaultValue),defaultValue:"monthly");
+    var changeFreq = node.HasValue("searchEngineChangeFrequency") && node.Value<string>("searchEngineChangeFrequency") != "" ? node.Value<string>("searchEngineChangeFrequency") : "monthly";
     // with the relative priority, this is a per page setting only, so we're not using recursion, so we won't fallback to ancestors here and we'll default to 0.5 if no value is set
     var priority = node.HasValue("searchEngineRelativePriority") ? node.Value<string>("searchEngineRelativePriority") : "0.5";
     


### PR DESCRIPTION
When using the current fallback to ancestors strategy for the changefreq variable, the view occasionally produces invalid output like this...

`<changefreq/>
`

... instead of:

`<changefreq>monthly</changefreq>
`

This is most likely due to undesired handling of empty strings (and not just null values) in the fallback function, and the suggested "old school" ternary operator method fixes the fallback handling (though the ancestors strategy would be better it worked for both null and empty strings).