### PR TITLE
Added rewrite example for vNext

### DIFF
--- a/Umbraco-Cloud/Set-Up/Manage-Hostnames/Rewrites-on-Cloud/index.md
+++ b/Umbraco-Cloud/Set-Up/Manage-Hostnames/Rewrites-on-Cloud/index.md
@@ -49,6 +49,23 @@ One approach for this is to add a new rewrite rule to the `<system.webServer><re
 </rule>
 ```
 
+If your Umbraco Cloud site is running on the new infrastucture then the rewrite rule needs to be like this 
+
+```xml
+<rule name="Redirects umbraco.io to actual domain" stopProcessing="true">
+  <match url=".*" />
+  <conditions>
+    <add input="{HTTP_HOST}" pattern="^(.*)?.euwest01.umbraco.io$" />
+    <add input="{REQUEST_URI}" negate="true" pattern="^/umbraco" />
+    <add input="{REQUEST_URI}" negate="true" pattern="^/DependencyHandler.axd" />
+    <add input="{REQUEST_URI}" negate="true" pattern="^/App_Plugins" />
+    <add input="{REQUEST_URI}" negate="true" pattern="localhost" />
+  </conditions>
+  <action type="Redirect" url="http://<your actual domain here>.com/{R:0}"
+        appendQueryString="true" redirectType="Permanent" />
+</rule>
+```
+
 :::note
 This will not rewrite anything under the `/umbraco` path so that you can still do content deployments. You don't have to give your editors the umbraco.io URL, and they won't see the umbraco.io URL if you give them the actual hostname. This rule will also not apply on your local copy of the site running on `localhost`.
 :::


### PR DESCRIPTION
I have added an example of how to redirect umbraco.io to the actual domain when you are on the new infrastructure on Umbraco Cloud