### PR TITLE
UmbracoContextAccessor doesn't contain a reference to UmbracoContext

### DIFF
--- a/Reference/Routing/custom-routes.md
+++ b/Reference/Routing/custom-routes.md
@@ -193,32 +193,39 @@ Now that we have our dependencies, and our action methods, we're finally ready t
 ```C#
 public IPublishedContent FindContent(ActionExecutingContext actionExecutingContext)
 {
-    var productRoot = _umbracoContextAccessor.UmbracoContext.Content.GetById(2074);
+    var umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
 
-    if (actionExecutingContext.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor)
+    if (umbracoContext != null)
     {
-        // Check which action is executing
-        switch (controllerActionDescriptor.ActionName)
+        var productRoot = umbracoContext.Content.GetById(2074);
+
+        if (actionExecutingContext.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor)
         {
-            case nameof(Index):
-                return productRoot;
-            
-            case nameof(Product):
-                // Get the SKU/Id from the route values
-                if (actionExecutingContext.ActionArguments.TryGetValue("id", out var sku))
-                {
-                    return productRoot
-                        .Children
-                        .FirstOrDefault(c => c.Value<string>(_publishedValueFallback, "sku") == sku.ToString());
-                }
-                else
-                {
+            // Check which action is executing
+            switch (controllerActionDescriptor.ActionName)
+            {
+                case nameof(Index):
                     return productRoot;
-                }
+                
+                case nameof(Product):
+                    // Get the SKU/Id from the route values
+                    if (actionExecutingContext.ActionArguments.TryGetValue("id", out var sku))
+                    {
+                        return productRoot
+                            .Children
+                            .FirstOrDefault(c => c.Value<string>(_publishedValueFallback, "sku") == sku.ToString());
+                    }
+                    else
+                    {
+                        return productRoot;
+                    }
+            }
         }
+
+        return productRoot;
     }
 
-    return productRoot;
+    return null;
 }
 ```
 

--- a/Reference/Routing/custom-routes.md
+++ b/Reference/Routing/custom-routes.md
@@ -191,7 +191,7 @@ public ShopController(
 Now that we have our dependencies, and our action methods, we're finally ready to implement the `FindContent` method: 
 
 ```C#
-public IPublishedContent FindContent(ActionExecutingContextactionExecutingContext)
+public IPublishedContent FindContent(ActionExecutingContext actionExecutingContext)
 {
     var productRoot = _umbracoContextAccessor.UmbracoContext.Content.GetById(2074);
 

--- a/Reference/Routing/custom-routes.md
+++ b/Reference/Routing/custom-routes.md
@@ -193,36 +193,37 @@ Now that we have our dependencies, and our action methods, we're finally ready t
 ```C#
 public IPublishedContent FindContent(ActionExecutingContext actionExecutingContext)
 {
-    var umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
-
-    if (umbracoContext != null)
-    {
+   if (_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
+   {
         var productRoot = umbracoContext.Content.GetById(2074);
-
-        if (actionExecutingContext.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor)
+        if (productRoot!=null)
         {
-            // Check which action is executing
-            switch (controllerActionDescriptor.ActionName)
-            {
-                case nameof(Index):
-                    return productRoot;
-                
-                case nameof(Product):
-                    // Get the SKU/Id from the route values
-                    if (actionExecutingContext.ActionArguments.TryGetValue("id", out var sku))
-                    {
-                        return productRoot
-                            .Children
-                            .FirstOrDefault(c => c.Value<string>(_publishedValueFallback, "sku") == sku.ToString());
-                    }
-                    else
-                    {
-                        return productRoot;
-                    }
-            }
-        }
 
-        return productRoot;
+            if (actionExecutingContext.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor)
+            {
+                // Check which action is executing
+                switch (controllerActionDescriptor.ActionName)
+                {
+                    case nameof(Index):
+                        return productRoot;
+
+                    case nameof(Product):
+                        // Get the SKU/Id from the route values
+                        if (actionExecutingContext.ActionArguments.TryGetValue("id", out var sku))
+                        {
+                            return productRoot
+                                .Children
+                                .FirstOrDefault(c => c.Value<string>(_publishedValueFallback, "sku") == sku.ToString());
+                        }
+                        else
+                        {
+                            return productRoot;
+                        }
+                 }
+            }           
+
+            return productRoot;
+        }
     }
 
     return null;


### PR DESCRIPTION
After trying to follow this example, I discovered that `IUmbracoContextAccessor` doesn't let you reference `UmbracoContext`, so you either have to use `_umbracoContextAccessor.GetRequiredUmbracoContext();` or `_umbracoContextAccessor.TryGetUmbracoContext()`