### PR TITLE
Inserting SqlWriteLockTimeOut into app settings section

### DIFF
--- a/Reference/Config/webconfig/index.md
+++ b/Reference/Config/webconfig/index.md
@@ -82,6 +82,14 @@ Makes sure that all of the requests in the backoffice are called over HTTPS inst
 Check out the [security documentation](../../security/use-https.md).
 :::
 
+### Umbraco.Core.SqlWriteLockTimeOut
+
+An int value representing the time in milliseconds to lock the database for a write operation. The default value is 1800.
+
+```xml
+<add key="Umbraco.Core.SqlWriteLockTimeOut" value="1800" />
+```
+
 ### Umbraco.Examine.LuceneDirectoryFactory
 
 The `SyncTempEnvDirectoryFactory` enables Examine to sync indexes between the remote file system and the local environment temporary storage directory. The indexes will be accessed from the temporary storage directory. 

--- a/Reference/Config/webconfig/index.md
+++ b/Reference/Config/webconfig/index.md
@@ -184,8 +184,11 @@ This value is primarily used on Umbraco Cloud for a small startup performance op
 
 ### Umbraco.Core.SqlWriteLockTimeOut
 
-An int value representing the time in milliseconds to lock the database for a write operation. The default value is 1800.
+The default value is: `5000` (5 seconds)
+
+This setting needs to be an int value that will represent the time in milliseconds to lock the database for a write operation.
+The setting is not mandatory, but can be used as a fix to extend the timeout if you have been seeing errors in your logs indicating that the default lock timeout is hit.
 
 ```xml
-<add key="Umbraco.Core.SqlWriteLockTimeOut" value="1800" />
+<add key="Umbraco.Core.SqlWriteLockTimeOut" value="6000" />
 ```

--- a/Reference/Config/webconfig/index.md
+++ b/Reference/Config/webconfig/index.md
@@ -82,14 +82,6 @@ Makes sure that all of the requests in the backoffice are called over HTTPS inst
 Check out the [security documentation](../../security/use-https.md).
 :::
 
-### Umbraco.Core.SqlWriteLockTimeOut
-
-An int value representing the time in milliseconds to lock the database for a write operation. The default value is 1800.
-
-```xml
-<add key="Umbraco.Core.SqlWriteLockTimeOut" value="1800" />
-```
-
 ### Umbraco.Examine.LuceneDirectoryFactory
 
 The `SyncTempEnvDirectoryFactory` enables Examine to sync indexes between the remote file system and the local environment temporary storage directory. The indexes will be accessed from the temporary storage directory. 
@@ -189,3 +181,11 @@ The default value is: `false`
 This is not a setting that commonly needs to be configured.
 
 This value is primarily used on Umbraco Cloud for a small startup performance optimization. When this is true, the website instance will automatically be configured to not support load balancing and the website instance will be configured to be the 'primary' server for scheduling so no [primary election](https://our.umbraco.com/documentation/Getting-Started/Setup/Server-Setup/load-balancing/flexible#scheduling-and-master-election) occurs. This will save 1 database call during startup.
+
+### Umbraco.Core.SqlWriteLockTimeOut
+
+An int value representing the time in milliseconds to lock the database for a write operation. The default value is 1800.
+
+```xml
+<add key="Umbraco.Core.SqlWriteLockTimeOut" value="1800" />
+```


### PR DESCRIPTION
With https://github.com/umbraco/Umbraco-CMS/pull/9744 a new app setting to be able to set the SQL write lock timeout was introduced. This PR inputs a short mentioning of this appsetting into the documentation 😅