### PR TITLE
Broken links in the Heartcore section

### DIFF
--- a/Umbraco-Heartcore/Client-Libraries/Dot-Net-Console/index.md
+++ b/Umbraco-Heartcore/Client-Libraries/Dot-Net-Console/index.md
@@ -58,9 +58,9 @@ Once you have entered the alias of the project, you are presented with the follo
 [X] Exit
 ```
 
-Option A - E uses the [Content Delivery API](../API-Documentation/Content-Delivery/index.md) and can be used for any Heartcore Project, which has public content.
+Option A - E uses the [Content Delivery API](../../API-Documentation/Content-Delivery/index.md) and can be used for any Heartcore Project, which has public content.
 
-Option F uses the [Content Management API](../API-Documentation/Content-Management/index.md). This means that an [API Key](../Getting-Started-Cloud/Backoffice-Users-and-API-Keys/index.md) is required to run this part of the sample, as it will create a new folder in the Media Library and upload an image to a new Media item.
+Option F uses the [Content Management API](../../API-Documentation/Content-Management/index.md). This means that an [API Key](../../Getting-Started-Cloud/Backoffice-Users-and-API-Keys/index.md) is required to run this part of the sample, as it will create a new folder in the Media Library and upload an image to a new Media item.
 
 ### Examples of the fetched data
 

--- a/Umbraco-Heartcore/Versions-and-updates/index.md
+++ b/Umbraco-Heartcore/Versions-and-updates/index.md
@@ -6,7 +6,7 @@ versionFrom: 8.0.0
 
 Umbraco Heartcore is a software as a service (SaaS) offering, which means that one of the benefits is that you do not have to worry about upgrades. All maintenance related to the CMS, its features and APIs are handling by Umbraco HQ.
 
-Umbraco HQ will regularly be adding new features to the CMS and new capabilities to the REST APIs. Each time new endpoints are added to the REST API the `api-version` will be updated to reflect the changes. API releases and versioning is handled following the [ASP.NET API versioning guidelines](https://github.com/microsoft/aspnet-api-versioning). 
+Umbraco HQ will regularly be adding new features to the CMS and new capabilities to the REST APIs. Each time new endpoints are added to the REST API the `api-version` will be updated to reflect the changes. API releases and versioning is handled following the [ASP.NET API versioning guidelines](https://github.com/microsoft/aspnet-api-versioning).
 
 We follow semver in terms of versioning, which means you can be sure that existing APIs will continue to work as expected without breaking. If a breaking change is required then the major version will be incremented, but the previous major version will continue to work.
 
@@ -16,6 +16,6 @@ When making calls to the API, we recommend that you **use the `api-version` head
 Learn more about which versions of the API is available as well as what version each endpoint uses in the [Umbraco Heartcore API Documentation](https://our.umbraco.com/documentation/Umbraco-Heartcore/API-Documentation/).
 :::
 
-When using our [Client Libraries](Client-libraries), the `api-version` is handled as part of the library and generally not something you need to worry about. 
+When using our [Client Libraries](../Client-libraries/), the `api-version` is handled as part of the library and generally not something you need to worry about.
 
 Be aware that the client library releases will have certain features available. As an example, if you are using the very first release (1.0) of the .NET Core client library it will not have the Forms API available. This was made available in the 1.1 version of the client library.

--- a/Umbraco-Heartcore/index.md
+++ b/Umbraco-Heartcore/index.md
@@ -42,8 +42,8 @@ You can read more about all the features and benefits on the [Umbraco Heartcore 
 
 There are 3 ways to get your hands on an Umbraco Heartcore project:
 
-- [Take a 14 day free trial](https://umbraco.com/try-umbraco-heartcore)
-- [Purchase a Heartcore from Umbraco.com](https://umbraco.com/umbraco-heartcore-pricing)
+- [Take a 14 day free trial](https://umbraco.com/try-umbraco-heartcore/)
+- [Purchase a Heartcore from Umbraco.com](https://umbraco.com/umbraco-heartcore-pricing/)
 - [Setup a project directly from the Umbraco Cloud Portal](https://umbraco.io) - requires that you already have an account
 
 ## [Getting Started with Umbraco Heartcore](Getting-Started-Cloud/)


### PR DESCRIPTION
I fixed a few broken links and made some changes to avoid 301's when pointing to Umbraco.com pages about Heartcore.