### PR TITLE
Timeouts more grouped

### DIFF
--- a/Umbraco-Cloud/Deployment/Deploy-Settings/index.md
+++ b/Umbraco-Cloud/Deployment/Deploy-Settings/index.md
@@ -59,10 +59,37 @@ Here is how it can look:
 
 These timeout settings default to 20 minutes, but if you are transferring a lot of data you may need to increase it. All of these times are in *seconds*:
 
+:::note
+It's important that these settings are added to both the source and target environments in order to work.
+:::
+
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <settings xmlns="urn:umbracodeploy-settings">
     <deploy sessionTimeout="1800" sourceDeployTimeout="1800" httpClientTimeout="1800" databaseCommandTimeout="1800" />
+</settings>
+```
+
+## Timeout issues
+
+Umbraco Deploy have a few built in timeouts, which on larger sites might needs to be modified. You will usually see these timeouts in the backoffice with an exception mentioning a timeout. It will be as part of a full restore or a full deploy of an entire site. In the normal workflow you should never hit these timeouts.
+
+The defaults will cover most though. Changing the defaults by updating the `/Config/UmbracoDeploy.settings.config`. There are four settings available, which all uses the default timeout which currently is set for 8 minutes.
+- sessionTimeout
+- sourceDeployTimeout
+- httpClientTimeout
+- databaseCommandTimeout
+
+The settings are set on the deploy element in the file. All settings are in seconds:
+
+:::note
+It's important that these settings are added to both the source and target environments in order to work.
+:::
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<settings xmlns="urn:umbracodeploy-settings">
+  <deploy sessionTimeout="1200" sourceDeployTimeout="1200" httpClientTimeout="1200"/>
 </settings>
 ```
 
@@ -98,27 +125,7 @@ Setting the `exportMemberGroups` to false will no longer export member groups to
 ```
 
 
-## Timeout issues
 
-Umbraco Deploy have a few built in timeouts, which on larger sites might needs to be modified. You will usually see these timeouts in the backoffice with an exception mentioning a timeout. It will be as part of a full restore or a full deploy of an entire site. In the normal workflow you should never hit these timeouts.
-
-The defaults will cover most though. Changing the defaults by updating the `/Config/UmbracoDeploy.settings.config`. There are four settings available, which all uses the default timeout which currently is set for 8 minutes.
-- sessionTimeout
-- sourceDeployTimeout
-- httpClientTimeout
-- databaseCommandTimeout
-
-The settings are set on the deploy element in the file. All settings are in seconds:
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<settings xmlns="urn:umbracodeploy-settings">
-  <deploy sessionTimeout="1200" sourceDeployTimeout="1200" httpClientTimeout="1200"/>
-</settings>
-```
-:::note
-It's important that these settings are added to both the source and target environments in order to work.
-:::
 
 ### Large media libraries
 If you are often hitting the timeouts on content transfer or restores it is likely because your media library is too large. It is recommended that you switch to Blob storage if you have a media library larger than 1gb. See how [here!](../../../Set-Up/Media)


### PR DESCRIPTION
I've added them a little closer together as these two subjects are very much the same.
However, I haven't merged them into one (yet) because I can see that having them seperate, but close/grouped, is good for two reasons:
1. If a user just needs to know about modifying the Timeout, we can link to that heading/section
2. If a user has timeout issues, then it has its seperate sections as of what you can do about it.

The scenario might be a bit too vague, but I am open to suggestions 😄