### PR TITLE
Add example using SendingMemberModel

### DIFF
--- a/Reference/Events/EditorModel-Events/index.md
+++ b/Reference/Events/EditorModel-Events/index.md
@@ -95,6 +95,12 @@ public class SubscribeToEditorModelEvents : IComponent
 
     private void EditorModelEventManager_SendingMemberModel(System.Web.Http.Filters.HttpActionExecutedContext sender, EditorModelEventArgs<Umbraco.Web.Models.ContentEditing.MemberDisplay> e)
     {
+        bool isNew = !int.TryParse(e.Model.Id?.ToString(), out int id) || id == 0;
+        
+        // Skip if entity not is new
+        if (isNew == false)
+            return;
+               
         // Set a default value member group for the member type `Member`
         if (e.Model.ContentTypeAlias == "Member")
         {

--- a/Reference/Events/EditorModel-Events/index.md
+++ b/Reference/Events/EditorModel-Events/index.md
@@ -98,13 +98,16 @@ public class SubscribeToEditorModelEvents : IComponent
         // Set a default value member group for the member type `Member`
         if (e.Model.ContentTypeAlias == "Member")
         {
+            // Find a specific member group
             var group = _memberGroupService.GetByName("Customer");
             if (group == null)
                 return;
-
+            
+            // Find member group property on member model
             var prop = e.Model.Properties.FirstOrDefault(x => x.Alias == $"{Umbraco.Core.Constants.PropertyEditors.InternalGenericPropertiesPrefix}membergroup");
             if (prop != null)
             {
+                // Assign a default value for member group property
                 prop.Value = new Dictionary<string, object>
                 {
                     { group.Name, true }

--- a/Reference/Events/EditorModel-Events/index.md
+++ b/Reference/Events/EditorModel-Events/index.md
@@ -97,7 +97,7 @@ public class SubscribeToEditorModelEvents : IComponent
     {
         bool isNew = !int.TryParse(e.Model.Id?.ToString(), out int id) || id == 0;
         
-        // Skip if entity not is new
+        // We only want to set the default group when the member is initially created, eg doesn't have an Id yet
         if (isNew == false)
             return;
                


### PR DESCRIPTION
Adding a basic example of how `SendingMemberModel` can be using to set default member group for a specific member type.
I have suggested in this feature request to be able to set a `MemberGroup` property https://github.com/umbraco/Umbraco-CMS/issues/10032 but for now this works 👍 