### PR TITLE
Adding page about resolving the "connection forcibly closed" error

### DIFF
--- a/Umbraco-Cloud/Troubleshooting/Deployments/Connection-Forcibly/index.md
+++ b/Umbraco-Cloud/Troubleshooting/Deployments/Connection-Forcibly/index.md
@@ -5,11 +5,12 @@ versionFrom: 7.0.0
 # Error: "An existing connection was forcibly closed by the remote host"
 
 Sometimes you will get an error that looks like this:
-
-    System.Net.Sockets.SocketException: An existing connection was forcibly closed by the remote host
-    System.IO.IOException: Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host.
-    System.Net.WebException: The underlying connection was closed: An unexpected error occurred on a send.
-    System.Net.Http.HttpRequestException: An error occurred while sending the request.
+```xml
+System.Net.Sockets.SocketException: An existing connection was forcibly closed by the remote host
+System.IO.IOException: Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host.
+System.Net.WebException: The underlying connection was closed: An unexpected error occurred on a send.
+System.Net.Http.HttpRequestException: An error occurred while sending the request.
+```
 
 This error indicates that your local environment can not connect to your Umbraco Cloud environment due to a socket exception. Since all Umbraco Cloud connections runs on TLS 1.2, your project will have to support this as well. TLS 1.2 is only supported in the .Net Framework 4.6+.
 

--- a/Umbraco-Cloud/Troubleshooting/Deployments/Connection-Forcibly/index.md
+++ b/Umbraco-Cloud/Troubleshooting/Deployments/Connection-Forcibly/index.md
@@ -16,4 +16,10 @@ This error indicates that your local environment can not connect to your Umbraco
 
 ## How to fix your connection error
 
-To resolve the issue, locate the two `targetFramework` properties in your `web.config` file. Update these to a .Net version higher than 4.6 - preferably 4.7.2. Note that you will need to have the runtime of your new .Net version, installed on your computer in order to run the project locally. [You can download all .Net run times from Microsoft right here](https://dotnet.microsoft.com/download).
+To resolve the issue, please follow the following two steps:
+1. Locate the two `targetFramework` properties in your `Web.config` file.
+2. Update these to a .Net version higher than 4.6 - preferably 4.7.2. 
+
+:::note
+You will need to have the runtime of your new .Net version, installed on your computer in order to run the project locally. [You can download all .Net run times from Microsoft right here](https://dotnet.microsoft.com/download).
+:::

--- a/Umbraco-Cloud/Troubleshooting/Deployments/Connection-Forcibly/index.md
+++ b/Umbraco-Cloud/Troubleshooting/Deployments/Connection-Forcibly/index.md
@@ -1,0 +1,18 @@
+---
+versionFrom: 7.0.0
+---
+
+# "An existing connection was forcibly closed by the remote host" error
+
+Sometimes you will get an error that looks like this:
+
+    System.Net.Sockets.SocketException: An existing connection was forcibly closed by the remote host
+    System.IO.IOException: Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host.
+    System.Net.WebException: The underlying connection was closed: An unexpected error occurred on a send.
+    System.Net.Http.HttpRequestException: An error occurred while sending the request.
+
+This error indicates that your local environment can not connect to your Umbraco Cloud environment due to a socket exception. Since all Umbraco Cloud connections runs on TLS 1.2, your project will have to support this as well. TLS 1.2 is only supported in the .Net Framework 4.6+.
+
+## How to fix your connection error
+
+To resolve the issue, locate the two `targetFramework` properties in your `web.config` file. Update these to a .Net version higher than 4.6 - preferably 4.7.2. Note that you will need to have the runtime of your new .Net version, installed on your computer in order to run the project locally. [You can download all .Net run times from Microsoft right here](https://dotnet.microsoft.com/download).

--- a/Umbraco-Cloud/Troubleshooting/Deployments/Connection-Forcibly/index.md
+++ b/Umbraco-Cloud/Troubleshooting/Deployments/Connection-Forcibly/index.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 ---
 
-# "An existing connection was forcibly closed by the remote host" error
+# Error: "An existing connection was forcibly closed by the remote host"
 
 Sometimes you will get an error that looks like this:
 

--- a/Umbraco-Cloud/Troubleshooting/Deployments/index.md
+++ b/Umbraco-Cloud/Troubleshooting/Deployments/index.md
@@ -24,6 +24,7 @@ The most common Content [Transfer](../../Deployment/Content-Transfer) / [Restore
 * [SQL Timeouts](Deploy-Settings)
 * [Dependency Exception](Dependency-Exceptions)
 * [Media path too long](Path-too-long-exception)
+* [An existing connection was forcibly closed by the remote host](Connection-Forcibly)
 
 
 ### Issues when using third party packages


### PR DESCRIPTION
This is a pretty common, but still undocumented error that Umbraco Cloud users will see if they're running on a .net version prior to 4.6. This can hopefully help some people resolve this :-)