### PR TITLE
Umbraco v9 configuration should be at least mentioned on the /config

### DIFF
--- a/Reference/Config/index.md
+++ b/Reference/Config/index.md
@@ -5,6 +5,10 @@ meta.Description: "Information on the various configuration files in Umbraco"
 versionRemoved: 9.0.0
 ---
 
+:::note
+If you are searching for Umbraco v9+ documentation, it currently lives under the folder [V9-Config](../V9-Config/index.md)
+:::
+
 # Configuration Files
 
 The release of V8 has moved many of the previous configuration options from XML configuration files in the usual /config folder to be configurable through code. 


### PR DESCRIPTION
certainly because the folder is much lower in the menu. We should have created (or moved) files within the config folder. The current solution is all but handy and practical