### PR TITLE
Fix deeplink

### DIFF
--- a/Getting-Started/Setup/Server-Setup/azure-web-apps-v7.md
+++ b/Getting-Started/Setup/Server-Setup/azure-web-apps-v7.md
@@ -78,7 +78,7 @@ For Umbraco installations that are hosted by Azure Web Apps it is recommend that
 <add key="umbracoLocalTempStorage" value="EnvironmentTemp" />
 ```
 
-This will set Umbraco to store `umbraco.config` and the other Umbraco TEMP files in the environment temporary folder. More info on this setting is available [here](../../../Reference/Config/webconfig/index.md#umbracolocaltempstorage-umbraco-v773)
+This will set Umbraco to store `umbraco.config` and the other Umbraco TEMP files in the environment temporary folder. More info on this setting is available [here](../../../Reference/Config/webconfig/index-v7.md#umbracolocaltempstorage-umbraco-v773)
 
 For **Umbraco v7.6 - v7.7.2**
 


### PR DESCRIPTION
This link didn't work as it tried to find this v7 headline on the v8 document. This change should do it 🙂