### PR TITLE
Docs on how to add the path of a node as a searchable field into the index

### DIFF
--- a/Reference/Searching/Examine/Quick-Start/index.md
+++ b/Reference/Searching/Examine/Quick-Start/index.md
@@ -242,6 +242,9 @@ To search through **all child nodes of a specific node** by their **bodyText pro
 ```csharp
 var results = searcher.CreateQuery("content").ParentId(1105).Field("bodyText", searchTerm).Execute();
 ```
+### Search descendants of a specific home node
+To search through **all descendants of a specific node** by their **bodyText property**, refer [here](../examine-events#Adding-the-path-of-the-node-as-a-searchable-field-into-the-index).
+
 :::tip
 If you are familiar with the MVC pattern of working with forms, then have a look at `SurfaceController` documentation. There you can learn how to create a strongly typed form that posts back to a SurfaceController, which then handles the validation of the form post with a custom ViewModel in an MVC-like pattern in Umbraco.
 :::

--- a/Reference/Searching/Examine/Quick-Start/index.md
+++ b/Reference/Searching/Examine/Quick-Start/index.md
@@ -242,8 +242,10 @@ To search through **all child nodes of a specific node** by their **bodyText pro
 ```csharp
 var results = searcher.CreateQuery("content").ParentId(1105).Field("bodyText", searchTerm).Execute();
 ```
+
 ### Search descendants of a specific home node
-To search through **all descendants of a specific node** by their **bodyText property**, refer [here](../examine-events#Adding-the-path-of-the-node-as-a-searchable-field-into-the-index).
+
+To search through **all descendants of a specific node** by their **bodyText property**, refer to [this article](../examine-events#Adding-the-path-of-the-node-as-a-searchable-field-into-the-index).
 
 :::tip
 If you are familiar with the MVC pattern of working with forms, then have a look at `SurfaceController` documentation. There you can learn how to create a strongly typed form that posts back to a SurfaceController, which then handles the validation of the form post with a custom ViewModel in an MVC-like pattern in Umbraco.

--- a/Reference/Searching/Examine/examine-events.md
+++ b/Reference/Searching/Examine/examine-events.md
@@ -149,7 +149,7 @@ var results = searcher.CreateQuery("content").Field("combinedField", searchTerm)
 
 ### Adding the path of the node as a searchable field into the index
 
-Sometimes you might want to search descendants of a node rather than just immediate children for a particular search term. In this instance we need to right out the `path` property as a searchable field into the index. The `path` property is a comma separated string. Due to presence of the comma in the path, the field is not tokenized therefore it is not searchable. We will inject new
+Sometimes you might want to search descendants of a node rather than immediate children for a particular search term. In this instance, we need to write out the `path` property as a searchable field into the index. The `path` property is a comma-separated string. Due to the presence of the comma in the path, the field is not tokenized therefore it is not searchable. We will inject new
 field with path that has comma removed this making it searchable. This can be done by adding the new field using `IndexProviderTransformingIndexValues` method. So continuing from the above example the method will look like below.
 
 ```csharp

--- a/Reference/Searching/Examine/examine-events.md
+++ b/Reference/Searching/Examine/examine-events.md
@@ -176,12 +176,7 @@ if (e.ValueSet.Category == IndexTypes.Content)
         {
             if (value != null)
             {
-                var path = value.ToString().Split(',');
-                
-                foreach (var p in path)
-                {
-                    pathBuilder.Append(" " + p + " ");  
-                }
+                var path = value.ToString().Replace(",", " ");
             }
         }
     }

--- a/Reference/Searching/Examine/examine-events.md
+++ b/Reference/Searching/Examine/examine-events.md
@@ -150,7 +150,7 @@ var results = searcher.CreateQuery("content").Field("combinedField", searchTerm)
 ### Adding the path of the node as a searchable field into the index
 
 Sometimes you might want to search descendants of a node rather than immediate children for a particular search term. In this instance, we need to write out the `path` property as a searchable field into the index. The `path` property is a comma-separated string. Due to the presence of the comma in the path, the field is not tokenized therefore it is not searchable. We will inject new
-field with path that has comma removed this making it searchable. This can be done by adding the new field using `IndexProviderTransformingIndexValues` method. So continuing from the above example the method will look like below.
+field with the path that has a comma removed this making it searchable. This can be done by adding the new field using to `IndexProviderTransformingIndexValues` method. So continuing from the above example the method will look like below.
 
 ```csharp
 if (e.ValueSet.Category == IndexTypes.Content)

--- a/Reference/Searching/Examine/examine-events.md
+++ b/Reference/Searching/Examine/examine-events.md
@@ -150,7 +150,7 @@ var results = searcher.CreateQuery("content").Field("combinedField", searchTerm)
 ### Adding the path of the node as a searchable field into the index
 
 Sometimes you might want to search descendants of a node rather than just immediate children for a particular search term. In this instance we need to right out the `path` property as a searchable field into the index. The `path` property is a comma separated string. Due to presence of the comma in the path, the field is not tokenized therefore it is not searchable. We will inject new
-field with path that has comma removed this making it searchable. This can be done by adding the new field using `IndexProviderTransformingIndexValues` method. So continuing from the above example the method will look like below
+field with path that has comma removed this making it searchable. This can be done by adding the new field using `IndexProviderTransformingIndexValues` method. So continuing from the above example the method will look like below.
 
 ```csharp
 if (e.ValueSet.Category == IndexTypes.Content)
@@ -195,6 +195,8 @@ if (e.ValueSet.Category == IndexTypes.Content)
     
 }
 ```
+
+The path of a node usually follows the format -1,1066,1234,1236 as an example where 1236 is the current node. In the code we split the path, loop through them and append it to a stringbuilder object, inserting a whitespace before and after the value. Finally we add the value to the stringbuilder object into a new field in the index.
 
 Once this is done you can update your search query to search the descendants of a particular node. In this example the query searches all descendants of node id 1105 for the search term.
 


### PR DESCRIPTION
Hi,

Working with indexing on v8 further today and I noticed the docs can be improved by adding a sample on how we can search the index by descendants. The `ParentId()` only does immediate children.

Poornima