### PR TITLE
Add trailing slash rewrite rule to the "Rewrites on Cloud" article

### DIFF
--- a/Umbraco-Cloud/Set-Up/Manage-Hostnames/Rewrites-on-Cloud/index.md
+++ b/Umbraco-Cloud/Set-Up/Manage-Hostnames/Rewrites-on-Cloud/index.md
@@ -83,7 +83,7 @@ It is possible to transform all of your URLs to use a trailing slash consistentl
 
 To accomplish this, add a rewrite rule to the Live environment's `web.config` in the `<system.webServer><rewrite><rules>` section.
 
-For example, the following rule will redirect all requests for the site https://mysite.com/page URL to the page https://mysite.com/page/ URL and respond with a permanent redirect status. This way you can ensure that you use the trailing slashes consistently on your site.
+For example, the following rule will redirect all requests for `https://mysite.com/page` to `https://mysite.com/page/`, and respond with a permanent redirect status. This way you can ensure that you use the trailing slashes consistently on your site.
 
 ```xml
 <rule name="Add trailing slash" stopProcessing="true">

--- a/Umbraco-Cloud/Set-Up/Manage-Hostnames/Rewrites-on-Cloud/index.md
+++ b/Umbraco-Cloud/Set-Up/Manage-Hostnames/Rewrites-on-Cloud/index.md
@@ -76,3 +76,31 @@ For example, the following rule will redirect all requests for the site http://m
 :::note
 This redirect rule will not apply when the request is already going to the secure HTTPS URL. This redirect rule will also not apply on your local copy of the site running on `localhost`.
 :::
+
+## Adding a trailing slash to your URLs
+
+It is possible to transform all of your URLs to use a trailing slash consistently for SEO.
+
+To accomplish this, add a rewrite rule to the live environment's `web.config` in the `<system.webServer><rewrite><rules>` section.
+
+For example, the following rule will redirect all requests for the site https://mysite.com/page URL to the page https://mysite.com/page/ URL and respond with a permanent redirect status. This way you can ensure that you use the trailing slashes consistently on your site.
+
+```xml
+<rule name="Add trailing slash" stopProcessing="true">
+  <match url="(.*[^/])$" />
+  <conditions>
+    <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+    <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+    <add input="{REQUEST_URI}" pattern="^/media" negate="true" />
+    <add input="{REQUEST_URI}" pattern="^/umbraco" negate="true" />
+    <add input="{REQUEST_URI}" pattern="^/DependencyHandler.axd" negate="true" />
+    <add input="{REQUEST_URI}" pattern="^/App_Plugins" negate="true" />
+    <add input="{REQUEST_URI}" pattern="^/\.well-known/acme-challenge" negate="true" />
+  </conditions>
+  <action type="Redirect" url="{R:1}/" />
+</rule>
+```
+
+:::note
+Take note of the negates in the rewrite rule. Especially the negate for the media folder is important because your media will not show correctly after [your site has been migrated to use Azure Blob Storage](https://our.umbraco.com/documentation/Umbraco-Cloud/Set-Up/Media/)
+:::

--- a/Umbraco-Cloud/Set-Up/Manage-Hostnames/Rewrites-on-Cloud/index.md
+++ b/Umbraco-Cloud/Set-Up/Manage-Hostnames/Rewrites-on-Cloud/index.md
@@ -81,7 +81,7 @@ This redirect rule will not apply when the request is already going to the secur
 
 It is possible to transform all of your URLs to use a trailing slash consistently for SEO.
 
-To accomplish this, add a rewrite rule to the live environment's `web.config` in the `<system.webServer><rewrite><rules>` section.
+To accomplish this, add a rewrite rule to the Live environment's `web.config` in the `<system.webServer><rewrite><rules>` section.
 
 For example, the following rule will redirect all requests for the site https://mysite.com/page URL to the page https://mysite.com/page/ URL and respond with a permanent redirect status. This way you can ensure that you use the trailing slashes consistently on your site.
 

--- a/Umbraco-Cloud/Set-Up/Manage-Hostnames/Rewrites-on-Cloud/index.md
+++ b/Umbraco-Cloud/Set-Up/Manage-Hostnames/Rewrites-on-Cloud/index.md
@@ -102,5 +102,7 @@ For example, the following rule will redirect all requests for `https://mysite.c
 ```
 
 :::note
-Take note of the negates in the rewrite rule. Especially the negate for the media folder is important because your media will not show correctly after [your site has been migrated to use Azure Blob Storage](https://our.umbraco.com/documentation/Umbraco-Cloud/Set-Up/Media/)
+Take note of the negates in the rewrite rule. 
+
+It is especially important to negate the path to the media folder because with the trailing slash added, your media will not show correctly after [your site has been migrated to use Azure Blob Storage](https://our.umbraco.com/documentation/Umbraco-Cloud/Set-Up/Media/).
 :::

--- a/Umbraco-Cloud/Set-Up/Media/index.md
+++ b/Umbraco-Cloud/Set-Up/Media/index.md
@@ -86,3 +86,8 @@ There is a total of 5 variables related to the Azure Blob Storage container on y
 * `APPSETTING_Umbraco.Cloud.StorageProviders.AzureBlob.SharedAccessSignature`
 
 Once you have the variables, use the ["Connect to Azure Storage Explorer"](Connect-to-Azure-Storage-Explorer) guide to connect to your storage container. 
+
+:::links
+## Related articles
+- [Rewrites will impact your media rendering as well - read about the best practices in here](https://our.umbraco.com/documentation/Umbraco-Cloud/Set-Up/Manage-Hostnames/Rewrites-on-Cloud/)
+:::


### PR DESCRIPTION
After migration to Azure Blob Storage, some customers have seen issues with trailing slashes causing their media not to show. When adding this into our section about trailing slashes, we can make sure that the best practices is followed.