### PR TITLE
Unattended-Install CLI arguments are incorrect

### DIFF
--- a/Fundamentals/Setup/Install/Unattended-Install.md
+++ b/Fundamentals/Setup/Install/Unattended-Install.md
@@ -117,7 +117,7 @@ We have added support for unattended installs with Name, Email and Password, and
 ### CLI
 
 ```powershell
-dotnet new umbraco -n MyNewProject --FriendlyName "Friendly User" --Email user@email.com --Password password1234 --ConnectionString "Server=(localdb)\\Umbraco;Database=MyDatabase;Integrated Security=true" --version 9.0.0
+dotnet new umbraco -n MyNewProject --friendly-name "Friendly User" --email user@email.com --password password1234 --connection-string "Server=(localdb)\Umbraco;Database=MyDatabase;Integrated Security=true" --version 9.0.0
 ```
 
 ### Visual Studio


### PR DESCRIPTION
The arguments for the CLI example don't work. the arguments are case sensitive and should be lower case. Also the `\` in the connection string should only be single as it gets escaped when added to the AppSettings Connection string. Entering `\\` caused the connection string to have 4 slashes `\\\\`  

You can verify the arguments against the (Install page)[] which are correct - https://our.umbraco.com/documentation/Fundamentals/Setup/Install/install-umbraco-with-templates