### PR TITLE
Update documentation for HasValue()

### DIFF
--- a/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/File-Upload/index.md
+++ b/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/File-Upload/index.md
@@ -28,7 +28,7 @@ Example: `"/media/o01axaqu/guidelines-on-remote-working.pdf"`
 ### Without Modelsbuilder
 ```csharp
 @{
-    if (Model.Value<string>("myFile").HasValue())
+    if (Model.HasValue("myFile"))
     {
         var myFile = Model.Value<string>("myFile");
 
@@ -41,8 +41,9 @@ Example: `"/media/o01axaqu/guidelines-on-remote-working.pdf"`
 ### With Modelsbuilder
 
 ```csharp
+@using ContentModels = Umbraco.Web.PublishedModels;
 @{
-    if (Model.MyFile.HasValue())
+    if (Model.HasValue(ContentModels.MyModel.GetModelPropertyType(x => x.MyFile).Alias))
     {
         <a href="@Model.MyFile">@Path.GetFileName(Model.MyFile)</a>
     }


### PR DESCRIPTION
The documentation here doesn't seem to be correct: https://our.umbraco.com/Documentation/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/File-Upload/

The extension exists as a method here:
https://github.com/umbraco/Umbraco-CMS/blob/d428a4543f33bb7094cf7db5f6b6fdc2d1de3063/src/Umbraco.Web/PublishedCache/PublishedElementPropertyBase.cs#L39

ModelsBuilder  return the value as a `string` property in File Upload and the `HasValue()` isn't an string extension method.