### PR TITLE
updating for v9

### DIFF
--- a/Reference/Templating/Modelsbuilder/configuration-v9.md
+++ b/Reference/Templating/Modelsbuilder/configuration-v9.md
@@ -1,6 +1,6 @@
 ---
 versionFrom: 9.0.0
-verified-against: beta-3
+verified-against: rc-1
 meta.Title: ModelsBuilder Configuration
 meta.Description:  Explanation of how to configure models builder 
 ---
@@ -17,7 +17,7 @@ The following configuration option can be set in the application settings (in th
     * `SourceCodeManual`: Generate models in `~/umbraco/models` (but do not compile them) whenever the user clicks the "Generate models" button on the Models Builder dashboard in the Settings section.
     * `SourceCodeAuto`: Generate models in `~/umbraco/models` (but do not compile them) anytime a content type changes.
 
-* `Umbraco.CMS.ModelsBuilder.ModelsNamespace` (string, default is `Umbraco.Web.PublishedModels`) specifies the generated models' namespace.
+* `Umbraco.CMS.ModelsBuilder.ModelsNamespace` (string, default is `Umbraco.Web.Common.PublishedModels`) specifies the generated models' namespace.
 
 * `Umbraco.CMS.ModelsBuilder.FlagOutOfDateModels` (bool, default is `true`) indicates whether out-of-date models (i.e. after a content type or data type has been modified) should be flagged.
 

--- a/Reference/Templating/Modelsbuilder/configuration-v9.md
+++ b/Reference/Templating/Modelsbuilder/configuration-v9.md
@@ -17,7 +17,7 @@ The following configuration option can be set in the application settings (in th
     * `SourceCodeManual`: Generate models in `~/umbraco/models` (but do not compile them) whenever the user clicks the "Generate models" button on the Models Builder dashboard in the Settings section.
     * `SourceCodeAuto`: Generate models in `~/umbraco/models` (but do not compile them) anytime a content type changes.
 
-* `Umbraco.CMS.ModelsBuilder.ModelsNamespace` (string, default is `Umbraco.Web.Common.PublishedModels`) specifies the generated models' namespace.
+* `Umbraco.CMS.ModelsBuilder.ModelsNamespace` (string, default is `Umbraco.Cms.Web.Common.PublishedModels`) specifies the generated models' namespace.
 
 * `Umbraco.CMS.ModelsBuilder.FlagOutOfDateModels` (bool, default is `true`) indicates whether out-of-date models (i.e. after a content type or data type has been modified) should be flagged.
 


### PR DESCRIPTION
The default PublishedModels namespace is missing "common", it's changed for v9.

See example from v9 RC1: 
![image](https://user-images.githubusercontent.com/9353655/126844799-d66ec07b-bd5d-47ff-830e-3143aab03a7b.png)
