### PR TITLE
Updated GetCropUrl for 8.7.0 +

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Image-Cropper/index-vpre8.7.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Image-Cropper/index-vpre8.7.md
@@ -1,5 +1,6 @@
 ---
-versionFrom: 8.0.0 versionTo: 8.6.0
+versionFrom: 8.0.0
+versionTo: 8.6.0
 ---
 
 # Image Cropper

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Image-Cropper/index-vpre8.7.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Image-Cropper/index-vpre8.7.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 8.7.0
+versionFrom: 8.0.0 versionTo: 8.6.0
 ---
 
 # Image Cropper
@@ -68,24 +68,13 @@ For rendering a cropped media item, the `.GetCropUrl` is used:
 ```
 
 Or, alternatively:
-```html
-<img src="@(Model.Image.GetCropUrl("banner", Current.ImageUrlGenerator))" />
-```
 
-This was obsoleted in 8.7.0:
 ```html
 <img src="@(Model.Image.GetCropUrl("banner"))" />
 ```
 
 ### MVC View Example to output create custom crops - in this case forcing a 300 x 400 px image
-```csharp
-@if (Model.HasValue("image"))
-{
-    <img src="@Model.Image.GetCropUrl(height: 300, width: 400, imageUrlGenerator: Current.ImageUrlGenerator)" />
-}
-```
 
-This was obsoleted in 8.7.0:
 ```csharp
 @if (Model.HasValue("image"))
 {

--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Image-Cropper/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Image-Cropper/index.md
@@ -72,24 +72,12 @@ Or, alternatively:
 <img src="@(Model.Image.GetCropUrl("banner", Current.ImageUrlGenerator))" />
 ```
 
-This was obsoleted in 8.7.0:
-```html
-<img src="@(Model.Image.GetCropUrl("banner"))" />
-```
-
 ### MVC View Example to output create custom crops - in this case forcing a 300 x 400 px image
+
 ```csharp
 @if (Model.HasValue("image"))
 {
     <img src="@Model.Image.GetCropUrl(height: 300, width: 400, imageUrlGenerator: Current.ImageUrlGenerator)" />
-}
-```
-
-This was obsoleted in 8.7.0:
-```csharp
-@if (Model.HasValue("image"))
-{
-    <img src="@Model.Image.GetCropUrl(height: 300, width: 400)" />
 }
 ```
 


### PR DESCRIPTION
Umbraco 8.7.0 saw the addition of Current.ImageUrlGenerator and GetCropUrl was updated to use this.  I've updated the docs to include this.

I've also updated the `html` code snippets with` <img src="@(...)" />` were the calls to GetCropUrl included strings this is because in some views the strings were causing compilation errors.

This is a PR for https://github.com/umbraco/UmbracoDocs/issues/2929