### PR TITLE
To add a link to a subject overview article

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Block-List-Editor/index.md
@@ -12,6 +12,8 @@ versionFrom: 8.7.0
 
 :::note
 A default Umbraco CMS installation does not ship with a defined *Data Type* using the Block List editor. In order to start using the property, follow the steps outlined below.
+
+<a href="https://umbraco.com/blog/deep-dive-the-block-list-editor/">Click here for an overview with a worked example and references back to the relevant documention.</a>
 :::
 
 ## Configure Block List


### PR DESCRIPTION
The documentation doesn't currently pull it all together as well as Niels Lyngsø's blog article. As that article has links back to the three relevant documentation sections I'm proposing that his article should be referenced here. I'd read the docs but couldn't see what the advantage was over Nested Content until I read his article which brought it all together. I hope you agree? :)