### PR TITLE
Update data type definition for v8

### DIFF
--- a/Reference/Management/Models/DataType-v6.md
+++ b/Reference/Management/Models/DataType-v6.md
@@ -8,12 +8,12 @@ versionFrom: 6.0.0
 
 A DataTypeDefinition is what you see in the backoffice in the Developer / DataTypes tree. The listed nodes are definitions of the DataTypes that are available to use on your PropertyTypes.
 
- * **Namespace:** `Umbraco.Core.Models`
- * **Assembly:** `Umbraco.Core.dll`
+-   **Namespace:** `Umbraco.Core.Models`
+-   **Assembly:** `Umbraco.Core.dll`
 
 All samples in this document will require references to the following dll:
 
-* Umbraco.Core.dll
+-   Umbraco.Core.dll
 
 All samples in this document will require the following using statement:
 
@@ -24,42 +24,51 @@ using Umbraco.Core.Models;
 ## Constructors
 
 ### new DataTypeDefinition(int parentId, Guid controlId)
+
 Constructor for creating a new `DataTypeDefinition` object where the necessary parameters are the id of the parent as `Int` and the Id of the DataType's control as a `Guid`.
 
 ## Properties
 
 ### .ControlId
+
 Gets the Id of the DataType as a `Guid`.
 
 ### .CreateDate
+
 Gets or Sets a `DateTime` object, indicating then the given Content was created.
 
 ### .CreatorId
+
 Gets or Sets the Id of the `User` who created the Content.
 
 ### .DatabaseType
+
 Gets or Sets the DatabaseType as a `DataTypeDatabaseType` enum for which the DataType's value is saved as.
 
 ### .Id
+
 Returns the unique `Content` Id as a `Int`, this ID is based on a Database identity field, and is therefore not safe to reference in code which are moved between different instances, use Key instead.
 
-### .Key
-Returns the `Guid` assigned to the Content during creation. This value is unique, and should never change, even if the content is moved between instances.
-
 ### .Level
+
 Gets or Sets the given `Content` level in the site hierarchy as an `Int`. Content placed at the root of the site, will return 1, content right underneath will return 2, and so on.
 
 ### .Name
+
 Gets or Sets the name of the content as a `String`.
 
 ### .ParentId
+
 Gets or Sets the parent `Content` Id as an `Int`.
 
 ### .Path
+
 Gets or Sets the path of the content as a `String`. This string contains a comma separated list of the ancestor Ids including the current contents own id at the end of the string.
 
 ### .SortOrder
+
 Returns the given `Content` index, compared to sibling content.
 
 ### .Trashed
+
 Returns a `Bool` indicating whether the given `Content` is currently in the recycle bin.

--- a/Reference/Management/Models/DataType-v6.md
+++ b/Reference/Management/Models/DataType-v6.md
@@ -1,0 +1,65 @@
+---
+versionFrom: 6.0.0
+---
+
+# DataTypeDefinition
+
+**Applies to Umbraco 6.x and newer**
+
+A DataTypeDefinition is what you see in the backoffice in the Developer / DataTypes tree. The listed nodes are definitions of the DataTypes that are available to use on your PropertyTypes.
+
+ * **Namespace:** `Umbraco.Core.Models`
+ * **Assembly:** `Umbraco.Core.dll`
+
+All samples in this document will require references to the following dll:
+
+* Umbraco.Core.dll
+
+All samples in this document will require the following using statement:
+
+```csharp
+using Umbraco.Core.Models;
+```
+
+## Constructors
+
+### new DataTypeDefinition(int parentId, Guid controlId)
+Constructor for creating a new `DataTypeDefinition` object where the necessary parameters are the id of the parent as `Int` and the Id of the DataType's control as a `Guid`.
+
+## Properties
+
+### .ControlId
+Gets the Id of the DataType as a `Guid`.
+
+### .CreateDate
+Gets or Sets a `DateTime` object, indicating then the given Content was created.
+
+### .CreatorId
+Gets or Sets the Id of the `User` who created the Content.
+
+### .DatabaseType
+Gets or Sets the DatabaseType as a `DataTypeDatabaseType` enum for which the DataType's value is saved as.
+
+### .Id
+Returns the unique `Content` Id as a `Int`, this ID is based on a Database identity field, and is therefore not safe to reference in code which are moved between different instances, use Key instead.
+
+### .Key
+Returns the `Guid` assigned to the Content during creation. This value is unique, and should never change, even if the content is moved between instances.
+
+### .Level
+Gets or Sets the given `Content` level in the site hierarchy as an `Int`. Content placed at the root of the site, will return 1, content right underneath will return 2, and so on.
+
+### .Name
+Gets or Sets the name of the content as a `String`.
+
+### .ParentId
+Gets or Sets the parent `Content` Id as an `Int`.
+
+### .Path
+Gets or Sets the path of the content as a `String`. This string contains a comma separated list of the ancestor Ids including the current contents own id at the end of the string.
+
+### .SortOrder
+Returns the given `Content` index, compared to sibling content.
+
+### .Trashed
+Returns a `Bool` indicating whether the given `Content` is currently in the recycle bin.

--- a/Reference/Management/Models/DataType.md
+++ b/Reference/Management/Models/DataType.md
@@ -2,11 +2,9 @@
 versionFrom: 8.0.0
 ---
 
-# DataTypeDefinition
+# DataType
 
-**Applies to Umbraco 6.x and newer**
-
-A DataTypeDefinition is what you see in the backoffice in the Developer / DataTypes tree. The listed nodes are definitions of the DataTypes that are available to use on your PropertyTypes.
+A DataType is what you see in the backoffice in the Settings / DataTypes tree. The listed nodes are definitions of the DataTypes that are available to use on your PropertyTypes.
 
  * **Namespace:** `Umbraco.Core.Models`
  * **Assembly:** `Umbraco.Core.dll`
@@ -23,8 +21,9 @@ using Umbraco.Core.Models;
 
 ## Constructors
 
-### new DataTypeDefinition(int parentId, Guid controlId)
-Constructor for creating a new `DataTypeDefinition` object where the necessary parameters are the id of the parent as `Int` and the Id of the DataType's control as a `Guid`.
+### new DataType(int parentId, Guid controlId)
+
+Constructor for creating a new `DataType` object where the necessary parameter is a `IDataEditor`.  Optionally, the parentId can be added, if not provided the default value is -1, which means it will be created at root level.
 
 ## Properties
 

--- a/Reference/Management/Models/DataType.md
+++ b/Reference/Management/Models/DataType.md
@@ -1,6 +1,5 @@
 ---
-versionFrom: 6.0.0
-needsV8Update: "true"
+versionFrom: 8.0.0
 ---
 
 # DataTypeDefinition

--- a/Reference/Management/Models/DataType.md
+++ b/Reference/Management/Models/DataType.md
@@ -27,38 +27,46 @@ Constructor for creating a new `DataType` object where the necessary parameter i
 
 ## Properties
 
-### .ControlId
-Gets the Id of the DataType as a `Guid`.
-
 ### .CreateDate
-Gets or Sets a `DateTime` object, indicating then the given Content was created.
+
+Gets or Sets a `DateTime` object, indicating then the given DataType was created.
 
 ### .CreatorId
-Gets or Sets the Id of the `User` who created the Content.
+
+Gets or Sets the Id of the `User` who created the DataType.
 
 ### .DatabaseType
+
 Gets or Sets the DatabaseType as a `DataTypeDatabaseType` enum for which the DataType's value is saved as.
 
 ### .Id
-Returns the unique `Content` Id as a `Int`, this ID is based on a Database identity field, and is therefore not safe to reference in code which are moved between different instances, use Key instead.
+
+Returns the unique `DataType` Id as a `Int`, this ID is based on a Database identity field, and is therefore not safe to reference in code which are moved between different instances, use Key instead.
 
 ### .Key
-Returns the `Guid` assigned to the Content during creation. This value is unique, and should never change, even if the content is moved between instances.
+
+Returns the `Guid` assigned to the DataType during creation. This value is unique, and should never change, even if the DataType is moved between instances.
 
 ### .Level
-Gets or Sets the given `Content` level in the site hierarchy as an `Int`. Content placed at the root of the site, will return 1, content right underneath will return 2, and so on.
+
+Gets or Sets the given `DataType` level in the site hierarchy as an `Int`. DataType placed at the root of the site, will return 1, DataType right underneath will return 2, and so on.
 
 ### .Name
-Gets or Sets the name of the content as a `String`.
+
+Gets or Sets the name of the `DataType` as a `String`.
 
 ### .ParentId
-Gets or Sets the parent `Content` Id as an `Int`.
+
+Gets or Sets the parent `DataType` Id as an `Int`.
 
 ### .Path
-Gets or Sets the path of the content as a `String`. This string contains a comma separated list of the ancestor Ids including the current contents own id at the end of the string.
+
+Gets or Sets the path of the `DataType` as a `String`. This string contains a comma separated list of the ancestor Ids including the current contents own id at the end of the string.
 
 ### .SortOrder
-Returns the given `Content` index, compared to sibling content.
+
+Returns the given `DataType` index, compared to sibling DataType.
 
 ### .Trashed
-Returns a `Bool` indicating whether the given `Content` is currently in the recycle bin.
+
+Returns a `Bool` indicating whether the given `DataType` is currently in the recycle bin.

--- a/Reference/Management/Models/index.md
+++ b/Reference/Management/Models/index.md
@@ -15,8 +15,8 @@ API reference for the Content class.
 ## [ContentType](ContentType.md)
 API reference for the ContentType class.
 
-## [DataTypeDefinition](DataTypeDefinition.md)
-API reference for the DataTypeDefinition class.
+## [DataType](DataType.md)
+API reference for the DataType class.
 
 ## DictionaryItem
 API reference for the DictionaryItem and DictionaryTranslation classes.


### PR DESCRIPTION
Update data type (definition) for v8

- Create a v6 version
- Rename DataTypeDefinition to DataType
- Update link in index.md
- Remove needsV8Update labels
- Update constructor and properties section