### PR TITLE
Added composer example for registering custom provider type

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Type.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Type.md
@@ -109,10 +109,23 @@ public override List<Exception> ValidateSettings() {
 To register the type, ensure your web application project has a reference to the class library - either via a project or NuGet reference - and add the following code into the startup pipeline.  In this example, the registration is implemented as an extension method to `IUmbracoBuilder` and should be called from `Startup.cs`:
 
 ```csharp
-public static IUmbracoBuilder AddUmbracoFormsCoreProviders(this IUmbracoBuilder builder)
+public static IUmbracoBuilder AddUmbracoFormsCustomProviders(this IUmbracoBuilder builder)
 {
     builder.WithCollectionBuilder<WorkflowCollectionBuilder>()
         .Add<LogWorkflow>();
+}
+```
+
+An alternative approach is to use a composer, as per this example:
+
+```csharp
+public class UmbracoFormsCustomProvidersComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.WithCollectionBuilder<WorkflowCollectionBuilder>()
+            .Add<LogWorkflow>();
+    }
 }
 ```
 


### PR DESCRIPTION
This came up in a [forum question](https://our.umbraco.com/forum/umbraco-9/107229-umbraco-9-upgrade-forms-issue) so I've added some additional detail to the documentation for Umbraco Forms.