### PR TITLE
Broken links in Cloud section

### DIFF
--- a/Umbraco-Cloud/Set-Up/Config-Transforms/index.md
+++ b/Umbraco-Cloud/Set-Up/Config-Transforms/index.md
@@ -105,7 +105,7 @@ Note that for the `compilation debug` and the `customErrors mode` there is a tog
 ![Toggle debug mode](images/toggle-debug.png)
 
 ## Umbraco Latch transforms
-All sites created on Cloud since Umbraco v7.12 will contain a web.config transform called: `Latch.Web.live.xdt.config`. See the [Latch documentation](../Umbraco-Latch/index.md#https-by-default) for more information
+All sites created on Cloud since Umbraco v7.12 will contain a web.config transform called: `Latch.Web.live.xdt.config`. See the [Latch documentation](../Manage-Hostnames/Umbraco-Latch/index.md#https-by-default) for more information
 
 ## Baseline config transforms
 It is possible to apply config transforms for specific child sites from a baseline. For more info see [Baseline Configuration Files documentation](https://our.umbraco.com/documentation/Umbraco-Cloud/Getting-Started/Baselines/Configuration-files/)

--- a/Umbraco-Cloud/Set-Up/Manage-Hostnames/index.md
+++ b/Umbraco-Cloud/Set-Up/Manage-Hostnames/index.md
@@ -39,7 +39,7 @@ You will also have to specify the hostname for each root node if you are using a
 
 ![Culture and Hostnames](images/culture-and-hostnames.png)
 
-Once you've assigned a hostname to your Umbraco Cloud environment, you may want to hide the default umbraco.io URL (e.g. *snoopy.s1.umbraco.io*). We've created a rewrite rule for this purpose - find it in the [Rewrites on Cloud](Rewrites-on-Cloud/#hiding-the-default-umbraco-io-url) article.
+Once you've assigned a hostname to your Umbraco Cloud environment, you may want to hide the default umbraco.io URL (e.g. *snoopy.s1.umbraco.io*). We've created a rewrite rule for this purpose - find it in the [Rewrites on Cloud](Rewrites-on-Cloud/#hiding-the-default-umbracoio-url) article.
 
 ### Automatic TLS (HTTPS)
 

--- a/Umbraco-Cloud/Troubleshooting/FAQ/index.md
+++ b/Umbraco-Cloud/Troubleshooting/FAQ/index.md
@@ -11,7 +11,7 @@ Yes, as Archetype is a third-party created data type you’ll need to include th
 
 ## I’m using BuzzHybrid / DonutCaching / LatestHotStuff / other custom add-ins or I’ve created my own data types - do I need to do anything special?
 
-Probably not! In most cases including the custom files (and configuration) is enough for Umbraco Cloud to understand how to deploy your site.  In some cases, namely where you’ve created a data type that serializes data or otherwise stores property data in a non-standard format, you’ll need to also create a corresponding data resolver.  Fortunately these are created using the guide and samples [here](https://github.com/umbraco/Umbraco.Courier.Contrib/blob/dev/README.md)
+Probably not! In most cases including the custom files (and configuration) is enough for Umbraco Cloud to understand how to deploy your site.  In some cases, namely where you’ve created a data type that serializes data or otherwise stores property data in a non-standard format, you’ll need to also create a corresponding value connector.  Fortunately these are created using the samples [here](https://github.com/umbraco/Umbraco.Deploy.ValueConnectors)
 
 
 ## I press the “Deploy to Staging/Live” button, then nothing happens.  What’s going on?

--- a/Umbraco-Cloud/Troubleshooting/FAQ/index.md
+++ b/Umbraco-Cloud/Troubleshooting/FAQ/index.md
@@ -11,7 +11,7 @@ Yes, as Archetype is a third-party created data type you’ll need to include th
 
 ## I’m using BuzzHybrid / DonutCaching / LatestHotStuff / other custom add-ins or I’ve created my own data types - do I need to do anything special?
 
-Probably not! In most cases including the custom files (and configuration) is enough for Umbraco Cloud to understand how to deploy your site.  In some cases, namely where you’ve created a data type that serializes data or otherwise stores property data in a non-standard format, you’ll need to also create a corresponding data resolver.  Fortunately these are created using the guide and samples [here](https://github.com/umbraco/Courier/blob/master/Documentation/Developer%20Documentation/Data%20Resolvers.md)
+Probably not! In most cases including the custom files (and configuration) is enough for Umbraco Cloud to understand how to deploy your site.  In some cases, namely where you’ve created a data type that serializes data or otherwise stores property data in a non-standard format, you’ll need to also create a corresponding data resolver.  Fortunately these are created using the guide and samples [here](https://github.com/umbraco/Umbraco.Courier.Contrib/blob/dev/README.md)
 
 
 ## I press the “Deploy to Staging/Live” button, then nothing happens.  What’s going on?

--- a/Umbraco-Cloud/Upgrades/index.md
+++ b/Umbraco-Cloud/Upgrades/index.md
@@ -17,7 +17,7 @@ When minor upgrades are available, you will need a Development environment on yo
 
 ## When do upgrades happen?
 
-* The status page will include all important roll out information: __[http://status.umbraco.io/](http://status.umbraco.io/)__
+* The status page will include all important roll out information: __[https://status.umbraco.io/](https://status.umbraco.io/)__
 * We will release product updates only on __Tuesday__
 * The decision to roll out an upgrade will be made no later than the __Thursday__ prior and that status page will be updated accordingly
 * A product upgrade will be rolled out if:


### PR DESCRIPTION
I fixed a few broken links in the Cloud section.

Please double-check the link in _Umbraco-Cloud/Troubleshooting/FAQ/index.md_ pointing to the Github Courier Data Resolvers repo. I'm not 100 % sure I found the perfect replacement, but I couldn't find anything matching the broken path.