### PR TITLE
Fixed a broad range of typo's in v9 notification pages

### DIFF
--- a/Reference/Events/index.md
+++ b/Reference/Events/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco events"
-meta.Description: "Information on various backofice events in Umbraco"
+meta.Description: "Information on various backoffice events in Umbraco"
 versionRemoved: 9.0.0
 ---
 
@@ -17,7 +17,7 @@ All available notifications are documented in the [Notifications](../Notificatio
 
 ## [Composing](../../Implementation/Composing/index-v8)
 
-Umbraco uses Composition and Components to allows you to execute code during startup. This is also the correct place to register for many other types of events including the ability to bind to HttpApplication events.
+Umbraco uses Compositions and Components to allow you to execute code during startup. This is also the correct place to register for many other types of events including the ability to bind to HttpApplication events.
 
 ## Events
 

--- a/Reference/Notifications/ContentService-Notifications.md
+++ b/Reference/Notifications/ContentService-Notifications.md
@@ -415,7 +415,7 @@ namespace MySite
       </ul>
     </td>
     <td>
-    Published when ContentService.SendToPublication is called in the API, after the entity has been sent to publlication.<br/>
+    Published when ContentService.SendToPublication is called in the API, after the entity has been sent to publication.<br/>
     Entity: Gets the IContent object being sent to publish.
     </td>
   </tr>

--- a/Reference/Notifications/ContentService-Notifications.md
+++ b/Reference/Notifications/ContentService-Notifications.md
@@ -67,7 +67,7 @@ namespace MySite
   </tr>
 
   <tr>
-    <td>ContentSavedNotifiaction</td>
+    <td>ContentSavedNotification</td>
     <td>
         <ul>
           <li>IEnumerable&ltIContent&gt SavedEntities</li>

--- a/Reference/Notifications/ContentTypeService-Notifications.md
+++ b/Reference/Notifications/ContentTypeService-Notifications.md
@@ -129,7 +129,7 @@ The ContentTypeService class implements IContentTypeService. It provides access 
       </ul>
     </td>
     <td>
-    Published when a ContentType is saved or deleted, after the transaction has completed. This is mainly used for caching purposes, and generally not recommended, use Saved and Delted notifications instead.<br/>
+    Published when a ContentType is saved or deleted, after the transaction has completed. This is mainly used for caching purposes, and generally not recommended, use Saved and Deleted notifications instead.<br/>
     Changes will for each item affected by the change prove:
     <ol>
       <li>Item: The IContentType affected by the change.</li>

--- a/Reference/Notifications/Creating-And-Publishing-Notifications.md
+++ b/Reference/Notifications/Creating-And-Publishing-Notifications.md
@@ -11,7 +11,7 @@ update-links: true
 
 There may be many reasons why you would like to create your own custom notifications, in this article we'll use the CleanUpYourRoom [recurring hosted service](../Scheduling/index-v9.md) as an example, which empties the recycle bin every 5 minutes. You might want to publish a notification once the task has started, and maybe once the task has successfully cleared the recycle bin.
 
-For a notification to be publishable there's only one requirement, it must implement the empty marker interface `INotifiaction`, the rest is up to you. For instance, we might want to create a notification that just signals that the clean your room task has started and nothing else, in this case, we'll create an empty class implementing `INotification`
+For a notification to be publishable there's only one requirement, it must implement the empty marker interface `INotification`, the rest is up to you. For instance, we might want to create a notification that just signals that the clean your room task has started and nothing else, in this case, we'll create an empty class implementing `INotification`
 
 ```C#
 using Umbraco.Cms.Core.Notifications;
@@ -44,7 +44,7 @@ namespace Umbraco.Cms.Web.UI.Notifications
 }
 ```
 
-Now you can create a handler that recieves the amount of items deleted through the notification.
+Now you can create a handler that receives the amount of items deleted through the notification.
 
 # Sending notifications
 

--- a/Reference/Notifications/EditorModel-Notifications/index.md
+++ b/Reference/Notifications/EditorModel-Notifications/index.md
@@ -198,7 +198,7 @@ namespace MySite
 
 #### ContentItemDisplay
 
-A model representing a conten item to be displayed in the backoffice
+A model representing a content item to be displayed in the backoffice
 
 * TemplateAlias
 * Urls

--- a/Reference/Notifications/MediaService-Notifications.md
+++ b/Reference/Notifications/MediaService-Notifications.md
@@ -239,7 +239,7 @@ namespace MySite
       </ul>
     </td>
     <td>
-    Published when MediaService.DeleteVersion, MediaService.DeleteVersions are called in the API, after the media version has been delelted<br/>
+    Published when MediaService.DeleteVersion, MediaService.DeleteVersions are called in the API, after the media version has been deleted<br/>
       <ol>
         <li>Id: Gets the id of the deleted IMedia object.</li>
         <li>DateToRetain: Gets the latest version date.</li>

--- a/Reference/Notifications/MediaTypeService-Notifications.md
+++ b/Reference/Notifications/MediaTypeService-Notifications.md
@@ -129,7 +129,7 @@ The MediaTypeService class implements IMediaTypeService. It provides access to o
       </ul>
     </td>
     <td>
-    Published when a MediaType is saved or deleted, after the transaction has completed. This is mainly used for caching purposes, and generally not recommended, use Saved and Delted notifications instead.<br/>
+    Published when a MediaType is saved or deleted, after the transaction has completed. This is mainly used for caching purposes, and generally not recommended, use Saved and Deleted notifications instead.<br/>
     Changes will for each item affected by the change prove:
     <ol>
       <li>Item: The IMediaType affected by the change.</li>

--- a/Reference/Notifications/MemberTypeService-Notifications.md
+++ b/Reference/Notifications/MemberTypeService-Notifications.md
@@ -129,7 +129,7 @@ The MemberTypeService class implements IMemberTypeService. It provides access to
       </ul>
     </td>
     <td>
-    Published when a MemberType is saved or deleted, after the transaction has completed. This is mainly used for caching purposes, and generally not recommended, use Saved and Delted notifications instead.<br/>
+    Published when a MemberType is saved or deleted, after the transaction has completed. This is mainly used for caching purposes, and generally not recommended, use Saved and Deleted notifications instead.<br/>
     Changes will for each item affected by the change prove:
     <ol>
       <li>Item: The IMemberType affected by the change.</li>

--- a/Reference/Notifications/index.md
+++ b/Reference/Notifications/index.md
@@ -140,9 +140,9 @@ Now all the notifications you registered in your extension method will be handle
 ## Other notifications
 
 * See [ContentTypeService Notifications](ContentTypeService-Notifications.md) for a listing of the ContentTypeService object notifications.
-* See [MediaTypeService Notifications](MediaTypeService-Notifications.md) for a listing of the MediaTypeService object notifiactions.
+* See [MediaTypeService Notifications](MediaTypeService-Notifications.md) for a listing of the MediaTypeService object notifications.
 * See [MemberTypeService Notifications](MemberTypeService-Notifications.md) for a listing of the MemberTypeService object notifications.
-* See [DataTypeService Notifications](DataTypeService-Notifications.md) for a listing of the DataTypeSErvice object notifications
+* See [DataTypeService Notifications](DataTypeService-Notifications.md) for a listing of the DataTypeService object notifications
 * See [FileService Notifications](FileService-Notifications.md) for a listing of the FileService object notifications.
 * See [LocalizationService Notifications](LocalizationService-Notifications.md) for a listing of the LocalizationService object notifications.
 

--- a/Reference/Notifications/index.md
+++ b/Reference/Notifications/index.md
@@ -71,7 +71,7 @@ The extension method takes two generic type parameters, the first `ContentPublis
 public class DontShout : INotificationHandler<ContentPublishingNotification>
 ```
 
-For the full handler implementation see [ContentService Notifications](Contentservice-Notifications.md).
+For the full handler implementation see [ContentService Notifications](ContentService-Notifications.md).
 
 #### Registering notification handlers in a composer
 


### PR DESCRIPTION
When working on creating a new blog on comparing v8 events and v9 Notifications, I came across a bunch of small mistakes and typo's across several pages having to do with Notifications.