### PR TITLE
Updating reference docs to v9

### DIFF
--- a/Reference/Notifications/index.md
+++ b/Reference/Notifications/index.md
@@ -160,4 +160,4 @@ Useful for manipulating the model before it is sent to an editor in the backoffi
 
 # Creating and publishing your own custom notifications
 
-Umbraco uses notifications to allow people to hook in various workflow processes, but the notification pattern is also extendible, allowing you to create your own custom notification and publishing them, allowing other people to hook into your processes, this can be very useful when for instance creating packages. For more information on how you create and publish your own notifications see the [creating and publishing notifications](Creating-And-Publishing-Notifications.md) article.
+Umbraco uses notifications to allow people to hook into various workflow processes. This notification pattern is extensible, allowing you to create and publish your own custom notifications, thus allowing other people to observe and hook into your custom processes. This approach can be very useful when creating Umbraco packages. For more information on how you create and publish your own notifications see the [creating and publishing notifications](Creating-And-Publishing-Notifications.md) article.

--- a/Reference/Notifications/index.md
+++ b/Reference/Notifications/index.md
@@ -1,7 +1,7 @@
 ---
 v8-equivalent: "https://our.umbraco.com/documentation/Reference/Events"
 versionFrom: 9.0.0
-verified-against: beta-2
+verified-against: 9.0.1
 ---
 
 :::note

--- a/Reference/V9-Config/index.md
+++ b/Reference/V9-Config/index.md
@@ -6,7 +6,7 @@ state: complete
 verified-against: beta-3
 update-links: true
 ---
-
+:::note In Umbraco 9 configuration is json based rather than xml, you can view the v8 config documentation [here](../Config/index.md) :::
 # Configuration Files
 
 In V9, we have moved away from the previous configuration using `.config` files, to instead using the netcore built-in configuration pattern. This means that there is no longer separate files for different configuration, the configuration is now primarily done from the `appsettings.json` file.

--- a/Reference/V9-Config/index.md
+++ b/Reference/V9-Config/index.md
@@ -3,7 +3,7 @@ versionFrom: 9.0.0
 meta.Title: "Umbraco configuration"
 meta.Description: "Information on configuring Umbraco"
 state: complete
-verified-against: beta-3
+verified-against: 9.0.1
 update-links: true
 ---
 :::note In Umbraco 9 configuration is json based rather than xml, you can view the v8 config documentation [here](../Config/index.md) :::

--- a/Reference/index-v8.md
+++ b/Reference/index-v8.md
@@ -1,0 +1,91 @@
+---
+versionFrom: 8.0.0
+meta.Title: "Reference section for the Umbraco APIs"
+meta.Description: "Developers' Reference primarily consists of API references of the different core Umbraco APIs. In many cases, the references come with code snippets with simple examples. For a more in-depth study of the different APIs, consult the using-umbraco and extending-umbraco sections of the documentation."
+---
+
+# Developers' Reference
+
+_Developers' Reference primarily consists of API references of the different core Umbraco APIs. In many cases, the references come with code snippets with examples. For a more in-depth study of the different APIs, consult the "using-umbraco" and "extending-umbraco" sections of the documentation._
+
+## [Configuration](Config/index.md)
+
+Information about all of Umbraco's configuration files and options.
+
+## [Templates](Templating/index.md)
+
+Working with Umbraco templates: views, partial views, child actions, razor syntax, macros and working with JavaScript/Css.
+
+## [Querying & models](Querying/index.md)
+
+Information about the data models used to display content in Umbraco and the various ways of querying it.
+
+## [Routing & Controllers](Routing/index.md)
+
+How routing works within Umbraco, how content is mapped to URLs and how URLs are generated for content.
+This section also describes the types of Controllers used in Umbraco, how they work and how they get routed.
+
+## [Searching](Searching/index.md)
+
+Details on how to implement search capabilities for your Umbraco website using Examine, which is a Lucene-based search engine for Umbraco.
+
+## [Events](Events/index.md)
+
+Event model covering all major aspects of the system for triggering custom code or automation.
+
+## [Management APIs](Management/index.md)
+
+APIs that focus on creating, updating and deleting.
+
+## [Plugins](Plugins/index.md)
+
+The term 'Plugins' refers to any types in Umbraco that are found in assemblies that are used to extend and/or enhance the Umbraco application.
+
+
+## [Caching](Cache/index.md)
+
+Describes how to work with caching custom data structures in Umbraco. When creating Umbraco packages that have custom data sources and you want to cache some of this data, it's important to understand how caching works in Umbraco and to understand how it affects Umbraco installations in load balanced environments.
+
+## [Security](Security/index.md)
+
+Information on Umbraco security, its various security options and configuring how authentication & authorization works in Umbraco.
+
+## [Common Pitfalls & Anti-patterns](Common-Pitfalls/index.md)
+
+This section is ultra important! It describes many common pitfalls that developers fall in to. Make sure you read this section - it might save your site!
+
+## API Documentation V8
+
+#### [C# API Documentation](https://our.umbraco.com/apidocs/v8/csharp/)
+
+__Note: opens a documentation browser that is different from the documentation section you're viewing now.__
+
+C# API references for the Umbraco Core and Web libraries.
+
+#### [Backoffice UI API documentation](https://our.umbraco.com/apidocs/v8/ui/)
+
+## [Rest APIs](Routing/WebApi/index.md)
+
+How to use [Web API](https://www.asp.net/web-api) with Umbraco to create REST services.
+
+## [Debugging](Debugging/index.md)
+How to debug your code with Visual Studio
+
+## [Language Variation](Language-Variation/index.md)
+Language Variation allows you to have several different variations of content based on a language culture. 
+
+## [Mapping](Mapping/index.md)
+Find out how to map one object's properties to another type of object.
+
+## [Scheduling](Scheduling/index.md)
+Run recurring code using the BackgroundTaskRunner.
+
+## [IoC & Dependency Injection](using-ioc.md)
+
+Information about setting up Inversion of Control / Dependency Injection to work with Umbraco.
+
+## External resources
+
+* [Umbraco and precompiled views](https://dobryak.org/road-to-precompiled-web-application-based-on-umbraco-cms/)
+
+

--- a/Reference/index.md
+++ b/Reference/index.md
@@ -1,6 +1,5 @@
 ---
-versionFrom: 8.0.0
-versionTo: 9.0.0
+versionFrom: 9.0.0
 meta.Title: "Reference section for the Umbraco APIs"
 meta.Description: "Developers' Reference primarily consists of API references of the different core Umbraco APIs. In many cases, the references come with code snippets with simple examples. For a more in-depth study of the different APIs, consult the using-umbraco and extending-umbraco sections of the documentation."
 ---
@@ -74,16 +73,6 @@ Run recurring code using the RecurringHostedServiceBase.
 ## [IoC & Dependency Injection](using-ioc.md)
 
 Information about setting up Inversion of Control / Dependency Injection to work with Umbraco.
-
-## API Documentation V8
-
-#### [C# API Documentation](https://our.umbraco.com/apidocs/v8/csharp/)
-
-__Note: opens a documentation browser that is different from the documentation section you're viewing now.__
-
-C# API references for the Umbraco Core and Web libraries.
-
-#### [Backoffice UI API documentation](https://our.umbraco.com/apidocs/v8/ui/)
 
 ## API Documentation V9
 

--- a/Reference/index.md
+++ b/Reference/index.md
@@ -9,11 +9,7 @@ meta.Description: "Developers' Reference primarily consists of API references of
 
 _Developers' Reference primarily consists of API references of the different core Umbraco APIs. In many cases, the references come with code snippets with examples. For a more in-depth study of the different APIs, consult the "using-umbraco" and "extending-umbraco" sections of the documentation._
 
-## [Configuration](Config/index.md)
-
-Information about all of Umbraco's configuration files and options.
-
-## [Configuration V9](V9-Config/index.md)
+## [Configuration](V9-Config/index.md)
 
 Information about all of Umbraco's configurations and options for Umbraco 9.
 
@@ -34,9 +30,9 @@ This section also describes the types of Controllers used in Umbraco, how they w
 
 Details on how to implement search capabilities for your Umbraco website using Examine, which is a Lucene-based search engine for Umbraco.
 
-## [Events](Events/index.md)
+## [Notifications](Notifications/index.md)
 
-Event model covering all major aspects of the system for triggering custom code or automation.
+Notifications covering all major aspects of the system for triggering custom code or automation.
 
 ## [Management APIs](Management/index.md)
 
@@ -58,6 +54,26 @@ Information on Umbraco security, its various security options and configuring ho
 ## [Common Pitfalls & Anti-patterns](Common-Pitfalls/index.md)
 
 This section is ultra important! It describes many common pitfalls that developers fall in to. Make sure you read this section - it might save your site!
+
+## [Rest APIs](Routing/WebApi/index.md)
+
+How to use [Web API](https://www.asp.net/web-api) with Umbraco to create REST services.
+
+## [Debugging](Debugging/index.md)
+How to debug your code with Visual Studio
+
+## [Language Variation](Language-Variation/index.md)
+Language Variation allows you to have several different variations of content based on a language culture. 
+
+## [Mapping](Mapping/index.md)
+Find out how to map one object's properties to another type of object.
+
+## [Scheduling](Scheduling/index.md)
+Run recurring code using the RecurringHostedServiceBase.
+
+## [IoC & Dependency Injection](using-ioc.md)
+
+Information about setting up Inversion of Control / Dependency Injection to work with Umbraco.
 
 ## API Documentation V8
 
@@ -82,27 +98,6 @@ C# API references for the Umbraco Core and Web libraries.
 __Note: opens a documentation browser that is different from the documentation section you're viewing now.__
 
 Angular, JavaScript, CSS & Less UI API references for building Umbraco backoffice components.
-
-
-## [Rest APIs](Routing/WebApi/index.md)
-
-How to use [Web API](https://www.asp.net/web-api) with Umbraco to create REST services.
-
-## [Debugging](Debugging/index.md)
-How to debug your code with Visual Studio
-
-## [Language Variation](Language-Variation/index.md)
-Language Variation allows you to have several different variations of content based on a language culture. 
-
-## [Mapping](Mapping/index.md)
-Find out how to map one object's properties to another type of object.
-
-## [Scheduling](Scheduling/index.md)
-Run recurring code using the BackgroundTaskRunner.
-
-## [IoC & Dependency Injection](using-ioc.md)
-
-Information about setting up Inversion of Control / Dependency Injection to work with Umbraco.
 
 ## External resources
 


### PR DESCRIPTION
Making the reference page v9 by default but adding a v8 version and some links to v8 versions where relevant.