### PR TITLE
Updates code language to xml

### DIFF
--- a/Add-ons/The-Licensing-model/index.md
+++ b/Add-ons/The-Licensing-model/index.md
@@ -96,7 +96,7 @@ It can be configured in the Umbraco installation's `Web.config` file by adding t
 This will also change the location for other Umbraco related licenses in this project.
 :::
 
-```
+```xml
 <appSettings>
     <add key="UmbracoLicensesDirectory" value="~/Licenses/" />
     ...


### PR DESCRIPTION
I'd missed the `xml` part of the language file in my previous PR, so the config file isn't showing on the front end:
https://our.umbraco.com/documentation/add-ons/The-Licensing-model/ 

I think this fixes it 🤔