### PR TITLE
Fix XPath query in My404ContentFinder

### DIFF
--- a/Reference/Routing/Request-Pipeline/IContentFinder-v7.md
+++ b/Reference/Routing/Request-Pipeline/IContentFinder-v7.md
@@ -103,7 +103,7 @@ public class My404ContentFinder : IContentFinder {
         // replace 'home_doctype_alias' with the alias of your homepage
         IPublishedContent rootNode = contentRequest.RoutingContext.UmbracoContext.ContentCache.GetByXPath("root/home_doctype_alias").FirstOrDefault(n => n.GetCulture().ThreeLetterWindowsLanguageName == culture.ThreeLetterWindowsLanguageName);
         // replace '404_doctype_alias' with the alias of your 404 page
-        IPublishedContent notFoundNode = contentRequest.RoutingContext.UmbracoContext.ContentCache.GetByXPath(String.Format("root/homeDocType[id={0}]/404_doctype_alias", rootNode.Id)).FirstOrDefault(n => n.GetCulture().ThreeLetterWindowsLanguageName == culture.ThreeLetterWindowsLanguageName);
+        IPublishedContent notFoundNode = contentRequest.RoutingContext.UmbracoContext.ContentCache.GetByXPath(String.Format("root/homeDocType[@id={0}]/404_doctype_alias", rootNode.Id)).FirstOrDefault(n => n.GetCulture().ThreeLetterWindowsLanguageName == culture.ThreeLetterWindowsLanguageName);
 
         if (notFoundNode != null) {
             contentRequest.PublishedContent = notFoundNode;


### PR DESCRIPTION
Just tested the XPath query on a v7 project, but it doesn't work, because the XPath query isn't correct.
Id is an attribute in XML, so it should be using `@id` instead of `id`.

See example example here: https://our.umbraco.com/forum/developers/xslt/20513-XPath-Expression-for-nodes-starting-at-specific-node#comment-77782