### PR TITLE
Updated editorService meta data

### DIFF
--- a/Reference/Angular/Services/editorService/Index.md
+++ b/Reference/Angular/Services/editorService/Index.md
@@ -1,6 +1,5 @@
 ---
-versionFrom: 7.0.0
-needsV9Update: "true"
+versionFrom: 8.0.0
 ---
 
 # Editor Service


### PR DESCRIPTION
Spotted that the meta data for this article is wrong, so here's a PR to rectify that.

This article was originally written for Umbraco 8, and should therefore also apply to Umbraco 9.

Earlier versions of Umbraco 7 also had an `editorService`, but it was deprecated in favor of the `<umb-overlay />` directive in later versions of Umbraco 7. This article was never about any of those two.