### PR TITLE
Updated permissions to match v9 + fixes index files

### DIFF
--- a/Fundamentals/Setup/Server-Setup/index-v9.md
+++ b/Fundamentals/Setup/Server-Setup/index-v9.md
@@ -1,0 +1,30 @@
+---
+meta.Title: "Information on server setup for Umbraco hosting"
+meta.Description: "This section describes different ways of setting up servers for use with Umbraco"
+versionFrom: 9.0.0
+---
+
+# Server setup
+
+*This section describes different ways of setting up servers for use with Umbraco*
+
+## SSL/HTTPS
+
+We strongly encourage the use of HTTPS with Umbraco installations especially in production environments. Using HTTPS will greatly enhance the security of your website, see the [Security reference](../../../Reference/Security/index.md) for more information.
+
+## [File & folder permissions](permissions-v9.md)
+
+To ensure a stable and smoothly running Umbraco installation, these permissions need to be set correctly.
+
+## [Load Balanced setup](Load-Balancing/index.md)
+
+:::note
+Please note that this section is currently not available for Umbraco 9.
+:::
+
+
+Information on how to deploy Umbraco in a Load Balanced scenario and other details to consider when setting up Umbraco for load balancing.
+
+## [Running Umbraco on Azure Web Apps](azure-web-apps-v9.md)
+
+Best practices for running Umbraco on Azure Web Apps.

--- a/Fundamentals/Setup/Server-Setup/permissions-v9.md
+++ b/Fundamentals/Setup/Server-Setup/permissions-v9.md
@@ -1,0 +1,100 @@
+---
+meta.Title: "Umbraco file and folder permissions"
+meta.Description: "Information on file and folder permissions required for Umbraco sites"
+versionFrom: 9.0.0
+---
+
+# File and folder permissions
+
+:::note
+To ensure a stable and smoothly running Umbraco installation, these permissions need to be set correctly. These permissions should be setup before or during the installation of Umbraco.
+
+The main account that requires 'modify' file permissions to be set on the folders below, is the account used start Umbraco. If Umbraco is hosted in IIS this will be the Application Pool Identity for the IIS website. Usually IIS APPPOOL\appPoolName or a specific local account or in some circumstances Network Service - If in doubt, ask your server admin / hosting company. Additionally the IUSR account and IIS_IUSRS account only require 'read only' access to the site's folders.
+
+Generally when developing locally with Visual Studio or Rider, permissions do not need to be strictly applied.
+:::
+
+:::note
+If you have any specific static files / media items / etc then you should add the appropriate permissions accordingly.
+The permissions documentation as it is should allow you to run a plain Umbraco install successfully, the rest.. is up to you! 👍
+:::
+
+
+<table border="0" style="margin-top:20px;">
+<thead>
+<tr>
+<th>File / folder</th>
+<th>Permission</th>
+<th>Comment</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<th>/appSettings*.json</th>
+<th>Modify / Full control</th>
+<td>
+<p>Only needed for setting database and a global identifier during
+installation. So can be set to read-only afterwards for enhanced
+security</p>
+</td>
+</tr>
+<tr>
+<th>/App_Plugins</th>
+<th>Modify / Full control</th>
+<td>
+<p>Should always have modify rights as the folder and its files
+are used by packages</p>
+</td>
+</tr>
+<tr>
+<th>/umbraco</th>
+<th>Modify / Full control</th>
+<td>
+<p>Should always have modify rights as the folder and its files
+are used for cache and storage</p>
+</td>
+</tr>
+<tr>
+<th>/Views</th>
+<th>Modify / Full control</th>
+<td>
+<p>Should always have modify rights as the folder and its files
+are used for template, partial view and macro files</p>
+</td>
+</tr>
+<tr>
+<th>/wwwroot/css</th>
+<th>Modify / Full control</th>
+<td>
+<p>Should always have modify rights as the folder and its files
+are used for css files</p>
+</td>
+</tr>
+<tr>
+<th>/wwwroot/media</th>
+<th>Modify / Full control</th>
+<td>
+<p>Should always have modify rights as the folder and its files
+are used for media files uploaded via Umbraco CMS interface</p>
+</td>
+</tr>
+<tr>
+<th>/wwwroot/scripts</th>
+<th>Modify / Full control</th>
+<td>
+<p>Should always have modify rights as the folder and its files
+are used for script files</p>
+</td>
+</tr>
+<tr>
+<th>/wwwroot/umbraco</th>
+<th>Modify / Full control</th>
+<td>
+<p>For upgrades and package installation, it should have modify
+rights, but can be set to read-only afterwards</p>
+</td>
+</tr>
+
+</tbody>
+</table>

--- a/Fundamentals/Setup/index-v9.md
+++ b/Fundamentals/Setup/index-v9.md
@@ -23,11 +23,8 @@ Umbraco installation steps and guidelines.
 
 Covers the steps to upgrade your copy of Umbraco to a newer version.
 
-## [Server Setup](Server-Setup/index.md)
+## [Server Setup](Server-Setup/index-v9.md)
 
-:::note
-Please note that this section is currently not available for Umbraco 9.
-:::
 
 Information about server setup for Umbraco including information about permissions and load balancing.
 


### PR DESCRIPTION
Updated the https://our.umbraco.com/documentation/Fundamentals/Setup/Server-Setup/ and https://our.umbraco.com/documentation/Fundamentals/Setup/Server-Setup/permissions to v9 versions.

As always most text is reused from v8