### PR TITLE
Update index.md

### DIFF
--- a/Reference/Events/EditorModel-Events/index.md
+++ b/Reference/Events/EditorModel-Events/index.md
@@ -19,6 +19,7 @@ using System.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco.Web.Editors;
+using Umbraco.Web.Models.ContentEditing;
 
 namespace My.Website
 {


### PR DESCRIPTION
Added this line:
`using Umbraco.Web.Models.ContentEditing;
`
Needed to make the example work. See https://our.umbraco.com/forum/using-umbraco-and-getting-started/106017-the-name-contentsavedstate-does-not-exist-in-the-current-context#comment-330534