### PR TITLE
Change javascript example code language

### DIFF
--- a/Umbraco-Heartcore/Getting-Started-Cloud/Preview/index.md
+++ b/Umbraco-Heartcore/Getting-Started-Cloud/Preview/index.md
@@ -60,7 +60,7 @@ The Preview API is always protected and will require an API Key.
 
 If you are using the [Node JS Client](https://github.com/umbraco/Umbraco.Headless.Client.NodeJs) you set `preview: true`, set an `apiKey` as shown below, this switches all of the `client.delivery` functions to use the Preview API instead of the Content Delivery API.
 
-```typescript
+```javascript
 import {Client} from '@umbraco/headless-client'
 
 const client = new Client({


### PR DESCRIPTION
Noticed the code sample for the typescript/javascript example wasn't highlighted on [this page](https://our.umbraco.com/documentation/Umbraco-Heartcore/Getting-Started-Cloud/Preview/) as our apparently doesn't support typescript as a language. I changed the language to javascript instead as there's no typescript specific code anyway.