### PR TITLE
Adding Discord Server details

### DIFF
--- a/Getting-Started/Where-can-I-get-help/index.md
+++ b/Getting-Started/Where-can-I-get-help/index.md
@@ -23,6 +23,8 @@ You can talk to developers across the globe via the Umbraco Forum, report an iss
 
 [Umbraco Support](https://umbraco.com/products/umbraco-support/what-is-umbraco-support/)
 
+[Umbraco Discord](https://discord.gg/umbraco)
+
 :::center
 ![Umbraco support](images/U_PRs.png)
 :::


### PR DESCRIPTION
Since it's an official Umbraco resource now I thought I'd add the Discord server link to the Where to get help.