### PR TITLE
Migrate events docs to notifications

### DIFF
--- a/Extending/Section-Trees/trees-v9.md
+++ b/Extending/Section-Trees/trees-v9.md
@@ -278,7 +278,7 @@ public class FavouritistThingsTreeController : TreeController
 
 All tree notications are defined in the namespace `Umbraco.Cms.Core.Notifications`. 
 
-For more information about registering and using notifications see [Notifications](../Notifications/index.md)
+For more information about registering and using notifications see [Notifications](../../Reference/Events/index-v9.md)
 
 ### RootNodeRenderingNotification
 

--- a/Extending/Section-Trees/trees-v9.md
+++ b/Extending/Section-Trees/trees-v9.md
@@ -274,152 +274,115 @@ To achieve this add an additional attribute `IsSingleNodeTree`, in the Tree attr
 public class FavouritistThingsTreeController : TreeController
 ```
 
-## Tree events
+## Tree notifications
 
-All tree events are defined on the class `Umbraco.Cms.Web.BackOffice.Trees.TreeControllerBase`
+All tree notications are defined in the namespace `Umbraco.Cms.Core.Notifications`. 
 
-### RootNodeRendering
+For more information about registering and using notifications see [Notifications](../Notifications/index.md)
 
-The `RootNodeRendering` is raised whenever a tree's root node is created.
+### RootNodeRenderingNotification
 
-**Definition:**
+The `RootNodeRenderingNotification` is published whenever a tree's root node is created.
 
-```csharp
-public static event TypedEventHandler<TreeControllerBase, TreeNodeRenderingEventArgs> RootNodeRendering;
-```
+**Members:**
+
+* `TreeNode Node`
+* `FormCollection QueryString`
+* `string TreeAlias`
 
 **Usage:**
 
 ```csharp
-// register the event listener using a component
-public void Initialize()
+public void Handle(RootNodeRenderingNotification notification)
 {
-    TreeControllerBase.RootNodeRendering += TreeControllerBase_RootNodeRendering;
-}
-
-// the event listener method:
-void TreeControllerBase_RootNodeRendering(TreeControllerBase sender, TreeNodeRenderingEventArgs e)
-{
-    // normally you will want to target a specific tree, this can be done by checking the
-    // tree alias of by checking the tree type (casting 'sender')
-    if (sender.TreeAlias == "content")
+    // normally you will want to target a specific tree, this can be done by checking the tree alias
+    if (notification.TreeAlias.Equals("content"))
     {
-        e.Node.Name = "My new title";
+        notification.Node.Name = "My new title";
     }
 }
-public void Terminate()
-{
-    // unsubscribe on shutdown
-    TreeControllerBase.RootNodeRendering -= TreeControllerBase_RootNodeRendering;
-}
 ```
 
-### TreeNodesRendering
+### TreeNodesRenderingNotification
 
-The `TreeNodesRendering` is raised whenever a list of child nodes are created.
+The `TreeNodesRenderingNotification` is published whenever a list of child nodes are created.
 
-**Definition:**
+**Members:**
 
-```csharp
-public static event TypedEventHandler<TreeControllerBase, TreeNodesRenderingEventArgs> TreeNodesRendering;
-```
+* `TreeNodeCollection Nodes`
+* `FormCollection QueryString`
+* `string TreeAlias`
 
 **Usage:**
 
 ```csharp
-public class MyComposer : IUserComposer
+public class TreeNotificationHandler :INotificationHandler<TreeNodesRenderingNotification>
 {
-    private Umbraco.Cms.Core.Security.IBackofficeSecurityAccessor  _backOfficeSecurityAccessor;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
-    public MyComposer(IBackofficeSecurityAccessor backOfficeSecurityAccessor)
+    public TreeNotificationHandler(IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
     {
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
-    // register the event listener with a component:
-    public void Initialize()
-    {
-        TreeControllerBase.TreeNodesRendering += TreeControllerBase_TreeNodesRendering;
-    }
-
-    // the event listener method:
-    void TreeControllerBase_TreeNodesRendering(TreeControllerBase sender, TreeNodesRenderingEventArgs e)
+    public void Handle(TreeNodesRenderingNotification notification)
     {
         // this example will filter any content tree node whose node name starts with
-
         // 'Private', for any user that is in the customUserGroup
-        if (sender.TreeAlias == "content"
-            && _backOfficeSecurityAccessor.BackOfficeSecurity.CurrentUser.Groups.Any(f => f.Alias == "customUserGroupAlias"))
+        if (notification.TreeAlias.Equals("content") &&
+            _backOfficeSecurityAccessor.BackOfficeSecurity.CurrentUser.Groups.Any(f =>
+                f.Alias.Equals("customUserGroupAlias")))
         {
-            e.Nodes.RemoveAll(node => node.Name.StartsWith("Private"));
+            notification.Nodes.RemoveAll(node => node.Name.StartsWith("Private"));
         }
-    }
-    public void Terminate()
-    {
-        // unsubscribe on shutdown
-        TreeControllerBase.TreeNodesRendering -= TreeControllerBase_TreeNodesRendering;
     }
 }
 ```
 
-### MenuRendering
+### MenuRenderingNotification
 
-The `MenuRendering` is raised whenever a menu is generated for a tree node.
+The `MenuRenderingNotification` is raised whenever a menu is generated for a tree node.
 
-**Definition:**
+**Members:**
 
-```csharp
-public static event TypedEventHandler<TreeControllerBase, MenuRenderingEventArgs> MenuRendering;
-```
+* `MenuItemCollection Menu`
+* `string NodeId`
+* `FormCollection QueryString`
+* `string TreeAlias`
 
 **Usage:**
 
 ```csharp
-public class MyComposer : IUserComposer
+public class TreeNotificationHandler : INotificationHandler<MenuRenderingNotification>
 {
-    private Umbraco.Cms.Core.Security.IBackofficeSecurityAccessor  _backOfficeSecurityAccessor;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
-    public MyComposer(IBackofficeSecurityAccessor backOfficeSecurityAccessor)
+    public TreeNotificationHandler(IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
     {
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
-    // register the event listener with a component:
-    public void Initialize()
-    {
-        TreeControllerBase.MenuRendering += TreeControllerBase_MenuRendering;
-    }
-
-    // the event listener method:
-    void TreeControllerBase_MenuRendering(TreeControllerBase sender, MenuRenderingEventArgs e)
+    public void Handle(MenuRenderingNotification notification)
     {
         // this example will add a custom menu item for all admin users
-
+        
         // for all content tree nodes
-        if (sender.TreeAlias == "content"
-            && _backOfficeSecurityAccessor.BackOfficeSecurity.CurrentUser.Groups.Any(x => x.Alias.InvariantEquals("admin")))
+        if (notification.TreeAlias.Equals("content") &&
+            _backOfficeSecurityAccessor.BackOfficeSecurity.CurrentUser.Groups.Any(x =>
+                x.Alias.InvariantEquals("admin")))
         {
-            // creates a menu action that will open /umbraco/currentSection/itemAlias.html
-            var i = new Umbraco.Cms.Core.Models.Trees.MenuItem("itemAlias", "Item name");
-
-            // optional, if you want to load a legacy page, otherwise it will follow convention
-            i.AdditionalData.Add("actionUrl", "my/long/url/to/webformshorror.aspx");
-
+            // Creates a menu action that will open /umbraco/currentSection/itemAlias.html
+            var menuItem = new Umbraco.Cms.Core.Models.Trees.MenuItem("itemAlias", "Item name");
+            
             // optional, if you don't want to follow the naming conventions, but do want to use a angular view
             // you can also use a direct path "../App_Plugins/my/long/url/to/view.html"
-            i.AdditionalData.Add("actionView", "my/long/url/to/view.html");
-
+            menuItem.AdditionalData.Add("actionView", "my/long/url/to/view.html");
+            
             // sets the icon to icon-wine-glass
-            i.Icon = "wine-glass";
-
+            menuItem.Icon = "wine-glass";
             // insert at index 5
-            e.Menu.Items.Insert(5, i);
+            notification.Menu.Items.Insert(5, menuItem);
         }
-    }
-    public void Terminate()
-    {
-        // unsubscribe on shutdown
-        TreeControllerBase.MenuRendering -= TreeControllerBase_MenuRendering;
     }
 }
 ```

--- a/Reference/Events/ContentService-Events-v9.md
+++ b/Reference/Events/ContentService-Events-v9.md
@@ -611,4 +611,4 @@ Furthermore, there was no reason to listen for the Creating/Created events. They
 
 #### What do we use instead?
 
-The ContentSavingNotification and ContentSavedNotification will always be published before and after an entity has been persisted. You can determine if an entity is brand new in either of those notifications. In the Saving notification - before the entity is persisted - you can check the entity's HasIdentity property which will be 'false' if it is brand new. In the Saved notification you can [check to see if the entity 'remembers being dirty'](./determining-new-identity.md)
+The ContentSavingNotification and ContentSavedNotification will always be published before and after an entity has been persisted. You can determine if an entity is brand new in either of those notifications. In the Saving notification - before the entity is persisted - you can check the entity's HasIdentity property which will be 'false' if it is brand new. In the Saved notification you can [check to see if the entity 'remembers being dirty'](determining-new-entity-v9.md)

--- a/Reference/Events/ContentService-Events-v9.md
+++ b/Reference/Events/ContentService-Events-v9.md
@@ -1,0 +1,614 @@
+---
+v8-equivalent: "https://our.umbraco.com/documentation/reference/events/ContentService-Events"
+versionFrom: 9.0.0
+verified-against: beta-2
+---
+
+# ContentService Notifications
+
+The ContentService class is the most commonly used type when extending Umbraco using notifications. ContentService implements IContentService. It provides access to operations involving IContent.
+
+## Usage
+
+Example usage of the ContentPublishingNotification:
+
+```C#
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Services.Notifications;
+
+namespace MySite
+{
+    public class DontShout : INotificationHandler<ContentPublishingNotification>
+    {
+        public void Handle(ContentPublishingNotification notification)
+        {
+            foreach (var node in notification.PublishedEntities)
+            {
+                if (node.ContentType.Alias.Equals("announcement"))
+                {
+                    var newsArticleTitle = node.GetValue<string>("title");
+                    if (newsArticleTitle.Equals(newsArticleTitle.ToUpper()))
+                    {
+                        notification.CancelOperation(new EventMessage("Corporate style guideline infringement",
+                            "Don't put the announcement title in upper case, no need to shout!",
+                            EventMessageType.Error));
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+## Notifications
+
+<table>
+  <tr>
+    <th>Notification</th>
+    <th>Members</th>
+    <th>Description</th>
+  </tr>
+
+  <tr>
+    <td>ContentSavingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIContent&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when the IContentService.Save is called in the API.<br />
+    NOTE: It can be skipped completely if the parameter "raiseEvents" is set to false during the Save method call (true by default).<br />
+    SavedEntities: The collection of IContent objects being saved. <br /><em>NOTE: If the entity is brand new then HasIdentity will equal false.</em>
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentSavedNotifiaction</td>
+    <td>
+        <ul>
+          <li>IEnumerable&ltIContent&gt SavedEntities</li>
+          <li>EventMessages Messages</li>
+          <li>IDictionary&ltstring,object&gt State</li>
+        </ul>
+    </td>
+    <td>
+    Published when IContentService.Save is called in the API and after data has been persisted.<br />
+    NOTE: It can be skipped completely if the parameter "raiseEvents" is set to false during the Save method call (true by default).<br />
+    <em>NOTE: <a href="./determining-new-entity">See here on how to determine if the entity is brand new</a></em><br />
+    SavedEntities: The saved collection of IContent objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentPublishingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIContent&gt PublishedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when IContentService.Publishing is called in the API.<br />
+    NOTE: It can be skipped completely if the parameter "raiseEvents" is set to false during the Publish method call (true by default).<br />
+    <em>NOTE: If the entity is brand new then HasIdentity will equal false.</em><br />
+    PublishedEntities: The collection of IContent objects being published.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentPublishedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIContent&gt PublishedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when IContentService.Publish is called in the API and after data has been published.<br />
+    NOTE: It can be skipped completely if the parameter "raiseEvents" is set to false during the Publish method call (true by default).<br />
+    <em>NOTE: <a href="./determining-new-entity">See here on how to determine if the entity is brand new</a></em><br />
+    PublishedEntities: The published collection of IContent objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentUnpublishingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIContent&gt UnpublishedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when IContentService.UnPublishing is called in the API.<br />
+    UnpublishedEntities: The collection of IContent being unpublished.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentUnpublishedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIContent&gt UnpublishedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when IContentService.UnPublish is called in the API and after data has been unpublished.<br />
+    UnpublishedEntities: The collection of unpublished IContent.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentCopyingNotification</td>
+    <td>
+      <ul>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+        <li>IContent Original</li>
+        <li>IContent Copy</li>
+        <li>int ParentId</li>
+      </ul>
+    </td>
+    <td>
+    Published when IContentService.Copy is called in the API.<br/>
+    The notification is published after a copy object has been created and had its parentId updated and its state has been set to unpublished.<br/>
+      <ol>
+        <li>Original: Gets the original IContent object.</li>
+        <li>Copy: Gets the IContent object being copied.</li>
+        <li>ParentId: Gets the Id of the parent of the IContent being copied.</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentCopiedNotification</td>
+    <td>
+      <ul>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>IContent Original</li>
+        <li>IContent Copy</li>
+        <li>int ParentId</li>
+        <li>bool RelateToOriginal</li>
+      </ul>
+    </td>
+    <td>
+    Published when IContentService.Copy is called in the API.<br/>
+    The notification is published after the content object has been copied.<br/>
+      <ol>
+        <li>Original: Gets the original IContent object.</li>
+        <li>Copy: Gets the IContent object being copied.</li>
+        <li>ParentId: Gets the Id of the parent of the IContent being copied.</li>
+        <li>RelateToOriginal: Boolean indicating whether the copy was related to the original</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentMovingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIContent&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when IContentService.Move is called in the API.<br/>
+    NOTE: If the target parent is the Recycle bin, this notification is never published. Try the ContentMovingToRecycleBinNotification instead.<br/>
+    MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the IContent object being moved</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the parent the entity will have after it has been moved</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentMovedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIContent&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when IContentService.Move is called in the API.
+    The notification is published after the content object has been moved.<br/>
+    NOTE: If the target parent is the Recycle bin, this notification is never published. Try the ContentMovedToRecycleBinNotification instead.<br/>
+    MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the IContent object being moved</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the parent the entity will have after it has been moved</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentMovingToRecycleBinNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIContent&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentService.MoveToRecycleBin is called in the API.<br/>
+    MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the IContent object being moved</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the RecycleBin</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentMovedToRecycleBinNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIContent&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentService.MoveToRecycleBin is called in the API. Is published after the content has been moved to the RecycleBin<br/>
+    MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the IContent object being moved</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the RecycleBin</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentDeletingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIContent&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentService.DeleteContentOfType, ContentService.Delete, ContentService.EmptyRecycleBin are called in the API.<br/>
+    DeletedEntities: Gets the collection of IContent objects being deleted.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentDeletedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIContent&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>Published when ContentService.Delete, ContentService.EmptyRecycleBin are called in the API, and the entity has been deleted.<br/>
+    DeletedEntities: Gets the collection of deleted IContent objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentDeletingVersionsNotification</td>
+    <td>
+      <ul>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+        <li>int Id</li>
+        <li>int SpecificVersion</li>
+        <li>DateTime DateToRetain</li>
+        <li>bool DeletePriorVersions</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentService.DeleteVersion, ContentService.DeleteVersions are called in the API.<br/>
+      <ol>
+        <li>Id: Gets the id of the IContent object being deleted.</li>
+        <li>DateToRetain: Gets the latest version date.</li>
+        <li>SpecificVersion: Gets the id of the IContent object version being deleted.</li>
+        <li>DeletePriorVersions: False by default</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentDeletedVersionsNotification</td>
+    <td>
+      <ul>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>int Id</li>
+        <li>int SpecificVersion</li>
+        <li>DateTime DateToRetain</li>
+        <li>bool DeletePriorVersions</li>
+      </ul>
+    </td>
+    <td>Published when ContentService.DeleteVersion, ContentService.DeleteVersions are called in the API, and the version has been deleted.<br/>
+      <ol>
+        <li>Id: Gets the id of the IContent object being deleted.</li>
+        <li>DateToRetain: Gets the latest version date.</li>
+        <li>SpecificVersion: Gets the id of the IContent object version being deleted.</li>
+        <li>DeletePriorVersions: False by default</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentRollingBackNotification</td>
+    <td>
+      <ul>
+        <li>IContent Entity</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentService.Rollback is called in the API.<br/>
+    Entity: Gets the IContent object being rolled back.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentRolledBackNotification</td>
+    <td>
+      <ul>
+        <li>IContent Entity</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentService.Rollback is called in the API, after the content has been rolled back.<br/>
+    Entity: Gets the IContent object being rolled back.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentSendingToPublishNotification</td>
+    <td>
+      <ul>
+        <li>IContent Entity</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentService.SendToPublication is called in the API.<br/>
+    Entity: Gets the IContent object being sent to publish.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentSentToPublishNotification</td>
+    <td>
+      <ul>
+        <li>IContent Entity</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentService.SendToPublication is called in the API, after the entity has been sent to publlication.<br/>
+    Entity: Gets the IContent object being sent to publish.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentEmptyingRecycleBinNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIContent&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentService.EmptyRecycleBin is called in the API.<br/>
+    DeletedEntities: The collection of IContent objects being deleted.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentEmptiedRecycleBinNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIContent&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentService.EmptyRecycleBin is called in the API, after the RecycleBin has been emptied.<br/>
+    DeletedEntities: The collection of deleted IContent object.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentSavedBlueprintNotification</td>
+    <td>
+      <ul>
+        <li>IContent SavedBlueprint</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentService.SavedBlueprint is called in the API.<br/>
+    SavedBlueprint: Gets the saved blueprint IContent object
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentDeletedBlueprintNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIContent&gt DeletedBlueprints</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentService.DeletedBlueprint is called in the API.<br/>
+    DeletedBlueprints: The collection of deleted blueprint IContent
+    </td>
+  </tr>
+</table>
+
+### Variants and Notifications
+
+Umbraco V8 introduced the concept of Variants for Document Types, initially to allow different language variants of particular properties within a Document Type to be edited/translated based on the languages configured in your instance of Umbraco.
+
+These variants can be saved, published and unpublished independently of each other. (Unpublishing a 'mandatory language' variant of a content item - will trigger all culture variants to be unpublished).
+
+This poses a problem when handling notifications from the ContentService - eg Which culture just got published? do I want to run my 'custom' code that fires on save if it's just the Spanish version that's been published? Also, if only the Spanish variant is 'unpublished' - that feels like a different situation to if 'all the variants' have been 'unpublished'. Depending on which event you are handling there are helper methods you can call to find out:
+
+#### Saving
+
+When handling the ContentSavingNotification which will be published whenever a variant is saved. You can tell 'which' variant has triggered the save using an extension method on the ContentSavingNotification called 'IsSavingCulture'
+
+```C#
+public bool IsSavingCulture(IContent content, string culture);
+```
+
+As an example, you could check which cultures are being saved (it could be multiple if multiple checkboxes are checked)
+
+```C#
+public void Handle(ContentSavingNotification notification)
+{
+    foreach (var entity in notification.SavedEntities)
+    {
+        // Cultures being saved
+        var savingCultures = entity.AvailableCultures
+            .Where(culture => notification.IsSavingCulture(entity, culture)).ToList();
+        // or
+        if (notification.IsSavingCulture(entity, "en-GB"))
+        {
+            // Do things differently if the UK version of the page is being saved.
+        }
+    }
+}
+```
+
+#### Saved
+
+With the Saved notification you can similarly use the 'HasSavedCulture' method of the 'ContentSavedNotification' to detect which culture caused the Save.
+
+```C#
+public bool HasSavedCulture(IContent content, string culture);
+```
+
+#### Unpublishing
+
+When handling the Unpublishing notification, this might not work how you would expect! If 'all the variants' are being unpublished at the same time (or the mandatory language is being unpublished, which forces this to occur, then the Unpublishing notification will be published as expected.
+
+However, if only one variant is being unpublished, the Unpublishing event will not be triggered. This is because the content item itself is not fully 'unpublished' by the action. Instead what occurs is a 'publish' action 'without' the variant that has been unpublished.
+
+You can therefore detect the Unpublishing of a variant in the publishing notification - using the IsUnpublishingCulture extension method of the `ContentPublishingNotification`
+
+```C#
+public void Handle(ContentPublishingNotification notification)
+{
+    foreach (var node in notification.PublishedEntities)
+    {
+        if (notification.IsUnpublishingCulture(node, "da-DK"))
+        {
+            // Bye bye DK!
+        }
+    }
+}
+```
+
+#### Unpublished
+
+Again the Unpublished notification does not get published when a single variant is Unpublished, instead, the Published notification can be used, and the 'HasUnpublishedCulture' extension method of the ContentPublishedNotification can determine which variant being unpublished triggered the publish.
+
+```C#
+public bool HasUnpublishedCulture(IContent content, string culture);
+```
+
+#### Publishing
+
+When handling the ContentPublishingNotification which will be triggered whenever a variant is published (or unpublished - see note in Unpublishing section).
+
+You can tell 'which' variant has triggered the publish using a helper method on the ContentPublishingNotification called IsPublishingCulture
+
+```C#
+public bool IsPublishingCulture(IContent content, string culture);
+```
+
+For example, you could check which cultures are being published and act accordingly (it could be multiple if multiple checkboxes are checked)
+
+```C#
+public void Handle(ContentPublishingNotification notification)
+{
+    foreach (var node in notification.PublishedEntities)
+    {
+        var publishingCultures = node.AvailableCultures
+            .Where(culture => notification.IsPublishingCulture(node, culture)).ToList();
+        
+        var unPublishingCultures = node.AvailableCultures
+            .Where(culture => notification.IsUnpublishingCulture(node, culture)).ToList();
+        // or
+        if (notification.IsPublishingCulture(node, "da-DK"))
+        {
+            // Welcome back DK!
+        }
+    }
+}
+```
+
+#### Published
+In the Published notification you can similarly use the HasPublishedCulture and HasUnpublishedCulture methods of the 'ContentPublishedEventArgs' to detect which culture caused the Publish or the UnPublish if it was only a single non-mandatory variant that was unpublished.
+
+```C#
+public bool HasPublishedCulture(IContent content, string culture);
+public bool HasUnpublishedCulture(ICotnent content, string culture);
+```
+
+#### IContent Helpers
+
+In each of these notifications, the entities being Saved, Published, and Unpublished are `IContent` entities. There are some useful helper methods on IContent to discover the status of the content item's variant cultures:
+
+```C#
+bool IsCultureAvailable(string culture);
+bool IsCultureEdited(string culture);
+bool IsCulturePublished(string culture);
+```
+
+### What happened to Creating and Created events?
+
+Both the ContentService.Creating and ContentService.Created events were removed, and therefore never moved to notifications. Why? Because these events were not guaranteed to trigger and therefore should not be used. This is because these events would only trigger when the ContentService.CreateContent method was used which is an entirely optional way to create content entities. It is also possible to construct a new content item - which is generally the preferred and consistent way - and therefore the Creating/Created events would not execute when constructing content that way.
+
+Furthermore, there was no reason to listen for the Creating/Created events. They were misleading since they didn't trigger before and after the entity was persisted. They triggered inside the CreateContent method which never persists the entity, it constructs a new content object.
+
+#### What do we use instead?
+
+The ContentSavingNotification and ContentSavedNotification will always be published before and after an entity has been persisted. You can determine if an entity is brand new in either of those notifications. In the Saving notification - before the entity is persisted - you can check the entity's HasIdentity property which will be 'false' if it is brand new. In the Saved notification you can [check to see if the entity 'remembers being dirty'](./determining-new-identity.md)

--- a/Reference/Events/ContentService-Events-v9.md
+++ b/Reference/Events/ContentService-Events-v9.md
@@ -488,7 +488,7 @@ Umbraco V8 introduced the concept of Variants for Document Types, initially to a
 
 These variants can be saved, published and unpublished independently of each other. (Unpublishing a 'mandatory language' variant of a content item - will trigger all culture variants to be unpublished).
 
-This poses a problem when handling notifications from the ContentService - eg Which culture just got published? do I want to run my 'custom' code that fires on save if it's just the Spanish version that's been published? Also, if only the Spanish variant is 'unpublished' - that feels like a different situation to if 'all the variants' have been 'unpublished'. Depending on which event you are handling there are helper methods you can call to find out:
+This poses a problem when handling notifications from the ContentService - eg which culture got published? Do I want to run my 'custom' code that fires on save if it's only the Spanish version that's been published? Also, if only the Spanish variant is 'unpublished' - that feels like a different situation to if 'all the variants' have been 'unpublished'. Depending on which event you are handling there are helper methods you can call to find out.
 
 #### Saving
 
@@ -527,7 +527,7 @@ public bool HasSavedCulture(IContent content, string culture);
 
 #### Unpublishing
 
-When handling the Unpublishing notification, this might not work how you would expect! If 'all the variants' are being unpublished at the same time (or the mandatory language is being unpublished, which forces this to occur, then the Unpublishing notification will be published as expected.
+When handling the Unpublishing notification, it might not work how you would expect. If 'all the variants' are being unpublished at the same time (or the mandatory language is being unpublished, which forces this to occur) then the Unpublishing notification will be published as expected.
 
 However, if only one variant is being unpublished, the Unpublishing event will not be triggered. This is because the content item itself is not fully 'unpublished' by the action. Instead what occurs is a 'publish' action 'without' the variant that has been unpublished.
 
@@ -556,15 +556,15 @@ public bool HasUnpublishedCulture(IContent content, string culture);
 
 #### Publishing
 
-When handling the ContentPublishingNotification which will be triggered whenever a variant is published (or unpublished - see note in Unpublishing section).
+When handling the ContentPublishingNotification which will be triggered whenever a variant is published (or unpublished - see note in the Unpublishing section above).
 
-You can tell 'which' variant has triggered the publish using a helper method on the ContentPublishingNotification called IsPublishingCulture
+You can tell 'which' variant has triggered the publish using a helper method on the ContentPublishingNotification called IsPublishingCulture.
 
 ```C#
 public bool IsPublishingCulture(IContent content, string culture);
 ```
 
-For example, you could check which cultures are being published and act accordingly (it could be multiple if multiple checkboxes are checked)
+For example, you could check which cultures are being published and act accordingly (it could be multiple if multiple checkboxes are checked).
 
 ```C#
 public void Handle(ContentPublishingNotification notification)
@@ -586,6 +586,7 @@ public void Handle(ContentPublishingNotification notification)
 ```
 
 #### Published
+
 In the Published notification you can similarly use the HasPublishedCulture and HasUnpublishedCulture methods of the 'ContentPublishedEventArgs' to detect which culture caused the Publish or the UnPublish if it was only a single non-mandatory variant that was unpublished.
 
 ```C#

--- a/Reference/Events/ContentTypeService-Events-v9.md
+++ b/Reference/Events/ContentTypeService-Events-v9.md
@@ -1,0 +1,140 @@
+---
+v8-equivalent: "https://our.umbraco.com/documentation/Reference/Events/ContentTypeService-Events"
+versionFrom: 9.0.0
+verified-against: beta-2
+---
+
+# ContentTypeService Notifications
+
+The ContentTypeService class implements IContentTypeService. It provides access to operations involving IContentType
+
+<table>
+  <tr>
+    <th>Notification</th>
+    <th>Members</th>
+    <th>Description</th>
+  </tr>
+
+  <tr>
+    <td>ContentTypeSavingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIContentType&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentTypeService.Save is called in the API.<br/>
+    SavedEntities: Gets the collection of IContentType objects being saved.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentTypeSavedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIContentType&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentTypeService.Save is called in the API, after the entities has been saved.<br/>
+    NOTE: <em><a href="determining-new-entity">See here on how to determine if the entity is brand new</a></em><br/>
+    SavedEntities: Gets the collection of saved IContentType objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentTypeDeletingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIContentType&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+      Published when ContentTypeService.Delete is called in the API.<br/>
+      DeletedEntities: Gets the collection of IContentType objects being deleted.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentTypeDeletedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIContentType&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+      Published when ContentTypeService.Delete is called in the API, after the entities has been deleted.<br/>
+      DeletedEntities: Gets the collection of deleted IContentType objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentTypeMovingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIContentType&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentTypeService.Move is called in the API<br/>
+    MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the IContentType object being moved</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the parent the entity will have after it has been moved</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentTypeMovedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIContentType&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when ContentTypeService.Move is called in the API, after the entities has been moved.<br/>
+    MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the IContentType object being moved</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the parent the entity will have after it has been moved</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>ContentTypeChangedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltContentTypeChange&ltIContentType&gt&gt Changes</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when a ContentType is saved or deleted, after the transaction has completed. This is mainly used for caching purposes, and generally not recommended, use Saved and Delted notifications instead.<br/>
+    Changes will for each item affected by the change prove:
+    <ol>
+      <li>Item: The IContentType affected by the change.</li>
+      <li>ChangeTypes: The type of change: Create, Remove, RefreshMain, etc.</li>
+    </ol>
+    </td>
+  </tr>
+</table>

--- a/Reference/Events/DataTypeService-Events-v9.md
+++ b/Reference/Events/DataTypeService-Events-v9.md
@@ -1,0 +1,122 @@
+---
+v8-equivalent: "https://our.umbraco.com/documentation/Reference/Events/DataTypeService-Events"
+versionFrom: 9.0.0
+verified-against: beta-2
+---
+
+# DataTypeService Notifications
+
+The DataTypeService class implements IDataTypeService. It provides access to operations involving IDataType.
+
+<table>
+  <tr>
+    <th>Notification</th>
+    <th>Members</th>
+    <th>Description</th>
+  </tr>
+
+  <tr>
+    <td>DataTypeSavingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIDataType&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when DataTypeService.Save is called in the API.<br/>
+    SavedEntities: Gets the collection of IDataType objects being saved.
+    </td>
+  </tr>
+
+  <tr>
+    <td>DataTypeSavedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIDataType&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when DataTypeService.Save is called in the API and after data has been persisted.
+    NOTE: <em><a href="./determining-new-entity">See here on how to determine if the entity is brand new</a></em><br>
+    SavedEntities: Gets the saved collection of IDataType objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>DataTypeDeletingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIDataType&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when DataTypeService.Delete is called in the API.<br/>
+    DeletedEntities: Gets the collection of IDataType objects being deleted.
+    </td>
+  </tr>
+
+  <tr>
+    <td>DataTypeDeletedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIDataType&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when DataTypeService.Delete is called in the API, after the IDataType objects has been deleted.<br/>
+    DeletedEntities: Gets the collection of deleted IDataType objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>DataTypeMovingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIDataType&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+      Published when IDataTypeService.Move is called in the API.<br/>
+      MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the IDataType object being moved</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the parent the entity will have after it has been moved</li>
+      </ol>
+    </td>
+  </tr>
+
+   <tr>
+    <td>DataTypeMovedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIDataType&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+      Published when IDataTypeService.Move is called in the API, after the IDataType has been moved.<br/>
+      MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the moved IDataType object</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the parent the entity will have after it has been moved</li>
+      </ol>
+    </td>
+  </tr>
+  
+</table>

--- a/Reference/Events/EditorModel-Events/Customizing-the-links-box-v9.md
+++ b/Reference/Events/EditorModel-Events/Customizing-the-links-box-v9.md
@@ -1,0 +1,26 @@
+# Customizing the "Links" box
+
+For a content item, Umbraco will show a **Links** box within the **Info** content app. By default, this box will show one or more links to content item.
+
+![image](./images/properties-info-app.png)
+
+With the `SendingContentNotification` event, we can manipulate the links in the `Urls` property - e.g. replace it with some custom links (although a URL provider would be more suitable):
+
+```C#
+public void Handle(SendingContentNotification notification)
+{
+    notification.Content.Urls = new[]
+    {
+        new UrlInfo($"/products/?id={notification.Content.Id}", true, CultureInfo.CurrentCulture.Name)
+    };
+}
+```
+
+or remove the box entirely by providing an empty list of links:
+
+```C#
+public void Handle(SendingContentNotification notification)
+{
+    notification.Content.Urls = null;
+}
+```

--- a/Reference/Events/EditorModel-Events/Customizing-the-links-box-v9.md
+++ b/Reference/Events/EditorModel-Events/Customizing-the-links-box-v9.md
@@ -2,7 +2,7 @@
 
 For a content item, Umbraco will show a **Links** box within the **Info** content app. By default, this box will show one or more links to content item.
 
-![image](./images/properties-info-app.png)
+![image](Images/properties-info-app.png)
 
 With the `SendingContentNotification` event, we can manipulate the links in the `Urls` property - e.g. replace it with some custom links (although a URL provider would be more suitable):
 

--- a/Reference/Events/EditorModel-Events/index-v9.md
+++ b/Reference/Events/EditorModel-Events/index-v9.md
@@ -1,0 +1,235 @@
+---
+v8-equivalent: "https://our.umbraco.com/documentation/Reference/Events/EditorModel-Events"
+versionFrom: 9.0.0
+verified-against: beta-2
+---
+
+# EditorModel Notifications
+
+EditorModel notifications enable you to manipulate the model used by the backoffice before it is loaded into an editor. For example the `SendingContentNotification` is published right before a content item is loaded into the backoffice for editing. It is therefore the perfect notification to use to set a default value for a particular property, or perhaps to hide a property/tab/Content App from a certain editor.
+
+## Usage
+
+Example usage of the `SendingContentNotification` - e.g. set the default PublishDate for a new NewsArticle to be today's Date:
+
+```C#
+using System;
+using System.Linq;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Web.BackOffice.Filters;
+using Umbraco.Extensions;
+
+namespace MySite
+{
+    public class EditorModelNotificationHandler : INotificationHandler<SendingContentNotification>
+    {
+        public void Handle(SendingContentNotification notification)
+        {
+            if (notification.Content.ContentTypeAlias.Equals("newsArticle"))
+            {
+                // Access the property you want to pre-populate
+                // each content item can have 'variations' - each variation is represented by the `ContentVariantDisplay` class.
+                // if your site uses variants, then you need to decide whether to set the default value for all variants or a specific variant
+                // eg. set by variant name:
+                // var variant = notification.Content.Variants.FirstOrDefault(f => f.Name == "specificVariantName");
+                // OR loop through all the variants:
+                foreach (var variant in notification.Content.Variants)
+                {
+                    // Check if variant is a 'new variant'
+                    // we only want to set the default value when the content item is first created
+                    if (variant.State == ContentSavedState.NotCreated)
+                    {
+                        // each variant has an IEnumerable of 'Tabs' (property groupings)
+                        // and each of these contain an IEnumerable of `ContentPropertyDisplay` properties
+                        var pubDateProperty = variant.Tabs.SelectMany(f => f.Properties)
+                            .FirstOrDefault(f => f.Alias.InvariantEquals("publishDate"));
+                        if (pubDateProperty is not null)
+                        {
+                            // set default value of the publish date property if it exists
+                            pubDateProperty.Value = DateTime.UtcNow;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+Another example could be to set  the default Member Group for a specific Member Type using `SendingMemberNotification`:
+
+```C#
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.BackOffice.Filters;
+
+namespace MySite
+{
+    public class EditorModelNotificationHandler : INotificationHandler<SendingMemberNotification>
+    {
+        private readonly IMemberGroupService _memberGroupService;
+
+        public EditorModelNotificationHandler(IMemberGroupService memberGroupService)
+        {
+            _memberGroupService = memberGroupService;
+        }
+        
+        public void Handle(SendingMemberNotification notification)
+        {
+            var isNew = !int.TryParse(notification.Member.Id?.ToString(), out int id) || id == 0;
+            
+            // We only want to set the default member group when the member is initially created, eg doesn't have an Id yet
+            if (isNew is false)
+            {
+                return;
+            }
+
+            // Set a default value member group for the member type `Member`
+            if (notification.Member.ContentTypeAlias.Equals("Member"))
+            {
+                var memberGroup = _memberGroupService.GetByName("Customer");
+                if (memberGroup is null)
+                {
+                    return;
+                }
+
+                // Find member group property on member model
+                var property = notification.Member.Properties.FirstOrDefault(x =>
+                    x.Alias.Equals($"{Constants.PropertyEditors.InternalGenericPropertiesPrefix}membergroup"));
+
+                if (property is not null)
+                {
+                    // Assign a default value for member group property
+                    property.Value = new Dictionary<string, object>
+                    {
+                        {memberGroup.Name, true}
+                    };
+                }
+            }
+        }
+    }
+}
+```
+
+## Notifications
+
+<table>
+  <tr>
+    <th>Notification</th>
+    <th>Members</th>
+    <th>Description</th>
+  </tr>
+
+  <tr>
+    <td>SendingContentNotification</td>
+    <td>
+      <ul>
+        <li>ContentItemDisplay Content</li>
+        <li>IUmbracoContext UmbracoContext</li>
+      </ul>
+    </td>
+    <td>
+    Published right before the editor model is sent for editing in the content section.<br/>
+    NOTE: Content is a Umbraco.Cms.Core.Models.ContentEditing.ContentItemDisplay type which contains the tabs and properties of the elements about to be loaded for editing.
+    </td>
+  </tr>
+
+  <tr>
+    <td>SendingMediaNotification</td>
+    <td>
+      <ul>
+        <li>MediaItemDisplay Media</li>
+        <li>IUmbracoContext UmbracoContext</li>
+      </ul>
+    </td>
+    <td>Published right before the editor model is sent for editing in the media section<br/>
+    NOTE: Media is a Umbraco.Cms.Core.Models.ContentEditing.MediaItemDisplay type which in turn contains the tabs and properties of the elements about to be loaded for editing.
+    </td>
+  </tr>
+
+  <tr>
+    <td>SendingMemberNotification</td>
+    <td>
+      <ul>
+        <li>MemberDisplay Member</li>
+        <li>IUmbracoContext UmbracoContext</li>
+      </ul>
+    </td>
+    <td>
+    Published right before the editor model is sent for editing in the member section.<br/>
+    NOTE: Member is a Umbraco.Cms.Core.Models.ContentEditing.MemberDisplay type which in turn contains the tabs and properties of the elements about to be loaded for editing.
+    </td>
+  </tr>
+
+  <tr>
+    <td>SendingUserNotification</td>
+    <td>
+      <ul>
+        <li>UserDisplay User</li>
+        <li>IUmbracoContext UmbracoContext</li>
+      </ul>
+    </td>
+    <td>
+    Published right before the editor model is sent for editing in the user section.<br/>
+    NOTE: User is a Umbraco.Cms.Core.Models.ContentEditing.UserDisplay type which in turn contains the tabs and properties of the elements about to be loaded for editing.
+    </td>
+  </tr>
+  
+  <tr>
+    <td>SendingDashboardsNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltTab&ltIDashboardSlim&gt&gt Dashboards</li>
+        <li>IUmbracoContext UmbracoContext</li>
+      </ul>
+    </td>
+    <td>
+    Published right before the a dashboard is retrieved in a section.<br>
+    NOTE: Dashboards is a collection of IDashboardSlim, each object gives you access to Label, Alias, Properties, whether it's expanded, and whether it IsActive.
+    </td>
+  </tr>
+</table>
+
+### Display models
+
+#### ContentItemDisplay
+
+A model representing a conten item to be displayed in the backoffice
+
+* TemplateAlias
+* Urls
+* AllowPreview - Determines whether previewing is allowed for this node, By default this is true but by using notifications developers can toggle this off for certain documents if there is nothing to preview
+* AllowedActions - The allowed 'actions' based on the user's permissions - Create, Update, Publish, Send to publish
+* IsBlueprint
+* Tabs - Defines the tabs containing display properties
+* Properties - properties based on the properties in the tabs collection
+* And more...
+
+#### MediaItemDisplay
+
+A model representing a media item to be displayed in the backoffice
+
+* Alias
+* Tabs - Defines the tabs containing display properties
+* Properties - properties based on the properties in the tabs collection
+* And more...
+
+#### MemberDisplay
+
+A model representing a member to be displayed in the backoffice
+
+* Username
+* Email
+* Tabs - Defines the tabs containing display properties
+* Properties - properties based on the properties in the tabs collection
+* And more...
+
+## Samples 
+
+The EditorModel notifications gives you a lot of options to customize the backoffice experience. You can find inspiration from the various samples provided below:
+
+* [Customizing the "Links" box](./customizing-the-links-box.md)

--- a/Reference/Events/EditorModel-Events/index-v9.md
+++ b/Reference/Events/EditorModel-Events/index-v9.md
@@ -232,4 +232,4 @@ A model representing a member to be displayed in the backoffice
 
 The EditorModel notifications gives you a lot of options to customize the backoffice experience. You can find inspiration from the various samples provided below:
 
-* [Customizing the "Links" box](./customizing-the-links-box.md)
+* [Customizing the "Links" box](Customizing-the-links-box-v9.md)

--- a/Reference/Events/FileService-Events-v9.md
+++ b/Reference/Events/FileService-Events-v9.md
@@ -1,0 +1,216 @@
+---
+v8-equivalent: "https://our.umbraco.com/documentation/Reference/Events/FileService-Events"
+versionFrom: 9.0.0
+verified-against: beta-2
+---
+
+# FileService Notifications
+
+The FileService class implements IFileService. It provides access to operations involving IFile objects like scripts, stylesheets and templates.
+
+<table>
+  <tr>
+    <th>Notification</th>
+    <th>Members</th>
+    <th>Description</th>
+  </tr>
+
+  <tr>
+    <td>TemplateSavingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltITemplate&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+        <li>string ContentTypeAlias</li>
+        <li>bool CreateTemplateForContentType</li>
+      </ul>
+    </td>
+    <td>
+    Published when FileService.SaveTemplate is called in the API.<br>
+      <ol>
+        <li>SavedEntities: Gets the collection of ITemplate objects being saved.</li>
+        <li>ContentTypeAlias: The alias of the ContentType the template is for, this is used when creating a Document Type with Template, it's not recommended to try and change or set this.</li>
+        <li>CreateTemplateForContentType: Boolean value determining if the template is create for a Document Type, it's not recommended to change this value.</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>TemplateSavedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltITemplate&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>string ContentTypeAlias</li>
+        <li>bool CreateTemplateForContentType</li>
+      </ul>
+    </td>
+    <td>
+    Published when FileService.SaveTemplate is called in the API, after the template has been saved.<br>
+      <ol>
+        <li>SavedEntities: Gets the collection of saved ITemplate objects.</li>
+        <li>ContentTypeAlias: The alias of the ContentType the template is for, this is used when creating a Document Type with Template, it's not recommended to try and change this value.</li>
+        <li>CreateTemplateForContentType: Boolean value determining if the template is create for a Document Type, it's not recommended to change this value.</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>ScriptSavingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIScript&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when FileService.SaveScript is called in the API.<br>
+    SavedEntities: Gets the collection of IScript objects being saved.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ScriptSavedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIScript&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when FileService.SaveScript is called in the API, after the script has been saved.<br>
+    SavedEntities: Gets the collection of saved IScript objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>StylesheetSavingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIStylesheet&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when FileService.SaveStyleSheet is called in the API.<br>
+    SavedEntities: Gets the collection of IStylesheet objects being saved.
+    </td>
+  </tr>
+
+  <tr>
+    <td>StylesheetSavedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIStylesheet&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when FileService.SaveStylesheet is called in the API, after the script has been saved.<br>
+    SavedEntities: Gets the collection of saved IStylesheet objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>TemplateDeletingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltITemplate&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+      Published when FileService.DeleteTemplate is called in the API.<br/>
+      DeletedEntities: Gets the collection of ITemplate objects being deleted.
+    </td>
+  </tr>
+
+  <tr>
+    <td>TemplateDeletedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltITemplate&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+      Published when FileService.DeleteTemplate is called in the API, after the template has been deleted.<br/>
+      DeletedEntities: Gets the collection of deleted ITemplate objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ScriptDeletingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIScript&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+      Published when FileService.DeleteScript is called in the API.<br/>
+      DeletedEntities: Gets the collection of IScript objects being deleted.
+    </td>
+  </tr>
+
+  <tr>
+    <td>ScriptDeletedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIScript&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+      Published when FileService.DeleteScript is called in the API, after the script has been deleted.<br/>
+      DeletedEntities: Gets the collection of deleted IScript objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>StylesheetDeletingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIStylesheet&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+      Published when FileService.DeleteStylesheet is called in the API.<br/>
+      DeletedEntities: Gets the collection of IStylesheet objects being deleted.
+    </td>
+  </tr>
+
+  <tr>
+    <td>StylesheetDeletedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIStylesheet&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+      Published when FileService.DeleteStylesheet is called in the API, after the stylesheet has been deleted.<br/>
+      DeletedEntities: Gets the collection of deleted IStylesheet objects.
+    </td>
+  </tr>
+
+</table>

--- a/Reference/Events/LocalizationService-Events-v9.md
+++ b/Reference/Events/LocalizationService-Events-v9.md
@@ -1,0 +1,141 @@
+---
+v8-equivalent: "https://our.umbraco.com/documentation/Reference/Events/LocalizationService-Events"
+versionFrom: 9.0.0
+verified-against: beta-2
+---
+
+# LocalizationService Events
+
+The LocalizationService class implements ILocalizationService. It provides access to operations involving Language and DictionaryItem.
+
+<table>
+  <tr>
+    <th>Notification</th>
+    <th>Members</th>
+    <th>Description</th>
+  </tr>
+
+  <tr>
+    <td>LanguageSavingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltILanguage&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when LocalizationService.Save (ILanguage overload) is called in the API.<br/>
+    SavedEntities: Gets the collection of ILanguage objects being saved.
+    </td>
+  </tr>
+
+  <tr>
+    <td>LanguageSavedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltILanguage&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    RPublished when LocalizationService.Save (ILanguage overload) is called in the API after data has been persisted.<br/>
+    SavedEntities: Gets the saved collection of ILanguage objects..
+    </td>
+  </tr>
+
+  <tr>
+    <td>DictionaryItemSavingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIDictionaryItem&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when LocalizationService.Save (IDictionaryItem overload) is called in the API.<br/>
+    SavedEntities: Gets the collection of IDictionaryItem objects being saved.
+    </td>
+  </tr>
+
+  <tr>
+    <td>DictionaryItemSavedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIDictionaryItem&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when LocalizationService.Save (IDictionaryItem overload) is called in the API and the data has been persisted.<br/>
+    SavedEntities: Gets the saved collection of IDictionary objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>LanguageDeletingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltILanguage&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when LocalizationService.Delete (ILanguage overload) is called in the API.<br/>
+    DeletedEntities: Gets the collection of ILanguage objects being deleted.
+    </td>
+  </tr>
+
+  <tr>
+    <td>LanguageDeletedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltILanguage&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when LocalizationService.Delete (ILanguage overload) is called in the API, after the languages has been deleted.<br/>
+    DeletedEntities: Gets the collection of deleted ILanguage objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>DictionaryItemDeletingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIDictionaryItem&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when LocalizationService.Delete (IDictionaryItem overload) is called in the API.<br/>
+    DeletedEntities: Gets the collection of IDictionaryItem objects being deleted
+    </td>
+  </tr>
+
+  <tr>
+    <td>DictionaryItemDeletedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIDictionaryItem&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when LocalizationService.Delete (IDictionaryItem overload) is called in the API, after the dictionary items has been deleted.<br/>
+    DeletedEntities: Gets the collection of deleted IDictionaryItem objects.
+    </td>
+  </tr>
+</table>

--- a/Reference/Events/MediaService-Events-v9.md
+++ b/Reference/Events/MediaService-Events-v9.md
@@ -1,0 +1,261 @@
+---
+v8-equivalent: "https://our.umbraco.com/documentation/Reference/Events/MediaService-Events"
+versionFrom: 9.0.0
+verified-against: beta-2
+---
+
+# MediaService Notifications
+
+The MediaService class implements IMediaService. It provides access to operations involving IMedia.
+
+## Usage
+
+Example usage of the MediaService notifications:
+
+```C#
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Services.Notifications;
+
+namespace MySite
+{
+    public class MediaNotificationHandler : INotificationHandler<MediaSavedNotification>
+    {
+        private readonly ILogger<MediaNotificationHandler> _logger;
+
+        public MediaNotificationHandler(ILogger<MediaNotificationHandler> logger)
+        {
+            _logger = logger;
+        }
+        
+        public void Handle(MediaSavedNotification notification)
+        {
+            foreach (var mediaItem in notification.SavedEntities)
+            {
+                if (mediaItem.ContentType.Alias.Equals("Image"))
+                {
+                    // Do something with the image, maybe send to Azure for AI analysis of image contents or something.
+                    _logger.LogDebug($"Sending {mediaItem.Name} to analysis");
+                    SendToAzure(mediaItem);
+                }
+            }
+        }
+    }
+}
+```
+
+## Events
+
+<table>
+  <tr>
+    <th>Notification</th>
+    <th>Members</th>
+    <th>Description</th>
+  </tr>
+
+  <tr>
+    <td>MediaSavingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMedia&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when MediaService.Save is called in the API.<br/>
+    NOTE: It can be skipped completely if the parameter "raiseEvents" is set to false during the Save method call (true by default).<br/>
+    SavedEntities: Gets the collection of IMedia objects being saved.
+    </td>
+  </tr>
+
+  <tr>
+    <td>MediaSavedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMedia&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when MediaService.Save is called in the API and after the data has been persisted.<br/>
+    NOTE: It can be skipped completely if the parameter "raiseEvents" is set to false during the Save method call (true by default).<br/>
+    SavedEntities: Gets the saved collection of IMedia objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>MediaMovingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIMedia&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when MediaService.Move is called in the API.<br/>
+    NOTE: If the target parent is the Recycle bin, this notification is never published. Try the MediaMovingToRecycleBinNotification instead.<br/>
+    MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the IMedia object being moved</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the parent the entity will have after it has been moved</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>MediaMovedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIMedia&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when MediaService.Move is called in the API.
+    The event is fired after the media object has been moved.<br/>
+    NOTE: If the target parent is the Recycle bin, this notification is never published. Try the MediaMovedToRecycleBinNotification instead.<br/>
+    MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the IMedia object being moved</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the parent the entity will have after it has been moved</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>MediaMovingToRecycleBinNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIMedia&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when MediaService.MoveToRecycleBin is called in the API.<br/>
+    MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the IMedia object being moved</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the RecycleBin</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>MediaMovedToRecycleBinNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIMedia&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when MediaService.MoveToRecycleBin is called in the API, after the media object has been moved to the RecycleBin.<br/>
+    MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the IMedia object being moved</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the RecycleBin</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>MediaDeletingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMedia&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when MediaService.DeleteMediaOfType, MediaService.Delete, MediaService.EmptyRecycleBin are called in the API.<br/>
+    DeletedEntities: Gets the collection of IMedia objects being deleted.
+    </td>
+  </tr>
+
+  <tr>
+    <td>MediaDeletedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMedia&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when MediaService.Delete, MediaService.EmptyRecycleBin are called in the API, after the media has been deleted.<br/>
+    DeletedEntities: Gets the collection of deleted IMedia objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>MediaDeletingVersionsNotification</td>
+    <td>
+      <ul>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+        <li>int Id</li>
+        <li>int SpecificVersion</li>
+        <li>DateTime DateToRetain</li>
+        <li>bool DeletePriorVersions</li>
+      </ul>
+    </td>
+    <td>
+    Published when MediaService.DeleteVersion, MediaService.DeleteVersions are called in the API.<br/>
+      <ol>
+        <li>Id: Gets the id of the IMedia object being deleted.</li>
+        <li>DateToRetain: Gets the latest version date.</li>
+        <li>SpecificVersion: Gets the id of the IMedia object version being deleted.</li>
+        <li>DeletePriorVersions: False by default</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>MediaDeletedVersionsNotification</td>
+    <td>
+      <ul>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>int Id</li>
+        <li>int SpecificVersion</li>
+        <li>DateTime DateToRetain</li>
+        <li>bool DeletePriorVersions</li>
+      </ul>
+    </td>
+    <td>
+    Published when MediaService.DeleteVersion, MediaService.DeleteVersions are called in the API, after the media version has been delelted<br/>
+      <ol>
+        <li>Id: Gets the id of the deleted IMedia object.</li>
+        <li>DateToRetain: Gets the latest version date.</li>
+        <li>SpecificVersion: Gets the id of the deleted IMedia object version.</li>
+        <li>DeletePriorVersions: False by default</li>
+      </ol>
+    </td>
+  </tr>
+</table>
+
+### What happened to Creating and Created events?
+
+Both the MediaService.Creating and MediaService.Created events was obsoleted, because of this these was not moved over to notifications, and no longer exist. Why? Because these events were not guaranteed to trigger and therefore should not have been used. This is because these events *only* triggered when the MediaService.CreateMedia method were used which is an entirely optional way to create media entities. It is also possible to construct a new media item - which is generally the preferred and consistent way - and therefore the Creating/Created events would not execute when constructing media that way.
+
+Furthermore, there was no reason to listen for the Creating/Created events because they were misleading. They didn't trigger before and after the entity had been persisted. Instead they triggered inside the CreateMedia method which never persists the entity. It constructs a new media object.
+
+#### What do we use instead?
+
+The MediaSavingNotification and MediaSavedNotification will always be published before and after an entity has been persisted. You can determine if an entity is brand new with either of those notifications. With the Saving notification - before the entity is persisted - you can check the entity's HasIdentity property which will be 'false' if it is brand new. In the Saved event you can [check to see if the entity 'remembers being dirty'](./determining-new-identity.md)

--- a/Reference/Events/MediaService-Events-v9.md
+++ b/Reference/Events/MediaService-Events-v9.md
@@ -258,4 +258,4 @@ Furthermore, there was no reason to listen for the Creating/Created events becau
 
 #### What do we use instead?
 
-The MediaSavingNotification and MediaSavedNotification will always be published before and after an entity has been persisted. You can determine if an entity is brand new with either of those notifications. With the Saving notification - before the entity is persisted - you can check the entity's HasIdentity property which will be 'false' if it is brand new. In the Saved event you can [check to see if the entity 'remembers being dirty'](./determining-new-identity.md)
+The MediaSavingNotification and MediaSavedNotification will always be published before and after an entity has been persisted. You can determine if an entity is brand new with either of those notifications. With the Saving notification - before the entity is persisted - you can check the entity's HasIdentity property which will be 'false' if it is brand new. In the Saved event you can [check to see if the entity 'remembers being dirty'](determining-new-entity-v9.md)

--- a/Reference/Events/MediaService-Events-v9.md
+++ b/Reference/Events/MediaService-Events-v9.md
@@ -252,7 +252,7 @@ namespace MySite
 
 ### What happened to Creating and Created events?
 
-Both the MediaService.Creating and MediaService.Created events was obsoleted, because of this these was not moved over to notifications, and no longer exist. Why? Because these events were not guaranteed to trigger and therefore should not have been used. This is because these events *only* triggered when the MediaService.CreateMedia method were used which is an entirely optional way to create media entities. It is also possible to construct a new media item - which is generally the preferred and consistent way - and therefore the Creating/Created events would not execute when constructing media that way.
+Both the MediaService.Creating and MediaService.Created events have been obsoleted. Because of this, these were not moved over to notifications, and no longer exist. Why? Because these events were not guaranteed to trigger and therefore should not have been used. This is because these events *only* triggered when the MediaService.CreateMedia method was used which is an entirely optional way to create media entities. It is also possible to construct a new media item - which is generally the preferred and consistent way - and therefore the Creating/Created events would not execute when constructing media that way.
 
 Furthermore, there was no reason to listen for the Creating/Created events because they were misleading. They didn't trigger before and after the entity had been persisted. Instead they triggered inside the CreateMedia method which never persists the entity. It constructs a new media object.
 

--- a/Reference/Events/MediaTypeService-Events-v9.md
+++ b/Reference/Events/MediaTypeService-Events-v9.md
@@ -1,0 +1,140 @@
+---
+v8-equivalent: "https://our.umbraco.com/documentation/Reference/Events/ContentTypeService-Events"
+versionFrom: 9.0.0
+verified-against: beta-2
+---
+
+# MediaTypeService Notifications
+
+The MediaTypeService class implements IMediaTypeService. It provides access to operations involving IMediaType
+
+<table>
+  <tr>
+    <th>Notification</th>
+    <th>Members</th>
+    <th>Description</th>
+  </tr>
+
+  <tr>
+    <td>MediaTypeSavingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMediaType&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when MediaTypeService.Save is called in the API.<br/>
+    SavedEntities: Gets the collection of IMediaType objects being saved.
+    </td>
+  </tr>
+
+  <tr>
+    <td>MediaTypeSavedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMediaType&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when MediaTypeService.Save is called in the API, after the entities has been saved.<br/>
+    NOTE: <em><a href="determining-new-entity">See here on how to determine if the entity is brand new</a></em><br/>
+    SavedEntities: Gets the collection of saved IMediaType objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>MediaTypeDeletingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMediaType&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+      Published when MediaTypeService.Delete is called in the API.<br/>
+      DeletedEntities: Gets the collection of IMediaType objects being deleted.
+    </td>
+  </tr>
+
+  <tr>
+    <td>MediaTypeDeletedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMediaType&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+      Published when MediaTypeService.Delete is called in the API, after the entities has been deleted.<br/>
+      DeletedEntities: Gets the collection of deleted IMediaType objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>MediaTypeMovingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIMediaType&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when MediaTypeService.Move is called in the API<br/>
+    MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the IMediaType object being moved</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the parent the entity will have after it has been moved</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>MediaTypeMovedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIMediaType&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when MediaTypeService.Move is called in the API, after the entities has been moved.<br/>
+    MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the IMediaType object being moved</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the parent the entity will have after it has been moved</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>MediaTypeChangedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMediaTypeChange&ltIMediaType&gt&gt Changes</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when a MediaType is saved or deleted, after the transaction has completed. This is mainly used for caching purposes, and generally not recommended, use Saved and Delted notifications instead.<br/>
+    Changes will for each item affected by the change prove:
+    <ol>
+      <li>Item: The IMediaType affected by the change.</li>
+      <li>ChangeTypes: The type of change: Create, Remove, RefreshMain, etc.</li>
+    </ol>
+    </td>
+  </tr>
+</table>

--- a/Reference/Events/MemberService-Events/index-v9.md
+++ b/Reference/Events/MemberService-Events/index-v9.md
@@ -1,0 +1,146 @@
+---
+v8-equivalent: "https://our.umbraco.com/documentation/Reference/Events/MemberService-Events/"
+versionFrom: 9.0.0
+verified-against: beta-2
+---
+
+# MemberService Notifications
+
+The MemberService implements IMemberService and provides access to operations involving IMember.
+
+## Usage
+
+```C#
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Services.Notifications;
+
+namespace MySite
+{
+    public class MemberNotificationHandler : INotificationHandler<MemberSavedNotification>
+    {
+        private readonly ILogger<MemberNotificationHandler> _logger;
+
+        public MemberNotificationHandler(ILogger<MemberNotificationHandler> logger)
+        {
+            _logger = logger;
+        }
+        
+        public void Handle(MemberSavedNotification notification)
+        {
+            foreach (var member in notification.SavedEntities)
+            {
+                // Write to the logs every time a member is saved.
+                _logger.LogInformation("Member {member} has been saved and notification published!", member.Name);
+            }
+        }
+    }
+}
+```
+
+<table>
+  <tr>
+    <th>Notification</th>
+    <th>Members</th>
+    <th>Description</th>
+  </tr>
+
+  <tr>
+    <td>MemberSavingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMember&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when MemberService.Saving is called in the API.<br/>
+    NOTE: It can be skipped completely if the parameter "raiseEvents" is set to false during the Save method call (true by default).<br/>
+    SavedEntities: Gets the collection of IMember objects being saved.
+    </td>
+  </tr>
+
+  <tr>
+    <td>MemberSavedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMember&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when MemberService.Save is called in the API and after data has been persisted.<br/>
+    NOTE: It can be skipped completely if the parameter "raiseEvents" is set to false during the Save method call (true by default).<br/>
+    <em>NOTE: <a href="./determining-new-entity">See here on how to determine if the entity is brand new</a></em><br />
+    SavedEntities: Gets the saved collection of IMember objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>MemberDeletingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMember&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when MemberService.Delete, and MemberService.DeleteMembersOfType are called in the API.<br/>
+    DeletedEntities: Gets the collection of IMember objects being deleted.
+    </td>
+  </tr>
+
+  <tr>
+    <td>MemberDeletedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMember&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+      Published when MemberService.Delete, and MemberService.DeleteMembersOfType are called in the API, after the members has been deleted.<br/>
+      DeletedEntities: Gets the collection of deleted IMember objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>AssignedMemberRolesNotification</td>
+    <td>
+      <ul>
+        <li>string[] Roles</li>
+        <li>int[] MemberIds</li>
+      </ul>
+    </td>
+    <td>
+    Published when MemberService.AssignRoles, and MemberService.ReplaceRoles are called in the API.
+      <ol>
+        <li>Roles: Collection of role names being assigned.</li>
+        <li>MemberIds: Collection of Ids of the members the roles are being assigned to.</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>RemovedMemberRolesNotification</td>
+    <td>
+      <ul>
+        <li>string[] Roles</li>
+        <li>int[] MemberIds</li>
+      </ul>
+    </td>
+    <td>
+    Published when MemberService.DissociateRoles are being called in the API.
+    <ol>
+        <li>Roles: Collection of role names being removed.</li>
+        <li>MemberIds: Collection of Ids of the members the roles are being removed from.</li>
+      </ol>
+    </td>
+  </tr>
+</table>

--- a/Reference/Events/MemberService-Events/index-v9.md
+++ b/Reference/Events/MemberService-Events/index-v9.md
@@ -74,7 +74,7 @@ namespace MySite
     <td>
     Published when MemberService.Save is called in the API and after data has been persisted.<br/>
     NOTE: It can be skipped completely if the parameter "raiseEvents" is set to false during the Save method call (true by default).<br/>
-    <em>NOTE: <a href="./determining-new-entity">See here on how to determine if the entity is brand new</a></em><br />
+    <em>NOTE: <a href="../determining-new-entity-v9.md">See here on how to determine if the entity is brand new</a></em><br />
     SavedEntities: Gets the saved collection of IMember objects.
     </td>
   </tr>

--- a/Reference/Events/MemberTypeService-Events-v9.md
+++ b/Reference/Events/MemberTypeService-Events-v9.md
@@ -1,0 +1,140 @@
+---
+v8-equivalent: "https://our.umbraco.com/documentation/Reference/Events/ContentTypeService-Events"
+versionFrom: 9.0.0
+verified-against: beta-2
+---
+
+# MemberTypeService Notifications
+
+The MemberTypeService class implements IMemberTypeService. It provides access to operations involving IMemberType
+
+<table>
+  <tr>
+    <th>Notification</th>
+    <th>Members</th>
+    <th>Description</th>
+  </tr>
+
+  <tr>
+    <td>MemberTypeSavingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMemberType&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when MemberTypeService.Save is called in the API.<br/>
+    SavedEntities: Gets the collection of IMemberType objects being saved.
+    </td>
+  </tr>
+
+  <tr>
+    <td>MemberTypeSavedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMemberType&gt SavedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when MemberTypeService.Save is called in the API, after the entities has been saved.<br/>
+    NOTE: <em><a href="determining-new-entity">See here on how to determine if the entity is brand new</a></em><br/>
+    SavedEntities: Gets the collection of saved IMemberType objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>MemberTypeDeletingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMemberType&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+      Published when MemberTypeService.Delete is called in the API.<br/>
+      DeletedEntities: Gets the collection of IMemberType objects being deleted.
+    </td>
+  </tr>
+
+  <tr>
+    <td>MemberTypeDeletedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltIMemberType&gt DeletedEntities</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+      Published when MemberTypeService.Delete is called in the API, after the entities has been deleted.<br/>
+      DeletedEntities: Gets the collection of deleted IMemberType objects.
+    </td>
+  </tr>
+
+  <tr>
+    <td>MemberTypeMovingNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIMemberType&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+        <li>bool Cancel</li>
+      </ul>
+    </td>
+    <td>
+    Published when MemberTypeService.Move is called in the API<br/>
+    MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the IMemberType object being moved</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the parent the entity will have after it has been moved</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>MemberTypeMovedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMoveEventInfo&ltIMemberType&gt&gt MoveInfoCollection</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when MemberTypeService.Move is called in the API, after the entities has been moved.<br/>
+    MoveInfoCollection will for each moving entity provide:
+      <ol>
+        <li>Entity: Gets the IMemberType object being moved</li>
+        <li>OriginalPath: The original path the entity is moved from</li>
+        <li>NewParentId: Gets the Id of the parent the entity will have after it has been moved</li>
+      </ol>
+    </td>
+  </tr>
+
+  <tr>
+    <td>MemberTypeChangedNotification</td>
+    <td>
+      <ul>
+        <li>IEnumerable&ltMemberTypeChange&ltIMemberType&gt&gt Changes</li>
+        <li>EventMessages Messages</li>
+        <li>IDictionary&ltstring,object&gt State</li>
+      </ul>
+    </td>
+    <td>
+    Published when a MemberType is saved or deleted, after the transaction has completed. This is mainly used for caching purposes, and generally not recommended, use Saved and Delted notifications instead.<br/>
+    Changes will for each item affected by the change prove:
+    <ol>
+      <li>Item: The IMemberType affected by the change.</li>
+      <li>ChangeTypes: The type of change: Create, Remove, RefreshMain, etc.</li>
+    </ol>
+    </td>
+  </tr>
+</table>

--- a/Reference/Events/MemberTypeService-Events-v9.md
+++ b/Reference/Events/MemberTypeService-Events-v9.md
@@ -42,7 +42,7 @@ The MemberTypeService class implements IMemberTypeService. It provides access to
     </td>
     <td>
     Published when MemberTypeService.Save is called in the API, after the entities has been saved.<br/>
-    NOTE: <em><a href="determining-new-entity">See here on how to determine if the entity is brand new</a></em><br/>
+    NOTE: <em><a href="determining-new-entity-v9.md">See here on how to determine if the entity is brand new</a></em><br/>
     SavedEntities: Gets the collection of saved IMemberType objects.
     </td>
   </tr>

--- a/Reference/Events/determining-new-entity-v9.md
+++ b/Reference/Events/determining-new-entity-v9.md
@@ -1,0 +1,32 @@
+---
+v8-equivalent: "https://our.umbraco.com/documentation/reference/events/determining-new-entity"
+versionFrom: 9.0.0
+verified-against: beta-2
+---
+
+# Determining if an entity is new
+
+Many of the Umbraco services publishes a 'Saved' notification (or similar). In some cases, it is beneficial to know if this entity is a brand new entity that has been persisted in the database. This is how you can determine this.
+
+## Checking if it's new
+
+We know that if an entity is new and hasn't been persisted that it will not have an ID. Therefore we know if an entity has been newly persisted to the database by checking if its ID was changed before being persisted.
+
+Here's the snippet of code that does that:
+
+```C#
+var dirty = (IRememberBeingDirty)entity;
+var isNew = dirty.WasPropertyDirty("Id");
+```
+
+To check if an entity is new in the ContentSavingNotification use the following:
+
+```C#
+var isNew = entity.HasIdentity is false;
+```
+
+Since the IContent has not been saved yet, it's not necessary to cast it to `IRememberBeingDirty`. It won't have an identity if it's new, since it hasn't been committed yet.
+
+## How it works
+
+This is all possible because of the `IRememberBeingDirty` interface. Indeed the name of this interface is hilarious but it describes exactly what it does. All entities implement this interface which is extremely handy. It tracks not only the property data that has changed (because it inherits from yet another hilarious interface called `ICanBeDirty`) but also the property data that was changed before it was committed.

--- a/Reference/Events/index-v9.md
+++ b/Reference/Events/index-v9.md
@@ -65,7 +65,7 @@ The extension method takes two generic type parameters, the first `ContentPublis
 ```C#
 public class DontShout : INotificationHandler<ContentPublishingNotification>
 ```
-For the full handler implementation see [ContentService Notifications](./contentservice-notifications.md).
+For the full handler implementation see [ContentService Notifications](Contentservice-Events-v9.md).
 
 #### Registering notification handlers in a composer
 

--- a/Reference/Events/index-v9.md
+++ b/Reference/Events/index-v9.md
@@ -1,0 +1,154 @@
+---
+v8-equivalent: "https://our.umbraco.com/documentation/Reference/Events"
+versionFrom: 9.0.0
+verified-against: beta-2
+---
+
+# Using notifications
+
+Umbraco uses Notifications, very similar to the Observer pattern, to allow you to hook into the workflow process for the backoffice. For example, you might want to execute some code every time a page is published. Notifications allow you to do that. 
+
+## Notifications
+
+All notifications reside in the `Umbraco.Cms.Core.Notifications` namespace and are postfixed with Notification.
+
+Typically, available notifications exist in pairs, with a "before" and "after" notification. For example, the ContentService class has the concept of publishing and publishes notifications when this occurs. In that case, there is both a ContentPublishingNotification and a ContentPublishedNotification notification.
+
+Which one you want to use depends on what you want to achieve. If you want to be able to cancel the action, you would use the "before" notification, and use the `CancelOperation` method on the notification to cancel it. See the sample in [ContentService Notifications](./contentservice-notifications.md). If you want to execute some code after the publishing has succeeded, then you would use the "after" notification.
+
+### Notification handlers lifetime
+
+It's important to note that the handlers you create and register to receive notifications will be transient, this means that they will be initialized every time they receive a notification, so you cannot rely on them having a specific state based on previous notifications. For instance, you cannot create a list in a handler and add something when a notification is received, and then check if that list contains what you added in an earlier notification, that list will always be empty because the object has just been initialized.
+
+If you need persistence between notifications, we recommend that you move that functionality into a service or similar, and register it with the DI container, and then inject that into your handler.
+
+As previously mentioned a lot of notifications exist in pairs, with a "before" and "after" notification, there may be cases where you want to add some information to the "before" notification, which will then be available to your "after" notification handler, in order to support this, the notification "pairs" are stateful. This means that the notifications contain a dictionary that is shared between the "before" and "after" notification that you can add values to, and later get them from like this:
+
+```C#
+public void Handle(TemplateSavingNotification notification)  
+{  
+ notification.State["SomeKey"] = "Some Value Relevant to the \"after\" notifiaction handler";  
+}  
+  
+  
+public void Handle(TemplateSavedNotification notification)  
+{  
+  var valueFromSaving = notification.State["SomeKey"];  
+}
+``` 
+
+### Registering notification handlers
+
+Once you've made your notification handlers you need to register them with the `AddNotificationHandler` extension method on the `IUmbracoBuilder`, so they're run whenever a notification they subscribe to is published. There are two ways to do this: In the Startup class, if you're making handlers for your site, or a composer if you're a package developer subscribing to notifications. 
+
+#### Registering notification handlers in the startup class
+
+In the Startup class register your notification handler in the `ConfigureServices` after `AddComposers()` but before `Build()`:
+
+```C#
+public void ConfigureServices(IServiceCollection services)
+{
+#pragma warning disable IDE0022 // Use expression body for methods
+    services.AddUmbraco(_env, _config)
+        .AddBackOffice()             
+        .AddWebsite()
+        .AddComposers()
+        .AddNotificationHandler<ContentPublishingNotification, DontShout>()
+        .Build();
+#pragma warning restore IDE0022 // Use expression body for methods
+
+}
+```
+
+The extension method takes two generic type parameters, the first `ContentPublishingNotification` is the notification you wish to subscribe to, the second `DontShout` is the class that handles the notification. This class must implement `INotificationHandler<>` with the type of notification it handles as the generic type parameter, in this case, the DontShout class definition looks like this: 
+
+```C#
+public class DontShout : INotificationHandler<ContentPublishingNotification>
+```
+For the full handler implementation see [ContentService Notifications](./contentservice-notifications.md).
+
+#### Registering notification handlers in a composer
+
+If you're writing a package for Umbraco you won't have access to the Startup class, you can instead use a composer which gives you access to the  `IUmbracoBuilder`, the rest is the same as when doing it in the Startup class:
+
+```C#
+public class DontShoutComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.AddNotificationHandler<ContentPublishingNotification, DontShout>();
+    }
+}
+```
+
+#### Registering many notification handlers
+
+You may want to subscribe to a lot of notifications, in this case, your `ConfigureServices` method or composer might end up being quite cluttered. You can avoid this by creating your own `IUmbracoBuilder` extension method for your events, keeping everything neatly wrapped up in one place, such an extension method can look like this:
+
+```C#
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Services.Notifications;
+
+namespace MySite
+{
+    public static class UmbracoBuilderNotificationExtensions
+    {
+        public static IUmbracoBuilder AddDontShoutNotifications(this IUmbracoBuilder builder)
+        {
+            builder
+                .AddNotificationHandler<ContentPublishingNotification, DontShout>()
+                .AddNotificationHandler<TemplateSavingNotification, DontShout>()
+                .AddNotificationHandler<MediaSavingNotification, DontShout>();
+            
+            return builder;
+        }
+    }
+}
+```
+
+You can then register all these notifications by calling `AddDontShoutNotifications` in `ConfigureServices` or your composer, just like you would `AddNotificationHandler`:
+
+```C#
+public void ConfigureServices(IServiceCollection services)
+{
+#pragma warning disable IDE0022 // Use expression body for methods
+    services.AddUmbraco(_env, _config)
+        .AddBackOffice()             
+        .AddWebsite()
+        .AddComposers()
+        .AddDontShoutNotifications()
+        .Build();
+#pragma warning restore IDE0022 // Use expression body for methods
+
+}
+```
+
+Now all the notifications you registered in your extension method will be handled by your handler.
+
+## Content, Media, and Member notifications
+
+* See [ContentService Notifications](./contentservice-notifications.md) for a listing of the ContentService object notifications.
+* See [MediaService Notifications](./mediaservice-notifications.md) for a listing of the MediaService object notifications.
+* See [MemberService Notifications](./memberservice-notifications.md) for a listing of the MemberService object notifications.
+
+## Other notifications
+
+* See [ContentTypeService Notifications](./contenttypeservice-notifications.md) for a listing of the ContentTypeService object notifications.
+* See [MediaTypeService Notifications](./mediatypeservice-notifications.md) for a listing of the MediaTypeService object notifiactions.
+* See [MemberTypeService Notifications](./membertypeservice-notifications.md) for a listing of the MemberTypeService object notifications.
+* See [DataTypeService Notifications](./datatypeservice-notifications.md) for a listing of the DataTypeSErvice object notifications
+* See [FileService Notifications](./fileservice-notifications.md) for a listing of the FileService object notifications.
+* See [LocalizationService Notifications](./localizationservice-notifications.md) for a listing of the LocalizationService object notifications.
+
+## Tree notifications
+
+See [Tree Notifications](../Section-Trees/trees.md) for a listing of the tree notifications.
+
+## Editor Model Notifications
+
+See [EditorModel Notifications](./editormodel-notifications.md) for a listing of the EditorModel events
+
+
+:::tip
+Useful for manipulating the model before it is sent to an editor in the backoffice - eg. perhaps to set a default value of a property on a new document.
+:::

--- a/Reference/Events/index-v9.md
+++ b/Reference/Events/index-v9.md
@@ -14,7 +14,7 @@ All notifications reside in the `Umbraco.Cms.Core.Notifications` namespace and a
 
 Typically, available notifications exist in pairs, with a "before" and "after" notification. For example, the ContentService class has the concept of publishing and publishes notifications when this occurs. In that case, there is both a ContentPublishingNotification and a ContentPublishedNotification notification.
 
-Which one you want to use depends on what you want to achieve. If you want to be able to cancel the action, you would use the "before" notification, and use the `CancelOperation` method on the notification to cancel it. See the sample in [ContentService Notifications](./contentservice-notifications.md). If you want to execute some code after the publishing has succeeded, then you would use the "after" notification.
+Which one you want to use depends on what you want to achieve. If you want to be able to cancel the action, you would use the "before" notification, and use the `CancelOperation` method on the notification to cancel it. See the sample in [ContentService Notifications](ContentService-Events-v9.md). If you want to execute some code after the publishing has succeeded, then you would use the "after" notification.
 
 ### Notification handlers lifetime
 
@@ -127,26 +127,26 @@ Now all the notifications you registered in your extension method will be handle
 
 ## Content, Media, and Member notifications
 
-* See [ContentService Notifications](./contentservice-notifications.md) for a listing of the ContentService object notifications.
-* See [MediaService Notifications](./mediaservice-notifications.md) for a listing of the MediaService object notifications.
-* See [MemberService Notifications](./memberservice-notifications.md) for a listing of the MemberService object notifications.
+* See [ContentService Notifications](ContentService-Events-v9.md) for a listing of the ContentService object notifications.
+* See [MediaService Notifications](MediaService-Events-v9.md) for a listing of the MediaService object notifications.
+* See [MemberService Notifications](MemberService-Events/index-v9.md) for a listing of the MemberService object notifications.
 
 ## Other notifications
 
-* See [ContentTypeService Notifications](./contenttypeservice-notifications.md) for a listing of the ContentTypeService object notifications.
-* See [MediaTypeService Notifications](./mediatypeservice-notifications.md) for a listing of the MediaTypeService object notifiactions.
-* See [MemberTypeService Notifications](./membertypeservice-notifications.md) for a listing of the MemberTypeService object notifications.
-* See [DataTypeService Notifications](./datatypeservice-notifications.md) for a listing of the DataTypeSErvice object notifications
-* See [FileService Notifications](./fileservice-notifications.md) for a listing of the FileService object notifications.
-* See [LocalizationService Notifications](./localizationservice-notifications.md) for a listing of the LocalizationService object notifications.
+* See [ContentTypeService Notifications](ContentTypeService-Events-v9.md) for a listing of the ContentTypeService object notifications.
+* See [MediaTypeService Notifications](MediaTypeService-Events-v9.md) for a listing of the MediaTypeService object notifiactions.
+* See [MemberTypeService Notifications](MemberTypeService-Events-v9.md) for a listing of the MemberTypeService object notifications.
+* See [DataTypeService Notifications](DataTypeService-Events-v9.md) for a listing of the DataTypeSErvice object notifications
+* See [FileService Notifications](FileService-Events-v9.md) for a listing of the FileService object notifications.
+* See [LocalizationService Notifications](LocalizationService-Events-v9.md) for a listing of the LocalizationService object notifications.
 
 ## Tree notifications
 
-See [Tree Notifications](../Section-Trees/trees.md) for a listing of the tree notifications.
+See [Tree Notifications](../../Extending/Section-Trees/trees-v9.md) for a listing of the tree notifications.
 
 ## Editor Model Notifications
 
-See [EditorModel Notifications](./editormodel-notifications.md) for a listing of the EditorModel events
+See [EditorModel Notifications](EditorModel-Events/index-v9.md) for a listing of the EditorModel events
 
 
 :::tip


### PR DESCRIPTION
This migrates the Events docs and sub-pages: https://our.umbraco.com/documentation/Reference/Events/

I've also updated the events mentioned in the trees docs to notifications instead.

While I was migrating this I also noted that the Events section in the MemberService page on the v8 docs (https://our.umbraco.com/documentation/Reference/Events/MemberService-Events/) is wrong, it looks like a copy-paste job gone bad, for instance, the "DeletingVersions" event doesn't exist, and the description column also mentions "Id: Gets the id of the IContent object being deleted.", which of course doesn't make sense, it's the same for a lot of the other events as well.

I also think it would make sense to add an "extending notifications" doc about creating and publishing your own custom notifications, but sadly I'm a little pressed for time to do it right now.

I initially made this for the wrong repo, oops 🙈, so I've had to change the filenames and links to this format, I think I got them all though, I have however split the ContentTypeService section into multiple, ContentTypeService, MediaTypeService and MemberTypeService, since these are three different services, that just inherits from the same base, so it made more sense to me for them to have their own pages.