### PR TITLE
Media updates on cloud

### DIFF
--- a/Umbraco-Cloud/Set-Up/Media/Connect-to-Azure-Storage-Explorer/index.md
+++ b/Umbraco-Cloud/Set-Up/Media/Connect-to-Azure-Storage-Explorer/index.md
@@ -4,51 +4,56 @@ versionFrom: 8.0.0
 
 # Connect to Azure Storage Explorer to upload files manually
 
-:::note
-**Important**: All Umbraco 8 projects created after May 6th 2020 will have Azure Blob Storage by default. That means that this guide only applies to your project has been created after May 6th 2020.
-:::
+In case you want to manually upload files to the Azure Blob Storage container provided to your Umbraco Cloud environments, you can take advantage of the "Microsoft Azure Storage Explorer" software.
 
-In case you want to manually upload files to the blob storage provided to your site, you can take advantage of the software "Microsoft Azure Storage Explorer".
+This article provides the steps you need, in order to connect to your Azure Blob Storage containers using Azure Storage Explorer.
 
 :::warning
 **Important**: If you upload your media files manually using this method, they will not be available in the backoffice.
+
+All media needs to be added through the Umbraco backoffice.
 :::
 
 ## Getting the credentials
-The first thing to sort out, if you want to connect to the blob storage of your site is the credentials of your site. You can find the credentials in KUDU (Power Tools) - under the "Environment" section.
 
-In the environment section, we want to locate the "Environment Variables" and find the following three variables: 
+The first thing to sort out, if you want to connect to the Azure Blob Storage container of your environment is the credentials. You can find the credentials in [Kudu (Power Tools)](../../Power-Tools) - under the "Environment" section.
 
-* `APPSETTING_Umbraco.Cloud.StorageProviders.AzureBlob.ContainerName`
-* `APPSETTING_Umbraco.Cloud.StorageProviders.AzureBlob.Endpoint` and 
-* `APPSETTING_Umbraco.Cloud.StorageProviders.AzureBlob.SharedAccessSignature`. 
+In the environment section, we want to locate the "Environment Variables" and find the following three variables:
+
+* `APPSETTING_Umbraco.Cloud.StorageProviders.AzureBlob.ContainerName`,
+* `APPSETTING_Umbraco.Cloud.StorageProviders.AzureBlob.Endpoint`, and
+* `APPSETTING_Umbraco.Cloud.StorageProviders.AzureBlob.SharedAccessSignature`.
 
 Note these down, as we will use them in the upcoming steps.
 
 ## Installing Azure Storage Explorer
-Next order of business is to have Azure Storage Explorer installed on your local computer. [Download the files from this page](https://azure.microsoft.com/en-us/features/storage-explorer/), and install it on your local machine.
+
+Next order of business is to have Azure Storage Explorer installed on your local computer. [Download the files from this page](https://azure.microsoft.com/en-us/features/storage-explorer/), and run through the installer.
 
 ## Connecting to your Azure Blob Storage
-In the following we will use the information you have gathered, and Azure Storage Explorer to get you connected to your Blob storage.
 
-1. Click the "Open connect dialogue" button to get the connect dialogue
+In the following we will use the information you have gathered, and Azure Storage Explorer to get you connected to your Blob storage container.
+
+1. Click the "Open connect dialogue" button to get the Connect dialogue.
 
     ![Connect my machine](images/storage-explorer-connection.png)
 
-2. Select "Use a shared access signature (SAS) URI" in the first prompt
-    
+2. Select "Use a shared access signature (SAS) URI" in the first prompt.
+
     ![Use a shared access signature (SAS) URI](images/select-connection.png)
 
-3. In the URI field, input the information you have gathered earlier in the following format `[Endpoint][ContainerName][SharedAccessSignature]` like the following 
+3. Input the information you have gathered earlier in the following format `[Endpoint][ContainerName][SharedAccessSignature]`, in the URI field. See below for an example.
 
-```
-https://ucmediastoragewelive.blob.core.windows.net/0e6ee123-5q22-1234-8618-ae7d0043710f?sv=2017-04-17&sr=c&si=umbraco&sig=f84%2F%2FRPPirgdzn15a%2BA12345678901%2FXA%3D&spr=https
-```
+    ```xml
+    https://ucmediastoragewelive.blob.core.windows.net/0e6ee123-5q22-1234-8618-ae7d0043710f?sv=2017-04-17&sr=c&si=umbraco&sig=f84%2F%2FRPPirgdzn15a%2BA12345678901%2FXA%3D&spr=https
+    ```
 
-  ![Attach with SAS URI](images/attach-blob.png)
+    ![Attach with SAS URI](images/attach-blob.png)
 
-4. In the "Connection Summary" prompt, ensure that the credentials are correct and press "Connect"
+4. ensure that the credentials are correctly set in the "Connection Summary" prompt.
 
-5. Open the media folder, and you now have access to your blob storage account.
+5. Select "Connect".
+
+6. Open the media folder, and you now have access to the Azure Blob Storage container for your environment.
 
     ![Open media folder](images/storage-explorer-connected.png)

--- a/Umbraco-Cloud/Set-Up/Media/Connect-to-Azure-Storage-Explorer/index.md
+++ b/Umbraco-Cloud/Set-Up/Media/Connect-to-Azure-Storage-Explorer/index.md
@@ -11,6 +11,8 @@ In case you want to manually upload files to the Azure Blob Storage container pr
 This article provides the steps you need, in order to connect to your Azure Blob Storage containers using Azure Storage Explorer.
 
 :::warning
+We strongly recommend that you add all media items to your Cloud environments through the backoffice. Clone your environment to your local machine in order to manage the files of your media library.
+
 **Important**: If you upload your media files manually using this method, they will not be available in the backoffice.
 
 All media needs to be added through the Umbraco backoffice.

--- a/Umbraco-Cloud/Set-Up/Media/Connect-to-Azure-Storage-Explorer/index.md
+++ b/Umbraco-Cloud/Set-Up/Media/Connect-to-Azure-Storage-Explorer/index.md
@@ -28,11 +28,11 @@ Note these down, as we will use them in the upcoming steps.
 
 ## Installing Azure Storage Explorer
 
-Next order of business is to have Azure Storage Explorer installed on your local computer. [Download the files from this page](https://azure.microsoft.com/en-us/features/storage-explorer/), and run through the installer.
+The next order of business is to have Azure Storage Explorer installed on your local computer. [Download the files from this page](https://azure.microsoft.com/en-us/features/storage-explorer/), and run through the installer.
 
 ## Connecting to your Azure Blob Storage
 
-In the following we will use the information you have gathered, and Azure Storage Explorer to get you connected to your Blob storage container.
+In the following, we will use the information you have gathered, and Azure Storage Explorer to get you connected to your Blob storage container.
 
 1. Click the "Open connect dialogue" button to get the Connect dialogue.
 

--- a/Umbraco-Cloud/Set-Up/Media/Connect-to-Azure-Storage-Explorer/index.md
+++ b/Umbraco-Cloud/Set-Up/Media/Connect-to-Azure-Storage-Explorer/index.md
@@ -1,5 +1,7 @@
 ---
-versionFrom: 8.0.0
+versionFrom: 7.0.0
+meta.Title: "Using Azure Storage Explorer with Umbraco Cloud"
+meta.Description: "All Media files for Umbraco Cloud projects are stored in Azure Blob Storage contaiers. Each environment has a separate container linked to it."
 ---
 
 # Connect to Azure Storage Explorer to upload files manually

--- a/Umbraco-Cloud/Set-Up/Media/index.md
+++ b/Umbraco-Cloud/Set-Up/Media/index.md
@@ -1,5 +1,7 @@
 ---
 versionFrom: 7.0.0
+meta.Title: "Azure Blob Storage on Umbraco Cloud"
+meta.Description: "All Media files for Umbraco Cloud projects are stored in Azure Blob Storage contaiers. Each environment has a separate container linked to it."
 ---
 
 # Media on Umbraco Cloud
@@ -21,6 +23,10 @@ In order to access the media files on your Umbraco Cloud project [you can connec
 Azure Blob Storage is an external storage system, that the Umbraco Cloud service uses to store all media files on Umbraco Cloud projects. This includes everything that is added to the Media library through the Umbraco backoffice, eg. images, PDFs, and other document formats.
 
 You can learn more about what Azure Blob Storage is in [the official documentation on Microsoft Docs](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-overview).
+
+## Working with media locally
+
+
 
 ## One storage per environment
 

--- a/Umbraco-Cloud/Set-Up/Media/index.md
+++ b/Umbraco-Cloud/Set-Up/Media/index.md
@@ -2,38 +2,16 @@
 versionFrom: 7.0.0
 ---
 
-# Azure Blob Storage on Umbraco Cloud
+# Media on Umbraco Cloud
 
-:::note
-**Important**: All Umbraco 8 projects created after May 6th 2020 will have Azure Blob Storage by default. In case you want to connect to your Blob storage provided on Umbraco Cloud [you can follow this step-by-step guide on using Azure Storage Explorer with Umbraco Cloud.](Connect-to-Azure-Storage-Explorer)
+:::warning
+We are currently migrating all media libraries on Umbraco Cloud projects to Azure Blob Storage.
 
-That means that this guide only applies to you, if your project was created before May 6th 2020 or if you are using Umbraco 7.
+You can follow the process here on the [Umbraco Cloud Statuspage](https://status.umbraco.io/incidents/hfnq16mq7l1k).
+
+In the article below, you can find more information about Azure Blob Storage and how it works with your Umbraco Cloud project.
 :::
 
-As Umbraco Cloud deployments are done using a web connection, large media deployments can be slow and are subject to timeouts and other restrictions associated with large uploads over a web connection.
+All media files on your Umbraco Cloud projects are stored using Azure Blob Storage. This means that the media files are not stored with the rest of your project files but in an external storage system.
 
-If this sounds like you, you should evaluate the Azure Blob Storage provider. It has very few limitations and can result in better site performance as well as faster media loading times - especially if your media takes advantage of an Azure CDN.
-
-## [FileSystemProviders: Azure Blob Storage](../../../Extending/FileSystemProviders/Azure-Blob-Storage)
-
-Setting up Azure Blob Storage requires you to install a few packages and follow a few steps which we've outline in a thorough guide on how to set it up.
-
-In this article you will find more specific information about setting up Azure Blob Storage on your Umbraco Cloud environments.
-
-### Video tutorial: Setup Azure Blob Storage with Umbraco Cloud
-
-<iframe width="800" height="450" src="https://www.youtube.com/embed/es3ImN-8o8o?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
-
-## Environment and Deployment considerations
-By default this provider will use a single blob container for the media used by all sites in a project. So development and live will all use the same media files. If this works with your workflow it is the recommended configuration. If you cannot use the same media across all environments then you will need to set up a different blob storage container for each environments. Each container will have a unique address and access keys.
-
-## Excluding media from deployments
-This is not something that should be done unless you really have a good reason to do it. But if nothing works and you wish to deploy changes without getting a lot of errors related to media files you can set the following in the `~/config/UmbracoDeploy.Settings.config` file:
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<settings xmlns="urn:umbracodeploy-settings">
-  <excludedEntityTypes>
-    <add type="media-file" />
-  </excludedEntityTypes>
-</settings>
-```
+In order to access the media files on your Umbraco Cloud project [you can connect to Azure Storage Explorer.](Connect-to-Azure-Storage-Explorer)

--- a/Umbraco-Cloud/Set-Up/Media/index.md
+++ b/Umbraco-Cloud/Set-Up/Media/index.md
@@ -16,7 +16,10 @@ In the article below, you can find more information about Azure Blob Storage and
 
 All media files on your Umbraco Cloud projects are stored using Azure Blob Storage. This means that the media files are not stored with the rest of your project files but in an external storage system.
 
-In order to access the media files on your Umbraco Cloud project [you can connect to Azure Storage Explorer.](Connect-to-Azure-Storage-Explorer)
+In order to access the media files on your Umbraco Cloud project you can either
+
+* Recommended: [Clone your Cloud environment to your local machine](../Working-Locally)
+* [Connect using Azure Storage Explorer](Connect-to-Azure-Storage-Explorer)
 
 ## About Azure Blob Storage
 
@@ -26,7 +29,9 @@ You can learn more about what Azure Blob Storage is in [the official documentati
 
 ## Working with media locally
 
+When you clone one of your Cloud environments to your local machine, you will automatically get a copy of all the media files from the Azure Blob Storage container connected to that environment.
 
+When you add new media files to your project while working on a local clone, the files will automatically be added to the Azure Blob Storage container connected to the environment you deploy to.
 
 ## One storage per environment
 

--- a/Umbraco-Cloud/Set-Up/Media/index.md
+++ b/Umbraco-Cloud/Set-Up/Media/index.md
@@ -5,7 +5,7 @@ versionFrom: 7.0.0
 # Media on Umbraco Cloud
 
 :::warning
-We are currently migrating all media libraries on Umbraco Cloud projects to Azure Blob Storage.
+We are currently migrating all media libraries on Umbraco Cloud projects to Azure Blob Storage. This is being done to optimize performance of Umbraco Cloud sites, and as a part of the continuous improvements added to the service.
 
 You can follow the process here on the [Umbraco Cloud Statuspage](https://status.umbraco.io/incidents/hfnq16mq7l1k).
 
@@ -15,3 +15,59 @@ In the article below, you can find more information about Azure Blob Storage and
 All media files on your Umbraco Cloud projects are stored using Azure Blob Storage. This means that the media files are not stored with the rest of your project files but in an external storage system.
 
 In order to access the media files on your Umbraco Cloud project [you can connect to Azure Storage Explorer.](Connect-to-Azure-Storage-Explorer)
+
+## About Azure Blob Storage
+
+Azure Blob Storage is an external storage system, that the Umbraco Cloud service use to store all media files on Umbraco Cloud projects. This includes everything that is added to the Media library through the Umbraco backoffice, eg. images, PDFs and other document formats.
+
+You can learn more about what Azure Blob Storage is in [the official documentation on Microsoft Docs](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-overview).
+
+## One storage per environment
+
+Each environment on your Umbraco Cloud project has a separate Azure Blob Storage container. This means that each of your environments will be using a storage container specific to that environment.
+
+When you deploy between two environments on your Umbraco Cloud project the media files will be copied from one storage to the other, depending on which environment is being transferred to and from.
+
+As an example, imagine that you are transferring new content changes from your Development environment to your Live environment. When you initiate the transfer, all media files from the Azure Blog Storage container connected to your Development environment will be copied and pasted into to the container connected to your Live environment. Once all content changes has also been transferred, and the transfer is complete, your Media libraries on the two environments will now be in sync.
+
+This way, the media library on your environments are kept in sync.
+
+## Media folder
+
+You will notice that there is a Media (`/media`) folder in the root of your project files. This folder usually holds all media files associated with an Umbraco project. As your Umbraco Cloud environments are all configured with the Azure Blob Storage, the media files are not in this media folder.
+
+Instead you will find a `web.config` file in the folder. This file is used to connect the Media library on your Cloud environment to an Azure Blob Storage container.
+
+Below is an example of how the `/media/web.config` file should look by default.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <clear />
+      <add name="AzureBlobStorageFile" path="*" verb="*" type="Umbraco.Cloud.StorageProviders.AzureBlob.FileHandler, Umbraco.Cloud.StorageProviders.AzureBlob" />
+    </handlers>
+  </system.webServer>
+</configuration>
+```
+
+## Environment variables
+
+In some cases, you might want to connect to your Azure Blob Storage container for the environments on your Umbraco Cloud project. This could be to clean up unwanted media files or to download the current contents of the library.
+
+In order to do this, you need to know some details about the connection between the environment and the Azure Blob Storage containers. Below are the steps you need to follow, in order to locate the necessary variables:
+
+1. Access [Kudu](../Power-Tools) on your Cloud environment.
+2. Locate the "Environment" page in the top-nagivation.
+3. Scroll to the section containing "Environment variables".
+
+There is a total of 5 variables related to the Azure Blob Storage container on your environment:
+
+* `APPSETTING_Umbraco.Cloud.AzureBlob.BlobStorageAccountName`
+* `APPSETTING_Umbraco.Cloud.StorageProviders.AzureBlob.ContainerAlias`
+* `APPSETTING_Umbraco.Cloud.StorageProviders.AzureBlob.ContainerName`
+* `APPSETTING_Umbraco.Cloud.StorageProviders.AzureBlob.Endpoint`
+* `APPSETTING_Umbraco.Cloud.StorageProviders.AzureBlob.SharedAccessSignature`
+
+Once you have the variables, use the ["Connect to Azure Storage Explorer"](Connect-to-Azure-Storage-Explorer) guide to connect to your storage container. 

--- a/Umbraco-Cloud/Set-Up/Media/index.md
+++ b/Umbraco-Cloud/Set-Up/Media/index.md
@@ -5,7 +5,7 @@ versionFrom: 7.0.0
 # Media on Umbraco Cloud
 
 :::warning
-We are currently migrating all media libraries on Umbraco Cloud projects to Azure Blob Storage. This is being done to optimize performance of Umbraco Cloud sites, and as a part of the continuous improvements added to the service.
+We are currently migrating all media libraries on Umbraco Cloud projects to Azure Blob Storage. This is being done to optimize the performance of Umbraco Cloud sites, and as a part of the continuous improvements added to the service.
 
 You can follow the process here on the [Umbraco Cloud Statuspage](https://status.umbraco.io/incidents/hfnq16mq7l1k).
 
@@ -18,7 +18,7 @@ In order to access the media files on your Umbraco Cloud project [you can connec
 
 ## About Azure Blob Storage
 
-Azure Blob Storage is an external storage system, that the Umbraco Cloud service use to store all media files on Umbraco Cloud projects. This includes everything that is added to the Media library through the Umbraco backoffice, eg. images, PDFs and other document formats.
+Azure Blob Storage is an external storage system, that the Umbraco Cloud service uses to store all media files on Umbraco Cloud projects. This includes everything that is added to the Media library through the Umbraco backoffice, eg. images, PDFs, and other document formats.
 
 You can learn more about what Azure Blob Storage is in [the official documentation on Microsoft Docs](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-overview).
 
@@ -28,15 +28,15 @@ Each environment on your Umbraco Cloud project has a separate Azure Blob Storage
 
 When you deploy between two environments on your Umbraco Cloud project the media files will be copied from one storage to the other, depending on which environment is being transferred to and from.
 
-As an example, imagine that you are transferring new content changes from your Development environment to your Live environment. When you initiate the transfer, all media files from the Azure Blog Storage container connected to your Development environment will be copied and pasted into to the container connected to your Live environment. Once all content changes has also been transferred, and the transfer is complete, your Media libraries on the two environments will now be in sync.
+As an example, imagine that you are transferring new content changes from your Development environment to your Live environment. When you initiate the transfer, all media files from the Azure Blog Storage container connected to your Development environment will be copied and pasted into the container connected to your Live environment. Once all content changes have also been transferred, and the transfer is complete, your Media libraries on the two environments will now be in sync.
 
 This way, the media library on your environments are kept in sync.
 
 ## Media folder
 
-You will notice that there is a Media (`/media`) folder in the root of your project files. This folder usually holds all media files associated with an Umbraco project. As your Umbraco Cloud environments are all configured with the Azure Blob Storage, the media files are not in this media folder.
+You will notice that there is a Media (`/media`) folder in the root of your project files. This folder usually holds all media files associated with a Umbraco project. As your Umbraco Cloud environments are all configured with the Azure Blob Storage, the media files are not in this media folder.
 
-Instead you will find a `web.config` file in the folder. This file is used to connect the Media library on your Cloud environment to an Azure Blob Storage container.
+Instead, you will find a `web.config` file in the folder. This file is used to connect the Media library on your Cloud environment to an Azure Blob Storage container.
 
 Below is an example of how the `/media/web.config` file should look by default.
 
@@ -59,7 +59,7 @@ In some cases, you might want to connect to your Azure Blob Storage container fo
 In order to do this, you need to know some details about the connection between the environment and the Azure Blob Storage containers. Below are the steps you need to follow, in order to locate the necessary variables:
 
 1. Access [Kudu](../Power-Tools) on your Cloud environment.
-2. Locate the "Environment" page in the top-nagivation.
+2. Locate the "Environment" page in the top navigation.
 3. Scroll to the section containing "Environment variables".
 
 There is a total of 5 variables related to the Azure Blob Storage container on your environment:


### PR DESCRIPTION
All Cloud sites are having their Media libraries migrated to Azure Blob Storage.

I've updated the Media article for the Umbraco Cloud docs, to reflect those changes.