### PR TITLE
Updated Forms front-end article for V9

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index-v9.md
+++ b/Add-ons/UmbracoForms/Developer/Prepping-Frontend/index-v9.md
@@ -1,6 +1,5 @@
 ---
-versionFrom: 7.0.0
-versionTo: 8.0.0
+versionFrom: 9.0.0
 ---
 
 # Preparing your Frontend
@@ -9,10 +8,10 @@ For Umbraco Forms to work correctly, you need to include some client dependencie
 
 ## Umbraco Forms version 8.6.0+
 
-You can use the following Razor helper to output script tags containing the dependencies. To access this method you will need a reference to `Umbraco.Forms.Mvc`:
+You can use the following Razor helper to output script tags containing the dependencies. To access this method you will need a reference to `Umbraco.Forms.Web`:
 
 ```html
-@using Umbraco.Forms.Mvc
+@using Umbraco.Forms.Web
 <head>
     @Html.RenderUmbracoFormDependencies()
 </head>
@@ -21,7 +20,7 @@ You can use the following Razor helper to output script tags containing the depe
 Alternatively, you can add the dependencies to the body tag:
 
 ```html
-@using Umbraco.Forms.Mvc
+@using Umbraco.Forms.Web
 ...
 
 <body>
@@ -31,7 +30,7 @@ Alternatively, you can add the dependencies to the body tag:
 
 All dependencies originate from your Umbraco Forms installation, which means that no external references are needed.
 
-## Using jQuery (Required for versions before 8.6.0)
+## Using jQuery
 
 In earlier versions (before Umbraco Forms 8.6) jQuery, jQuery Validate, and jQuery Validate Unobtrusive are hard dependencies for client-side validation and advanced functionality such as conditional fields.
 


### PR DESCRIPTION
Mostly this is just a namespace change, but also removed some references to specific V8 versions that aren't relevant for the V9 version.