### PR TITLE
Confirm where to apply the Maindom.Lock setting

### DIFF
--- a/Getting-Started/Setup/Server-Setup/Load-Balancing/azure-web-apps.md
+++ b/Getting-Started/Setup/Server-Setup/Load-Balancing/azure-web-apps.md
@@ -36,7 +36,7 @@ Several file system based services in Umbraco such as the Published Cache and Lu
 ```xml
 <add key="Umbraco.Core.MainDom.Lock" value="SqlMainDomLock" />
 ```
-
+Apply this setting to both the __PRIMARY__ Administrative server and the __REPLICA__ scalable public facing servers.
 ##### v8.6.0 - v8.6.3
 
 The `Umbraco.Core.MainDom.Lock` should be applied to your __MASTER__ Administrative server only.

--- a/Getting-Started/Setup/Server-Setup/Load-Balancing/azure-web-apps.md
+++ b/Getting-Started/Setup/Server-Setup/Load-Balancing/azure-web-apps.md
@@ -36,7 +36,7 @@ Several file system based services in Umbraco such as the Published Cache and Lu
 ```xml
 <add key="Umbraco.Core.MainDom.Lock" value="SqlMainDomLock" />
 ```
-Apply this setting to both the __PRIMARY__ Administrative server and the __REPLICA__ scalable public facing servers.
+Apply this setting to both the __MASTER__ Administrative server and the __REPLICA__ scalable public-facing servers.
 ##### v8.6.0 - v8.6.3
 
 The `Umbraco.Core.MainDom.Lock` should be applied to your __MASTER__ Administrative server only.


### PR DESCRIPTION
Keeps coming up in the forum that it's not clear now in 8.4+ in these docs whether the setting is applied just to Primary, or to Replica servers or to both