### PR TITLE
Documentation updates for Forms V9.

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Configuration/index-v9.md
+++ b/Add-ons/UmbracoForms/Developer/Configuration/index-v9.md
@@ -11,9 +11,7 @@ With Umbraco Forms it's possible to customize the functionality with various con
 
 ## Editing configuration values
 
-Configuration in version 9 has moved from the `UmbracoForms.config` file used in previous versions, replaced by standard .NET configuration.
-
-By default this is held in an `appSettings.json` file found in the root of your Umbraco website.  If configuration has been customized to use another source, then the same keys and values discussed in this article can be applied there.
+All configuration for your Umbraco Forms is held in an `appSettings.json` file found at the root of your Umbraco website.  If the configuration has been customized to use another source, then the same keys and values discussed in this article can be applied there.
 
 The convention for Umbraco configuration is to have package based options stored as a child structure below the `Umbraco` element, and as a sibling of `CMS`.  Forms configuration follows this pattern, i.e.:
 

--- a/Add-ons/UmbracoForms/Developer/Configuration/index-v9.md
+++ b/Add-ons/UmbracoForms/Developer/Configuration/index-v9.md
@@ -196,6 +196,6 @@ Google has renamed these recently and the `Site Key` refers to `RecaptchaPublicK
 
 #### SiteKey & PrivateKey
 
-Both of these configuration values are needed in order to use the "*reCAPTCHA V3 with Score*" field type implementing ReCaptcha V3 from Google. This field type is available in Umbraco Forms from v8.7+. 
+Both of these configuration values are needed in order to use the "*reCAPTCHA V3 with Score*" field type implementing ReCaptcha V3 from Google.
 
 You can obtain both of these values after signing up to create a ReCaptcha key here:  https://www.google.com/recaptcha/admin.

--- a/Add-ons/UmbracoForms/Developer/Configuration/index-v9.md
+++ b/Add-ons/UmbracoForms/Developer/Configuration/index-v9.md
@@ -31,9 +31,9 @@ The convention for Umbraco configuration is to have package based options stored
 }
 ```
 
-All configuration for Forms is optional.  In other words, all values have defaults that will be applied if no configuration is available for a particular key.
+All configuration for Forms is optional. In other words, all values have defaults that will be applied if no configuration is available for a particular key.
 
-For illustration purposes though, the following structure represents the full set of options for configuration of Forms, along with the default values.  This will help when you need to provide a different setting to understand where it should be applied.
+For illustration purposes, the following structure represents the full set of options for configuration of Forms, along with the default values. This will help when you need to provide a different setting to understand where it should be applied.
 
 ```json
   "Forms": {
@@ -83,69 +83,87 @@ For illustration purposes though, the following structure represents the full se
 ## Form design configuration
 
 ### DisableAutomaticAdditionOfDataConsentField
-This configuration value expects a `true` or `false` value and can be used to disable the feature where all new forms are provided with a default "Consent for storing submitted data" field on creation.  Defaults to `false`.
+
+This configuration value expects a `true` or `false` value and can be used to disable the feature where all new forms are provided with a default "Consent for storing submitted data" field on creation. Defaults to `false`.
 
 ### DisableDefaultWorkflow
+
 This configuration value expects a `true` or `false` value and can be used to toggle if new forms that are created adds an email workflow to send the result of the form to the current user who created the form. Defaults to `false`.
 
 ### MaxNumberOfColumnsInFormGroup
-This setting controls the maximum number of columns that can be created by editors when they configure groups within a form.  The default value used if the setting value is not provided is 12.
+
+This setting controls the maximum number of columns that can be created by editors when they configure groups within a form. The default value used if the setting value is not provided is 12.
 
 ### Form default settings configuration
 
-The following configured values are applied to all forms as they are created.  They can then be amended on a per-form basis via the user interface.
+The following configured values are applied to all forms as they are created. They can then be amended on a per-form basis via the Umbraco backoffice.
 
 #### ManualApproval
-This setting needs to be a `true` or `false` value and will allow you to toggle if a form allows submissions to be post moderated. Most use cases are for publicly shown entries such as blog post comments or submissions for a social campaign.  Defaults to `false`.
+
+This setting needs to be a `true` or `false` value and will allow you to toggle if a form allows submissions to be post moderated. Most use cases are for publicly shown entries such as blog post comments or submissions for a social campaign. Defaults to `false`.
 
 #### DisableStylesheet
-This setting needs to be a `true` or `false` value and will allow you to toggle if the form will include some default styling with the Umbraco Forms CSS stylesheet.  Defaults to `false`.
+
+This setting needs to be a `true` or `false` value and will allow you to toggle if the form will include some default styling with the Umbraco Forms CSS stylesheet. Defaults to `false`.
 
 #### MarkFieldsIndicator
+
 This setting can have the following values to allow you to toggle the mode of marking mandatory or optional fields:
+
 * `NoIndicator` (default)
 * `MarkMandatoryFields`
 * `MarkOptionalFields`
 
 #### Indicator
-This setting is used to mark the mandatory or optional fields based on the setting above. By default this is an asterisk `*`
+
+This setting is used to mark the mandatory or optional fields based on the setting above. By default this is an asterisk `*`.
 
 #### RequiredErrorMessage
+
 This allows you to configure the required error validation message. By default this is `Please provide a value for {0}` where the `{0}` is used to replace the name of the field that is required.
 
 #### InvalidErrorMessage
+
 This allows you to configure the invalid error validation message. By default this is `Please provide a valid value for {0}` where the `{0}` is used to replace the name of the field that is invalid.
 
 #### ShowValidationSummary
+
 This setting needs to be a `true` or `false` value and will allow you to toggle if the form will display all form validation error messages in a validation summary together.  Defaults to `false`.
 
 #### HideFieldValidationLabels
+
 This setting needs to be a `true` or `false` value and will allow you to toggle if the form will show inline validation error messages next to the form field that is invalid.  Defaults to `false`.
 
 #### MessageOnSubmit
-This allows you to configure what text is displayed when a form is submitted and is not being redirected to a different content node. Defaullts to `Thank you`.
+
+This allows you to configure what text is displayed when a form is submitted and is not being redirected to a different content node. Defaults to `Thank you`.
 
 #### StoreRecordsLocally
-This setting needs to be a `true` or `false` value and will allow you to toggle if form submission data will be stored in the Umbraco Forms database tables.  By default this is set to `True`.
 
-## Package options configuration 
+This setting needs to be a `True` or `False` value and will allow you to toggle if form submission data should be stored in the Umbraco Forms database tables. By default this is set to `True`.
+
+## Package options configuration
 
 ### IgnoreWorkFlowsOnEdit
-This configuration expects a `True` or `False` string value, or a comma-separated list of form names, and allows you to toggle if a form submission is edited again, that the workflows on the form will re-fire after an update to the form submission. This is used in conjunction with the `AllowEditableFormSubmissions` configuration value.  Defaults to `True`.
+
+This configuration expects a `True` or `False` string value, or a comma-separated list of form names, and allows you to toggle if a form submission is edited again, that the workflows on the form will re-fire after an update to the form submission. This is used in conjunction with the `AllowEditableFormSubmissions` configuration value. Defaults to `True`.
 
 ### ExecuteWorkflowAsync
-This configuration key is *experimental* and will allow Workflows to be executed in an asynchronous manner.  The value can be a `True` or `False` string value, or a comma-separated list of form names.  Defaults to `False`.
+
+This configuration key is *experimental* and will allow Workflows to be executed in an asynchronous manner. The value can be a `True` or `False` string value, or a comma-separated list of form names. Defaults to `False`.
 
 ### AllowEditableFormSubmissions
-This configuration value expects a `true` or `false` value  and can be used to toggle the functionality to allow a form submission to be editable and re-submitted. When the value is set to `true` it allows Form Submissions to be edited using the following querystring for the page containing the form on the site. `?recordId=GUID` Replace `GUID` with the GUID of the form submission.  Defaults to `false`.
+
+This configuration value expects a `true` or `false` value and can be used to toggle the functionality to allow a form submission to be editable and re-submitted. When the value is set to `true` it allows Form Submissions to be edited using the following querystring for the page containing the form on the site. `?recordId=GUID` Replace `GUID` with the GUID of the form submission. Defaults to `false`.
 
 :::warning
-Enable this feature ONLY if you do understand the security implications.
+Enable this feature ONLY if you understand the security implications.
 :::
 
-## Security configuration 
+## Security configuration
 
 ### DisallowedFileUploadExtensions
+
 When using the File Upload field in a form, editors can choose which file extensions they want to accept. When an image is expected, they can for example specify that only `.jpg` or `.png` files are uploaded.
 
 There are certain file extensions that in almost all cases should never be allowed, which are held in this configuration value. This means that even if an editor has selected to allow all files, any files that match the extensions listed here will be blocked.
@@ -153,21 +171,25 @@ There are certain file extensions that in almost all cases should never be allow
 By default, .NET related code files like `.config` and `.aspx` are included in this deny list. You can add or - if you are sure - remove values from this list to meet your needs.
 
 ### EnableAntiForgeryToken
-This setting needs to be a `true` or `false` value and will enable the ASP.NET Anti Forgery Token and we recommend that you enable this option.  Defaults to `true`.
+
+This setting needs to be a `true` or `false` value and will enable the ASP.NET Anti Forgery Token and we recommend that you enable this option. Defaults to `true`.
 
 ### SavePlainTextPasswords
-This setting needs to be a `true` or `false` value and controls whether password fields provided in forms will be saved to the database.  Defaults to `false`.
+
+This setting needs to be a `true` or `false` value and controls whether password fields provided in forms will be saved to the database. Defaults to `false`.
 
 ## Field type specific configuration 
 
 ### Date picker field type configuration 
 
 #### DatePickerYearRange
+
 This setting is used to configure the Date Picker form field range of years that is available in the date picker. By default this is a small range of 10 years.
 
 ### reCAPTCHA v2 field type configuration 
 
 #### PublicKey & PrivateKey
+
 Both of these configuration values are needed in order to use the "*Recaptcha2*" field type implementing legacy ReCaptcha V2 from Google. You can obtain both of these values after signing up to create a ReCaptcha key here - https://www.google.com/recaptcha/admin
 
 Google has renamed these recently and the `Site Key` refers to `RecaptchaPublicKey` and `Secret Key` is to be used for `RecaptchaPrivateKey`
@@ -175,6 +197,7 @@ Google has renamed these recently and the `Site Key` refers to `RecaptchaPublicK
 ### reCAPTCHA v3 field type configuration 
 
 #### SiteKey & PrivateKey
+
 Both of these configuration values are needed in order to use the "*reCAPTCHA V3 with Score*" field type implementing ReCaptcha V3 from Google. This field type is available in Umbraco Forms from v8.7+. 
 
 You can obtain both of these values after signing up to create a ReCaptcha key here:  https://www.google.com/recaptcha/admin.

--- a/Add-ons/UmbracoForms/Developer/Configuration/index-v9.md
+++ b/Add-ons/UmbracoForms/Developer/Configuration/index-v9.md
@@ -1,0 +1,180 @@
+---
+versionFrom: 9.0.0
+meta.Title: "Umbraco Forms configuration"
+meta.Description: "In Umbraco Forms it's possible to customize the functionality with various configuration values."
+state: complete
+verified-against: beta001
+---
+
+# Configuration
+With Umbraco Forms it's possible to customize the functionality with various configuration values.  
+
+## Editing configuration values
+
+Configuration in version 9 has moved from the `UmbracoForms.config` file used in previous versions, replaced by standard .NET configuration.
+
+By default this is held in an `appSettings.json` file found in the root of your Umbraco website.  If configuration has been customized to use another source, then the same keys and values discussed in this article can be applied there.
+
+The convention for Umbraco configuration is to have package based options stored as a child structure below the `Umbraco` element, and as a sibling of `CMS`.  Forms configuration follows this pattern, i.e.:
+
+```json
+{
+  ...
+  "Umbraco": {
+    "CMS": {
+        ...
+    },
+    "Forms": {
+        ...
+    }
+  }
+}
+```
+
+All configuration for Forms is optional.  In other words, all values have defaults that will be applied if no configuration is available for a particular key.
+
+For illustration purposes though, the following structure represents the full set of options for configuration of Forms, along with the default values.  This will help when you need to provide a different setting to understand where it should be applied.
+
+```json
+  "Forms": {
+    "FormDesign": {
+      "DisableAutomaticAdditionOfDataConsentField": false,
+      "DisableDefaultWorkflow": false,
+      "MaxNumberOfColumnsInFormGroup": 12,
+      "Defaults": {
+        "ManualApproval": false,
+        "DisableStylesheet": false,
+        "MarkFieldsIndicator": "NoIndicator",
+        "Indicator": "*",
+        "RequiredErrorMessage": "Please provide a value for {0}",
+        "InvalidErrorMessage": "Please provide a valid value for {0}",
+        "ShowValidationSummary": false,
+        "HideFieldValidationLabels": false,
+        "MessageOnSubmit": "Thank you",
+        "StoreRecordsLocally": true
+      }      
+    },
+    "PackageOptions": {
+      "IgnoreWorkFlowsOnEdit": "True",
+      "ExecuteWorkflowAsync": "False",
+      "AllowEditableFormSubmisisons": false
+    },
+    "Security": {
+      "DisallowedFileUploadExtensions": "config,exe,dll,asp,aspx",
+      "EnableAntiForgeryToken": true,
+      "SavePlainTextPasswords": false
+    },
+    "FieldTypes": {
+      "DatePicker": {
+        "DatePickerYearRange": 10
+      },
+      "Recaptcha2": {
+        "PublicKey": "",
+        "PrivateKey": ""
+      },
+      "Recaptcha3": {
+        "SiteKey": "",
+        "PrivateKey": ""
+      }            
+    }
+  }
+```
+
+## Form design configuration
+
+### DisableAutomaticAdditionOfDataConsentField
+This configuration value expects a `true` or `false` value and can be used to disable the feature where all new forms are provided with a default "Consent for storing submitted data" field on creation.  Defaults to `false`.
+
+### DisableDefaultWorkflow
+This configuration value expects a `true` or `false` value and can be used to toggle if new forms that are created adds an email workflow to send the result of the form to the current user who created the form. Defaults to `false`.
+
+### MaxNumberOfColumnsInFormGroup
+This setting controls the maximum number of columns that can be created by editors when they configure groups within a form.  The default value used if the setting value is not provided is 12.
+
+### Form default settings configuration
+
+The following configured values are applied to all forms as they are created.  They can then be amended on a per-form basis via the user interface.
+
+#### ManualApproval
+This setting needs to be a `true` or `false` value and will allow you to toggle if a form allows submissions to be post moderated. Most use cases are for publicly shown entries such as blog post comments or submissions for a social campaign.  Defaults to `false`.
+
+#### DisableStylesheet
+This setting needs to be a `true` or `false` value and will allow you to toggle if the form will include some default styling with the Umbraco Forms CSS stylesheet.  Defaults to `false`.
+
+#### MarkFieldsIndicator
+This setting can have the following values to allow you to toggle the mode of marking mandatory or optional fields:
+* `NoIndicator` (default)
+* `MarkMandatoryFields`
+* `MarkOptionalFields`
+
+#### Indicator
+This setting is used to mark the mandatory or optional fields based on the setting above. By default this is an asterisk `*`
+
+#### RequiredErrorMessage
+This allows you to configure the required error validation message. By default this is `Please provide a value for {0}` where the `{0}` is used to replace the name of the field that is required.
+
+#### InvalidErrorMessage
+This allows you to configure the invalid error validation message. By default this is `Please provide a valid value for {0}` where the `{0}` is used to replace the name of the field that is invalid.
+
+#### ShowValidationSummary
+This setting needs to be a `true` or `false` value and will allow you to toggle if the form will display all form validation error messages in a validation summary together.  Defaults to `false`.
+
+#### HideFieldValidationLabels
+This setting needs to be a `true` or `false` value and will allow you to toggle if the form will show inline validation error messages next to the form field that is invalid.  Defaults to `false`.
+
+#### MessageOnSubmit
+This allows you to configure what text is displayed when a form is submitted and is not being redirected to a different content node. Defaullts to `Thank you`.
+
+#### StoreRecordsLocally
+This setting needs to be a `true` or `false` value and will allow you to toggle if form submission data will be stored in the Umbraco Forms database tables.  By default this is set to `True`.
+
+## Package options configuration 
+
+### IgnoreWorkFlowsOnEdit
+This configuration expects a `True` or `False` string value, or a comma-separated list of form names, and allows you to toggle if a form submission is edited again, that the workflows on the form will re-fire after an update to the form submission. This is used in conjunction with the `AllowEditableFormSubmissions` configuration value.  Defaults to `True`.
+
+### ExecuteWorkflowAsync
+This configuration key is *experimental* and will allow Workflows to be executed in an asynchronous manner.  The value can be a `True` or `False` string value, or a comma-separated list of form names.  Defaults to `False`.
+
+### AllowEditableFormSubmissions
+This configuration value expects a `true` or `false` value  and can be used to toggle the functionality to allow a form submission to be editable and re-submitted. When the value is set to `true` it allows Form Submissions to be edited using the following querystring for the page containing the form on the site. `?recordId=GUID` Replace `GUID` with the GUID of the form submission.  Defaults to `false`.
+
+:::warning
+Enable this feature ONLY if you do understand the security implications.
+:::
+
+## Security configuration 
+
+### DisallowedFileUploadExtensions
+When using the File Upload field in a form, editors can choose which file extensions they want to accept. When an image is expected, they can for example specify that only `.jpg` or `.png` files are uploaded.
+
+There are certain file extensions that in almost all cases should never be allowed, which are held in this configuration value. This means that even if an editor has selected to allow all files, any files that match the extensions listed here will be blocked.
+
+By default, .NET related code files like `.config` and `.aspx` are included in this deny list. You can add or - if you are sure - remove values from this list to meet your needs.
+
+### EnableAntiForgeryToken
+This setting needs to be a `true` or `false` value and will enable the ASP.NET Anti Forgery Token and we recommend that you enable this option.  Defaults to `true`.
+
+### SavePlainTextPasswords
+This setting needs to be a `true` or `false` value and controls whether password fields provided in forms will be saved to the database.  Defaults to `false`.
+
+## Field type specific configuration 
+
+### Date picker field type configuration 
+
+#### DatePickerYearRange
+This setting is used to configure the Date Picker form field range of years that is available in the date picker. By default this is a small range of 10 years.
+
+### reCAPTCHA v2 field type configuration 
+
+#### PublicKey & PrivateKey
+Both of these configuration values are needed in order to use the "*Recaptcha2*" field type implementing legacy ReCaptcha V2 from Google. You can obtain both of these values after signing up to create a ReCaptcha key here - https://www.google.com/recaptcha/admin
+
+Google has renamed these recently and the `Site Key` refers to `RecaptchaPublicKey` and `Secret Key` is to be used for `RecaptchaPrivateKey`
+
+### reCAPTCHA v3 field type configuration 
+
+#### SiteKey & PrivateKey
+Both of these configuration values are needed in order to use the "*reCAPTCHA V3 with Score*" field type implementing ReCaptcha V3 from Google. This field type is available in Umbraco Forms from v8.7+. 
+
+You can obtain both of these values after signing up to create a ReCaptcha key here:  https://www.google.com/recaptcha/admin.

--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Exporttype-v9.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Exporttype-v9.md
@@ -1,0 +1,219 @@
+---
+versionFrom: 9.0.0
+meta.Title: "Adding a Export type to Umbraco Forms"
+state: complete
+verified-against: beta001
+---
+
+# Adding a Export type to Umbraco Forms
+*This builds on the "[adding a type to the provider model](Adding-a-Type-v9.md)" chapter and applies to Umbraco Forms version 4.4.1 and higher*
+
+Add a new class to your project and have it inherit from `Umbraco.Forms.Core.ExportType` and you have two options when implementing the class.
+
+## Basic Example
+When implementing the method `public override string ExportRecords(RecordExportFilter filter)` in your export provider class. You need to return the final string you wish to write to a file. Such as .txt file or .csv and you can perform your logic to build up a comma separated string for a CSV file in the `ExportRecords` method.
+
+In the constructor of your provider, note that you will need a further two properties, `FileExtension` and `Icon`. The FileExtension property is the file extension such as `zip`, `txt` or `csv` of the file you will be generating & serving from the file system as the export file.
+
+In this example below we will create a single HTML file which takes all the submissions/entries to be displayed as a HTML report. We will do this in conjunction with a Razor partial view to help build up our HTML and thus merge it with the form submission data to generate a string of HTML.
+
+### Provider Class
+
+```csharp
+using System;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Forms.Core;
+using Umbraco.Forms.Core.Models;
+using Umbraco.Forms.Core.Searchers;
+using Umbraco.Forms.Web.Helpers;
+
+namespace MyFormsExtensions
+{
+    public class ExportToHtmlReport : ExportType
+    {
+        private readonly IFormRecordSearcher _formRecordSearcher;
+
+        public ExportToHtmlReport(
+            IHostingEnvironment hostingEnvironment,
+            IFormRecordSearcher formRecordSearcher)
+            : base(hostingEnvironment)
+        {
+            _formRecordSearcher = formRecordSearcher;
+
+            this.Name = "Export as HTML";
+            this.Description = "Export entries as a single HTML report";
+            this.Id = new Guid("4117D352-FB41-4A4C-96F5-F6EF35B384D2");
+            this.FileExtension = "html";
+            this.Icon = "icon-article";        }
+
+        public override string ExportRecords(RecordExportFilter filter)
+        {
+            var view = "~/Views/Partials/Forms/Export/html-report.cshtml";
+            EntrySearchResultCollection model = _formRecordSearcher.QueryDataBase(filter);
+            return ViewHelper.RenderPartialViewToString(view, model);
+        }
+    }
+}
+```
+
+### Razor Partial View
+
+```csharp
+@model Umbraco.Forms.Web.Models.Backoffice.EntrySearchResultCollection
+
+@{
+    var submissions = Model.Results.ToList();
+    var schemaItems = Model.schema.ToList();
+}
+
+<h1>Form Submissions</h1>
+
+@foreach (var submission in submissions)
+{
+    var values = submission.Fields.ToList();
+
+    for (int i = 0; i < schemaItems.Count; i++)
+    {
+        <strong>@schemaItems[i].Name</strong> @values[i] <br />
+    }
+
+    <hr/>
+}
+```
+
+## Advanced Example
+This approach gives us more flexibility in creating the file we wish to serve as the exported file. We do this for the export to Excel file export provider we ship in Umbraco Forms. With this we can use a library to create the Excel file and store it in a temporary location before we send back the filepath for the browser to stream down the export file.
+
+In this example we will create a collection of text files, one for each submission which is then zipped up into a single file and served as the export file.
+
+```csharp
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Forms.Core;
+using Umbraco.Forms.Core.Models;
+using Umbraco.Forms.Core.Searchers;
+
+namespace MyFormsExtensions
+{
+    public class ExportToTextFiles : ExportType
+    {
+        private readonly IFormRecordSearcher _formRecordSearcher;
+
+        public ExportToTextFiles(
+            IHostingEnvironment hostingEnvironment,
+            IFormRecordSearcher formRecordSearcher)
+            : base(hostingEnvironment)
+        {
+            _formRecordSearcher = formRecordSearcher;
+
+            this.Name = "Export as text files";
+            this.Description = "Export entries as text files inside a zip file";
+            this.Id = new Guid("171CABC9-2207-4575-83D5-2A77E824D5DB");
+            this.FileExtension = "zip";
+            this.Icon = "icon-zip";
+        }
+
+        /// <summary>
+        /// We do not implement this method from the interface
+        /// As this method is called from ExportToFile that we also override here & is expecting the file contents as a string to be written as a stream to a file
+        /// Which would be OK if we were creating a CSV or a single based file that can have a simple string written as a string such as one large HTML report or XML file perhaps
+        /// </summary>
+        public override string ExportRecords(RecordExportFilter filter) => throw new NotImplementedException();
+
+        /// <summary>
+        /// This gives us greater control of the export process
+        /// </summary>
+        /// <param name="filter">
+        /// This filter contains the date range & other search parameters to limit the entries we are exporting
+        /// </param>
+        /// <param name="filepath">
+        /// The filepath that the export file is expecting to be served from
+        /// So ensure that the zip of text files is saved at this location
+        /// </param>
+        /// <returns>The final file path to serve up as the export - this is unlikely to change through the export logic</returns>
+        public override string ExportToFile(RecordExportFilter filter, string filepath)
+        {
+            // Before Save - Check Path, Directory & Previous File export does not exist
+            string pathToSaveZipFile = filepath;
+
+            // Check our path does not contain \\
+            // If not, use the filePath
+            if (filepath.Contains('\\') == false)
+            {
+                pathToSaveZipFile = HostingEnvironment.MapPathContentRoot(filepath);
+            }
+
+            // Get the directory (strip out \\ if it exists)
+            var dir = filepath.Substring(0, filepath.LastIndexOf('\\'));
+            var tempFileDir = Path.Combine(dir, "text-files");
+
+
+            // If the path does not end with our file extension, ensure it's added
+            if (pathToSaveZipFile.EndsWith("." + FileExtension) == false)
+            {
+                pathToSaveZipFile += "." + FileExtension;
+            }
+
+            // Check that the directory where we will save the ZIP file temporarily exists
+            // If not just create it
+            if (Directory.Exists(tempFileDir) == false)
+            {
+                Directory.CreateDirectory(tempFileDir);
+            }
+
+            // Check if the zip file exists already - if so delete it, as we have a new update
+            if (File.Exists(pathToSaveZipFile))
+            {
+                File.Delete(pathToSaveZipFile);
+            }
+
+            // Query the DB for submissions to export based on the filter
+            EntrySearchResultCollection submissions = _formRecordSearcher.QueryDataBase(filter);
+
+            // Get the schema objects to a list so we can get items using position index
+            var schemaItems = submissions.schema.ToList();
+
+            // We will use this to store our contents of our file to save as a text file
+            var fileContents = string.Empty;
+
+            // For each submission we have build up a string to save to a text file
+            foreach (EntrySearchResult submission in submissions.Results)
+            {
+                // The submitted data for the form submission
+                var submissionData = submission.Fields.ToList();
+
+                // For loop to match the schema position to the submission data
+                for (int i = 0; i < schemaItems.Count; i++)
+                {
+                    // Concat a string of the name of the field & its stored data
+                    fileContents += schemaItems[i].Name + ": " + submissionData[i] + Environment.NewLine;
+                }
+
+                // Now save the contents to a text file
+                // Base it on the format of the record submission unique id
+                var textFileName = Path.Combine(tempFileDir, submission.UniqueId + ".txt");
+                File.WriteAllText(textFileName, fileContents);
+
+                // Reset fileContents to be empty again
+                fileContents = string.Empty;
+            }
+
+            // Now we have a temp folder full of text files
+            // Generate a zip file containing them & save that
+            ZipFile.CreateFromDirectory(tempFileDir, pathToSaveZipFile);
+
+            // Tidy up after ourselves & delete the temp folder of text files
+            if (Directory.Exists(tempFileDir))
+            {
+                Directory.Delete(tempFileDir, true);
+            }
+
+            // Return the path where we saved the zip file containing the text files
+            return pathToSaveZipFile;
+        }
+    }
+}
+```

--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Fieldtype-v9.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Fieldtype-v9.md
@@ -1,0 +1,91 @@
+---
+versionFrom: 9.0.0
+meta.Title: "Adding a field type to Umbraco Forms"
+state: complete
+verified-against: beta001
+---
+
+# Adding a field type to Umbraco Forms #
+
+*This builds on the "[adding a type to the provider model](Adding-a-Type-v9.md)" chapter*
+
+## C#
+
+Add a new class to the Visual Studio solution, make it inherit from `Umbraco.Forms.Core.FieldType` and fill in the constructor:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Umbraco.Forms.Core.Enums;
+using Umbraco.Forms.Core.Models;
+using Umbraco.Forms.Core.Services;
+
+namespace MyFormsExtensions
+{
+    public class MyCustomField : Umbraco.Forms.Core.FieldType
+    {
+        public MyCustomField()
+        {
+            this.Id = new Guid("08b8057f-06c9-4ca5-8a42-fd1fc2a46eff"); // Replace this!
+            this.Name = "My Custom Field";
+            this.Description = "Render a custom text field.";
+            this.Icon = "icon-autofill";
+            this.DataType = FieldDataType.String;
+            this.SortOrder = 10;
+            this.SupportsRegex = true;
+        }
+
+        // You can do custom validation in here which will occur when the form is submitted.
+        // Any strings returned will cause the submit to be invalid!
+        // Where as returning an empty ienumerable of strings will say that it's okay.
+        public override IEnumerable<string> ValidateField(Form form, Field field, IEnumerable<object> postedValues, HttpContext context, IPlaceholderParsingService placeholderParsingService)
+        {
+            var returnStrings = new List<string>();
+
+            if (!postedValues.Any(value => value.ToString().ToLower().Contains("custom")))
+            {
+                returnStrings.Add("You need to include 'custom' in the field!");
+            }
+
+            // Also validate it against the original default method.
+            returnStrings.AddRange(base.ValidateField(form, field, postedValues, context, placeholderParsingService));
+
+            return returnStrings;
+        }
+    }
+}
+
+```
+
+In the constructor, we specify the standard provider information (remember to set the ID to a unique ID).
+
+And then we set the field type specific information. In this case a preview Icon for the form builder UI and what kind of data it will return, this can either be string, longstring, integer, datetime or boolean.
+
+## Partial view
+
+Then we will start building the view for the default theme of the form at `Views\Partials\Forms\Themes\default\FieldTypes\FieldType.MyCustomField.cshtml` 
+
+```csharp
+@model Umbraco.Forms.Mvc.Models.FieldViewModel
+<input type="text" name="@Model.Name" id="@Model.Id" class="text" value="@Model.ValueAsHtmlString" maxlength="500"
+        @{if (string.IsNullOrEmpty(Model.PlaceholderText) == false) { <text> placeholder="@Model.PlaceholderText" </text> }}
+        @{if (Model.Mandatory || Model.Validate) { <text> data-val="true" </text> }}
+        @{if (Model.Mandatory) { <text> data-val-required="@Model.RequiredErrorMessage" </text> }}
+        @{if (Model.Validate) { <text> data-val-regex="@Model.InvalidErrorMessage" data-val-regex-pattern="@Html.Raw(Model.Regex)" </text> }} />
+```
+
+This will be rendered when the default theme is used.
+
+## Umbraco backoffice view
+
+The final step involves building the HTML view which will be rendered in Umbraco as an example of how our end result will look. We will create a file at `App_Plugins\UmbracoForms\Backoffice\Common\FieldTypes\mycustomfield.html` which will contain the following:
+
+```html
+<input
+    type="text" tabindex="-1"
+    class="input-block-level"
+    style="max-width: 100px"
+/>
+```

--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Type-v9.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Type-v9.md
@@ -122,7 +122,7 @@ Also look in the reference chapter for complete class implementations of workflo
 
 It is possible to override and inherit the original provider, be it a Field Type or Workflow etc. The only requirement when inheriting a fieldtype that you wish to override is to ensure you do not override/change the Id set for the provider, and make sure your class is public.
 
-Here is an example of overriding the Textarea field aka Long Answer that is taken from Per's CodeGarden 17 talk, which has been updated for Forms 9.
+Here is an example of overriding the Textarea field aka Long Answer.
 
 ```csharp
 public class TextareaWithCount : Umbraco.Forms.Core.Providers.FieldTypes.Textarea

--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Type-v9.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Type-v9.md
@@ -1,0 +1,162 @@
+---
+versionFrom: 9.0.0
+meta.Title: "Adding a type to the provider model"
+state: complete
+verified-against: beta001
+---
+
+# Adding a type to the provider model
+
+To add a new type, no matter if it's a workflow, field, data source, etc, there is a number of tasks to perform to connect to the Forms provider model. This chapter walks through each step and describes how each part works. This chapter will reference the creation of a workflow type. It is, however, the same process for all types.
+
+## Preparations
+
+Create a new class library project in Visual Studio add references to the Umbraco.Forms.Core.dll (available via referencing the [NuGet package](https://www.nuget.org/packages/UmbracoForms.Core/)).
+
+## Adding the type to Forms
+
+The Forms API contains a collection of classes that can be registered at startup or in an Umbraco component. So to add a new type to Forms you inherit from the right class. In the sample below we use the class for the workflow type.
+
+```csharp
+public class LogWorkflow : Umbraco.Forms.Core.WorkflowType
+{
+    private readonly ILogger<LogWorkflow> _logger;
+
+    public LogWorkflow(ILogger<LogWorkflow> logger)
+    {
+        _logger = logger;
+    }
+
+    public override WorkflowExecutionStatus Execute(WorkflowExecutionContext context)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override List<Exception> ValidateSettings() {
+        throw new NotImplementedException();
+    }
+}
+```
+
+When you implement this class you get two methods added. One of them is Execute which performs the execution of the workflow and the other is a method which validates the workflow settings, we will get back to these settings later on.
+
+Any dependencies required that are registered with the dependency injection container can be provided via the constructor.
+
+Even though we have the class inheritance in place, we still need to add a bit of default information.
+
+## Setting up basic type information
+
+Even though we have the class inheritance in place, we still need to add a bit of default information. This information is added in the class's constructor like this:
+
+```csharp
+public LogWorkflow(ILogger<LogWorkflow> logger) {
+
+    _logger = logger;
+
+    this.Name = "The logging workflow";
+    this.Id = new Guid("D6A2C406-CF89-11DE-B075-55B055D89593");
+    this.Description = "This will save an entry to the log";
+}
+```
+
+All three are mandatory and the ID must be unique, otherwise the type might conflict with an existing one.
+
+## Adding settings to a type
+
+Now that we have a basic class setup, we would like to pass setting items to the type. So we can reuse the type on multiple items but with different settings. To add a setting to a type, we add a property to the class, and give it a specific attribute like this:
+
+```csharp
+[Umbraco.Forms.Core.Attributes.Setting("Log Header",
+        Description = "Log item header",
+        View = "TextField")]
+public string LogHeader { get; set; }
+```
+
+The Umbraco.Forms.Core.Attributes.Setting registers the property in Umbraco Forms and there will automatically be UI and storage generated for it. In the attribute, a name, description and the view to be rendered is defined.
+
+With the attribute in place, the property value is set every time the class is instantiated by Umbraco Forms. This means you can use the property in your code like this:
+
+```csharp
+[Umbraco.Forms.Core.Attributes.Setting("Document ID",
+        Description = "Node the log entry belongs to",
+        View = "Pickers.Content")]
+public string Document { get; set; }
+
+public override WorkflowExecutionStatus Execute(WorkflowExecutionContext context) {
+    _logger.LogInformation("Record submitted from: {IP}", context.Record.IP);
+    return WorkflowExecutionStatus.Completed;
+}
+```
+
+For all types that use the provider model, settings work this way. By adding the Setting attribute Forms automatically registers the property in the UI and sets the value when the class is instantiated.
+
+## Validate type settings with ValidateSettings()
+
+The `ValidateSettings()` method which can be found on all types supporting dynamic settings, is used for making sure the data entered by the user is valid and works with the type.
+
+```csharp
+public override List<Exception> ValidateSettings() {
+    List<Exception> exceptions = new List<Exception>();
+    int docId = 0;
+    if (!int.TryParse(Document, out docId))
+        exceptions.Add(new Exception("Document is not a valid integer"));
+    return exceptions;
+}
+```
+
+## Registering the class with Umbraco and Forms
+
+To register the type, ensure your web application project has a reference to the class library - either via a project or NuGet reference - and add the following code into the startup pipeline.  In this example, the registration is implemented as an extension method to `IUmbracoBuilder` and should be called from `Startup.cs`:
+
+```csharp
+public static IUmbracoBuilder AddUmbracoFormsCoreProviders(this IUmbracoBuilder builder)
+{
+    builder.WithCollectionBuilder<WorkflowCollectionBuilder>()
+        .Add<LogWorkflow>();
+}
+```
+
+Also look in the reference chapter for complete class implementations of workflows, fields and export types.
+
+## Overriding default providers in Umbraco Forms
+
+It is possible to override and inherit the original provider, be it a Field Type or Workflow etc. The only requirement when inheriting a fieldtype that you wish to override is to ensure you do not override/change the Id set for the provider, and make sure your class is public.
+
+Here is an example of overriding the Textarea field aka Long Answer that is taken from Per's CodeGarden 17 talk, which has been updated for Forms 9.
+
+```csharp
+public class TextareaWithCount : Umbraco.Forms.Core.Providers.FieldTypes.Textarea
+{
+    // Added a new setting when we add our field to the form
+    [Umbraco.Forms.Core.Attributes.Setting("Max length",
+    Description = "Max length",
+    View = "TextField")]
+    public string MaxNumberOfChars { get; set; }
+
+    public TextareaWithCount()
+    {
+        // Set a different view for this fieldtype
+        this.FieldTypeViewName = "FieldType.TextareaWithCount.cshtml";
+
+        // We can change the default name of 'Long answer' to something that suits us
+        this.Name = "Long Answer with Limit";
+    }
+
+    public override IEnumerable<string> ValidateField(Form form, Field field, IEnumerable<object> postedValues, HttpContextBase context, IFormStorage formStorage)
+    {
+        var baseValidation = base.ValidateField(form, field, postedValues, context, formStorage);
+        var value = postedValues.FirstOrDefault();
+
+        if (value != null && value.ToString().Length < int.Parse(MaxNumberOfChars))
+        {
+            return baseValidation;
+        }
+
+        var custom = new List<string>();
+        custom.AddRange(baseValidation);
+        custom.Add("String is way way way too long!");
+
+        return custom;
+    }
+}
+```

--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Workflowtype-v9.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Workflowtype-v9.md
@@ -1,9 +1,11 @@
 ---
-versionFrom: 8.0.0
+versionFrom: 9.0.0
+state: complete
+verified-against: beta001
 ---
 
 # Adding a workflow type to Umbraco Forms
-*This builds on the "[adding a type to the provider model](Adding-a-Type.md)" chapter*
+*This builds on the "[adding a type to the provider model](Adding-a-Type-V9.md)" chapter*
 
 Add a new class to your project and have it inherit from `Umbraco.Forms.Core.WorkflowType`, implement the class. For this sample we will focus on the execute method. This method process the current record (the data submitted by the form) and have the ability to change data and state.
 
@@ -18,25 +20,27 @@ using Umbraco.Forms.Core.Persistence.Dtos;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Composing;
 
-namespace PrereleaseForm8_4.Workflows
+namespace MyFormsExtensions
 {
-    /// <summary>
-    /// Summary description for TestWorkflow
-    /// </summary>
     public class TestWorkflow : WorkflowType
     {   
-        public TestWorkflow()
+        private readonly ILogger<TestWorkflow> _logger;
+
+        public TestWorkflow(ILogger<TestWorkflow> logger)
         {
+            _logger = logger;
+
             this.Id = new Guid("ccbeb0d5-adaa-4729-8b4c-4bb439dc0202");
             this.Name = "TestWorkflow";
             this.Description = "This workflow is just for testing";
             this.Icon = "icon-chat-active";
             this.Group = "Services";                      
         }
-        public override WorkflowExecutionStatus Execute(Record record, RecordEventArgs e)
+
+        public override WorkflowExecutionStatus Execute(WorkflowExecutionContext context)
         {
             // first we log it
-            Current.Logger.Debug<TestWorkflow>("the IP " + record.IP + " has submitted a record");            
+            _logger.LogDebug("the IP " + context.Record.IP + " has submitted a record");            
 
             // we can then iterate through the fields
             foreach (RecordField rf in record.RecordFields.Values)
@@ -51,8 +55,8 @@ namespace PrereleaseForm8_4.Workflows
             //Change the state
             record.State = FormState.Approved;
 
-            Current.Logger.Debug<TestWorkflow>("The record with unique id {RecordId} that was submitted via the Form {FormName} with id {FormId} has been changed to {RecordState} state",
-               record.UniqueId, e.Form.Name, e.Form.Id, "approved");
+            _logger.LogDebug("The record with unique id {RecordId} that was submitted via the Form {FormName} with id {FormId} has been changed to {RecordState} state",
+               record.UniqueId, context.Form.Name, context.Form.Id, "approved");
 
             return WorkflowExecutionStatus.Completed;
         }
@@ -60,10 +64,9 @@ namespace PrereleaseForm8_4.Workflows
         public override List<Exception> ValidateSettings()
         {
             return new List<Exception>();
-        }
-       
+        }       
     }
 }
 ```
 
-The `Execute()` method gets a `Record` and a `RecordEventArgs` argument. These 2 arguments contains all information related to the workflow. The record contains all data and meta data submitted by the form. The RecordEventArgs contains references to what form the record is from, what state it is in and a reference to the current `HttpContext`.
+The `Execute()` method gets a `WorkflowExecutionContext` which has properties for the related `Form`, `Record` and `FormState`.  Essentially, this parameter contains all information related to the workflow.  The `Record` contains all data and meta data submitted by the form. The `Form` references the form the record is from, and `FormState` provides it's state.  Other context, such as the current `HttpContext`, if needed can be passed as constructor parameters (e.g. the `HttpContext` can be accessed by injecting `IHttpContextAccessor`).

--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-an-Event-Handler-v9.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-an-Event-Handler-v9.md
@@ -1,12 +1,12 @@
 ---
 versionFrom: 9.0.0
-meta.Title: "Adding Event Handlers in Umbraco Forms"
+meta.Title: "Adding Notification Handlers in Umbraco Forms"
 meta.Description: "See an example of validating a form server-side"
 state: complete
 verified-against: beta001
 ---
 
-# Adding a server-side event handler to Umbraco Forms
+# Adding a server-side notification handler to Umbraco Forms
 
 Add a new class to your project as a handler for the `FormValidateNotification` notification:
 

--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-an-Event-Handler-v9.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-an-Event-Handler-v9.md
@@ -1,0 +1,79 @@
+---
+versionFrom: 9.0.0
+meta.Title: "Adding Event Handlers in Umbraco Forms"
+meta.Description: "See an example of validating a form server-side"
+state: complete
+verified-against: beta001
+---
+
+# Adding a server-side event handler to Umbraco Forms
+
+Add a new class to your project as a handler for the `FormValidateNotification` notification:
+
+```csharp
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Forms.Core.Models;
+using Umbraco.Forms.Core.Services.Notifications;
+
+namespace MyFormsExtensions
+{
+    /// <summary>
+    /// Catch form submissions before being saved and perform custom validation.
+    /// </summary>
+    public class FormValidateNotificationHandler : INotificationHandler<FormValidateNotification>
+    {
+        public void Handle(FormValidateNotification notification)
+        {
+            // If needed, be selective about which form submissions you affect.
+            if (notification.Form.Name == "Form Name")
+            {
+                // Check the ModelState
+                if (notification.ModelState.IsValid == false)
+                {
+                    return;
+                }
+
+                // A sample validation
+                var email = GetPostFieldValue(notification.Form, "email");
+                var emailConfirm = GetPostFieldValue(notification.Form, notification.Context, "verifyEmail");
+
+                // If the validation fails, return a ModelError
+                if (email.ToLower() != emailConfirm.ToLower())
+                {
+                    notification.ModelState.AddModelError(GetPostField(e, "verifyEmail").Id.ToString(), "Email does not match");
+                }
+            }
+        }
+
+        private static string GetPostFieldValue(Form form, HttpContext context, string key)
+        {
+            Field field = GetPostField(form, key);
+            if (field == null)
+            {
+                return string.Empty;
+            }
+
+
+            return context.Request.HasFormContentType &&  context.Request.Form.Keys.Contains(field.Id.ToString())
+                ? context.Request.Form[field.Id.ToString()].ToString().Trim()
+                : string.Empty;
+        }
+
+        private static Field GetPostField(Form form, string key) => form.AllFields.SingleOrDefault(f => f.Alias == key);
+    }
+}
+
+```
+
+The handler will check the `ModelState` and `Form` field values provided in the notification. If validation fails, we add a ModelError.
+
+To register the handler, add the following code into the startup pipeline.  In this example, the registration is implemented as an extension method to `IUmbracoBuilder` and should be called from `Startup.cs`:
+
+```csharp
+public static IUmbracoBuilder AddUmbracoFormsCoreProviders(this IUmbracoBuilder builder)
+{
+    builder.AddNotificationHandler<FormValidateNotification, FormValidateNotificationHandler>();
+}
+```

--- a/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
+++ b/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
@@ -8,7 +8,9 @@ As of Umbraco Forms version 8.5.0 it is possible to persist all forms data in th
 
 In this article you will find instructions on how to migrate your Umbraco Forms data to the database.
 
+:::note
 As of Umbraco Forms version 9.0.0 it is *only* possible to store form data in the database.  As such, if upgrading to Umbraco 9 and using Forms, you should first migrate the forms to the database using Forms 8.
+:::
 
 :::note
 **Custom file system providers**

--- a/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
+++ b/Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index.md
@@ -8,6 +8,8 @@ As of Umbraco Forms version 8.5.0 it is possible to persist all forms data in th
 
 In this article you will find instructions on how to migrate your Umbraco Forms data to the database.
 
+As of Umbraco Forms version 9.0.0 it is *only* possible to store form data in the database.  As such, if upgrading to Umbraco 9 and using Forms, you should first migrate the forms to the database using Forms 8.
+
 :::note
 **Custom file system providers**
 

--- a/Add-ons/UmbracoForms/Developer/IFileSystem/index.md
+++ b/Add-ons/UmbracoForms/Developer/IFileSystem/index.md
@@ -4,7 +4,7 @@ needsV8Update: "true"
 ---
 
 # Storing Form Files with IFileSystem
-Umbraco Forms available in version 4.4.0 and newer allows you to use an IFileSystem to abstract how and where the physical JSON files such as Forms, Workflows and PreValues.
+Umbraco Forms available in version 4.4.0 and up to version 8 allows you to use an `IFileSystem` to abstract how and where the physical JSON files such as Forms, Workflows and PreValues.
 
 ## What on earth is an IFileSystem
 To summarise this allows the saving & getting of files to be abstracted away to a provider, where it can save & retrieve say from Azure Blob Cloud storage or some other place. You can [learn more about IFileSystems in the Umbraco core](../../../../Extending/Custom-File-Systems.md)

--- a/Add-ons/UmbracoForms/Developer/IFileSystem/index.md
+++ b/Add-ons/UmbracoForms/Developer/IFileSystem/index.md
@@ -1,6 +1,7 @@
 ---
 versionFrom: 7.0.0
 needsV8Update: "true"
+versionRemoved : 9.0.0
 ---
 
 # Storing Form Files with IFileSystem


### PR DESCRIPTION
I think this covers everything that has changed in V9.  The main things are:

- Developer documentation for extending via creating custom field types, workflow types etc.  All the code samples needed some amends, so I've created "v9" versions of all of these.
- Configuration is quite different in .NET Core even though most of the settings have carried over, so I've created a V9 version of this.

Otherwise have read through and made a few other small amends, where something isn't available in V9 or is just subtly different to not justify a new version specific page.

Given the UI hasn't changed, I don't expect the editor documentation to need updating.