### PR TITLE
Updating the Hiding the Default umbraco.io Url rewrite rule

### DIFF
--- a/Umbraco-Cloud/Set-Up/Manage-Hostnames/Rewrites-on-Cloud/index.md
+++ b/Umbraco-Cloud/Set-Up/Manage-Hostnames/Rewrites-on-Cloud/index.md
@@ -38,7 +38,7 @@ One approach for this is to add a new rewrite rule to the `<system.webServer><re
 <rule name="Redirects umbraco.io to actual domain" stopProcessing="true">
   <match url=".*" />
   <conditions>
-    <add input="{HTTP_HOST}" pattern="^(.*)?.s1.umbraco.io$" />
+    <add input="{HTTP_X_Forwarded_For}" pattern="^(.*)?.s1.umbraco.io$" />
     <add input="{REQUEST_URI}" negate="true" pattern="^/umbraco" />
     <add input="{REQUEST_URI}" negate="true" pattern="^/DependencyHandler.axd" />
     <add input="{REQUEST_URI}" negate="true" pattern="^/App_Plugins" />


### PR DESCRIPTION
After we switched to Cloudflare the rewrite rule to hide the default umbraco.io url will have to use {HTTP_X_Forwarded_For} rather than {HTTP_HOST} to not cause a redirect loop, effectively making the website unavailable.