### PR TITLE
Update index.md

### DIFF
--- a/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Member-Picker/index.md
+++ b/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Member-Picker/index.md
@@ -61,9 +61,12 @@ See the example below to see how a value can be added or changed programmaticall
 
     // Create a variable for the GUID of the member ID
     var authorId = Guid.Parse("ed944097281e4492bcdf783355219450");
-
-    // Set the value of the property with alias 'author'. 
-    content.SetValue("author", authorId);
+    
+    // Create a variable for the UDI of the member
+    var authorUdi = Udi.Create(Umbraco.Core.Constants.UdiEntityType.Member, authorId);
+    
+    // Set the value of the property with alias 'author' to the memberUdi. 
+    content.SetValue("author", authorUdi);
 
     // Save the change
     contentService.Save(content);


### PR DESCRIPTION
 content.SetValue(String Alias, System.Guid Guid);  doesn't automatically set the propData to a UDI as suggested. Need to take the interim step and generate a UDI.

Although the property editor can work out that if only Guid stored then correct member is displayed...  if after programmatic create you try to access the property it returns member picked == null. (until you visit the document and publish via the back office, at which point the database reflects a udi reference, not guide.)

![image](https://user-images.githubusercontent.com/12418214/122059759-e0a3c980-cde4-11eb-90e6-1b7c49edeed2.png)
