### PR TITLE
Fixing a broken link in docs

### DIFF
--- a/Extending/Health-Check/Guides/index.md
+++ b/Extending/Health-Check/Guides/index.md
@@ -9,7 +9,7 @@ verified-against: alpha-3
 
 Below is a list of guides for Health Checks in Umbraco.
 
-## [Click jack protection](ClickJackProtection.md)
+## [Click jack protection](ClickJackingProtection.md)
 
 ## [Content sniffing protection](ContentSniffingProtection.md)
 


### PR DESCRIPTION
Noticed a broken link on https://our.umbraco.com/documentation/Extending/Health-Check/Guides/ so thought I'd fix :)

Thanks,
Carole