### PR TITLE
Note formatting

### DIFF
--- a/Reference/Routing/custom-routes.md
+++ b/Reference/Routing/custom-routes.md
@@ -221,8 +221,9 @@ public IPublishedContent FindContent(ActionExecutingContextactionExecutingContex
     return productRoot;
 }
 ```
+
 :::note
-If the endpoint of your custom route is considered a client-side request e.g. **/sitemap.xml**, you will need to replace the use of **IUmbracoContextAccessor** in the **FindContent** method with **IUmbracoContextFactory**. You will also need to remove the implementation of **IVirtualPageController**. [Read more](https://our.umbraco.com/documentation/implementation/Services/#accessing-published-content-outside-of-a-http-request).
+If the endpoint of your custom route is considered a client-side request e.g. **/sitemap.xml**, you will need to replace the use of **IUmbracoContextAccessor** in the **FindContent** method with **IUmbracoContextFactory**. There is a currently a bug in V9, all versions less than 9.4 are affected, where this fix won't work for mapping a client-side request to an Umbraco Controller - see [https://github.com/umbraco/Umbraco-CMS/issues/12083](https://github.com/umbraco/Umbraco-CMS/issues/12083) for more details and hopefully news of a fix!
 :::
 
 We start off by getting our product root using the `UmbracoContext` to get it based off its id. Next we need to figure out what action is being requested, to do this we cast the `actionExecutingContext.ActionDescriptor` to a `ControllerActionDescriptor` and use its `ActionName` propperty. If the action name is index, we just return the product root, but if it's product, we try to get the SKU from the route value `id`, and try to find the child node which matches the SKU and return that.

--- a/Reference/Routing/custom-routes.md
+++ b/Reference/Routing/custom-routes.md
@@ -222,7 +222,7 @@ public IPublishedContent FindContent(ActionExecutingContextactionExecutingContex
 }
 ```
 :::note
-    If the endpoint of your custom route is considered a client-side request e.g. `/sitemap.xml`, you will need to replace the use of `IUmbracoContextAccessor` in the `FindContent` method with `IUmbracoContextFactory`. [Read more](https://our.umbraco.com/documentation/implementation/Services/#accessing-published-content-outside-of-a-http-request).
+If the endpoint of your custom route is considered a client-side request e.g. **/sitemap.xml**, you will need to replace the use of **IUmbracoContextAccessor** in the **FindContent** method with **IUmbracoContextFactory**. [Read more](https://our.umbraco.com/documentation/implementation/Services/#accessing-published-content-outside-of-a-http-request).
 :::
 
 We start off by getting our product root using the `UmbracoContext` to get it based off its id. Next we need to figure out what action is being requested, to do this we cast the `actionExecutingContext.ActionDescriptor` to a `ControllerActionDescriptor` and use its `ActionName` propperty. If the action name is index, we just return the product root, but if it's product, we try to get the SKU from the route value `id`, and try to find the child node which matches the SKU and return that.

--- a/Reference/Routing/custom-routes.md
+++ b/Reference/Routing/custom-routes.md
@@ -222,7 +222,7 @@ public IPublishedContent FindContent(ActionExecutingContextactionExecutingContex
 }
 ```
 :::note
-If the endpoint of your custom route is considered a client-side request e.g. **/sitemap.xml**, you will need to replace the use of **IUmbracoContextAccessor** in the **FindContent** method with **IUmbracoContextFactory**. [Read more](https://our.umbraco.com/documentation/implementation/Services/#accessing-published-content-outside-of-a-http-request).
+If the endpoint of your custom route is considered a client-side request e.g. **/sitemap.xml**, you will need to replace the use of **IUmbracoContextAccessor** in the **FindContent** method with **IUmbracoContextFactory**. You will also need to remove the implementation of **IVirtualPageController**. [Read more](https://our.umbraco.com/documentation/implementation/Services/#accessing-published-content-outside-of-a-http-request).
 :::
 
 We start off by getting our product root using the `UmbracoContext` to get it based off its id. Next we need to figure out what action is being requested, to do this we cast the `actionExecutingContext.ActionDescriptor` to a `ControllerActionDescriptor` and use its `ActionName` propperty. If the action name is index, we just return the product root, but if it's product, we try to get the SKU from the route value `id`, and try to find the child node which matches the SKU and return that.


### PR DESCRIPTION
Changes sections formatted as code inside a note to be formatted as bold. The rendering of the note looks wierd, and I suspect it's the code formatting inside the note that is the issue. I also added to the note, that you can't implement IVirtualPageController when your request is a client-side request.

What I am trying to fix:
![image](https://user-images.githubusercontent.com/6904597/143856861-722f37eb-de9c-4bed-90f1-113a9396f2b7.png)
