### PR TITLE
Clarify Edge browser requirements

### DIFF
--- a/Fundamentals/Setup/Requirements/index-v8.md
+++ b/Fundamentals/Setup/Requirements/index-v8.md
@@ -8,10 +8,10 @@ versionFrom: 8.0.0
 
 The Umbraco UI should work in all modern browsers:
 
-* Firefox (Latest)
 * Chrome (Latest)
+* Edge (Chromium)
+* Firefox (Latest)
 * Safari (Latest)
-* Edge
 
 ## Local Development
 

--- a/Fundamentals/Setup/Requirements/index.md
+++ b/Fundamentals/Setup/Requirements/index.md
@@ -11,10 +11,10 @@ updated-links: true
 
 The Umbraco UI should work in all modern browsers:
 
-* Firefox (Latest)
 * Chrome (Latest)
+* Edge (Chromium)
+* Firefox (Latest)
 * Safari (Latest)
-* Edge
 
 ## Local Development
 

--- a/Fundamentals/Setup/Requirements/index.md
+++ b/Fundamentals/Setup/Requirements/index.md
@@ -19,7 +19,7 @@ The Umbraco UI should work in all modern browsers:
 ## Local Development
 
 * Either OS:
-  * Microsoft Windows 7 SP1, 8.1 and 10
+  * Microsoft Windows 7 SP1, 8.1, 10 and 11
   * MacOS High Sierra 10.13
   * Linux (Ubuntu, Alpine, CentOS, Debian, Fedora, openSUSE and other major distributions)
 * One of the following .NET Tools or Editors:


### PR DESCRIPTION
As discussed on [Twitter](https://twitter.com/callumbwhyte/status/1455522459504029698), the docs around system requirements are a little ambiguous around support for Edge.

Microsoft released Chromium Edge in January 2020 and "Edge Legacy" has been considered obsolete since March 2021: https://support.microsoft.com/en-gb/microsoft-edge/what-is-microsoft-edge-legacy-3e779e55-4c55-08e6-ecc8-2333768c0fb0

Some [recent changes](https://github.com/umbraco/Umbraco-CMS/commit/f43d84787dfaa6b47562a5d2af148c9f17be9563) have meant the backoffice breaks in non-Chromium edge. Perhaps this is a bug and should be fixed anyway...?

This PR aims to clarify that the supported Edge browser is only the Chromium version.