### PR TITLE
Added detail to how different "Lifetimes" work

### DIFF
--- a/Implementation/Services/index.md
+++ b/Implementation/Services/index.md
@@ -346,28 +346,30 @@ namespace Umbraco8.Composers
     {
         public void Compose(Composition composition)
         {
-            // if your service makes use of the current UmbracoContext, eg AssignedContentItem - register the service in Request scope
+            // if your service makes use of the current UmbracoContext, eg AssignedContentItem - register the service using the 'Request' or 'Scope' lifetimes
             // composition.Register<ISiteService, SiteService>(Lifetime.Request);
-            // if not then it is better to register in 'Singleton' Scope
+            // if not then it is better to register using the 'Singleton' lifetime
             composition.Register<ISiteService, SiteService>(Lifetime.Singleton);
         }
     }
 }
 ```
 
-#### Lifespans
+#### Lifetimes
 
 **"Transient"** services can be injected into "Transient" and below ⤵. (i.e. "Transient" services can be injected anywhere)
 
 - "Transient" means that anytime this type is needed a brand new instance of this type will be created.
 
+**"Request"** services can be injected into "Request"/"Scope" based lifetimes only
+- "Request" based lifetime is very similar to the "Transient" lifetime - anytime this type is needed a brand new instance of this type will be created. The difference between "Request" and "Transient" is that, with "Request", the instance will be disposed of at the end of the current HttpRequest.
+
+**"Scope"** services can be injected into "Request"/"Scope" based lifetimes only
+- "Scope" means that a single instance of this type will be created for the duration of the current HttpRequest. The instance will be disposed of at the end of the current HttpRequest.
+
 **"Singleton"** services can be injected into "Singletons" and below ⤵.
 
 - "Singleton" means that only a single instance of this type will ever be created for the lifetime of the application.
-
-**"Request"** services can be injected into "Request" based lifespans only
-
-- "Request" based lifetime means anytime this type is needed one new instance of this type will be created for the duration of the current HttpRequest. The object will be disposed of at the end of the current HttpRequest.
 
 #### Implementing the service
 

--- a/Reference/Using-Ioc/index.md
+++ b/Reference/Using-Ioc/index.md
@@ -48,20 +48,30 @@ The `Lifetime` supports:
 ```csharp
 public enum Lifetime
 {
-    // Always get a new instance.
-    // This is the default lifetime.
+    // Always creates a new instance
+    // This is the default lifetime
     Transient = 0,
 
-    //One unique instance per request.
+    // One unique instance per request (or per "injection")
     Request = 1,
 
-    // One unique instance per scope.
+    // One unique instance per scope (or per "web request")
     Scope = 2,
 
-    // One unique instance per container.
+    // One unique instance per container (or per "application")
     Singleton = 3
 }
 ```
+* `Lifetime.Transient` - always creates a new instance:
+    * A new instance will get created each time it is injected.
+* `Lifetime.Request` - always creates a new instance:
+    * A new instance will get created each time it is injected.  Instances will get disposed at the end of a web request.
+    * Purely used to dispose objects created during a request at the end of the request, this does **not** mean they'll only be created once per web request.
+* `Lifetime.Scope` - one unique instance per web request (or "scope"):
+    * Only creates one instance per web request.  Instances will get disposed at the end of a web request.
+    * e.g. if you wanted to create a single instance of a database context to be used in multiple places within a single web request.
+* `Lifetime.Singleton` - one unique instance for the whole web application:
+    * The single instance will be shared across all web requests.
 
 ## Injecting dependencies
 

--- a/Reference/Using-Ioc/index.md
+++ b/Reference/Using-Ioc/index.md
@@ -69,7 +69,7 @@ public enum Lifetime
     * Purely used to dispose objects created during a request at the end of the request, this does **not** mean they'll only be created once per web request.
 * `Lifetime.Scope` - one unique instance per web request (or "scope"):
     * Only creates one instance per web request.  Instances will get disposed at the end of a web request.
-    * e.g. if you wanted to create a single instance of a database context to be used in multiple places within a single web request.
+    * E.g. if you wanted to create a single instance of a database context to be used in multiple places within a single web request.
 * `Lifetime.Singleton` - one unique instance for the whole web application:
     * The single instance will be shared across all web requests.
 


### PR DESCRIPTION
I recently used `Lifetime.Request`, assuming that this is would create a new instance per web-request.  I remember looking at the docs and having to make a guess, and went with `Lifetime.Request` because it sounded the most similar to "web request".  It turned out I actually should have used `Lifetime.Scope`.

This is because the terminology is based on Lightinject (which uses "Request" and "Scope" lifetimes), which is confusing in the context of a web application - this was [highlighted and clarified with Lightinject](https://github.com/seesharper/LightInject/issues/494) by @Shazwazza last year.  It looks like other people have also made the same mistake as me judging by [a forum post I came across](https://our.umbraco.com/forum/umbraco-8/98389-iusercomposer-with-lifetimerequest-works-as-lifetimetransient) which helped me solve my issue.

This PR is to update the IoC docs to add more information around the differences between the different lifetimes for those unfamiliar with the nuances in the terminology (and also for "future me" when I come to look into this again next time I'm setting up the DI for a new project!).