### PR TITLE
Updated indentation to avoid breaking csharp code formatting.

### DIFF
--- a/Extending/Health-Check/index.md
+++ b/Extending/Health-Check/index.md
@@ -250,9 +250,11 @@ namespace Umbraco.Web.HealthCheck.Checks.SEO
         {
             var success = false;
             var message = string.Empty;
-            const string content = @"# robots.txt for Umbraco
-User-agent: *
-Disallow: /umbraco/";
+            
+            const string content = 
+                @"# robots.txt for Umbraco
+                User-agent: *
+                Disallow: /umbraco/";
 
             try
             {


### PR DESCRIPTION
Look at the second code snippet on this page: https://our.umbraco.com/documentation/Extending/Health-Check/

The csharp code snippet is not formatted properly an I think it is because the second row of the content of the robots.txt file does not have any indentation which confuses the opening/closing csharp block.