### PR TITLE
Update wrong Editor Alias for Umbraco.Integer

### DIFF
--- a/Umbraco-Heartcore/API-Documentation/GraphQL/Property-Editors/index.md
+++ b/Umbraco-Heartcore/API-Documentation/GraphQL/Property-Editors/index.md
@@ -177,7 +177,7 @@ This editor configuration is not supported and will not be present in the genera
 
 ## Numeric
 
-**Editor Alias**: `Umbraco.Numeric`<br>
+**Editor Alias**: `Umbraco.Integer`<br>
 **GraphQL Type**: `Int`
 
 ## Radio button List


### PR DESCRIPTION
Sees there's the Editor Alias of the Numeric field is wrong. It should be `Umbraco.Integer` and not `Umbraco.Numeric`.

https://our.umbraco.com/documentation/getting-started/backoffice/property-editors/built-in-property-editors/Numeric/