### PR TITLE
add example of content cache event

### DIFF
--- a/Reference/Events/CacheRefresher-Events.md
+++ b/Reference/Events/CacheRefresher-Events.md
@@ -34,13 +34,16 @@ namespace Test.Composers {
         private readonly IIndex _index;
         private readonly IPublishedContentValueSetBuilder _valueSetBuilder;
 
-        public ContentCacheRefresherEventComponent(IContentService contentService, IIndex index, IPublishedContentValueSetBuilder valueSetBuilder) {
+        public ContentCacheRefresherEvent(IContentService contentService, IPublishedContentValueSetBuilder valueSetBuilder, IExamineManager examineManager) {
             _contentService = contentService;
-            _index = index;
             _valueSetBuilder = valueSetBuilder;
+            _examineManager = examineManager;            
         }
 
         public void Initialize() {
+             if (!_examineManager.TryGetIndex(Umbraco.Core.Constants.UmbracoIndexes.ExternalIndexName, out IIndex index))
+                throw new InvalidOperationException($"No index found by name {Umbraco.Core.Constants.UmbracoIndexes.ExternalIndexName}");
+            _index = index;
             ContentCacheRefresher.CacheUpdated += ContentCacheRefresher_CacheUpdated;
         }
 

--- a/Reference/Events/CacheRefresher-Events.md
+++ b/Reference/Events/CacheRefresher-Events.md
@@ -7,11 +7,11 @@ meta.Description: "Information on the various CacheRefresher events available"
 
 # CacheRefresher Events
 
-Cacherefresher events happen when the cache updates. They are not commonly used, but are sometimes nessecary instead of the Content or Media Service events as the cache events trigger later.
+Cache refresher events are executed when the Umbraco Cache is updated. They can be useful to use in load balanced environments since they fire whenever the cache is updated on each server, whereas Content or Media Service events, eg 'ContentService_Published' event are only triggered on the server you are accessing the backoffice on. So if you need 'something' to happen on all servers after something is published, then the CacheUpdate event is the one to use.
 
 ## Usage
 
-Image you have some sort of product content nodes that are nested under product collection nodes. But you've extended the ExternalIndex for the product items to contain some of the collection info to make them searchable in a productsearcher. If you then update the product collection you'd want the index for the products under it to also be updated with the new collection data. Here we can use a concentcache event:
+Imagine you have some sort of product content nodes that are nested under product collection nodes. But you've extended the ExternalIndex for the product items to contain some of the collection info to make them searchable in a productsearcher. If you then update the product collection you'd want the index for the products under it to also be updated with the new collection data. Here we can use a contentcache event:
 
 ```csharp
 using Examine;

--- a/Reference/Events/CacheRefresher-Events.md
+++ b/Reference/Events/CacheRefresher-Events.md
@@ -1,0 +1,69 @@
+---
+versionFrom: 8.0.0
+versionRemoved: 9.0.0
+meta.Title: "Umbraco CacheRefresher Events"
+meta.Description: "Information on the various CacheRefresher events available"
+---
+
+# CacheRefresher Events
+
+Cacherefresher events happen when the cache updates. They are not commonly used, but are sometimes nessecary instead of the Content or Media Service events as the cache events trigger later.
+
+## Usage
+
+Image you have some sort of product content nodes that are nested under product collection nodes. But you've extended the ExternalIndex for the product items to contain some of the collection info to make them searchable in a productsearcher. If you then update the product collection you'd want the index for the products under it to also be updated with the new collection data. Here we can use a concentcache event:
+
+```csharp
+using Examine;
+using System.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Composing;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+using Umbraco.Core.Services.Changes;
+using Umbraco.Examine;
+using Umbraco.Web.Cache;
+
+namespace Test.Composers {
+    [RuntimeLevel(MinLevel = RuntimeLevel.Run)]
+    public class ContentCacheRefresherEventComposer : ComponentComposer<ContentCacheRefresherEventComponent> {
+    }
+
+    public class ContentCacheRefresherEventComponent : IComponent {
+        private readonly IContentService _contentService;
+        private readonly IIndex _index;
+        private readonly IPublishedContentValueSetBuilder _valueSetBuilder;
+
+        public ContentCacheRefresherEventComponent(IContentService contentService, IIndex index, IPublishedContentValueSetBuilder valueSetBuilder) {
+            _contentService = contentService;
+            _index = index;
+            _valueSetBuilder = valueSetBuilder;
+        }
+
+        public void Initialize() {
+            ContentCacheRefresher.CacheUpdated += ContentCacheRefresher_CacheUpdated;
+        }
+
+        private void ContentCacheRefresher_CacheUpdated(ContentCacheRefresher sender, Umbraco.Core.Cache.CacheRefresherEventArgs e) {
+            foreach (var payload in (ContentCacheRefresher.JsonPayload[])e.MessageObject) {
+                if (payload.ChangeTypes.HasType(TreeChangeTypes.RefreshNode)) {
+                    var content = _contentService.GetById(payload.Id);
+
+                    if(content.ContentType.Alias == "productCollection") {
+                        // May need to do smaller pages for larger sites, but for smaller simple sites we can just get all children like this
+                        var children = _contentService.GetPagedChildren(payload.Id, 0, 999, out long totalRecords);
+
+                        IContent[] childArray = children.Cast<IContent>().ToArray();
+
+                        _index.IndexItems(_valueSetBuilder.GetValueSets(childArray));
+                    }                    
+                }
+            }
+        }
+
+        public void Terminate() {
+            ContentCacheRefresher.CacheUpdated -= ContentCacheRefresher_CacheUpdated;
+        }
+    }
+}
+```


### PR DESCRIPTION
Added an example of a cache event - the use case described is something I've been working on recently, and found that the cache events are covered in the docs at all, so figured I'd kick it off with an example 🙂