### PR TITLE
Change meta Umbraco v of the permissions

### DIFF
--- a/Getting-Started/Setup/Server-Setup/permissions.md
+++ b/Getting-Started/Setup/Server-Setup/permissions.md
@@ -1,7 +1,7 @@
 ---
 meta.Title: "Umbraco file and folder permissions"
 meta.Description: "Information on file and folder permissions required for Umbraco sites"
-versionFrom: 7.0.0
+versionFrom: 8.0.0
 ---
 
 # File and folder permissions


### PR DESCRIPTION
There are currently two sets of permissions, https://github.com/umbraco/UmbracoDocs/blob/main/Getting-Started/Setup/Server-Setup/permissions-v7.md and this one which has the v7 folders removed.