### PR TITLE
Fixing broken link to Examining Examine article

### DIFF
--- a/Reference/Searching/Examine/Quick-Start/index-v7.md
+++ b/Reference/Searching/Examine/Quick-Start/index-v7.md
@@ -110,5 +110,5 @@ The XSLT implementation of Examine has a few specific steps that you'll need to 
 ## Recommended resources
 For more detailed examples of implementing search with Examine, the following resources can be extremely helpful
 
-- [Examining Examine](overview-explanation.md) by Peter Gregory.
+- [Examining Examine](https://our.umbraco.com/Documentation/Reference/Searching/Examine/overview-explanation) by Peter Gregory.
 - [The worlds friendliest post on getting started with Examine](https://24days.in/umbraco-cms/2013/getting-started-with-examine/) (24 Days in Umbraco)


### PR DESCRIPTION
This link might work is it's just `/Documentation/Reference/Searching/Examine/quick-start/index-v7` but I wasn't 100% sure. 
Happy to update it if that would work. 

