### PR TITLE
Added note about templates failing to install

### DIFF
--- a/Fundamentals/Setup/Install/install-umbraco-with-templates.md
+++ b/Fundamentals/Setup/Install/install-umbraco-with-templates.md
@@ -24,8 +24,9 @@ Templates                    Short Name               Language          Tags
 Umbraco Solution             umbraco                  [C#]              Web/CMS/Umbraco
 Umbraco Package              umbracopackage           [C#]              Web/CMS/Umbraco/Package/Plugin
 ```
-
-> Note that in some cases the templates may silently fail to install (usually this is an issue with NuGet sources). If this occurs you can try specifying the NuGet source in the command by running `dotnet new -i Umbraco.Templates::* --nuget-source "https://api.nuget.org/v3/index.json"`.
+:::note
+In some cases the templates may silently fail to install (usually this is an issue with NuGet sources). If this occurs you can try specifying the NuGet source in the command by running `dotnet new -i Umbraco.Templates::* --nuget-source "https://api.nuget.org/v3/index.json"`.
+:::
 
 To get **help** on a project template with `dotnet new` run the following command:
 


### PR DESCRIPTION
Encountered an issue with templates failing (silently) to install in a case where NuGet sources were misconfigured, @nul800sebastiaan [helped out on Discord](https://discord.com/channels/869656431308189746/882984410432012360/896343399223930930) and suggested that it might be worth mentioning this in the documentation.