### PR TITLE
Update SMTP.md for local development example

### DIFF
--- a/Extending/Health-Check/Guides/SMTP.md
+++ b/Extending/Health-Check/Guides/SMTP.md
@@ -49,8 +49,11 @@ One example that can be used on localhost, if you have a (fake) SMTP server runn
             "Global": {
                 "Smtp": {
                     "From": "my@email.com",
-                    "Host": "localhost",
-                    "Port": "25"
+                    "Host": "127.0.0.1",
+                    "Username": "username",
+                    "Password": "password",
+                    "SecureSocketOptions": "None",
+                    "Port": 25
                 }
             }
         }


### PR DESCRIPTION
If you use SMTP4dev as suggested (as I do) you'll likely hit SSL handshake errors with the previous example. This example works. Also the port number in the previous example should have been an int as per intellisense / validation.