### PR TITLE
Updated the IIS logs section

### DIFF
--- a/Umbraco-Cloud/Troubleshooting/Log-files/index.md
+++ b/Umbraco-Cloud/Troubleshooting/Log-files/index.md
@@ -78,5 +78,7 @@ Find more information about IIS Logging on [the Official Microsoft Documentation
 :::note
 IIS Logging is only available if your project is on a Professional plan.
 
+Do note that IIS logging will automatically turn off after 12 hours.
+
 See our [Cloud Pricing plans](https://umbraco.com/umbraco-cloud-pricing/) for more details on various tiers.
 :::


### PR DESCRIPTION
Added a comment, as the way this feature works is different on the new infrastructure.

Was considering to add "if your project is hosted on the new infrastructure." at the end there but decided not to, as I think that docs should be focused on the new infra and not the old one. Feel free to add that if you think that it makes sense :)