### PR TITLE
Update namespaces in ContentService-Notifications

### DIFF
--- a/Reference/Notifications/ContentService-Notifications.md
+++ b/Reference/Notifications/ContentService-Notifications.md
@@ -14,7 +14,7 @@ Example usage of the ContentPublishingNotification:
 
 ```C#
 using Umbraco.Cms.Core.Events;
-using Umbraco.Cms.Core.Services.Notifications;
+using Umbraco.Cms.Core.Notifications;
 
 namespace MySite
 {

--- a/Reference/Notifications/ContentService-Notifications.md
+++ b/Reference/Notifications/ContentService-Notifications.md
@@ -1,7 +1,7 @@
 ---
 v8-equivalent: "https://our.umbraco.com/documentation/reference/events/ContentService-Events"
 versionFrom: 9.0.0
-verified-against: beta-2
+verified-against: rc-3
 ---
 
 # ContentService Notifications


### PR DESCRIPTION
Umbraco.Cms.Core.Service.Notifications namespace does not exist. The above docs worked when changing the namespace to Umbraco.Cms.Core.Notifications