### PR TITLE
How to get file stream from MediaFileSystem in v7

### DIFF
--- a/Reference/Config/fileSystemProviders/index-v7.md
+++ b/Reference/Config/fileSystemProviders/index-v7.md
@@ -59,3 +59,35 @@ To store media files in different systems, the type of provider must be changed.
 At the moment when a file is saved, its full url is stored as node property, so a configuration change will not apply to pre-existing media files but only to the ones saved after that.
 
 If you want all your media files in the same location you have to copy all pre-existing files to the new path, and update the `path` property of the media item to the new url. This can be either directly inside the database or by using the `MediaService`.
+
+## Get the contents of a file as a stream
+To get the content of a file as a stream, the best practice is to use the `MediaFileSystem` to do so, rather than reading the file from the server using something like `Server.MapPath`. This will ensure that, regardless of the file system provider, the stream will be returned correctly.
+This is an example of how you can, on one hand - use `MediaFileSystem` to check whether the file exist, and on the other hand return the file as a stream in a controller.
+
+```csharp
+using System.IO;
+using System.Web;
+using System.Web.Mvc;
+using Umbraco.Core.IO;
+
+public class MediaController : Controller
+{
+    private readonly MediaFileSystem _media = FileSystemProviderManager.Current.GetFileSystemProvider<MediaFileSystem>();
+    public ActionResult Index(string id, string file)
+    {
+        string path = "/media/" + id + "/" + file;
+        if (_media.FileExists(path))
+        {
+            var stream = _media.OpenFile(path);
+            stream.Seek(0, SeekOrigin.Begin);
+
+            return new FileStreamResult(stream, MimeMapping.GetMimeMapping(file));
+        }
+        else
+        {
+            return HttpNotFound();
+        }
+
+    }
+}
+```


### PR DESCRIPTION
This addition explains and exemplifies how to use MediaFileSystem to get the contents of a file in a stream using v7.