### PR TITLE
Fix typo in Members Group Service code example

### DIFF
--- a/Reference/Management/Services/MemberGroupService/Index.md
+++ b/Reference/Management/Services/MemberGroupService/Index.md
@@ -42,7 +42,7 @@ public class MyClass
 
     private IMemberGroupService _memberGroupService;
     
-    public MyClass(IMemberService memberGroupService)
+    public MyClass(IMemberGroupService memberGroupService)
     {
         _memberGroupService = memberGroupService;
     }


### PR DESCRIPTION
The code example was referencing the `IMemberService` when it should be `IMemberGroupService`.

Thanks