### PR TITLE
Fix to custom health check code

### DIFF
--- a/Extending/Health-Check/index.md
+++ b/Extending/Health-Check/index.md
@@ -195,7 +195,7 @@ namespace Umbraco.Web.HealthCheck.Checks.SEO
     [HealthCheck("3A482719-3D90-4BC1-B9F8-910CD9CF5B32", "Robots.txt",
     Description = "Create a robots.txt file to block access to system folders.",
     Group = "SEO")]
-    public class RobotsTxt : HealthCheck.HealthCheck
+    public class RobotsTxt : HealthCheck
     {
         private readonly ILocalizedTextService _textService;
 


### PR DESCRIPTION
I copied the custom 'SEO' health check sample code into my project from https://our.umbraco.com/documentation/Extending/Health-Check/ (8.0.0). 

To compile, the class needed to inherit from `HealthCheck` not  `HealthCheck.HealthCheck`.

This was in a v8.14 project.