### PR TITLE
Added documentation for editorService

### DIFF
--- a/Reference/Angular/Services/editorService/Index.md
+++ b/Reference/Angular/Services/editorService/Index.md
@@ -1,0 +1,83 @@
+# Editor Service
+
+In Umbraco 8, the Angular `editorService` service is the primary resource used for opening overlays and handling infinite editing. Besides the `open` and `close` functions, the service also contains functions for opening specialized overlays/editors - eg. `contentPicker` or `mediaPicker`.
+
+### Content Picker
+
+The `contentPicker` function opens a content picker in infinite editing. Depending on the options, it may be used for picking a single content item or a set of content items. Options for the function is as following:
+
+| Alias           | Description |
+|-----------------|-------------|
+| **multiPicker** | Indicates a boolean value for whether the editor should work as a single content picker (`false`) or a multi content picker (`true`). |
+| **submit**      | Is a callback function for then the user selects and submits one or more content items.  |
+| **close**       | Is a callback function when the close button is clicked. |
+
+The content picker could be opened as:
+
+```js
+editorService.contentPicker({
+    multiPicker: true,
+    submit: function(model) {
+        model.selection.forEach(item, function() {
+            console.log(item.name);
+        });
+        editorService.close();
+    },
+    close: function() {
+        editorService.close();
+    }
+});
+```
+
+This example snippet will open a new multi content picker. If the user submits one or more content items, the name of each content item will be printed to to the console. The user may also close the content picker without selecting any content items, in which case the `close` callback function is invoked.
+
+
+
+
+
+### Document Type Editor
+
+The `documentTypeEditor` function of the editor service can be used for opening a new overlay for either creating a new document type or editing an existing document type.
+
+The function supports the following options:
+
+| Alias          | Description |
+|----------------|-------------|
+| **id**         | Indicates the numeric ID of the document type which should be opened for editing.  |
+| **create**     | A boolean value indicating whether the overlay should be used for creating a new document type (opposed to editing an existing document type). |
+| **noTemplate** | When part of a create overlay, this option specifies whether the document type should be created without a corresponding template. |
+| **submit**     | A callback function for when the user submits/saves the document type. |
+| **close**      | A callback function for when the close button is clicked. |
+
+An overlay for creating a new document type may be opened as:
+
+```javascript
+editorService.documentTypeEditor({
+    id: -1,
+    create: true,
+    submit: function (model) {
+        console.log(model.documentTypeAlias);
+	    editorService.close();
+    },
+    close: function () {
+        editorService.close();
+    }
+});
+```
+
+Notice that both the `id` and `create` options must be specified. When the overlay submits, you'll be able to get the alias of the created document type through `model.documentTypeAlias`.
+
+Opening an overlay for editing an existing document type can be opened as:
+
+```javascript
+editorService.documentTypeEditor({
+    id: 1103,
+    submit: function (model) {
+        console.log(model.documentTypeAlias);
+        editorService.close();
+    },
+    close: function () {
+        editorService.close();
+    }
+});
+```

--- a/Reference/Angular/Services/editorService/Index.md
+++ b/Reference/Angular/Services/editorService/Index.md
@@ -8,7 +8,7 @@ The `contentPicker` function opens a Content Picker in infinite editing. Dependi
 
 | Alias           | Description |
 |-----------------|-------------|
-| **multiPicker** | Indicates a boolean value for whether the editor should work as a single content picker (`false`) or a multi content picker (`true`). |
+| **multiPicker** | Indicates a boolean value for whether the editor should work as a single Content Picker (`false`) or a Multi Content Picker (`true`). |
 | **submit**      | Is a callback function for then the user selects and submits one or more content items.  |
 | **close**       | Is a callback function when the close button is clicked. |
 

--- a/Reference/Angular/Services/editorService/Index.md
+++ b/Reference/Angular/Services/editorService/Index.md
@@ -29,7 +29,7 @@ editorService.contentPicker({
 });
 ```
 
-This example snippet will open a new multi content picker. If the user submits one or more content items, the name of each content item will be printed to to the console. The user may also close the content picker without selecting any content items, in which case the `close` callback function is invoked.
+This example snippet will open a new Multi Content Picker. If the user submits one or more content items, the name of each content item will be printed to the console. The user may also close the Content Picker without selecting any content items, in which case the `close` callback function is invoked.
 
 
 

--- a/Reference/Angular/Services/editorService/Index.md
+++ b/Reference/Angular/Services/editorService/Index.md
@@ -43,10 +43,10 @@ The function supports the following options:
 
 | Alias          | Description |
 |----------------|-------------|
-| **id**         | Indicates the numeric ID of the document type which should be opened for editing.  |
-| **create**     | A boolean value indicating whether the overlay should be used for creating a new document type (opposed to editing an existing document type). |
-| **noTemplate** | When part of a create overlay, this option specifies whether the document type should be created without a corresponding template. |
-| **submit**     | A callback function for when the user submits/saves the document type. |
+| **id**         | Indicates the numeric ID of the Document Type which should be opened for editing.  |
+| **create**     | A boolean value indicating whether the overlay should be used for creating a new Document Type (opposed to editing an existing Document Type). |
+| **noTemplate** | When part of a create-overlay, this option specifies whether the Document Type should be created without a corresponding Template. |
+| **submit**     | A callback function for when the user submits/saves the Document Type. |
 | **close**      | A callback function for when the close button is clicked. |
 
 An overlay for creating a new document type may be opened as:

--- a/Reference/Angular/Services/editorService/Index.md
+++ b/Reference/Angular/Services/editorService/Index.md
@@ -49,7 +49,7 @@ The function supports the following options:
 | **submit**     | A callback function for when the user submits/saves the Document Type. |
 | **close**      | A callback function for when the close button is clicked. |
 
-An overlay for creating a new document type may be opened as:
+An overlay for creating a new Document Type may be opened as:
 
 ```javascript
 editorService.documentTypeEditor({

--- a/Reference/Angular/Services/editorService/Index.md
+++ b/Reference/Angular/Services/editorService/Index.md
@@ -4,7 +4,7 @@ The Angular `editorService` service is the primary resource used for opening ove
 
 ### Content Picker
 
-The `contentPicker` function opens a content picker in infinite editing. Depending on the options, it may be used for picking a single content item or a set of content items. Options for the function is as following:
+The `contentPicker` function opens a Content Picker in infinite editing. Depending on the options, it may be used for picking a single content item or a set of content items. Options for the function is as following:
 
 | Alias           | Description |
 |-----------------|-------------|

--- a/Reference/Angular/Services/editorService/Index.md
+++ b/Reference/Angular/Services/editorService/Index.md
@@ -12,7 +12,7 @@ The `contentPicker` function opens a Content Picker in infinite editing. Dependi
 | **submit**      | Is a callback function for then the user selects and submits one or more content items.  |
 | **close**       | Is a callback function when the close button is clicked. |
 
-The content picker could be opened as:
+The Content Picker could be opened as:
 
 ```js
 editorService.contentPicker({

--- a/Reference/Angular/Services/editorService/Index.md
+++ b/Reference/Angular/Services/editorService/Index.md
@@ -37,7 +37,7 @@ This example snippet will open a new Multi Content Picker. If the user submits o
 
 ### Document Type Editor
 
-The `documentTypeEditor` function of the editor service can be used for opening a new overlay for either creating a new document type or editing an existing document type.
+The `documentTypeEditor` function of the editor service can be used for opening a new overlay for either creating a new Document Type or editing an existing Document Type.
 
 The function supports the following options:
 

--- a/Reference/Angular/Services/editorService/Index.md
+++ b/Reference/Angular/Services/editorService/Index.md
@@ -65,9 +65,9 @@ editorService.documentTypeEditor({
 });
 ```
 
-Notice that both the `id` and `create` options must be specified. When the overlay submits, you'll be able to get the alias of the created document type through `model.documentTypeAlias`.
+Notice that both the `id` and `create` options must be specified. When the overlay submits, you'll be able to get the alias of the created Document Type through `model.documentTypeAlias`.
 
-Opening an overlay for editing an existing document type can be opened as:
+Opening an overlay for editing an existing Document Type can be opened as:
 
 ```javascript
 editorService.documentTypeEditor({

--- a/Reference/Angular/Services/editorService/Index.md
+++ b/Reference/Angular/Services/editorService/Index.md
@@ -1,6 +1,6 @@
 # Editor Service
 
-In Umbraco 8, the Angular `editorService` service is the primary resource used for opening overlays and handling infinite editing. Besides the `open` and `close` functions, the service also contains functions for opening specialized overlays/editors - eg. `contentPicker` or `mediaPicker`.
+The Angular `editorService` service is the primary resource used for opening overlays and handling infinite editing. Besides the `open` and `close` functions, the service also contains functions for opening specialized overlays/editors - eg. `contentPicker` or `mediaPicker`.
 
 ### Content Picker
 

--- a/Reference/Angular/Services/index.md
+++ b/Reference/Angular/Services/index.md
@@ -1,4 +1,7 @@
 # Services
 
+- [**Editor service**](editorService/)  
+  Service for opening and working with editors and overlays.
+
 - [**Events service**](eventsService/)  
   Service for listening for and sending broadcasts.

--- a/Reference/Angular/index.md
+++ b/Reference/Angular/index.md
@@ -11,4 +11,5 @@ Generally you can find information about these via the [Backoffice UI API docume
 
 ## Services
 
+- [Editor service](Services/editorService/)
 - [Events service](Services/eventsService/)


### PR DESCRIPTION
Started on this a while back, so while most of the functions aren't described, here is documentation for the `contentPicker` and `documentTypeEditor` functions.