### PR TITLE
Add Umbraco Volatile docs

### DIFF
--- a/Reference/UmbracoVolatile.md
+++ b/Reference/UmbracoVolatile.md
@@ -1,0 +1,59 @@
+# Umbraco Volatile Error
+
+Umbraco Volatile Errors occurs when you are trying to use a method which *should* be internal, but is left 
+public since it's useful when testing. 
+
+Methods marked with UmbracoVolatile may break in the future, however if you want to use the method for testing, 
+you can use an assembly level attribute called ```UmbracoSuppressVolatile```, when the attribute is applied to an assembly 
+any occurrences of Umbraco Volatiel Error will be suppressed to a warning. 
+
+
+```UmbracoSuppressVolatile``` is located in the ```Umbraco.Core.CodeAnnotations```, however any attribute named UmbracoSuppressVolatile 
+will do the trick if you don't have access to that specific namespace. 
+
+## Example of suppresing Umbraco Volatile Error
+
+~~~c#
+    public class DemoClass
+    {
+	    [UmbracoVolatile]
+        public void VolatileMethod()
+        {
+           // Volatile things here...
+        }
+    }
+~~~
+
+Assume you're trying to use the VolatileMethod which is marked as Volatile, this will throw an Umbraco Volatile Error, 
+however you're just using it in a test and want to suppress the error to a warning.
+
+You simply add the assembly level attribute by adding ```[assembly: UmbracoSuppressVolatile]``` above the namespace in any file within your assembly.
+
+~~~c#
+[assembly: UmbracoSuppressVolatile]
+namespace VolatileDemo
+{
+    public class DemoClass2
+    {
+        public void Test()
+        {
+            var testClass = new DemoClass();
+            testClass.VolatileMethod();
+        }
+    }
+}
+~~~
+
+## Defining your own UmbracoSuppressVolatileAttribute
+
+If you for some reason don't have access to the ```Umbraco.Core.CodeAnnotations``` namespace you can easily define your own attribute 
+and it should do the trick as well, simply create a class called ```UmbracoSuppressVolatileAttribute``` containing the following code: 
+
+~~~c#
+[AttributeUsage(AttributeTargets.Assembly)]
+public class UmbracoSuppressVolatileAttribute : Attribute
+{
+}
+~~~
+
+Now just use at as described in the previous section and your project will build again.

--- a/Reference/UmbracoVolatile.md
+++ b/Reference/UmbracoVolatile.md
@@ -13,7 +13,7 @@ will do the trick, if you don't have access to that specific namespace.
 
 ## Example of suppresing Umbraco Volatile Error
 
-~~~c#
+```c#
     public class DemoClass
     {
 	    [UmbracoVolatile]
@@ -22,14 +22,14 @@ will do the trick, if you don't have access to that specific namespace.
            // Volatile things here...
         }
     }
-~~~
+```
 
 Assume you're trying to use the VolatileMethod which is marked as Volatile. This will throw an Umbraco Volatile Error, 
 however you're only using it in a test and want to suppress the error to a warning.
 
 To supress the error to a warning, add the assembly level attribute by adding `[assembly: UmbracoSuppressVolatile]` above the namespace in any file within your assembly.
 
-~~~c#
+```c#
 [assembly: UmbracoSuppressVolatile]
 namespace VolatileDemo
 {
@@ -42,17 +42,17 @@ namespace VolatileDemo
         }
     }
 }
-~~~
+```
 
 ## Defining your own UmbracoSuppressVolatileAttribute
 
 If you for some reason don't have access to the `Umbraco.Core.CodeAnnotations` namespace you can easily define your own attribute and it should do the trick as well. Simply create a class called `UmbracoSuppressVolatileAttribute` containing the following code: 
 
-~~~c#
+```c#
 [AttributeUsage(AttributeTargets.Assembly)]
 public class UmbracoSuppressVolatileAttribute : Attribute
 {
 }
-~~~
+```
 
 Use it as described in the previous section and your project will build again.

--- a/Reference/UmbracoVolatile.md
+++ b/Reference/UmbracoVolatile.md
@@ -4,7 +4,7 @@ Umbraco Volatile Errors occurs when you are trying to use a method which *should
 public since it's useful when testing. 
 
 Methods marked with UmbracoVolatile may break in the future, however if you want to use the method for testing, 
-you can use an assembly level attribute called ```UmbracoSuppressVolatile```, when the attribute is applied to an assembly 
+you can use an assembly level attribute called `UmbracoSuppressVolatile`, when the attribute is applied to an assembly 
 any occurrences of Umbraco Volatile Error will be suppressed to a warning. 
 
 
@@ -27,7 +27,7 @@ will do the trick, if you don't have access to that specific namespace.
 Assume you're trying to use the VolatileMethod which is marked as Volatile. This will throw an Umbraco Volatile Error, 
 however you're only using it in a test and want to suppress the error to a warning.
 
-To supress the error to a warning, add the assembly level attribute by adding ```[assembly: UmbracoSuppressVolatile]``` above the namespace in any file within your assembly.
+To supress the error to a warning, add the assembly level attribute by adding `[assembly: UmbracoSuppressVolatile]` above the namespace in any file within your assembly.
 
 ~~~c#
 [assembly: UmbracoSuppressVolatile]
@@ -46,7 +46,7 @@ namespace VolatileDemo
 
 ## Defining your own UmbracoSuppressVolatileAttribute
 
-If you for some reason don't have access to the ```Umbraco.Core.CodeAnnotations``` namespace you can easily define your own attribute and it should do the trick as well. Simply create a class called ```UmbracoSuppressVolatileAttribute``` containing the following code: 
+If you for some reason don't have access to the `Umbraco.Core.CodeAnnotations` namespace you can easily define your own attribute and it should do the trick as well. Simply create a class called `UmbracoSuppressVolatileAttribute` containing the following code: 
 
 ~~~c#
 [AttributeUsage(AttributeTargets.Assembly)]
@@ -55,4 +55,4 @@ public class UmbracoSuppressVolatileAttribute : Attribute
 }
 ~~~
 
-Use at as described in the previous section and your project will build again.
+Use it as described in the previous section and your project will build again.

--- a/Reference/UmbracoVolatile.md
+++ b/Reference/UmbracoVolatile.md
@@ -2,14 +2,18 @@
 meta.Title: "Umbraco Volatile Error"
 meta.Description: "Explanation of Umbraco Volatile Error, why it occurs, and what to do about it."
 ---
+
 # Umbraco Volatile Error
 
-Umbraco Volatile Errors occurs when you are trying to use a method which *should* be internal, but is left 
-public since it's useful when testing. 
+:::note
+This article is intended for the .NET Core release of Umbraco CMS.
 
-Methods marked with UmbracoVolatile may break in the future, however if you want to use the method for testing, 
-you can use an assembly level attribute called `UmbracoSuppressVolatile`, when the attribute is applied to an assembly 
-any occurrences of Umbraco Volatile Error will be suppressed to a warning. 
+If you are using Umbraco 7 or 8, this article is not for you.
+:::
+
+Umbraco Volatile Errors occurs when you are trying to use a method which *should* be internal, but is left public since it's useful when testing. 
+
+Methods marked with UmbracoVolatile may break in the future, however if you want to use the method for testing, you can use an assembly level attribute called `UmbracoSuppressVolatile`. When the attribute is applied to an assembly any occurrences of Umbraco Volatile Error will be suppressed to a warning. 
 
 
 `UmbracoSuppressVolatile` is located in the `Umbraco.Core.CodeAnnotations`, however, any attribute named UmbracoSuppressVolatile 

--- a/Reference/UmbracoVolatile.md
+++ b/Reference/UmbracoVolatile.md
@@ -5,11 +5,11 @@ public since it's useful when testing.
 
 Methods marked with UmbracoVolatile may break in the future, however if you want to use the method for testing, 
 you can use an assembly level attribute called ```UmbracoSuppressVolatile```, when the attribute is applied to an assembly 
-any occurrences of Umbraco Volatiel Error will be suppressed to a warning. 
+any occurrences of Umbraco Volatile Error will be suppressed to a warning. 
 
 
 ```UmbracoSuppressVolatile``` is located in the ```Umbraco.Core.CodeAnnotations```, however any attribute named UmbracoSuppressVolatile 
-will do the trick if you don't have access to that specific namespace. 
+will do the trick, if you don't have access to that specific namespace. 
 
 ## Example of suppresing Umbraco Volatile Error
 

--- a/Reference/UmbracoVolatile.md
+++ b/Reference/UmbracoVolatile.md
@@ -1,3 +1,7 @@
+---
+meta.Title: "Umbraco Volatile Error"
+meta.Description: "Explanation of Umbraco Volatile Error, why it occurs, and what to do about it."
+---
 # Umbraco Volatile Error
 
 Umbraco Volatile Errors occurs when you are trying to use a method which *should* be internal, but is left 

--- a/Reference/UmbracoVolatile.md
+++ b/Reference/UmbracoVolatile.md
@@ -46,8 +46,7 @@ namespace VolatileDemo
 
 ## Defining your own UmbracoSuppressVolatileAttribute
 
-If you for some reason don't have access to the ```Umbraco.Core.CodeAnnotations``` namespace you can easily define your own attribute 
-and it should do the trick as well, simply create a class called ```UmbracoSuppressVolatileAttribute``` containing the following code: 
+If you for some reason don't have access to the ```Umbraco.Core.CodeAnnotations``` namespace you can easily define your own attribute and it should do the trick as well. Simply create a class called ```UmbracoSuppressVolatileAttribute``` containing the following code: 
 
 ~~~c#
 [AttributeUsage(AttributeTargets.Assembly)]

--- a/Reference/UmbracoVolatile.md
+++ b/Reference/UmbracoVolatile.md
@@ -46,7 +46,7 @@ namespace VolatileDemo
 
 ## Defining your own UmbracoSuppressVolatileAttribute
 
-If you for some reason don't have access to the `Umbraco.Core.CodeAnnotations` namespace you can easily define your own attribute and it should do the trick as well. Simply create a class called `UmbracoSuppressVolatileAttribute` containing the following code: 
+If you for some reason don't have access to the `Umbraco.Core.CodeAnnotations` namespace you can define your own attribute and it should do the trick as well. Create a class called `UmbracoSuppressVolatileAttribute` containing the following code: 
 
 ```c#
 [AttributeUsage(AttributeTargets.Assembly)]

--- a/Reference/UmbracoVolatile.md
+++ b/Reference/UmbracoVolatile.md
@@ -25,9 +25,9 @@ will do the trick if you don't have access to that specific namespace.
 ~~~
 
 Assume you're trying to use the VolatileMethod which is marked as Volatile, this will throw an Umbraco Volatile Error, 
-however you're just using it in a test and want to suppress the error to a warning.
+however you're only using it in a test and want to suppress the error to a warning.
 
-You simply add the assembly level attribute by adding ```[assembly: UmbracoSuppressVolatile]``` above the namespace in any file within your assembly.
+To supress the error to a warning, add the assembly level attribute by adding ```[assembly: UmbracoSuppressVolatile]``` above the namespace in any file within your assembly.
 
 ~~~c#
 [assembly: UmbracoSuppressVolatile]
@@ -56,4 +56,4 @@ public class UmbracoSuppressVolatileAttribute : Attribute
 }
 ~~~
 
-Now just use at as described in the previous section and your project will build again.
+Use at as described in the previous section and your project will build again.

--- a/Reference/UmbracoVolatile.md
+++ b/Reference/UmbracoVolatile.md
@@ -8,7 +8,7 @@ you can use an assembly level attribute called ```UmbracoSuppressVolatile```, wh
 any occurrences of Umbraco Volatile Error will be suppressed to a warning. 
 
 
-```UmbracoSuppressVolatile``` is located in the ```Umbraco.Core.CodeAnnotations```, however any attribute named UmbracoSuppressVolatile 
+`UmbracoSuppressVolatile` is located in the `Umbraco.Core.CodeAnnotations`, however, any attribute named UmbracoSuppressVolatile 
 will do the trick, if you don't have access to that specific namespace. 
 
 ## Example of suppresing Umbraco Volatile Error

--- a/Reference/UmbracoVolatile.md
+++ b/Reference/UmbracoVolatile.md
@@ -24,7 +24,7 @@ will do the trick, if you don't have access to that specific namespace.
     }
 ~~~
 
-Assume you're trying to use the VolatileMethod which is marked as Volatile, this will throw an Umbraco Volatile Error, 
+Assume you're trying to use the VolatileMethod which is marked as Volatile. This will throw an Umbraco Volatile Error, 
 however you're only using it in a test and want to suppress the error to a warning.
 
 To supress the error to a warning, add the assembly level attribute by adding ```[assembly: UmbracoSuppressVolatile]``` above the namespace in any file within your assembly.


### PR DESCRIPTION
Added a document about Umbraco Volatile Error, currently it shouldn't be available in the menu since it's not finished yet, however we need somewhere to link to from the error tooltip.