### PR TITLE
Examine - Fixed a issue with code sample

### DIFF
--- a/Reference/Searching/Examine/Quick-Start/index.md
+++ b/Reference/Searching/Examine/Quick-Start/index.md
@@ -240,7 +240,7 @@ var results = searcher.CreateQuery().NativeQuery("+__IndexType:content +nodeName
 ### Search children of a specific node
 To search through **all child nodes of a specific node** by their **bodyText property**, amend the query from before like this:
 ```csharp
-var results = searcher.CreateQuery("content").ParentId(1105).Field("bodyText", searchTerm).Execute();
+var results = searcher.CreateQuery("content").ParentId(1105).And().Field("bodyText", searchTerm).Execute();
 ```
 :::tip
 If you are familiar with the MVC pattern of working with forms, then have a look at `SurfaceController` documentation. There you can learn how to create a strongly typed form that posts back to a SurfaceController, which then handles the validation of the form post with a custom ViewModel in an MVC-like pattern in Umbraco.


### PR DESCRIPTION
Hi,

Noticed while working today that there is an issue with the code sample https://our.umbraco.com/Documentation/Reference/Searching/Examine/quick-start/#search-children-of-a-specific-node 

While searching for children of specific node there needs to be an `And()` before the `Field()` can be used

Poornima