### PR TITLE
Updated the Backoffice IP filtering examples with two variations

### DIFF
--- a/Umbraco-Cloud/Security/index.md
+++ b/Umbraco-Cloud/Security/index.md
@@ -121,12 +121,12 @@ Please note these two different variations, which differ if you have a reverse p
 :::note
 Since December 8th, 2020 all Umbraco Cloud sites uses Cloudflare for DNS, so new and updated projects should use the Reverse Proxy version.
 
-If you are ensure whether your Cloud project uses Cloudflare or not, get in touch with the friendly support team, and they will help you out.
+If you are unsure whether your Cloud project uses Cloudflare or not, get in touch with the friendly support team, and they will help you out.
 :::
 
 **Reverse Proxy version (eg. Cloudflare)**
 
-When using Cloudflare, which is the default setup for all Cloud projects, the project will use reverse proxy which gets the IPs from the `X-Forwarded-For` header. In this case, which is most cases, use the first variation here to restrict access to your backoffice using IP filtering.
+When using Cloudflare, which is the default setup for all Cloud projects, the project will from behind a reverse proxy which gets the IPs from the `X-Forwarded-For` header. In this case, which is most cases, use the first variation here to restrict access to your backoffice using IP filtering.
 
 ```xml
 <rule name="Backoffice IP Filter" enabled="true">

--- a/Umbraco-Cloud/Security/index.md
+++ b/Umbraco-Cloud/Security/index.md
@@ -116,6 +116,39 @@ It is possible to restrict who can access the Umbraco backoffice by applying an 
 
 The following rule can be added to your web.config file in the `system.webServer/rewrite/rules/` section.
 
+Please note these two different variations, which differ if you have a reverse proxy like Cloudflare (with Proxying turned on) in front of the website:
+
+Reserve Proxy version, which gets the IP from the `X-Forwarded-For` header:
+
+```xml
+<rule name="Backoffice IP Filter" enabled="true">
+    <match url="(^umbraco/backoffice/(.*)|^umbraco($|/$))"/>
+    <conditions logicalGrouping="MatchAll">
+
+        <!-- Umbraco Cloud to Cloud connections should be allowed -->
+        <add input="{HTTP_X_Forwarded_For}" pattern="52.166.147.129" negate="true" />
+        <add input="{HTTP_X_Forwarded_For}" pattern="13.95.93.29" negate="true" />
+        <add input="{HTTP_X_Forwarded_For}" pattern="40.68.36.142" negate="true" />
+        <add input="{HTTP_X_Forwarded_For}" pattern="13.94.247.45" negate="true" />
+        <add input="{HTTP_X_Forwarded_For}" pattern="52.157.96.229" negate="true" />
+
+        <!-- Don't apply rules on localhost so your local environment still works -->
+        <add input="{HTTP_HOST}" pattern="localhost" negate="true" />
+
+        <!-- Allow the  Umbraco Cloud Autoupgrade to access the site -->
+         <add input="{HTTP_X_Forwarded_For}" pattern="52.232.105.169" negate="true" />
+         <add input="{HTTP_X_Forwarded_For}" pattern="52.174.66.30" negate="true" />
+
+        <!-- Add other client IPs that need access to the backoffice -->
+        <add input="{HTTP_X_Forwarded_For}" pattern="123.123.123.123" negate="true" />
+
+    </conditions>
+    <action type="CustomResponse" statusCode="403"/>
+</rule>
+```
+
+Standard version, which gets the Remote IP address of the website visitor:
+
 ```xml
 <rule name="Backoffice IP Filter" enabled="true">
     <match url="(^umbraco/backoffice/(.*)|^umbraco($|/$))"/>

--- a/Umbraco-Cloud/Security/index.md
+++ b/Umbraco-Cloud/Security/index.md
@@ -116,9 +116,17 @@ It is possible to restrict who can access the Umbraco backoffice by applying an 
 
 The following rule can be added to your web.config file in the `system.webServer/rewrite/rules/` section.
 
-Please note these two different variations, which differ if you have a reverse proxy like Cloudflare (with Proxying turned on) in front of the website:
+Please note these two different variations, which differ if you have a reverse proxy like Cloudflare (with Proxying turned on) in front of the website.
 
-Reserve Proxy version, which gets the IP from the `X-Forwarded-For` header:
+:::note
+Since December 8th, 2020 all Umbraco Cloud sites uses Cloudflare for DNS, so new and updated projects should use the Reverse Proxy version.
+
+If you are ensure whether your Cloud project uses Cloudflare or not, get in touch with the friendly support team, and they will help you out.
+:::
+
+**Reverse Proxy version (eg. Cloudflare)**
+
+When using Cloudflare, which is the default setup for all Cloud projects, the project will use reverse proxy which gets the IPs from the `X-Forwarded-For` header. In this case, which is most cases, use the first variation here to restrict access to your backoffice using IP filtering.
 
 ```xml
 <rule name="Backoffice IP Filter" enabled="true">
@@ -147,7 +155,9 @@ Reserve Proxy version, which gets the IP from the `X-Forwarded-For` header:
 </rule>
 ```
 
-Standard version, which gets the Remote IP address of the website visitor:
+**Non-Reverse Proxy (eg. non-Cloudflare)**
+
+When your Cloud project is not using Cloudflare, your site gets the Remote IP address of the website visitor. In this case, you should use the second variation as shown below, when restricting access to your backoffice.
 
 ```xml
 <rule name="Backoffice IP Filter" enabled="true">


### PR DESCRIPTION
The first variation is relevant when you have a reverse proxy like Cloudflare in front of the website, which will be the common approach on Cloud going forward. The second variation is the standard way of using rewrite rules for restricting access to the backoffice based on the IP of the visitor. This will be relevant to old Cloud sites and anything running outside of Cloud.