### PR TITLE
Update index-vpost8.6.0.md

### DIFF
--- a/Reference/Config/umbracoSettings/index-vpost8.6.0.md
+++ b/Reference/Config/umbracoSettings/index-vpost8.6.0.md
@@ -16,3 +16,8 @@ Here's the default configuration of the `keepAlive` node:
 ```xml
 <keepAlive disableKeepAliveTask="false" keepAlivePingUrl="{umbracoApplicationUrl}/api/keepalive/ping" />
 ```
+
+:::note
+There is an `[OnlyLocalRequests]` attribute which verifies if the request to the KeepAliveController.Ping action came from the local machine.
+If the request is made from an external source, Umbraco will return a HTTP 404 response.
+:::

--- a/Reference/Config/umbracoSettings/index-vpost8.6.0.md
+++ b/Reference/Config/umbracoSettings/index-vpost8.6.0.md
@@ -18,6 +18,7 @@ Here's the default configuration of the `keepAlive` node:
 ```
 
 :::note
-There is an `[OnlyLocalRequests]` attribute which verifies if the request to the KeepAliveController.Ping action came from the local machine.
-If the request is made from an external source, Umbraco will return a HTTP 404 response.
+There is an `[OnlyLocalRequests]` attribute which verifies if the request to the `KeepAliveController.Ping` action came from the local machine.
+
+If the request is made from an external source, Umbraco will return an HTTP 404 response.
 :::


### PR DESCRIPTION
Saw a user try to ping the keepalive URL from an external source. Adding some details about the OnlyLocalRequests attribute to clarify that this is not possible. :) 

Discussion and a link to the OnlyLocalRequests attribute
- https://github.com/umbraco/Umbraco-CMS/pull/7164
- https://github.com/umbraco/Umbraco-CMS/blob/v8/dev/src/Umbraco.Web/WebApi/Filters/OnlyLocalRequestsAttribute.cs