### PR TITLE
Microsoft abandoned the development of Windows Phone

### DIFF
--- a/Fundamentals/Code/Debugging/Logging/index-v8.md
+++ b/Fundamentals/Code/Debugging/Logging/index-v8.md
@@ -209,7 +209,7 @@ Learn more about the [logviewer dashboard](../../../Backoffice/LogViewer/) in th
 
 This is a tool for viewing & querying JSON log files from disk in the same way as the built in log viewer dashboard.
 
-<a href='//www.microsoft.com/store/apps/9N8RV8LKTXRJ?cid=storebadge&ocid=badge'><img src='https://skeddle.com/wp-content/uploads/2018/03/English_get-it-from-MS_InvariantCulture_Default.png' alt='English badge' style='height: 38px;' height="38" /></a> <a href="https://itunes.apple.com/gb/app/compact-log-viewer/id1456027499"><img src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-mac-app-store.svg" /></a>
+<a href='//www.microsoft.com/store/apps/9N8RV8LKTXRJ?cid=storebadge&ocid=badge'><img src='https://developer.microsoft.com/store/badges/images/English_get-it-from-MS.png' alt='English badge' style='height: 38px;' height="38" /></a> <a href="https://itunes.apple.com/gb/app/compact-log-viewer/id1456027499"><img src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-mac-app-store.svg" /></a>
 
 ## Serilog project/references shipped
 

--- a/Fundamentals/Code/Debugging/Logging/index-v8.md
+++ b/Fundamentals/Code/Debugging/Logging/index-v8.md
@@ -209,7 +209,7 @@ Learn more about the [logviewer dashboard](../../../Backoffice/LogViewer/) in th
 
 This is a tool for viewing & querying JSON log files from disk in the same way as the built in log viewer dashboard.
 
-<a href='//www.microsoft.com/store/apps/9N8RV8LKTXRJ?cid=storebadge&ocid=badge'><img src='https://assets.windowsphone.com/85864462-9c82-451e-9355-a3d5f874397a/English_get-it-from-MS_InvariantCulture_Default.png' alt='English badge' style='height: 38px;' height="38" /></a> <a href="https://itunes.apple.com/gb/app/compact-log-viewer/id1456027499"><img src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-mac-app-store.svg" /></a>
+<a href='//www.microsoft.com/store/apps/9N8RV8LKTXRJ?cid=storebadge&ocid=badge'><img src='https://skeddle.com/wp-content/uploads/2018/03/English_get-it-from-MS_InvariantCulture_Default.png' alt='English badge' style='height: 38px;' height="38" /></a> <a href="https://itunes.apple.com/gb/app/compact-log-viewer/id1456027499"><img src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-mac-app-store.svg" /></a>
 
 ## Serilog project/references shipped
 

--- a/Fundamentals/Code/Debugging/Logging/index-vpre-8.6.0.md
+++ b/Fundamentals/Code/Debugging/Logging/index-vpre-8.6.0.md
@@ -218,7 +218,7 @@ Learn more about the [logviewer dashboard](../../../Backoffice/LogViewer/) in th
 
 This is a tool for viewing & querying JSON log files from disk in the same way as the built in log viewer dashboard.
 
-<a href='//www.microsoft.com/store/apps/9N8RV8LKTXRJ?cid=storebadge&ocid=badge'><img src='https://assets.windowsphone.com/85864462-9c82-451e-9355-a3d5f874397a/English_get-it-from-MS_InvariantCulture_Default.png' alt='English badge' style='height: 38px;' height="38" /></a> <a href="https://itunes.apple.com/gb/app/compact-log-viewer/id1456027499"><img src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-mac-app-store.svg" /></a>
+<a href='//www.microsoft.com/store/apps/9N8RV8LKTXRJ?cid=storebadge&ocid=badge'><img src='https://skeddle.com/wp-content/uploads/2018/03/English_get-it-from-MS_InvariantCulture_Default.png' alt='English badge' style='height: 38px;' height="38" /></a> <a href="https://itunes.apple.com/gb/app/compact-log-viewer/id1456027499"><img src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-mac-app-store.svg" /></a>
 
 ## Serilog project/references shipped
 

--- a/Fundamentals/Code/Debugging/Logging/index-vpre-8.6.0.md
+++ b/Fundamentals/Code/Debugging/Logging/index-vpre-8.6.0.md
@@ -218,7 +218,7 @@ Learn more about the [logviewer dashboard](../../../Backoffice/LogViewer/) in th
 
 This is a tool for viewing & querying JSON log files from disk in the same way as the built in log viewer dashboard.
 
-<a href='//www.microsoft.com/store/apps/9N8RV8LKTXRJ?cid=storebadge&ocid=badge'><img src='https://skeddle.com/wp-content/uploads/2018/03/English_get-it-from-MS_InvariantCulture_Default.png' alt='English badge' style='height: 38px;' height="38" /></a> <a href="https://itunes.apple.com/gb/app/compact-log-viewer/id1456027499"><img src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-mac-app-store.svg" /></a>
+<a href='//www.microsoft.com/store/apps/9N8RV8LKTXRJ?cid=storebadge&ocid=badge'><img src='https://developer.microsoft.com/store/badges/images/English_get-it-from-MS.png' alt='English badge' style='height: 38px;' height="38" /></a> <a href="https://itunes.apple.com/gb/app/compact-log-viewer/id1456027499"><img src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-mac-app-store.svg" /></a>
 
 ## Serilog project/references shipped
 


### PR DESCRIPTION
Microsoft deleted the assets.windowsphone.com domain therefore Get it for Windows badge is failing to render. I've just replaced it with a different URL to get the badge