### PR TITLE
Describe how to create a `grid.editors.config.js` in v9

### DIFF
--- a/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors-v7.md
+++ b/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors-v7.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 9.0.0
+versionFrom: 7.2.0
 ---
 
 # Grid Editors
@@ -12,73 +12,9 @@ A grid editor is the component responsible for getting data into the grid - that
 
 The view is what the editor sees, the controller handles how it acts and the cshtml determines how the entered data is rendered in the template.
 
-### Default configuration
-
-Grid editors are specified in `/config/grid.editors.config.js`. By default this file doesn't exist, so before you attempt to extend the configuration, make sure to create it first. 
-
-The default items in the config file are as follows below. It is recommended that you copy all of editors below before you add more, in case some of them are already in use. 
-
-:::tip
-You will need to restart your site before any new customizations become available to use.
-:::
-
-
-```json
-[
-    {
-        "name": "Rich text editor",
-        "alias": "rte",
-        "view": "rte",
-        "icon": "icon-article"
-    },
-    {
-        "name": "Image",
-        "nameTemplate": "{{ value && value.udi ? (value.udi | ncNodeName) : '' }}",
-        "alias": "media",
-        "view": "media",
-        "icon": "icon-picture"
-    },
-    {
-        "name": "Macro",
-        "nameTemplate": "{{ value && value.macroAlias ? value.macroAlias : '' }}",
-        "alias": "macro",
-        "view": "macro",
-        "icon": "icon-settings-alt"
-    },
-    {
-        "name": "Embed",
-        "alias": "embed",
-        "view": "embed",
-        "icon": "icon-movie-alt"
-    },
-    {
-        "name": "Headline",
-        "nameTemplate": "{{ value }}",
-        "alias": "headline",
-        "view": "textstring",
-        "icon": "icon-coin",
-        "config": {
-            "style": "font-size: 36px; line-height: 45px; font-weight: bold",
-            "markup": "<h1>#value#</h1>"
-        }
-    },
-    {
-        "name": "Quote",
-        "nameTemplate": "{{ value ? value.substring(0,32) + (value.length > 32 ? '...' : '') : '' }}",
-        "alias": "quote",
-        "view": "textstring",
-        "icon": "icon-quote",
-        "config": {
-            "style": "border-left: 3px solid #ccc; padding: 10px; color: #ccc; font-family: serif; font-style: italic; font-size: 18px",
-            "markup": "<blockquote>#value#</blockquote>"
-        }
-    }
-]
-```
-
 ### Default Grid editors
 
-Grid editor are created in the JSON format and each editor is an object like so:
+The default editors are specified in `/config/grid.editors.config.js`. They are written in the JSON format and each editor is an object like so:
 
 ```json
 {
@@ -127,7 +63,7 @@ For a grid editor, the required values are:
 - `view` the view defines the editor used to enter a value. By default Umbraco will look in `/umbraco/views/propertyeditors/grid/editors` for a html view to use - but you can pass in your own path
 
 :::tip
-You can also add a name template for generating grid item labels using the syntax `{{ value.propertyAlias }}`.
+In **Umbraco 8.4** you can also add a name template for generating grid item labels using the syntax `{{ value.propertyAlias }}`.
 
 - If you would like to include the index position in the label, you can use `{{$index}}`.
 - If your editor links to a content, media or member node, you can use the Angular filter `{{ value.udi | ncNodeName }}` to show the node name rather than the node ID.

--- a/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors-v7.md
+++ b/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors-v7.md
@@ -10,7 +10,7 @@ A grid editor is the component responsible for getting data into the grid - that
 - .js controller
 - .cshtml server side renderer
 
-The view is what the editor sees, the controller handles how it acts and the cshtml determines how the entered data is rendered in the template.
+The 'view' is what the editor sees, the 'controller' handles how it acts and the 'renderer' determines how the entered data is rendered in the template.
 
 ### Default Grid editors
 
@@ -79,7 +79,7 @@ The built-in views you can use are:
 - `macro`
 - `media`
 
-In most cases you will either use the textstring or media view, or built your own from scratch. The textstring and media editors come with some additional configuration to make it quick to customise these.
+In most cases, you will either use the textstring or media view, or build your own from scratch. The textstring and media editors come with additional configuration to make it quick to customise.
 
 ##### Sample textstring config
 

--- a/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors.md
+++ b/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/Grid-Editors.md
@@ -18,6 +18,8 @@ Grid editors are specified in `/config/grid.editors.config.js`. By default this 
 
 The default items in the config file are as follows below. It is recommended that you copy all of editors below before you add more, in case some of them are already in use. 
 
+If you don't add the editors below to this config file then they won't be available in your grid editors, even if there are existing grid datatypes already using these editors.
+
 :::tip
 You will need to restart your site before any new customizations become available to use.
 :::


### PR DESCRIPTION
This file doesn't exist by default any more and you need to add in order to do any customizations