### PR TITLE
Added documentation on the Deploy configuration option ignoreBrokenDependencies

### DIFF
--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v9.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v9.md
@@ -131,3 +131,11 @@ In order for Deploy to handle Forms data as content, you'll to ensure the `Trans
 This setting is to be defined and set to `false` only if you are using an external membership provider for your members. You will not want to export Member Groups that would no longer be managed by Umbraco but by an external membership provider.
 
 Setting the `exportMemberGroups` to false will no longer export Member Groups to .uda files on disk. By default if this setting is not present, its value will automatically be set to true as most sites use Umbraco's built-in membership provider and thus will want the membership groups exported.
+
+## IgnoreBrokenDependencies
+
+When restoring or transferring content, Umbraco Deploy will make checks to ensure that any dependent content, media or other items are either present in the target environment, or can be deployed from the source environment.
+
+For example, if you have a media picker on a content item, that references a media item that's been deleted or is in the recycle bin, you'll get an error and the deploy won't complete until the issue is resolved (by removing the reference to the deleted media item).
+
+You can configure deploy to ignore these issues and proceed with the transfer operation without warning, by setting the value of this option to `true`.

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -96,7 +96,7 @@ In order for Deploy to handle Forms data as content, you'll need to add the foll
 </settings>
 ```
 
-## ExportMemberGroups
+## Exporting member groups
 
 This setting is to be defined and set to false only if you are using an external membership provider for your members. You will not want to export Member Groups that would no longer be managed by Umbraco but by an external membership provider.
 
@@ -108,3 +108,19 @@ Setting the `exportMemberGroups` to false will no longer export Member Groups to
     <deploy exportMemberGroups="false" />
 </settings>
 ```
+
+## Ignore broken dependencies
+
+When restoring or transferring content, Umbraco Deploy will make checks to ensure that any dependent content, media or other items are either present in the target environment, or can be deployed from the source environment.
+
+For example, if you have a media picker on a content item, that references a media item that's been deleted or is in the recycle bin, you'll get an error and the deploy won't complete until the issue is resolved (by removing the reference to the deleted media item).
+
+You can configure deploy to ignore these issues and proceed with the transfer operation without warning, with the following setting:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<settings xmlns="urn:umbracodeploy-settings">
+    <deploy ignoreBrokenDependencies="true" />
+</settings>
+```
+


### PR DESCRIPTION
This setting was references as being an "undocumented feature" in [an issue](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/5) I've been looking into, and doesn't seem to be any reason why it shouldn't be documented, so I think that's just an oversight.

Hence this PR to document it for V4 and V9.