### PR TITLE
Inserting a warning and reverting earlier change to rewrites section

### DIFF
--- a/Umbraco-Cloud/Set-Up/Manage-Hostnames/Rewrites-on-Cloud/index.md
+++ b/Umbraco-Cloud/Set-Up/Manage-Hostnames/Rewrites-on-Cloud/index.md
@@ -34,11 +34,18 @@ Once you've assigned a hostname to your Live environment you may want to "hide" 
 
 One approach for this is to add a new rewrite rule to the `<system.webServer><rewrite><rules>` section in the `web.config` file. For example, the following rule will redirect all requests for the projects mysite.s1.umbraco.io URL to the mysite.com URL and respond with a permanent redirect status.
 
+:::warning
+This rewrite only works for hostnames that are using Umbraco Latch, which was the old way of managing hostnames on Umbraco Cloud. Every hostname created after December 8th 2020 or hostnames that have had their DNS moved will use Cloudflare. If your hostname is using Cloudflare this rewrite will not work.
+We are working on updating the documentation to provide a correct redirect that will also work on Cloudflare.
+
+If you are unsure whether your hostname uses Umbraco Latch or Cloudflare, feel free to reach out to support directly from the Cloud portal.
+:::
+
 ```xml
 <rule name="Redirects umbraco.io to actual domain" stopProcessing="true">
   <match url=".*" />
   <conditions>
-    <add input="{HTTP_X_Forwarded_For}" pattern="^(.*)?.s1.umbraco.io$" />
+    <add input="{HTTP_HOST}" pattern="^(.*)?.s1.umbraco.io$" />
     <add input="{REQUEST_URI}" negate="true" pattern="^/umbraco" />
     <add input="{REQUEST_URI}" negate="true" pattern="^/DependencyHandler.axd" />
     <add input="{REQUEST_URI}" negate="true" pattern="^/App_Plugins" />


### PR DESCRIPTION
Due to the recent changes to Cloudflare, a redirect that was working before is not working anymore. This PR inserts a warning box to not use this rewrite whilst we are working on finding an appropriate way of creating this rewrite in the Cloudflare setup.