### PR TITLE
Reference cache examples tags

### DIFF
--- a/Reference/Cache/Examples/tags-v9.md
+++ b/Reference/Cache/Examples/tags-v9.md
@@ -93,7 +93,7 @@ using Doccers.Core.Services;
 using Doccers.Core.Services.Implement;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Doccers.Core
 {
@@ -101,7 +101,7 @@ namespace Doccers.Core
     {
         public void Compose(IUmbracoBuilder builder)
         {
-            builder.Services.AddUnique<ICacheTagService, CacheTagService>();
+            builder.Services.AddScoped<ICacheTagService, CacheTagService>();
         }
     }
 }

--- a/Reference/Cache/Examples/tags-v9.md
+++ b/Reference/Cache/Examples/tags-v9.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 8.0.0
+versionFrom: 9.0.0
 meta.Title: "Working with the runtime cache in Umbraco"
 meta.Description: "Information on how to insert and delete from the runtime cache"
 ---
@@ -31,9 +31,10 @@ First we want to create our `CacheTagService`. In this example it's a basic clas
 ```csharp
 using System;
 using System.Collections.Generic;
-using Umbraco.Core.Cache;
-using Umbraco.Web;
-using Umbraco.Web.Models;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Extensions;
 
 namespace Doccers.Core.Services.Implement
 {
@@ -71,7 +72,7 @@ As you can see we inherit from the `ICacheTagService` interface. All that has is
 ```csharp
 using System;
 using System.Collections.Generic;
-using Umbraco.Web.Models;
+using Umbraco.Cms.Core.Models;
 
 namespace Doccers.Core.Services
 {
@@ -90,16 +91,17 @@ The interface was created to better register it so we can use dependency injecti
 ```csharp
 using Doccers.Core.Services;
 using Doccers.Core.Services.Implement;
-using Umbraco.Core;
-using Umbraco.Core.Composing;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Extensions;
 
 namespace Doccers.Core
 {
-    public class Composer : IUserComposer
+    public class Composer : IComposer
     {
-        public void Compose(Composition composition)
+        public void Compose(IUmbracoBuilder builder)
         {
-            composition.Register<ICacheTagService, CacheTagService>();
+            builder.Services.AddUnique<ICacheTagService, CacheTagService>();
         }
     }
 }
@@ -112,12 +114,13 @@ Now you can inject `ICacheTagService` in any constructor in your project - wohoo
 Now that we have our service it's time to create an endpoint where we can fetch the (cached) tags.
 
 ```csharp
-using Doccers.Core.Services;
 using System;
 using System.Collections.Generic;
-using System.Web.Http;
-using Umbraco.Web.Models;
-using Umbraco.Web.WebApi;
+using Microsoft.AspNetCore.Mvc;
+using Doccers.Core.Services;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Web.Common.Controllers;
+
 
 namespace Doccers.Core.Controllers.Api
 {

--- a/Reference/Cache/Examples/tags.md
+++ b/Reference/Cache/Examples/tags.md
@@ -91,16 +91,17 @@ The interface was created to better register it so we can use dependency injecti
 ```csharp
 using Doccers.Core.Services;
 using Doccers.Core.Services.Implement;
-using Umbraco.Core;
-using Umbraco.Core.Composing;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Extensions;
 
 namespace Doccers.Core
 {
-    public class Composer : IUserComposer
+    public class Composer : IComposer
     {
-        public void Compose(Composition composition)
+        public void Compose(IUmbracoBuilder builder)
         {
-            composition.Register<ICacheTagService, CacheTagService>();
+            builder.Services.AddUnique<ICacheTagService, CacheTagService>();
         }
     }
 }

--- a/Reference/Cache/Examples/tags.md
+++ b/Reference/Cache/Examples/tags.md
@@ -31,9 +31,10 @@ First we want to create our `CacheTagService`. In this example it's a basic clas
 ```csharp
 using System;
 using System.Collections.Generic;
-using Umbraco.Core.Cache;
-using Umbraco.Web;
-using Umbraco.Web.Models;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Extensions;
 
 namespace Doccers.Core.Services.Implement
 {
@@ -71,7 +72,7 @@ As you can see we inherit from the `ICacheTagService` interface. All that has is
 ```csharp
 using System;
 using System.Collections.Generic;
-using Umbraco.Web.Models;
+using Umbraco.Cms.Core.Models;
 
 namespace Doccers.Core.Services
 {

--- a/Reference/Cache/Examples/tags.md
+++ b/Reference/Cache/Examples/tags.md
@@ -221,5 +221,4 @@ public void Compose(Composition composition)
     composition.Components().Append<Component>();
 }
 ```
-
 Awesome! Now we have set up caching on our tags - making the site a bit faster. :)

--- a/Reference/Cache/Examples/tags.md
+++ b/Reference/Cache/Examples/tags.md
@@ -114,12 +114,13 @@ Now you can inject `ICacheTagService` in any constructor in your project - wohoo
 Now that we have our service it's time to create an endpoint where we can fetch the (cached) tags.
 
 ```csharp
-using Doccers.Core.Services;
 using System;
 using System.Collections.Generic;
-using System.Web.Http;
-using Umbraco.Web.Models;
-using Umbraco.Web.WebApi;
+using Microsoft.AspNetCore.Mvc;
+using Doccers.Core.Services;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Web.Common.Controllers;
+
 
 namespace Doccers.Core.Controllers.Api
 {


### PR DESCRIPTION
Update [Reference cache examples tags](https://our.umbraco.com/documentation/Reference/Cache/examples/tags)

Belongs to: https://github.com/umbraco/UmbracoDocs/issues/3145