### PR TITLE
Update request handler settings

### DIFF
--- a/Reference/V9-Config/RequestHandlerSettings/index.md
+++ b/Reference/V9-Config/RequestHandlerSettings/index.md
@@ -22,7 +22,8 @@ Here is a snippet containing all the default values of the `RequestHandler` sect
 			"RequestHandler": {
 				"AddTrailingSlash": true,
 				"ConvertUrlsToAscii": "try",
-				"CharCollection": [{
+				"CharCollection": [
+                    {
 						"Char": " ",
 						"Replacement": "-"
 					},


### PR DESCRIPTION
Updated the formatting a bit for request handler settings here: https://our.umbraco.com/documentation/Reference/V9-Config/RequestHandlerSettings/

However it seems to JSON isn't shown correct although it is valid JSON. It doesn't show the "Umbraco > CMS" part at all :)

![image](https://user-images.githubusercontent.com/2919859/137474534-af4d7fd1-7e26-41a8-91a3-807b4ef20986.png)
