### PR TITLE
V9: Add scheduling documentation

### DIFF
--- a/Reference/Notifications/Creating-And-Publishing-Notifications.md
+++ b/Reference/Notifications/Creating-And-Publishing-Notifications.md
@@ -9,9 +9,9 @@ update-links: true
 
 # Creating a custom notification
 
-There may be many reason why you would like to create your own custom notifications, in this article we'll use the CleanUpYourRoom [recurring hosted service](../Scheduling/index-v9.md) as an example, which empties the recycle bin every 5 minutes. You might want to publish a notification once the task has started, and maybe once the task has sucessfully cleared the recycle bin.
+There may be many reasons why you would like to create your own custom notifications, in this article we'll use the CleanUpYourRoom [recurring hosted service](../Scheduling/index-v9.md) as an example, which empties the recycle bin every 5 minutes. You might want to publish a notification once the task has started, and maybe once the task has successfully cleared the recycle bin.
 
-For a notification to be publishable there's only one requirement, it must implement the empty marker interface `INotifiaction`, the rest is up to you. For instance we might want to create a notification that just signals that the clean your room task has started and nothing else, in this case we'll create an empty class implementing `INotification`
+For a notification to be publishable there's only one requirement, it must implement the empty marker interface `INotifiaction`, the rest is up to you. For instance, we might want to create a notification that just signals that the clean your room task has started and nothing else, in this case, we'll create an empty class implementing `INotification`
 
 ```C#
 using Umbraco.Cms.Core.Notifications;
@@ -25,7 +25,7 @@ namespace Umbraco.Cms.Web.UI.Notifications
 }
 ```
 
-This notification can now be published, and we can create a notification handler to recieve it with, see [MediaService-Notifications](MediaService-Notifications.md) for an example of how to implement a notification handler. But this notification alone might not be super helpful, we might want to be able to send some additional information with the notification, however, since this is, in essence, just a normal class, we can include whatever information we want. Let's try and create a `RoomCleanedNotification` which contains the amount of nodes removed from the recycle bin:
+This notification can now be published, and we can create a notification handler to receive it with, see [MediaService-Notifications](MediaService-Notifications.md) for an example of how to implement a notification handler. But this notification alone might not be super helpful, we might want to be able to send some additional information with the notification, however, since this is, in essence, just a normal class, we can include whatever information we want. Let's try and create a `RoomCleanedNotification` which contains the number of nodes removed from the recycle bin:
 
 ```C#
 using Umbraco.Cms.Core.Notifications;
@@ -53,7 +53,7 @@ Just creating the notification classes is not enough, we also want to be able to
 * `IEventAggregator` - Notifications published with `IEventAggregator` will always be published immediately.
 * `IScope.Notifications` - Notifications published with a scope will only be published once the scope has been completed and disposed. 
 
-The method you use to publish notifications depends on what your needs are, the benefits of publishing notifications with a scope is that the notification will only be published if you complete the scope, and then only once the scope is disposed. This can be useful if you access the database, or do some other operation that might fail causing you to do a rollback, disposing the scope without completing it, in this case you might not want to publish a notification that signals that the operation was a success, using scopes will handle this for you. On the other hand you might want to publish the notification imidiately no matter what, for instance with the `CleanYourRoomStartedNotification`, for this the `IEventAggregator` is the right choice.
+The method you use to publish notifications depends on what your needs are, the benefits of publishing notifications with a scope is that the notification will only be published if you complete the scope, and then only once the scope is disposed of. This can be useful if you access the database, or do some other operation that might fail causing you to do a rollback, disposing of the scope without completing it, in this case, you might not want to publish a notification that signals that the operation was a success, using scopes will handle this for you. On the other hand, you might want to publish the notification immediately no matter what, for instance with the `CleanYourRoomStartedNotification`, for this, the `IEventAggregator` is the right choice.
 
 ## Example
 
@@ -111,5 +111,5 @@ namespace Umbraco.Cms.Web.UI
 }
 ```
 
-In this case the `CleanYourRoomStartedNotification` will always be published imidiately, however `RoomCleanedNotification` will only be published once the operation is done, and if you remove the `scope.Complete();` line it will never be published, the recycle bin won't be emptied either. 
+In this case, the `CleanYourRoomStartedNotification` will always be published immediately, however, `RoomCleanedNotification` will only be published once the operation is done, and if you remove the `scope.Complete();` line it will never be published, the recycle bin won't be emptied either. 
 

--- a/Reference/Notifications/Creating-And-Publishing-Notifications.md
+++ b/Reference/Notifications/Creating-And-Publishing-Notifications.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 verified-against: rc002
-meta-title: Creating And Publishing Notifications
+meta-title: Creating and Publishing Custom Notifications
 meta.Description: How to create and publish your own custom notifications
 state: complete
 update-links: true
@@ -25,7 +25,7 @@ namespace Umbraco.Cms.Web.UI.Notifications
 }
 ```
 
-This notification can now be published, and we can create a notification handler to recieve it with, see [MediaService-Notifications](MediaService-Notifications.md) for an example of how to implement a notification handler. But this notification alone might not be super helpful, we might want to be able to send some additional information with the notification, however, since this is in essence just a normal class, we can include whatever information we want. Let's try and create a `RoomCleanedNotification` which contains the amount of nodes removed from the recycle bin:
+This notification can now be published, and we can create a notification handler to recieve it with, see [MediaService-Notifications](MediaService-Notifications.md) for an example of how to implement a notification handler. But this notification alone might not be super helpful, we might want to be able to send some additional information with the notification, however, since this is, in essence, just a normal class, we can include whatever information we want. Let's try and create a `RoomCleanedNotification` which contains the amount of nodes removed from the recycle bin:
 
 ```C#
 using Umbraco.Cms.Core.Notifications;

--- a/Reference/Notifications/Creating-And-Publishing-Notifications.md
+++ b/Reference/Notifications/Creating-And-Publishing-Notifications.md
@@ -1,0 +1,115 @@
+---
+versionFrom: 9.0.0
+verified-against: rc002
+meta-title: Creating And Publishing Notifications
+meta.Description: How to create and publish your own custom notifications
+state: complete
+update-links: true
+---
+
+# Creating a custom notification
+
+There may be many reason why you would like to create your own custom notifications, in this article we'll use the CleanUpYourRoom [recurring hosted service](../Scheduling/index-v9.md) as an example, which empties the recycle bin every 5 minutes. You might want to publish a notification once the task has started, and maybe once the task has sucessfully cleared the recycle bin.
+
+For a notification to be publishable there's only one requirement, it must implement the empty marker interface `INotifiaction`, the rest is up to you. For instance we might want to create a notification that just signals that the clean your room task has started and nothing else, in this case we'll create an empty class implementing `INotification`
+
+```C#
+using Umbraco.Cms.Core.Notifications;
+
+namespace Umbraco.Cms.Web.UI.Notifications
+{
+    public class CleanYourRoomStartedNotification : INotification
+    {
+
+    }
+}
+```
+
+This notification can now be published, and we can create a notification handler to recieve it with, see [MediaService-Notifications](MediaService-Notifications.md) for an example of how to implement a notification handler. But this notification alone might not be super helpful, we might want to be able to send some additional information with the notification, however, since this is in essence just a normal class, we can include whatever information we want. Let's try and create a `RoomCleanedNotification` which contains the amount of nodes removed from the recycle bin:
+
+```C#
+using Umbraco.Cms.Core.Notifications;
+
+namespace Umbraco.Cms.Web.UI.Notifications
+{
+    public class RoomCleanedNotification : INotification
+    {
+        public int ItemsDeleted { get; }
+
+        public RoomCleanedNotification(int itemsDeleted)
+        {
+            ItemsDeleted = itemsDeleted;
+        }
+    }
+}
+```
+
+Now you can create a handler that recieves the amount of items deleted through the notification.
+
+# Sending notifications
+
+Just creating the notification classes is not enough, we also want to be able to publish them. There's two ways of publishing notifications:
+
+* `IEventAggregator` - Notifications published with `IEventAggregator` will always be published immediately.
+* `IScope.Notifications` - Notifications published with a scope will only be published once the scope has been completed and disposed. 
+
+The method you use to publish notifications depends on what your needs are, the benefits of publishing notifications with a scope is that the notification will only be published if you complete the scope, and then only once the scope is disposed. This can be useful if you access the database, or do some other operation that might fail causing you to do a rollback, disposing the scope without completing it, in this case you might not want to publish a notification that signals that the operation was a success, using scopes will handle this for you. On the other hand you might want to publish the notification imidiately no matter what, for instance with the `CleanYourRoomStartedNotification`, for this the `IEventAggregator` is the right choice.
+
+## Example
+
+```C#
+using System;
+using System.Threading.Tasks;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.HostedServices;
+using Umbraco.Cms.Web.UI.Notifications;
+
+namespace Umbraco.Cms.Web.UI
+{
+    public class CleanUpYourRoom : RecurringHostedServiceBase
+    {
+        private readonly IContentService _contentService;
+        private readonly IScopeProvider _scopeProvider;
+        private readonly IEventAggregator _eventAggregator;
+        private static TimeSpan HowOftenWeRepeat => TimeSpan.FromMinutes(5);
+        private static TimeSpan DelayBeforeWeStart => TimeSpan.FromMinutes(1);
+
+        public CleanUpYourRoom(
+            IContentService contentService,
+            IScopeProvider scopeProvider,
+            IEventAggregator eventAggregator)
+            : base(HowOftenWeRepeat, DelayBeforeWeStart)
+        {
+            _contentService = contentService;
+            _scopeProvider = scopeProvider;
+            _eventAggregator = eventAggregator;
+        }
+
+        public override Task PerformExecuteAsync(object state)
+        {
+            // This will be published immediately
+            _eventAggregator.Publish(new CleanYourRoomStartedNotification());
+
+            using IScope scope = _scopeProvider.CreateScope();
+            int numberOfThingsInBin = _contentService.CountChildren(Constants.System.RecycleBinContent);
+
+            if (_contentService.RecycleBinSmells())
+            {
+                _contentService.EmptyRecycleBin(userId: -1);
+                // This will only be published when the scope is completed and disposed.
+                scope.Notifications.Publish(new RoomCleanedNotification(numberOfThingsInBin));
+            }
+
+            // Remember to complete the scope when done.
+            scope.Complete();
+            return Task.CompletedTask;
+        }
+    }
+}
+```
+
+In this case the `CleanYourRoomStartedNotification` will always be published imidiately, however `RoomCleanedNotification` will only be published once the operation is done, and if you remove the `scope.Complete();` line it will never be published, the recycle bin won't be emptied either. 
+

--- a/Reference/Notifications/index.md
+++ b/Reference/Notifications/index.md
@@ -160,4 +160,4 @@ Useful for manipulating the model before it is sent to an editor in the backoffi
 
 # Creating and publishing your own custon notifications
 
-Umbraco uses notification to allow people to hook in various workflow processes, but the notification pattern is also extendable, allowing you to create your own custom notification and publishing them, allowing other people to hook into your processes, this can be very useful, when for instance creating packages. For more information on how you create and publish you own notifications see the [creating and publishing noticiations](Creating-And-Publishing-Notifications.md) article.
+Umbraco uses notifications to allow people to hook in various workflow processes, but the notification pattern is also extendable, allowing you to create your own custom notification and publishing them, allowing other people to hook into your processes, this can be very useful when for instance creating packages. For more information on how you create and publish your own notifications see the [creating and publishing noticiations](Creating-And-Publishing-Notifications.md) article.

--- a/Reference/Notifications/index.md
+++ b/Reference/Notifications/index.md
@@ -158,6 +158,6 @@ See [EditorModel Notifications](EditorModel-Notifications) for a listing of the 
 Useful for manipulating the model before it is sent to an editor in the backoffice - eg. perhaps to set a default value of a property on a new document.
 :::
 
-# Creating your own custom notifications and publishing them
+# Creating and publishing your own custon notifications
 
 Umbraco uses notification to allow people to hook in various workflow processes, but the notification pattern is also extendable, allowing you to create your own custom notification and publishing them, allowing other people to hook into your processes, this can be very useful, when for instance creating packages. For more information on how you create and publish you own notifications see the [creating and publishing noticiations](Creating-And-Publishing-Notifications.md) article.

--- a/Reference/Notifications/index.md
+++ b/Reference/Notifications/index.md
@@ -157,3 +157,7 @@ See [EditorModel Notifications](EditorModel-Notifications) for a listing of the 
 :::tip
 Useful for manipulating the model before it is sent to an editor in the backoffice - eg. perhaps to set a default value of a property on a new document.
 :::
+
+# Creating your own custom notifications and publishing them
+
+Umbraco uses notification to allow people to hook in various workflow processes, but the notification pattern is also extendable, allowing you to create your own custom notification and publishing them, allowing other people to hook into your processes, this can be very useful, when for instance creating packages. For more information on how you create and publish you own notifications see the [creating and publishing noticiations](Creating-And-Publishing-Notifications.md) article.

--- a/Reference/Scheduling/index-v9.md
+++ b/Reference/Scheduling/index-v9.md
@@ -1,0 +1,258 @@
+---
+versionFrom: 9.0.0
+verified-against: rc002
+meta-title: Scheduling with hosted services in Umbraco
+meta.Description: Use hosted services to run a background task
+state: complete
+update-links: true
+---
+
+# Scheduling with RecurringHostedServiceBase
+
+In Umbraco 9 it is possible to run recurring code using a hosted service.
+Below is a complete example showing how to create and register a hosted service that will regularly empty out the recycle bin every five minutes. 
+
+:::warning
+Be aware you may or may not want this hosted service code to run on all servers, if you are using Load Balancing with multiple servers, see [load balancing documentation](../../Fundamentals/Setup/Server-Setup/Load-Balancing/index-v9.md) for more information
+:::
+
+## RecurringHostedService example
+
+```C#
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Logging;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Infrastructure.HostedServices;
+
+namespace Umbraco.Cms.Web.UI
+{
+    public class CleanUpYourRoom : RecurringHostedServiceBase
+    {
+        private readonly IRuntimeState _runtimeState;
+        private readonly IContentService _contentService;
+        private readonly IServerRoleAccessor _serverRoleAccessor;
+        private readonly IProfilingLogger _profilingLogger;
+        private readonly ILogger<CleanUpYourRoom> _logger;
+        private readonly IScopeProvider _scopeProvider;
+
+        private static TimeSpan HowOftenWeRepeat => TimeSpan.FromMinutes(5);
+        private static TimeSpan DelayBeforeWeStart => TimeSpan.FromMinutes(1);
+
+        public CleanUpYourRoom(
+            IRuntimeState runtimeState,
+            IContentService contentService,
+            IServerRoleAccessor serverRoleAccessor,
+            IProfilingLogger profilingLogger,
+            ILogger<CleanUpYourRoom> logger,
+            IScopeProvider scopeProvider)
+            : base(HowOftenWeRepeat, DelayBeforeWeStart)
+        {
+            _runtimeState = runtimeState;
+            _contentService = contentService;
+            _serverRoleAccessor = serverRoleAccessor;
+            _profilingLogger = profilingLogger;
+            _logger = logger;
+            _scopeProvider = scopeProvider;
+        }
+
+        public override Task PerformExecuteAsync(object state)
+        {
+            // Don't do anything if the site is not running.
+            if (_runtimeState.Level != RuntimeLevel.Run)
+            {
+                return Task.CompletedTask;
+            }
+
+            // Wrap the three content service calls in a scope to do it all in one transaction.
+            using IScope scope = _scopeProvider.CreateScope();
+            
+            int numberOfThingsInBin = _contentService.CountChildren(Constants.System.RecycleBinContent);
+            _logger.LogInformation("Go clean your room - {ServerRole}", _serverRoleAccessor.CurrentServerRole);
+            _logger.LogInformation("You have {NumberOfThinsInTheBing} items to clean", numberOfThingsInBin);
+
+            if (_contentService.RecycleBinSmells())
+            {
+                // Take out the trash
+                using (_profilingLogger.TraceDuration<CleanUpYourRoom>("Mum, I am emptying out the bing",
+                    "It's all clean now"))
+                {
+                    _contentService.EmptyRecycleBin(userId: -1);
+                }
+            }
+
+            // Remember to complete the scope when done.
+            scope.Complete();
+            return Task.CompletedTask;
+        }
+    }
+}
+
+```
+
+### Registering with extension method
+
+First we needto create out extension method:
+
+```C#
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
+
+namespace Umbraco.Cms.Web.UI
+{
+    public static class BuilderExtensions
+    {
+        public static IUmbracoBuilder AddHostedServices(this IUmbracoBuilder builder)
+        {
+            builder.Services.AddHostedService<CleanUpYourRoom>();
+            return builder;
+        }
+    }
+}
+```
+
+Now we can invoke it in the `ConfigureServices` method in `Startup.cs`:
+
+```C#
+public void ConfigureServices(IServiceCollection services)
+{
+#pragma warning disable IDE0022 // Use expression body for methods
+    services.AddUmbraco(_env, _config)
+        .AddBackOffice()
+        .AddWebsite()
+        .AddComposers()
+        .AddHostedServices() // Register CleanUpYourRoom
+        .Build();
+#pragma warning restore IDE0022 // Use expression body for methods
+}
+```
+
+### Registering with a composer
+
+All we need to do here is to create the composer which will be run automatically:
+
+```C#
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+
+namespace Umbraco.Cms.Web.UI
+{
+    public class CleanUpYourRoomComposer : IComposer
+    {
+        public void Compose(IUmbracoBuilder builder)
+        {
+            builder.Services.AddHostedService<CleanUpYourRoom>();
+        }
+    }
+}
+
+```
+
+## RecurringHostedServiceBase
+
+This class provides the base class for any hosted service. 
+
+You can override the `PerformExecuteAsync` method to implement the class. Hosted services are always run asynchronously.
+
+The `RecurringHostedServiceBase` is a base class that implements the netcore interface `IHostedService`, and makes the task recurring, if you don't need your task to run recurringly you can implement `IHostedService` yourself, and register your hosted service in the same way. For more information about hosted services, take a look at [the Microsoft documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-5.0).
+
+## BackgroundTaskRunner Notifications
+
+Background tasks can also trigger events. [Browse the API documentation for BackgroundTaskRunner events.](https://our.umbraco.com/apidocs/v8/csharp/api/Umbraco.Web.Scheduling.BackgroundTaskRunner-1.html#events)
+
+You can subscribe to the events in the `Initialize` method of your `CleanUpYourRoomComponent`. The events are registered on the `BackgroundTaskRunner` object, in this case `_cleanUpYourRoomRunner`.
+
+```csharp
+
+public class CleanUpYourRoomComponent : IComponent
+{
+    private IProfilingLogger _logger;
+    private IRuntimeState _runtime;
+    private IContentService _contentService;
+    private BackgroundTaskRunner<IBackgroundTask> _cleanUpYourRoomRunner;
+
+    public CleanUpYourRoomComponent(IProfilingLogger logger, IRuntimeState runtime, IContentService contentService)
+    {
+        _logger = logger;
+        _runtime = runtime;
+        _contentService = contentService;
+        _cleanUpYourRoomRunner = new BackgroundTaskRunner<IBackgroundTask>("CleanYourRoom", _logger);
+    }
+
+    public void Initialize()
+    {
+        int delayBeforeWeStart = 60000; // 60000ms = 1min
+        int howOftenWeRepeat = 300000; //300000ms = 5mins
+
+        var task = new CleanRoom(_cleanUpYourRoomRunner, delayBeforeWeStart, howOftenWeRepeat, _runtime, _logger, _contentService);
+
+        //declare the events
+        _cleanUpYourRoomRunner.TaskCompleted += Task_Completed;
+
+        _cleanUpYourRoomRunner.TaskStarting += this.Task_Starting;
+
+        _cleanUpYourRoomRunner.TaskCancelled += this.Task_Cancelled;
+
+        _cleanUpYourRoomRunner.TaskError += this.Task_Error;
+
+        //As soon as we add our task to the runner it will start to run (after its delay period)
+        _cleanUpYourRoomRunner.TryAdd(task);
+    }
+
+    private void Task_Error(BackgroundTaskRunner<IBackgroundTask> sender, TaskEventArgs<IBackgroundTask> e)
+    {
+        _logger.Info<CleanUpYourRoomComponent>("CleanUpYourRoom error");
+    }
+
+    private void Task_Cancelled(BackgroundTaskRunner<IBackgroundTask> sender, TaskEventArgs<IBackgroundTask> e)
+    {
+        _logger.Info<CleanUpYourRoomComponent>("CleanUpYourRoom cancelled");
+    }
+
+    private void Task_Starting(BackgroundTaskRunner<IBackgroundTask> sender, TaskEventArgs<IBackgroundTask> e)
+    {
+        _logger.Info<CleanUpYourRoomComponent>("CleanUpYourRoom starting");
+    }
+
+    private void Task_Completed(BackgroundTaskRunner<IBackgroundTask> sender, TaskEventArgs<IBackgroundTask> e)
+    {
+        _logger.Info<CleanUpYourRoomComponent>("CleanUpYourRoom run finished");
+    }
+
+    public void Terminate()
+    {
+        //unsubscribe during shutdown
+        _cleanUpYourRoomRunner.TaskCompleted -= Task_Completed;
+
+        _cleanUpYourRoomRunner.TaskStarting -= this.Task_Starting;
+
+        _cleanUpYourRoomRunner.TaskCancelled -= this.Task_Cancelled;
+
+        _cleanUpYourRoomRunner.TaskError -= this.Task_Error;
+    }
+}
+
+```
+
+### Using RuntimeState
+
+In the example above you could add the following switch case at the beginning to help determine the server role & thus if you want to run code on that type of server and exit out early.
+
+```csharp
+// Do not run the code on replicas nor unknown role servers
+// ONLY run for Master server or Single
+switch (_runtime.ServerRole)
+{
+    case ServerRole.Replica:
+        _logger.Debug<CleanRoom>("Does not run on replica servers.");
+        return true; // We return true to try again as the server role may change!
+    case ServerRole.Unknown:
+        _logger.Debug<CleanRoom>("Does not run on servers with unknown role.");
+        return true; // We return true to try again as the server role may change!
+}
+```

--- a/Reference/Scheduling/index-v9.md
+++ b/Reference/Scheduling/index-v9.md
@@ -96,7 +96,7 @@ namespace Umbraco.Cms.Web.UI
 
 ### Registering with extension method
 
-First we needto create out extension method:
+First we need to create our extension method where we register the hosted service with `AddHostedService`:
 
 ```C#
 using Microsoft.Extensions.DependencyInjection;
@@ -133,7 +133,7 @@ public void ConfigureServices(IServiceCollection services)
 
 ### Registering with a composer
 
-All we need to do here is to create the composer which will be run automatically:
+All we need to do here is to create the composer where we register the hosted service with `AddHostedService`, which will be run automatically:
 
 ```C#
 using Microsoft.Extensions.DependencyInjection;
@@ -159,7 +159,7 @@ This class provides the base class for any hosted service.
 
 You can override the `PerformExecuteAsync` method to implement the class. Hosted services are always run asynchronously.
 
-The `RecurringHostedServiceBase` is a base class that implements the netcore interface `IHostedService`, and makes the task recurring, if you don't need your task to run recurringly you can implement `IHostedService` yourself, and register your hosted service in the same way. For more information about hosted services, take a look at [the Microsoft documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-5.0).
+The `RecurringHostedServiceBase` is a base class that implements the netcore interface `IHostedService`, and makes the task recurring, if you don't need your task to run recurringly you can implement `IHostedService` yourself, and register your hosted service in the same way. For more information about hosted services, take a look at the [Microsoft documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-5.0).
 
 ## BackgroundTaskRunner Notifications
 
@@ -167,7 +167,7 @@ In earlier versions of Umbraco, there were a series of events triggered by backg
 
 ## Using ServerRoleAccessor
 
-In the example above you could add the following switch case at the beginning to help determine the server role & thus if you don't want to run code on that type of server and exit out early.
+In the example above you could add the following switch case at the beginning to help determine the server role & thus if you don't want to run code on that type of server you can exit out early.
 
 ```C#
 // Do not run the code on replicas nor unknown role servers

--- a/Reference/Scheduling/index-v9.md
+++ b/Reference/Scheduling/index-v9.md
@@ -159,11 +159,11 @@ This class provides the base class for any hosted service.
 
 You can override the `PerformExecuteAsync` method to implement the class. Hosted services are always run asynchronously.
 
-The `RecurringHostedServiceBase` is a base class that implements the netcore interface `IHostedService`, and makes the task recurring, if you don't need your task to run recurringly you can implement `IHostedService` yourself, and register your hosted service in the same way. For more information about hosted services, take a look at the [Microsoft documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-5.0).
+The `RecurringHostedServiceBase` is a base class that implements the netcore interface `IHostedService` and makes the task recurring, if you don't need your task to run recurringly you can implement `IHostedService` yourself, and register your hosted service in the same way. For more information about hosted services, take a look at the [Microsoft documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-5.0).
 
 ## BackgroundTaskRunner Notifications
 
-In earlier versions of Umbraco, there were a series of events triggered by background tasks, with the switch to notifications this no longer exists, however, fear not, because you can publish any custom notification you desire from within you background task. For more information about creating and publishing your own custon notifications see: [Creating and Publishing Custom Notifications](../Notifications/Creating-And-Publishing-Notifications.md)
+In earlier versions of Umbraco, there were a series of events triggered by background tasks, with the switch to notifications this no longer exists, however, fear not, because you can publish any custom notification you desire from within your background task. For more information about creating and publishing your own custom notifications see: [Creating and Publishing Custom Notifications](../Notifications/Creating-And-Publishing-Notifications.md)
 
 ## Using ServerRoleAccessor
 


### PR DESCRIPTION
Migrates the scheduling documentation for running recurring background jobs to V9.

As a part of this I've also created a page about creating and publishing custom notifications, since this was needed for the  HostedService documentation, but it didn't make sense to me for it to live within the HostedService documentations, since it's really about notifiactions.