### PR TITLE
Adds note about getting Context in FindContent

### DIFF
--- a/Reference/Routing/custom-routes.md
+++ b/Reference/Routing/custom-routes.md
@@ -221,6 +221,9 @@ public IPublishedContent FindContent(ActionExecutingContextactionExecutingContex
     return productRoot;
 }
 ```
+:::note
+    If the endpoint of your custom route is considered a client-side request e.g. `/sitemap.xml`, you will need to replace the use of `IUmbracoContextAccessor` in the `FindContent` method with `IUmbracoContextFactory`. [Read more](https://our.umbraco.com/documentation/implementation/Services/#accessing-published-content-outside-of-a-http-request).
+:::
 
 We start off by getting our product root using the `UmbracoContext` to get it based off its id. Next we need to figure out what action is being requested, to do this we cast the `actionExecutingContext.ActionDescriptor` to a `ControllerActionDescriptor` and use its `ActionName` propperty. If the action name is index, we just return the product root, but if it's product, we try to get the SKU from the route value `id`, and try to find the child node which matches the SKU and return that.
 


### PR DESCRIPTION
Added a note about using `IUmbracoContextFactory `instead of `IUmbracoContextAccessor `to get Umbraco Context inside `FindContent `if your controller endpoint is considered a client side request. 
Related to this issue: https://github.com/umbraco/Umbraco-CMS/issues/11692