### PR TITLE
Add sendingcontentnotification example

### DIFF
--- a/Reference/Events/EditorModel-Events/index-v9.md
+++ b/Reference/Events/EditorModel-Events/index-v9.md
@@ -1,0 +1,73 @@
+---
+keywords: EditorModelEventManager setting default values defaultvalue SendingContentNotifications
+versionFrom: 9.0.0
+meta.Title: "SendingContentNotifications - or how to set a default value"
+meta.Description: "Explanation of how handle the SendingContentNotifications event to set an initial default value for a propery when the editor creates a new content item in the backoffice"
+---
+
+# SendingContentNotification Events
+
+The `SendingContentNotification` class is used to emit events that enable you to manipulate the model used by the backoffice before it is loaded into an editor. For example the SendingContentModel event fires right before a content item is loaded into the backoffice for editing. It is therefore the perfect event to use to set a default value for a particular property, or perhaps to hide a property/tab/Content App from a certain editor.
+
+## Usage
+
+Example usage of the `SendingContentNotification` event - eg set the default PublishDate for a new NewsArticle to be today's date:
+
+First register a composer:
+
+```csharp
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Notifications;
+
+namespace BetaTwo.Code.Events
+{
+    public class EditorModelComposer : IUserComposer
+    {
+        public void Compose(IUmbracoBuilder builder)
+        {
+            builder.AddNotificationHandler<SendingContentNotification, EditorModelNotificationHandler>();
+        }
+    }
+}
+```
+
+Then add the notification handler class:
+
+```csharp
+using System;
+using System.Linq;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Extensions;
+
+namespace BetaTwo.Code.Events
+{
+    public class EditorModelNotificationHandler : INotificationHandler<SendingContentNotification>
+    {
+        public void Handle(SendingContentNotification notification)
+        {
+            // fail if not the homepage type
+            if (notification.Content.ContentTypeAlias != "NewsArticle")
+                return;
+
+            foreach(var variant in notification.Content.Variants)
+            {
+                // fail if its not a brand new node
+                if (variant.State != ContentSavedState.NotCreated)
+                    return;
+
+                var pubDateProperty = variant.Tabs.SelectMany(f => f.Properties).FirstOrDefault(f => f.Alias.InvariantEquals("todaysDate"));
+
+                // fail if the date property can't be found
+                if (pubDateProperty == null)
+                    return;
+                    
+                // set datetime value to current time
+                pubDateProperty.Value = DateTime.UtcNow;       
+            }            
+        }
+    }
+}
+```

--- a/Reference/Events/EditorModel-Events/index-v9.md
+++ b/Reference/Events/EditorModel-Events/index-v9.md
@@ -13,26 +13,7 @@ The `SendingContentNotification` class is used to emit events that enable you to
 
 Example usage of the `SendingContentNotification` event - eg set the default PublishDate for a new NewsArticle to be today's date:
 
-First register a composer:
-
-```csharp
-using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Cms.Core.Notifications;
-
-namespace BetaTwo.Code.Events
-{
-    public class EditorModelComposer : IUserComposer
-    {
-        public void Compose(IUmbracoBuilder builder)
-        {
-            builder.AddNotificationHandler<SendingContentNotification, EditorModelNotificationHandler>();
-        }
-    }
-}
-```
-
-Then add the notification handler class:
+First add the notification handler class:
 
 ```csharp
 using System;
@@ -67,6 +48,62 @@ namespace BetaTwo.Code.Events
                 // set datetime value to current time
                 pubDateProperty.Value = DateTime.UtcNow;       
             }            
+        }
+    }
+}
+```
+
+Now we need to register it in Umbraco. For that there are 2 ways - composing and builder extension methods. If you are building a package you probably want to use a Composer, but otherwise a builder extension method is the way to go:
+
+Builder extension method example:
+
+```csharp
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Notifications;
+
+namespace BetaTwo.Code.Events
+{
+    public static class UmbracoBuilderExtensions
+    {
+        public static IUmbracoBuilder AddNotifierEvents(this IUmbracoBuilder builder)
+        {
+            builder.AddNotificationHandler<SendingContentNotification, EditorModelNotificationHandler>();
+            return builder;
+        }
+    }
+}
+```
+
+Then you want to register this new extension in your startup.cs after the standard Umbraco methods:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddUmbraco(_env, _config)
+        .AddBackOffice()
+        .AddWebsite()
+        .AddComposers()
+        .AddNotifierEvents()
+        .Build();
+
+}
+```
+
+
+Composer example:
+
+```csharp
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Notifications;
+
+namespace BetaTwo.Code.Events
+{
+    public class EditorModelComposer : IUserComposer
+    {
+        public void Compose(IUmbracoBuilder builder)
+        {
+            builder.AddNotificationHandler<SendingContentNotification, EditorModelNotificationHandler>();
         }
     }
 }


### PR DESCRIPTION
A v9 example of automatically setting values when creating a new node.

Used to be an EditorModelEvent, now it's a SendingContentNotification event.