### PR TITLE
Remove 15 hostnames mention

### DIFF
--- a/Umbraco-Cloud/Set-Up/Manage-Hostnames/index.md
+++ b/Umbraco-Cloud/Set-Up/Manage-Hostnames/index.md
@@ -27,8 +27,6 @@ Under *Settings* in the Umbraco Cloud Portal, you'll find **Hostnames**. This is
 
 You can bind any hostname to your project environments. Keeping in mind, of course, that the hostname will need to have a DNS entry so that it resolves to the Umbraco Cloud service.
 
-You can bind a total of 15 hostnames to each Umbraco Cloud environments.
-
 Once you add a hostname to one of your environments make sure to update the hostname DNS entry to resolve to the umbraco.io service. We recommend setting an ALIAS record for your root hostname (e.g. mysite.s1.umbraco.io), rather than an A record for the umbraco.io service IP address - 23.100.15.180. Check with your DNS host or hostname registrar for details on how to configure this for your hostnames.
 
 You will also have to specify the hostname for each root node if you are using a multisite setup.


### PR DESCRIPTION
Removed the mention that you can add up to 15 hostnames to a cloud plan. This is now dependent on the cloud plan you have purchased.