### PR TITLE
Adding HQ IPs to backoffice restriction section

### DIFF
--- a/Umbraco-Cloud/Security/index.md
+++ b/Umbraco-Cloud/Security/index.md
@@ -134,6 +134,10 @@ The following rule can be added to your web.config file in the `system.webServer
         <!-- Allow the  Umbraco Cloud Autoupgrade to access the site -->
          <add input="{REMOTE_ADDR}" pattern="52.232.105.169" negate="true" />
          <add input="{REMOTE_ADDR}" pattern="52.174.66.30" negate="true" />
+        
+        <!-- Allow Umbraco HQ IPs in case you'd need support -->
+        <add input="{REMOTE_ADDR}" pattern="2.109.65.126" negate="true" />
+        <add input="{REMOTE_ADDR}" pattern="165.22.124.72" negate="true" />
 
         <!-- Add other client IPs that need access to the backoffice -->
         <add input="{REMOTE_ADDR}" pattern="123.123.123.123" negate="true" />


### PR DESCRIPTION
In order for Cloud users to be able to get support, with their backoffice restricted by IP filtering, they'll need to allow HQ IPs access.
With this change the IP addresses for the network at HQ as well as the Umbraco HQ VPN is added.