### PR TITLE
Remind users about content restore on Media Files

### DIFF
--- a/Umbraco-Cloud/Set-Up/Media/index.md
+++ b/Umbraco-Cloud/Set-Up/Media/index.md
@@ -29,7 +29,9 @@ You can learn more about what Azure Blob Storage is in [the official documentati
 
 ## Working with media locally
 
-When you clone one of your Cloud environments to your local machine, you will automatically get a copy of all the media files from the Azure Blob Storage container connected to that environment. Once you have done a content restore the media files will be available locally.
+When you clone one of your Cloud environments to your local machine, you will need to run a content restore from the backoffice to get a copy of all the media files from the Azure Blob Storage container connected to that environment.
+
+You can learn more about how this works in the [Restoring content](../../Deployment/Restoring-content) article.
 
 When you add new media files to your project while working on a local clone, the files will automatically be added to the Azure Blob Storage container connected to the environment you deploy to.
 

--- a/Umbraco-Cloud/Set-Up/Media/index.md
+++ b/Umbraco-Cloud/Set-Up/Media/index.md
@@ -29,7 +29,7 @@ You can learn more about what Azure Blob Storage is in [the official documentati
 
 ## Working with media locally
 
-When you clone one of your Cloud environments to your local machine, you will automatically get a copy of all the media files from the Azure Blob Storage container connected to that environment.
+When you clone one of your Cloud environments to your local machine, you will automatically get a copy of all the media files from the Azure Blob Storage container connected to that environment. Once you have done a content restore the media files will be available locally.
 
 When you add new media files to your project while working on a local clone, the files will automatically be added to the Azure Blob Storage container connected to the environment you deploy to.
 


### PR DESCRIPTION
I had a customer today who thought the documentation was misleading, because he did not get any Media files when he cloned down the project locally, as the documentation stated he would.
I was told by my colleagues that you need to do a Content Restore first, which makes sense, but maybe not that obvious for a new user of Umbraco Cloud.
Therefore I suggest we add this (or rephrase it however you like) so users are aware that they need to do this.