### PR TITLE
Heartcore GraphQL filtering, ordering and paging

### DIFF
--- a/Umbraco-Heartcore/API-Documentation/GraphQL/Filtering-and-Ordering/index.md
+++ b/Umbraco-Heartcore/API-Documentation/GraphQL/Filtering-and-Ordering/index.md
@@ -1,0 +1,221 @@
+---
+versionFrom: 8.0.0
+meta.Title: "Filtering content in Umbraco Heartcore with GraphQL"
+meta.Description: "Documentation for GraphQL filtering in Umbraco Heartcore."
+---
+
+# Introduction
+
+The GraphQL API allows for filtering and ordering root and traversion collections (ancestors, children and descendants).
+
+For information on the different filters available and how the filter ad order types are generated see [Schema Generation](../Schema-Generation#filtering).
+
+## Using filters
+
+To start filtering the content, an `where` argument can be passed to the collection query. E.g. to find all products where it's price is higher that 100 we can write the following query.
+
+```graphql
+query {
+  allProduct(
+    where: {
+      price_gte: 100
+    }
+  ) {
+    edges {
+      node {
+        name
+        price
+      }
+    }
+  }
+}
+```
+
+Filters can be combined with `AND` and `OR`, e.g. if we want to find all content on level `2` or `3` that is updated after `2020-03-13` we write the following query.
+
+```graphql
+query {
+  allContent(
+    where {
+      AND: [
+        { level_any: [2, 3] }
+        { updateDate_gt: "2020-09-13" }
+      ]
+    }
+  ) {
+    edges {
+      node {
+        name
+      }
+    }
+  }
+}
+```
+
+Or if we want to get all of type person which names does not start with `t` we can write the following query.
+
+```graphql
+query {
+  allContent(
+    where {
+      NOT: [
+        { name_starts_with: `t` }
+      ]
+    }
+  ) {
+    edges {
+      node {
+        name
+      }
+    }
+  }
+}
+```
+
+We can combine `AND`, `OR` and `NOT` in a single query e.g. if we wan't to get all content on level `1` or `2` that does not start with `b` or `j` we can write the following query.
+
+```graphql
+query {
+  allContent(
+    where: {
+      AND: [
+        { level_any: [1, 2] }
+        {
+          NOT: [
+            {
+              OR: [
+                { name_starts_with: "b" }
+                { name_starts_with: "j" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ) {
+    edges {
+      node {
+        name
+      }
+    }
+  }
+}
+```
+
+## Ordering
+
+The collection can also be sorted by passing the `orderBy` argument to the query.
+
+If `orderBy` is not specified the collections are ordered by `path` which is the order they apear in, in the Umbraco Backoffice tree.
+
+Lets say we wan't to show all our products ordered by price in ascending order, we can write the following query.
+
+```graphql
+query {
+  allProduct(
+    orderBy: price_ASC
+  ) {
+    edges {
+      node {
+        name
+      }
+    }
+  }
+}
+```
+
+We can even add multiple values to the `orderBy` argument to order by multiple fields. E.g. if we want to order products by price and then by name, we write the following query.
+
+```graphql
+query {
+  allProduct(
+    orderBy: [ price_ASC, name_ASC ]
+  ) {
+    edges {
+      node {
+        name
+        price
+      }
+    }
+  }
+}
+```
+
+## Paging
+
+We can also limit the number of results returned by paging. To achive this one can use `first` and `after` to do forward paging and `last` and `before` to do backward paging.
+
+The cursor can be obtained by including the `cursor` field on an edge e.g. to get the first `50` products we can write the following query.
+
+```graphql
+query {
+  allProduct(
+    first: 50
+  ) {
+    edges {
+      cursor
+      node {
+        name
+        price
+      }
+    }
+  }
+}
+```
+
+We can then use the `cursor` from the last item to get items that appear after that one. We can also request the `PageInfo` object which holds information on the start and end cursors and if there are more pages.
+
+:::note
+`first` can only be used in combination with `after`, and `last` can only used with `before`.
+
+Also `hasNextPage` is only populated when doing forward paging and `hasPreviousPage` is populated when doing backward paging.
+:::
+
+```graphql
+query {
+  allProduct(
+    first: 50
+  ) {
+    edges {
+      cursor
+      node {
+        name
+        price
+      }
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+  }
+}
+```
+
+## Combining filter, order and paging
+
+Everything shown up untill now can be combined in a single query, the following query will get the first 50 products where the `price` is greater than `100` and order the result in ascending order by `price` and then by `name`.
+
+
+```graphql
+query {
+  allProduct(
+    first: 50
+    where: {
+      price_gte: 100
+    }
+    orderBy: [price_ASC, name_ASC]
+  ) {
+    edges {
+      cursor
+      node {
+        name
+        price
+      }
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+  }
+}
+```

--- a/Umbraco-Heartcore/API-Documentation/GraphQL/index.md
+++ b/Umbraco-Heartcore/API-Documentation/GraphQL/index.md
@@ -56,3 +56,7 @@ Information on how the GraphQL schema is generated, reserved names and built-in 
 ## [Property Editors](Property-Editors/)
 
 A list of all the built-in Umbraco Property Editors and their GraphQL types.
+
+## [Filtering and Ordering](Filtering-and-Ordering/)
+
+Documentation on how to filter and order collections with the GraphQL API.

--- a/Umbraco-Heartcore/index.md
+++ b/Umbraco-Heartcore/index.md
@@ -10,6 +10,26 @@ In this section you will find documentation on how to work with Umbraco Heartcor
 
 It includes REST API documentation, the basics on how to get started and how to work with the available Client Libraries. Please note that Umbraco Heartcore is a specific type of project only available via Umbraco Cloud.
 
+## [API Documentation for the Umbraco Heartcore REST API endpoints](API-Documentation/)
+
+Reference documentation for the two APIs available, as well as details about common HTTP headers, versioning, REST Standard and how to work with authentication and authorization.
+
+- [Authentication and Authorization](API-Documentation/#authentication-and-authorization)
+- [Content Delivery API](API-Documentation/Content-Delivery)
+- [Content Management API](API-Documentation/Content-Management)
+- [GraphQL API](API-Documentation/GraphQL)
+
+## GraphQL
+
+Reference documentation and tutorials for the GraphQL API.
+
+- [GraphQL API Documentation](API-Documentation/GraphQL)
+- [GraphQL Filter and Ordering Documentation](API-Documentation/GraphQL/Filtering-and-Ordering)
+
+### Tutorials
+
+- [Querying With GraphQL](Tutorials/Querying-With-GraphQL) - Learn how to query Umbraco Heartcore with GraphQL
+
 ## What is Umbraco Heartcore?
 
 Umbraco Heartcore is a headless SaaS (Software as a Service) offered by Umbraco. The service enables you to create and manage content and media in the Umbraco backoffice and make it available to any - and multiple - platforms, devices, channels etc. in order to distribute your content.
@@ -35,15 +55,6 @@ In this article you will learn how to create your first Umbraco Heartcore projec
 ### Setup a Trial project
 
 <iframe width="800" height="450" src="https://www.youtube.com/embed/VL87NCz5Dwg?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
-
-## [API Documentation for the Umbraco Heartcore REST API endpoints](API-Documentation/)
-
-Reference documentation for the two APIs available, as well as details about common HTTP headers, versioning, REST Standard and how to work with authentication and authorization.
-
-- [Authentication and Authorization](API-Documentation/#authentication-and-authorization)
-- [GraphQL API](API-Documentation/GraphQL)
-- [Content Delivery API](API-Documentation/Content-Delivery)
-- [Content Management API](API-Documentation/Content-Management)
 
 ## [Client libraries](Client-Libraries)
 


### PR DESCRIPTION
Added an article describing how to use GraphQL filtering, ordering and paging.

I've also moved the "API Documentation" links on the landing page to the top of the page, since when you are on our you are most likely looking for documentation and it wasn't easy to spot some of the pages, given they are not visible in the navigation and only accessible from the child pages.

**NOTE** this is targeting https://github.com/umbraco/UmbracoDocs/pull/2817