### PR TITLE
Copy/paste text mistake on Cookie hijacking and protocol downgrade at…

### DIFF
--- a/Extending/Health-Check/Guides/StrictTransportSecurityHeader.md
+++ b/Extending/Health-Check/Guides/StrictTransportSecurityHeader.md
@@ -15,7 +15,7 @@ This health check can be fixed by adding a header before the response is started
 
 Preferable you use a security library like [NWebSec](https://docs.nwebsec.com/).
 
-### Adding Click-Jacking Protection using NWebSec
+### Adding Cookie hijacking and protocol downgrade attacks Protection using NWebSec
 
 If you take a NuGet dependency on [NWebsec.AspNetCore.Middleware/](https://www.nuget.org/packages/NWebsec.AspNetCore.Middleware/), you can use third extension methods on `IApplicationBuilder`.
 
@@ -31,7 +31,7 @@ public class Startup
 }
 ```
 
-### Adding Click-Jacking Protection using manual middleware
+### Adding Cookie hijacking and protocol downgrade attacks Protection using manual middleware
 
 If you don't like to have a dependency on third party libraries. You can add the following custom middleware to the request pipeline.
 

--- a/Extending/Health-Check/Guides/StrictTransportSecurityHeader.md
+++ b/Extending/Health-Check/Guides/StrictTransportSecurityHeader.md
@@ -15,7 +15,7 @@ This health check can be fixed by adding a header before the response is started
 
 Preferable you use a security library like [NWebSec](https://docs.nwebsec.com/).
 
-### Adding Cookie hijacking and protocol downgrade attacks Protection using NWebSec
+### Adding Protection using NWebSec
 
 If you take a NuGet dependency on [NWebsec.AspNetCore.Middleware/](https://www.nuget.org/packages/NWebsec.AspNetCore.Middleware/), you can use third extension methods on `IApplicationBuilder`.
 
@@ -31,7 +31,7 @@ public class Startup
 }
 ```
 
-### Adding Cookie hijacking and protocol downgrade attacks Protection using manual middleware
+### Adding Protection using manual middleware
 
 If you don't like to have a dependency on third party libraries. You can add the following custom middleware to the request pipeline.
 


### PR DESCRIPTION
…tacks Protection page

The titles said "Click Jacking protection" instead of "Cookie hijacking and protocol downgrade attacks Protection". Titles were identical to https://our.umbraco.com/documentation/Extending/Health-Check/Guides/ClickJackingProtection so looks like a copy/paste error.

As a side note, this makes the titles rather long. Should it be shortened to "Adding Protection using NWebSec" and "Adding Protection using manual middleware" as the context of the page is only for Cookie hijacking and protocol downgrade attacks Protection, so may not be needed.