### PR TITLE
Removed unused instance of ICultureDictionary

### DIFF
--- a/Implementation/Unit-Testing/index.md
+++ b/Implementation/Unit-Testing/index.md
@@ -293,8 +293,7 @@ public class HomeController : RenderMvcController
 public class HomeControllerTests : UmbracoBaseTest
 {
     private HomeController controller;
-    private Mock<ICultureDictionary> cultureDictionary;
-
+    
     [SetUp]
     public override void SetUp()
     {


### PR DESCRIPTION
Turns out the local mocked instance of ICultureDictionary is unused in this test, since the actual test uses the base.CultureDictionary. Probably a result of previous refactoring.