### PR TITLE
Change add Component to add AddNotificationHandler

### DIFF
--- a/Reference/Cache/Examples/tags-v9.md
+++ b/Reference/Cache/Examples/tags-v9.md
@@ -199,7 +199,7 @@ namespace Doccers.Core
 }
 ```
 
-Now that we have our component we also need to register it. Add `composition.Components().Append<Component>();` to the `Compose` method in the `Composer` class so it becomes:
+Now that we have our notification we also need to register it. Add `builder.AddNotificationHandler<ContentPublishedNotification, Notification>();` to the `Compose` method in the `Composer` class so it becomes:
 
 ```csharp
 public void Compose(IUmbracoBuilder builder)


### PR DESCRIPTION
Small fix for my previous [PR](https://github.com/umbraco/UmbracoDocs/pull/3410). 

Update text, use `builder.AddNotificationHandler<ContentPublishedNotification, Notification>();` instead of `composition.Components().Append<Component>();`