### PR TITLE
Update the Block List documentation to show how to add an angularJS controller

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
@@ -244,7 +244,7 @@ angular.module("umbraco").controller("customBlockController", function ($scope) 
 }
 ```
 #### Example: Displaying an image from a Media Picker
-Your block may enable you to 'pick' an image for use as the background for a particular block or to display as part of the block layout, but if you try to display this image directly in the view from the property `block.data.image` you'll see the unique id and not the image.
+Your block may enable you to 'pick' an image for use as the background for a particular block or to display as part of the block layout. If you try to display this image directly in the view from the property `block.data.image` you'll see the unique id and not the image.
 
 We'll need to use the Id in our custom angularJS controller to get the ImageUrl to display in our Backoffice Block Editor View.
 

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
@@ -249,7 +249,7 @@ Your block may enable you to 'pick' an image for use as the background for a par
 We'll need to use the Id in our custom angularJS controller to get the ImageUrl to display in our Backoffice Block Editor View.
 
 With the setup of files above, we would amend our customBlock.controller.js file, injecting the mediaResource to retrieve the image from the id:
-```
+```javascript
 angular.module("umbraco").controller("customBlockController", function ($scope, mediaResource) {
 
     //your property is called image so the following will contain the udi:

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
@@ -212,7 +212,7 @@ If you'd like to display properties of `settings`, you can access these by `bloc
 ### Adding custom implementation to your View
 
 To achieve this you need to add a custom angularJS controller to your custom view, using the ng-controller attribute:
-```
+```html
 <div ng-controller="customBlockController" ng-click="block.edit()"> 
     <h2 ng-bind="block.data.headline"></h2>
     <p ng-bind="block.data.description"></p>
@@ -288,7 +288,6 @@ angular.module("umbraco").controller("customBlockController", function ($scope, 
     });    
 });
 ```
-
 
 
 

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
@@ -209,4 +209,86 @@ The following example displays the property with the alias `headline` together w
 
 If you'd like to display properties of `settings`, you can access these by `block.settingsData.myPropertyAlias`.
 
-See this forum post to [display an image or add other custom behaviour to your custom backoffice view](https://our.umbraco.com/forum/using-umbraco-and-getting-started/103560-image-in-custom-block-editor-view#comment-323696).
+### Adding custom implementation to your View
+
+To achieve this you need to add a custom angularJS controller to your custom view, using the ng-controller attribute:
+```
+<div ng-controller="customBlockController" ng-click="block.edit()"> 
+    <h2 ng-bind="block.data.headline"></h2>
+    <p ng-bind="block.data.description"></p>
+</div>
+```
+
+Create a folder inside the App_Plugins folder called 'CustomBlockView' or something more meaningful for your implementation.
+
+Inside this folder create two files, one called package.manifest that contains the following:
+```
+{
+  "javascript": [
+    "~/App_Plugins/CustomBlockView/customBlock.controller.js"    
+  ]  
+}
+```
+Umbraco will parse all package.manifest files and load any resources they reference into the backoffice during startup.
+
+and secondly add a javascript file called
+
+**customBlock.controller.js**
+
+(to match the file referenced in your package.manifest file)
+
+this file then should register your 'customBlockController' mentioned in your view ng-controller attribute with Umbraco's angular module's controllers
+```
+angular.module("umbraco").controller("customBlockController", function ($scope) {
+// you can do your custom functionality here!
+}
+```
+#### Example: Displaying an image from a Media Picker
+Your block may enable you to 'pick' an image for use as the background for a particular block or to display as part of the block layout, but if you try to display this image directly in the view from the property `block.data.image` you'll see the unique id and not the image.
+
+We'll need to use the Id in our custom angularJS controller to get the ImageUrl to display in our Backoffice Block Editor View.
+
+With the setup of files above, we would amend our customBlock.controller.js file, injecting the mediaResource to retrieve the image from the id:
+```
+angular.module("umbraco").controller("customBlockController", function ($scope, mediaResource) {
+
+    //your property is called image so the following will contain the udi:
+        var imageUdi = $scope.block.data.image;
+    //the mediaResource has a getById method:
+        mediaResource.getById(imageUdi)
+            .then(function (media) {
+                console.log(media);
+                //set a property on the 'scope' called imageUrl for the returned media object's mediaLink
+                $scope.imageUrl = media.MediaLink;
+    });    
+});
+```
+Update the View to use the 'imageUrl' property to display the image:
+
+```
+<div ng-controller="customBlockController" ng-click="block.edit()">
+    <h2 ng-bind="block.data.headline"></h2>
+    <img src="{{imageUrl}}" />
+    <p ng-bind="block.data.description"></p>
+</div>
+```
+If you need to use a specific crop, you can inject the `imageUrlGeneratorResource` resource, which has a `getCropUrl(mediaPath, width, height, imageCropMode, animationProcessMode)` method:
+```
+angular.module("umbraco").controller("customBlockController", function ($scope, mediaResource,imageUrlGeneratorResource) {
+
+    //your property is called image so the following will contain the udi:
+        var imageUdi = $scope.block.data.image;
+    //the mediaResource has a getById method:
+        mediaResource.getById(imageUdi)
+            .then(function (media) {
+                imageUrlGeneratorResource.getCropUrl(media.mediaLink, 150, 150).then(function (cropUrl) {
+                console.log(cropUrl);
+                $scope.imageUrl = cropUrl;
+            });
+    });    
+});
+```
+
+
+
+

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
@@ -221,7 +221,7 @@ To achieve this you need to add a custom angularJS controller to your custom vie
 
 Create a folder inside the App_Plugins folder called 'CustomBlockView' or something more meaningful for your implementation.
 
-Inside this folder create two files, one called package.manifest that contains the following:
+Inside this folder create two files,. The first file should be called package.manifest that contain the following:
 ```
 {
   "javascript": [
@@ -288,6 +288,5 @@ angular.module("umbraco").controller("customBlockController", function ($scope, 
     });    
 });
 ```
-
 
 

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
@@ -237,7 +237,7 @@ The second file should be a javascript file called
 
 (to match the file referenced in your package.manifest file)
 
-this file then should register your 'customBlockController' mentioned in your view ng-controller attribute with Umbraco's angular module's controllers
+This file then should register your 'customBlockController' mentioned in your view ng-controller attribute with Umbraco's angular module's controllers
 ```
 angular.module("umbraco").controller("customBlockController", function ($scope) {
 // you can do your custom functionality here!
@@ -288,4 +288,3 @@ angular.module("umbraco").controller("customBlockController", function ($scope, 
     });    
 });
 ```
-

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
@@ -273,7 +273,7 @@ Update the View to use the 'imageUrl' property to display the image:
 </div>
 ```
 If you need to use a specific crop, you can inject the `imageUrlGeneratorResource` resource, which has a `getCropUrl(mediaPath, width, height, imageCropMode, animationProcessMode)` method:
-```
+```javascript
 angular.module("umbraco").controller("customBlockController", function ($scope, mediaResource,imageUrlGeneratorResource) {
 
     //your property is called image so the following will contain the udi:

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
@@ -231,7 +231,7 @@ Inside this folder create two files,. The first file should be called package.ma
 ```
 Umbraco will parse all package.manifest files and load any resources they reference into the backoffice during startup.
 
-and secondly add a javascript file called
+The second file should be a javascript file called
 
 **customBlock.controller.js**
 
@@ -288,5 +288,4 @@ angular.module("umbraco").controller("customBlockController", function ($scope, 
     });    
 });
 ```
-
 

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
@@ -238,7 +238,7 @@ The second file should be a javascript file called
 (to match the file referenced in your package.manifest file)
 
 This file then should register your 'customBlockController' mentioned in your view ng-controller attribute with Umbraco's angular module's controllers
-```
+```javascript
 angular.module("umbraco").controller("customBlockController", function ($scope) {
 // you can do your custom functionality here!
 }

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
@@ -222,7 +222,7 @@ To achieve this you need to add a custom angularJS controller to your custom vie
 Create a folder inside the App_Plugins folder called 'CustomBlockView' or something more meaningful for your implementation.
 
 Inside this folder create two files,. The first file should be called package.manifest that contain the following:
-```
+```json
 {
   "javascript": [
     "~/App_Plugins/CustomBlockView/customBlock.controller.js"    


### PR DESCRIPTION
 to the backoffice view

with example to display an image from a media picker