### PR TITLE
Removed warning about bug that has been resolved

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Type.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Type.md
@@ -78,12 +78,6 @@ For all types that use the provider model, settings work this way. By adding the
 
 ## Validate type settings with ValidateSettings()
 
-:::warning
-Currently, there is a bug with using this specific code snippet.
-
-The bug has been reported, and you can follow the process here: [UmbracoForms.Issues](https://github.com/umbraco/Umbraco.Forms.Issues/issues/433). As long as the issue is open, this code snippet below will not be triggered when applied to your application.
-:::
-
 The ValidateSettings() method which can be found on all types supporting dynamic settings, is used for making sure the data entered by the user is valid and works with the type.
 
 ```csharp


### PR DESCRIPTION
There was a bug in Umbraco Forms that caused one of the code snippets in this article to not work properly.

This has now been fixed and will be released in Forms v8.7.

Related: 
Forms PR: https://github.com/umbraco/Forms/pull/447
Forms Issue: https://github.com/umbraco/Umbraco.Forms.Issues/issues/433
Docs Issue: https://github.com/umbraco/UmbracoDocs/issues/1739