### PR TITLE
Remove broken styleguide rule

### DIFF
--- a/.github/valeStyle/Terms.yml
+++ b/.github/valeStyle/Terms.yml
@@ -6,7 +6,6 @@ ignorecase: true
 swap:
   back office: "'backoffice'"
   back-office: "'backoffice'" 
-  app_plugins: "'App_Plugins'"
   blacklist: "'deny list'"
   whitelist: "'allow list'"
   black list: "'deny list'"


### PR DESCRIPTION
Just copied the Vale rules into a different repo and noticed this App Plugins rule a bunch of places. The idea to capitalize it is good, but this ruleset is meant more for wrong terms or spaces, hyphens, etc. 

The rule has this line: `ignorecase: true`, which means this rule will always trigger and will never be "correct".

If you want a seperate rule to check for correct casing of terms I can add that, just let me know 🙂

