### PR TITLE
Update reference for SiteService example

### DIFF
--- a/Implementation/Services/index.md
+++ b/Implementation/Services/index.md
@@ -404,6 +404,7 @@ namespace Umbraco8.Services
 using System.Linq;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Web;
+using Umbraco.Web.PublishedCache;
 
 namespace Umbraco8.Services
 {


### PR DESCRIPTION
Line 424...

IPublishedContentCache contentCache = umbracoContextReference.UmbracoContext.Content;

... currently gives and error:

CS0246 The type or namespace name 'IPublishedContentCache' could not be found (are you missing a using directive or an assembly reference?)