### PR TITLE
Include a Umbraco ID section.

### DIFF
--- a/Umbraco-Cloud/Set-Up/SMTP-settings/index.md
+++ b/Umbraco-Cloud/Set-Up/SMTP-settings/index.md
@@ -34,7 +34,7 @@ The second scenario where you'd need to setup an SMTP service for your Umbraco C
 
 :::note
 The option to request password resets for backoffice users is disabled by default on Umbraco Cloud projects. This is mainly to ensure that your backoffice login stays in sync with your Umbraco ID.
-You can reset your Umbraco ID password from the Umbraco Cloud login page.
+You can reset your Umbraco ID password from the Umbraco Cloud login page.  <<<< This should be a section by itself that explains Umbraco ID and that you can't use SMTP to request "reset password" mails
 
 ![reset password](images/Reset_password.png)
 


### PR DESCRIPTION
Some customers think they can use SMTP to configure user invite and forgotten password emails to be sent out through the SMTP server. However, user authentication on Umbraco cloud is all managed through https://identity.umbraco.com, and therefore these emails come from Umbraco's SMTP server and therefore not able to do it via SMTP.

There is only a "note" regarding Umbraco ID and some customers would like more clarification on this. So a Umbraco ID section would be helpful.