### PR TITLE
Updating config folder

### DIFF
--- a/Extending/Dashboards/index-v9.md
+++ b/Extending/Dashboards/index-v9.md
@@ -206,7 +206,7 @@ For reference, here is a list of the weighting values for the default Umbraco da
 
 After registering your dashboard, it will appear in the backoffice - however, it will have its dashboard alias [mycustomdashboard] wrapped in square brackets. This is because it is missing a language key. The language key allows people to provide a translation of the dashboard name in multilingual environments. To remove the square brackets - add a language key:
 
-If your dashboard is unique to your Umbraco installation then you can modify the following application language file: `config/lang/en-US.user.xml`. If the dashboard is to be released as an Umbraco package and shared with others to use in their own Umbraco installation, you will need to create a *lang* folder in your custom dashboard folder. You also need to create a package specific language file:  `App_Plugins/Mycustomdashboard/lang/en-US.xml`.
+If your dashboard is unique to your Umbraco installation then you can modify the following application language file: `umbraco/config/lang/en-US.user.xml`. If the dashboard is to be released as an Umbraco package and shared with others to use in their own Umbraco installation, you will need to create a *lang* folder in your custom dashboard folder. You also need to create a package specific language file:  `App_Plugins/Mycustomdashboard/lang/en-US.xml`.
 
 [Read more about language files](../Language-Files/index-v9.md)
 

--- a/Extending/Section-Trees/trees-v9.md
+++ b/Extending/Section-Trees/trees-v9.md
@@ -40,7 +40,7 @@ The SortOrder controls the order of the custom tree within the Tree Group.
 
 Tree Groups enable you to group trees in a section. You provide the alias of the Tree Group name, you wish to add your tree to - see [Constants.Trees.Groups](https://our.umbraco.com/apidocs/v8/csharp/api/Umbraco.Core.Constants.Trees.Groups.html) for a list of existing group alias. An example of tree groups in the backoffice would be the *Settings* tree group and the *Templating* tree group in the *Settings* section.
 
-If you add your own alias, you'll need to add a translation key to `config/lang/en-US.user.xml` to avoid the alias appearing as the header in [square brackets] eg
+If you add your own alias, you'll need to add a translation key to `umbraco/config/lang/en-us.user.xml` to avoid the alias appearing as the header in [square brackets] eg
 
 ```xml
 <language>


### PR DESCRIPTION
Hello,

I noticed a few of the articles suggest we update files in the /config folder, but in v9 we don't have that as standard. It looks like those needed in: https://our.umbraco.com/documentation/Extending/Section-Trees/trees are inside /umbraco/config instead, and this works when running through the tutorial. So I have updated these in this PR. However...

I noticed this article: https://our.umbraco.com/documentation/Extending/Health-Check/index-v9 says _"Don't add the translations to ~/Umbraco/Config/Lang files, the correct location is ~/Config/Lang/*-*.user.xml"_, so maybe this should just be /config after all? If so I think we should mention that it won't exist as default anymore and folks will need to add it.

Feedback appreciated :)

Thanks,
Carole