### PR TITLE
Add Custom routing docs for V9.

### DIFF
--- a/Implementation/Custom-Routing/index-v9.md
+++ b/Implementation/Custom-Routing/index-v9.md
@@ -1,0 +1,126 @@
+---
+versionFrom: 9.0.0
+product: "CMS"
+meta.Title: "Custom routing in Umbraco"
+meta.Description: "There are a couple of ways of controlling the routing behavior in Umbraco: customizing how the inbound request pipeline finds content & creating custom MVC routes that integrate within the Umbraco pipeline"
+
+---
+
+# Custom routing in Umbraco
+
+_There are a couple of ways of controlling the routing behavior in Umbraco: customizing how the inbound request pipeline finds content & creating custom MVC routes that integrate within the Umbraco pipeline_.
+
+## Customizing the inbound pipeline
+
+Below lists the ways in which you can customize the inbound request pipeline, this is done by using native Umbraco plugin classes, notifications or defining your own routes.
+
+### IContentFinder
+
+All Umbraco content is looked up based on the URL in the current request using an `IContentFinder`. IContentFinder's you can create and implement on your own which will allow you to map any URL to an Umbraco content item.
+
+See: [IContentFinder documentation](../../Reference/Routing/Request-Pipeline/IContentFinder-v9.md)
+
+### Last Chance IContentFinder
+
+A `IContentLastChanceFinder` is a special implementation of an `IContentFinder` for use with handling 404's. You can implement one of these plugins to decide which Umbraco content page you would like to show when the URL hasn't matched an Umbraco content node.
+
+To set your own 404 finder create a `IContentLastChanceFinder` and set it as the `ContentLastChanceFinder`. A `ContentLastChanceFinder` will always return a 404 status code. Example:
+
+
+```csharp
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Extensions;
+
+namespace My.Website
+{
+    public class UpdateContentFindersComposer : IComposer
+    {
+        public void Compose(IUmbracoBuilder builder)
+        {
+            //set the last chance content finder
+            builder.SetContentLastChanceFinder<My404ContentFinder>();
+        }
+    }
+}
+```
+
+For more detailed information see: [IContentFinder documentation](../../Reference/Routing/Request-Pipeline/IContentFinder-v9#notfoundhandlers)
+
+## Custom MVC routes
+
+You can specify your own custom MVC routes to work within the Umbraco pipeline. It requires your controller to inherit from `UmbracoPageController` and either implement `IVirtualPageController` or use `.ForUmbracoPage` when registering your route, for more information and a complete example of both approaches see [Custom routing documentation](../../Reference/Routing/custom-routes-v9#custom-routes-within-the-umbraco-pipeline)
+
+An example of registering a `UmbracoPageController` using `.ForUmbracoPage`:
+
+```csharp
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Web.Common.ApplicationBuilder;
+using Umbraco.Extensions;
+
+namespace CustomRoutes
+{
+    public class MyCustomRouteComposer : IComposer
+    {
+        public void Compose(IUmbracoBuilder builder)
+        {
+            builder.Services.Configure<UmbracoPipelineOptions>(options =>
+            {
+                options.AddFilter(new UmbracoPipelineFilter(nameof(MyController))
+                {
+                    Endpoints = app => app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapControllerRoute(
+                            "My custom controller",
+                            "/custom/{action}",
+                            new {Controller = "My", Action = "Index"})
+                            .ForUmbracoPage(FindContent);
+                    })
+                });
+            });
+        }
+
+        private IPublishedContent FindContent(ActionExecutingContext actionExecutingContext)
+        {
+            var umbracoContextAccessor = actionExecutingContext.HttpContext.RequestServices
+                .GetRequiredService<IUmbracoContextAccessor>();
+            var umbracoContext = umbracoContextAccessor.GetRequiredUmbracoContext();
+
+            return umbracoContext.Content.GetById(1064);
+        }
+    }
+}
+```
+
+:::note
+This is an approach for mapping a custom route to a custom MVC controller. For creating routes for existing content pages you can use a custom MVC controller to handle the request by naming convention: see [Custom Controllers - Route Hijacking](../../Reference/Routing/custom-controllers-v9.md). 
+:::
+
+### RoutingRequestNotification
+
+You can subscribe to the `RoutingRequestNotification` which is published right after the point when the `PublishedRequestBuilder` is prepared - (but before it is ready to be processed). Here you can modify anything in the request before it is processed, eg. content, template, etc: 
+
+```csharp
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+
+namespace CustomRoutes
+{
+    public class PublishedRequestHandler : INotificationHandler<RoutingRequestNotification>
+    {
+        public void Handle(RoutingRequestNotification notification)
+        {
+            var requestBuilder = notification.RequestBuilder;
+            // Do something with the IPublishedRequestBuilder here
+        }
+    }
+}
+```
+
+For more information on how to register and use notification handlers see [Notifications documentation](../../Reference/Notifications/index)

--- a/Reference/Routing/Request-Pipeline/IContentFinder-v9.md
+++ b/Reference/Routing/Request-Pipeline/IContentFinder-v9.md
@@ -50,6 +50,7 @@ public class MyContentFinder : IContentFinder
         {
             return false;
         }
+
         // Have we got a node with ID 1234
         var content = umbracoContext.Content.GetById(1234);
         if (content is null)
@@ -124,7 +125,7 @@ using Umbraco.Cms.Core.Routing;
 
 namespace RoutingDocs.ContentFinders
 {
-    public class UpdateContentFindersComposer : IUserComposer
+    public class UpdateContentFindersComposer : IComposer
     {
         public void Compose(IUmbracoBuilder builder)
         {
@@ -146,7 +147,7 @@ In Umbraco 7 there existed an IContentFinder that would find content and display
 
 Eg: `/blog/my-blog-post/blogfullstory` would 'find' the `/blog/my-blog-post` page and display using the `blogfullstory` template. 
 
-In Umbraco 9 this convention has been removed from the default configuration of Umbraco. You can reintroduce this behaviour by adding the `ContentFinderByUrlAndTemplate` ContentFinder back into the ContentFinderCollection, using an `IUserComposer`, or Umbraco builder extension (see above example).
+In Umbraco 9 this convention has been removed from the default configuration of Umbraco. You can reintroduce this behaviour by adding the `ContentFinderByUrlAndTemplate` ContentFinder back into the ContentFinderCollection, using an `IComposer`, or Umbraco builder extension (see above example).
 :::
 
 # NotFoundHandlers
@@ -183,6 +184,7 @@ namespace RoutingDocs.ContentFinders
                 .Where(f => f.DomainName == contentRequest.Uri.Authority || f.DomainName == $"https://{contentRequest.Uri.Authority}")
                 .FirstOrDefault();
             var siteId = domain != null ? domain.RootContentId : allDomains.Any() ? allDomains.FirstOrDefault()?.RootContentId : null;
+
             if(!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
             {
                 return false;
@@ -218,7 +220,7 @@ using Umbraco.Extensions;
 
 namespace RoutingDocs.ContentFinders
 {
-    public class UpdateContentFindersComposer : IUserComposer
+    public class UpdateContentFindersComposer : IComposer
     {
         public void Compose(IUmbracoBuilder builder)
         {

--- a/Reference/Routing/custom-routes-v9.md
+++ b/Reference/Routing/custom-routes-v9.md
@@ -267,7 +267,7 @@ using Umbraco.Cms.Web.Common.ApplicationBuilder;
 
 namespace RoutingDocs.Controllers
 {
-    public class ShopControllerComposer : IUserComposer
+    public class ShopControllerComposer : IComposer
     {
         public void Compose(IUmbracoBuilder builder)
         {
@@ -397,7 +397,7 @@ As you can see we still inherit from `UmbracoPageController` to get access to th
 The Umbraco magic will now instead happen where we route the controller, here we will pass a `Func<ActionExecutingContext, IPublishedContent>` delegate to the `ForUmbracoPage` method, this delegate is then responsible for finding the content, for instance using a composer with the same logic as in the `IVirtualPageController` it will look like this: 
 
 ```C#
- public class ShopControllerComposer : IUserComposer
+ public class ShopControllerComposer : IComposer
 {
     public void Compose(IUmbracoBuilder builder)
     {
@@ -425,7 +425,8 @@ The Umbraco magic will now instead happen where we route the controller, here we
         var publishedValueFallback = actionExecutingContext.HttpContext.RequestServices
             .GetRequiredService<IPublishedValueFallback>();
 
-        var productRoot = umbracoContextAccessor.UmbracoContext.Content.GetById(2074);
+        var umbracoContext = umbracoContextAccessor.GetRequiredUmbracoContext();
+        var productRoot = umbracoContext.Content.GetById(2074);
 
         if (actionExecutingContext.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor)
         {


### PR DESCRIPTION
I've retained the majority of the text since it's still relevant, I have updated the Custom MVC "Custom MVC routes" and event section to better reflect how it works. 

Other than I've updated the code examples to work with V9.

Lastly, I noticed some usages of `IUserComposer` which should be replaced with `IComposer`, and I've updated a place where the `IUmbracoContextAccessor` interface has changed