### PR TITLE
V9: Added Cache docs, updated from v7.

### DIFF
--- a/Reference/Cache/cache-refresher-v9.md
+++ b/Reference/Cache/cache-refresher-v9.md
@@ -1,0 +1,15 @@
+---
+versionFrom: 9.0.0
+---
+
+# ICacheRefresher
+
+_This section describes what ICacheRefresher and ICacheRefresher&lt;T&gt; are and how to use them to invalidate your cache correctly including load balanced environments_
+
+## What is an ICacheRefresher
+
+This interface has been in the Umbraco core for quite some time but has really only been used to ensure that content cache is refreshed among all server nodes participating in a load balanced scenario.
+
+With changes in 6.1, this has changed slightly, an `ICacheRefresher` is now the primary way to invalidate *any* cache that needs to be refreshed or removed regardless of whether we are in a load balanced environment.
+
+There are now a few different types of `ICacheRefreshers` in the Umbraco core and it is important to understand the differences between them and how cache invalidation works across multiple server nodes.

--- a/Reference/Cache/index-v9.md
+++ b/Reference/Cache/index-v9.md
@@ -2,9 +2,91 @@
 versionFrom: 9.0.0
 ---
 
-# Caching
+# Cache & Distributed Cache
 
-We're busy getting the documentation up to date for Umbraco 9. Below you can find a list of examples made to give you an idea about how you can work with caching in Umbraco 9.
+_This section refers to how to implement caching features in the Umbraco application in a consistent way that will work in both single server environments and load balanced (multi-server) environments. The caching described in this section relates to application caching in the context of a web application only._
+
+## IF YOU ARE CACHING, PLEASE READ THIS
+
+Although caching is a pretty standard concept it is very important to make sure that caching is done correctly and consistently. It is always best to ensure performance is at its best before applying any cache and also beware of *over caching* as this can cause degraded performance in your application because of cache turnover.
+
+In normal environments caching seems to be a pretty standard concept. If you are a package developer or developer who is going to publish a codebase to a loadbalanced environment then you need to be aware of how to invalidate your cache properly, so that it works in load balanced environments. If it is not done correctly then your package and/or codebase will not work the way that you would expect in a load balanced scenario.
+
+**If you are caching businesslogic data that changes based on a user's action in the backoffice and you are not using an *ICacheRefresher* then you will need to review your code and update it based on the below documentation.**
+
+## Retrieving and Adding items in the cache
+
+You can [update and insert items in the cache](updating-cache-v9.md).
+
+## Refreshing/Invalidating cache
+
+### [ICacheRefresher](cache-refresher-v9.md)
+
+The standard way to invalidate cache in Umbraco is to implement an `ICacheRefresher`.
+
+The interface consists of the following methods:
+
+* `Guid RefresherUniqueId { get; }`
+  - Which you'd return your own unique GUID identifier
+* `string Name { get; }`
+  - The name of the cache refresher (informational purposes)
+* `void RefreshAll();`
+  - This would invalidate or refresh all caches of the caching type that this `ICacheRefresher` is created for. For example, if you were caching `Employee` objects, this method would invalidate all `Employee` caches.
+* `void Refresh(int Id);`
+  - This would invalidate or refresh a single cache for an object with the provided INT id.
+* `void Refresh(Guid Id);`
+  - This would invalidate or refresh a single cache for an object with the provided GUID id.
+* `void Remove(int Id);`
+  - This would invalidate a single cache for an object with the provided INT id. In many cases Remove and Refresh perform the same operation but in some cases `Refresh` doesn't remove/invalidate a cache entry, it might update it. `Remove` is specifically used to remove/invalidate a cache entry.
+
+_Some of these methods may not be relevant to the needs of your own cache invalidation so not all of them may need to perform logic._
+
+There are 2 other base types of `ICacheRefresher` which are:
+
+* `ICacheRefresher<T>` - this inherits from `ICacheRefresher` and provides a set of strongly typed methods for cache invalidation. This is useful when executing the method to invoke the cache refresher, when you have the instance of the object already since this avoids the overhead of retrieving the object again.
+    * `void Refresh(T instance);` - this would invalidate/refresh a single cache for the specified object.
+    * `void Remove(T instance);` - this would invalidate a single cache for the specified object.
+* `IJsonCacheRefresher` - this inherits from `ICacheRefresher` but provides more flexibility if you need to invalidate cache based on more complex scenarios (e.g. the [MemberGroupCacheRefresher](https://github.com/umbraco/Umbraco-CMS/blob/v7/dev/src/Umbraco.Web/Cache/MemberGroupCacheRefresher.cs)).
+    * `void Refresh(string jsonPayload)` - Invalidates/refreshes any cache based on the information provided in the JSON. The JSON value is any value that is used when executing the method to invoke the cache refresher.
+
+There are several examples of `ICacheRefresher`'s in the core: https://github.com/umbraco/Umbraco-CMS/tree/v9/dev/src/Umbraco.Core/Cache
+
+### Executing an ICacheRefresher
+
+To execute your `ICacheRefresher` you call these methods on the `DistributedCache` instance (the `DistributedCache` object exists in the `Umbraco.Cms.Core.Cache` namespace):
+
+* `void Refresh<T>(Guid cacheRefresherId, Func<T, int> getNumericId, params T[] instances)`
+  - This executes an `ICacheRefresher<T>.Refresh(T instance)` of the specified cache refresher Id
+* `void Refresh(Guid cacheRefresherId, int id)`
+  - This executes an `ICacheRefresher.Refresh(int id)` of the specified cache refresher Id
+* `void Refresh(Guid cacheRefresherId, Guid id)`
+  - This executes an `ICacheRefresher.Refresh(Guid id)` of the specified cache refresher Id
+* `void Remove(Guid refresherGuid, int id)`
+  - This executes an `ICacheRefresher.Remove(int id)` of the specified cache refresher Id
+* `void Remove<T>(Guid refresherGuid, Func<T, int> getNumericId, params T[] instances)`
+  - This executes an `ICacheRefresher<T>.Remove(T instance)` of the specified cache refresher Id
+* `void RefreshAll(Guid refresherGuid)`
+  - This executes an `ICacheRefresher.RefreshAll()` of the specified cache refresher Id
+
+**So when do you use these methods to invalidate your cache?**
+
+This really comes down to what you are caching and when it needs to be invalidated.
+
+### What happens when an ICacheRefresher is executed?
+
+When an `ICacheRefresher` is executed via the `DistributedCache` a notification is sent out to all servers that are hosting your web application to execute the specified cache refresher.
+When not load balancing, this means that the single server hosting your web application executes the `ICacheRefresher` directly.
+However when load balancing, this means that Umbraco will ensure that each server hosting your web application executes the `ICacheRefresher` so that each server's cache stays in sync.
+
+## Events handling to refresh cache
+
+To use the extensions add a using to `Umbraco.Extensions`;  You can then invoke them on the injected `DistributedCache` object.
+
+## IServerMessenger
+
+The server messenger broadcasts 'distributed cache notifications' to each server in the load balanced environment.
+The server messenger ensures that the notification is processed on the local environment.
+
 
 ## Getting and clearing cached content
 

--- a/Reference/Cache/index-v9.md
+++ b/Reference/Cache/index-v9.md
@@ -10,7 +10,7 @@ _This section refers to how to implement caching features in the Umbraco applica
 
 Although caching is a pretty standard concept it is very important to make sure that caching is done correctly and consistently. It is always best to ensure performance is at its best before applying any cache and also beware of *over caching* as this can cause degraded performance in your application because of cache turnover.
 
-In normal environments caching seems to be a pretty standard concept. If you are a package developer or developer who is going to publish a codebase to a loadbalanced environment then you need to be aware of how to invalidate your cache properly, so that it works in load balanced environments. If it is not done correctly then your package and/or codebase will not work the way that you would expect in a load balanced scenario.
+In normal environments caching seems to be a pretty standard concept. If you are a package developer or developer who is going to publish a codebase to a load balanced environment then you need to be aware of how to invalidate your cache properly, so that it works in load balanced environments. If it is not done correctly then your package and/or codebase will not work the way that you would expect in a load balanced scenario.
 
 **If you are caching businesslogic data that changes based on a user's action in the backoffice and you are not using an *ICacheRefresher* then you will need to review your code and update it based on the below documentation.**
 

--- a/Reference/Cache/index-v9.md
+++ b/Reference/Cache/index-v9.md
@@ -6,13 +6,15 @@ versionFrom: 9.0.0
 
 _This section refers to how to implement caching features in the Umbraco application in a consistent way that will work in both single server environments and load balanced (multi-server) environments. The caching described in this section relates to application caching in the context of a web application only._
 
-## IF YOU ARE CACHING, PLEASE READ THIS
+:::warning
+**Please read this if you are Caching**
 
 Although caching is a pretty standard concept it is very important to make sure that caching is done correctly and consistently. It is always best to ensure performance is at its best before applying any cache and also beware of *over caching* as this can cause degraded performance in your application because of cache turnover.
 
 In normal environments caching seems to be a pretty standard concept. If you are a package developer or developer who is going to publish a codebase to a load balanced environment then you need to be aware of how to invalidate your cache properly, so that it works in load balanced environments. If it is not done correctly then your package and/or codebase will not work the way that you would expect in a load balanced scenario.
 
-**If you are caching businesslogic data that changes based on a user's action in the backoffice and you are not using an *ICacheRefresher* then you will need to review your code and update it based on the below documentation.**
+**If you are caching business logic data that changes based on a user's action in the backoffice and you are not using an *ICacheRefresher* then you will need to review your code and update it based on the below documentation.**
+:::
 
 ## Retrieving and Adding items in the cache
 

--- a/Reference/Cache/updating-cache-v9.md
+++ b/Reference/Cache/updating-cache-v9.md
@@ -1,0 +1,46 @@
+---
+versionFrom: 9.0.0
+
+---
+
+# Getting/Adding/Updating/Inserting Into Cache
+
+_This section describes how you should be getting/adding/updating/inserting items in the cache._
+
+## Adding and retrieving items in the cache
+
+The recommended way to put data in and get data out is to use one of the many overloaded methods of: `GetCacheItem`. The `GetCacheItem` methods (all except one) are designed to "Get or Add" to the cache. For example, the following will retrieve an item from the cache and if it doesn't exist will ensure that the item is added to it:
+
+```csharp
+MyObject cachedItem = _appCaches.RuntimeCache.GetCacheItem<MyObject>("MyCacheKey", () => new MyObject());
+```
+
+where `_appCaches` is injected as type `AppCaches`.
+
+Notice 2 things:
+
+* The `GetCacheItem` method is strongly typed and
+* We are supplying a callback method which is used to populate the cache if it doesn't exist.
+
+The example above will retrieve a strongly typed object of `MyObject` from the cache with the key of "MyCacheKey", if the object doesn't exist in the cache a new instance of `MyObject` will be added to it with the same key.
+
+There are a couple of overloads of `GetCacheItem` allowing you to customize how your object is cached from cache dependencies to expiration times.
+
+To use this generic implementation, add the `Umbraco.Extensions` namespace to your code.
+
+### Retrieving an item from the cache without a callback
+
+One of the overloads of `GetCacheItem` doesn't specify a callback, this will allow  you to retrieve an item from the cache without populating it if it doesn't exist.
+
+An example of usage:
+
+```csharp
+MyObject cachedItem = _appCaches.RuntimeCache.GetCacheItem<MyObject>("MyCacheKey");
+```
+where `_appCaches` is injected as type `AppCaches`.
+
+### Inserting an item into the cache without retrieval
+
+Sometimes you might want to put something in the cache without retrieving it.
+In this case there is an `InsertCacheItem<T>` method.
+This method will add or update the cache item specified by the key so if the item already exists in the cache, it will be replaced.

--- a/Reference/Cache/updating-cache-v9.md
+++ b/Reference/Cache/updating-cache-v9.md
@@ -30,7 +30,7 @@ To use this generic implementation, add the `Umbraco.Extensions` namespace to yo
 
 ### Retrieving an item from the cache without a callback
 
-One of the overloads of `GetCacheItem` doesn't specify a callback, this will allow  you to retrieve an item from the cache without populating it if it doesn't exist.
+One of the overloads of `GetCacheItem` doesn't specify a callback, this will allow you to retrieve an item from the cache without populating it if it doesn't exist.
 
 An example of usage:
 


### PR DESCRIPTION
Added more docs to the Reference/Cache section. 
Most docs are updated from v7 version, but a few changes are made. *
- Removed an example with donut cache that do not make sense for v9 / .NET5+
- Removed the small individual page for ICacheRefresher<T>.