### PR TITLE
Add tilde pattern to paths in config example

### DIFF
--- a/Reference/V9-Config/ContentSettings/index.md
+++ b/Reference/V9-Config/ContentSettings/index.md
@@ -24,8 +24,8 @@ To get an overview of the keys and values in the global section, the following s
       "DisallowedUploadFiles": ["ashx", "aspx", "ascx", "config", "cshtml", "vbhtml", "asmx", "air", "axd", "xamlx"],
       "AllowedUploadFiles": [],
       "ShowDeprecatedPropertyEditors": false,
-      "LoginBackgroundImage": "assets/img/login.jpg",
-      "LoginLogoImage": "assets/img/application/umbraco_logo_white.svg",
+      "LoginBackgroundImage": "~/assets/img/login.jpg",
+      "LoginLogoImage": "~/assets/img/application/umbraco_logo_white.svg",
       "Notifications": {
         "Email": "",
         "DisableHtmlEmail": false


### PR DESCRIPTION
I've added "~/" to the path examples in the config to align it with how it's done elsewhere in the config documentation like in https://our.umbraco.com/documentation/Reference/V9-Config/GlobalSettings/