### PR TITLE
Link to same major version

### DIFF
--- a/Getting-Started/Setup/Server-Setup/Load-Balancing/flexible-v7.md
+++ b/Getting-Started/Setup/Server-Setup/Load-Balancing/flexible-v7.md
@@ -201,4 +201,4 @@ Scaling will be a slightly manual process because it would involve you adding se
 
 ## Advanced techniques
 
-Once you are familiar with how flexible load balancing works, you might be interested in some [advanced techniques](flexible-advanced.md).
+Once you are familiar with how flexible load balancing works, you might be interested in some [advanced techniques](flexible-advanced-v7.md).


### PR DESCRIPTION
The v7 version of the flexible LB docs link to advanced v8 features instead of advanced v7. It would be nice to link on to the same major 😊