### PR TITLE
Replacing the link for the template temporarily

### DIFF
--- a/Tutorials/Creating-Basic-Site/Getting-Started/index.md
+++ b/Tutorials/Creating-Basic-Site/Getting-Started/index.md
@@ -10,7 +10,7 @@ The following sections of the "Creating a Basic Site" tutorial provide step by s
 To take you through a demo of installing a basic site in the Umbraco CMS you need the following:
 
 *    A clean, empty installation of the Umbraco CMS without the starter site installed. See the notes below for what to do when running through the installation wizard.  
-*    This tutorial uses a copy of Retrospect – a HTML5, responsive website template from Templated.co - [https://templated.co/retrospect](https://templated.co/retrospect) or, if you prefer, you can use your own flat HTML files.
+*    This tutorial uses a copy of Retrospect – a HTML5, responsive website template from Templated.co - [https://templated.co/retrospect](https://web.archive.org/web/20160428170630/http://templated.co/retrospect/download) or, if you prefer, you can use your own flat HTML files.
 
 # **Getting Started**
 


### PR DESCRIPTION
I know we're currently working on the new tutorial but for temporary, I thought it'd be good to still have the template downloadable version on the page until the new changes come :) Maybe it'd prevent the new issues created for the same broken link! Got the link from @kfairris on issue [#3175](https://github.com/umbraco/UmbracoDocs/issues/3175)