### PR TITLE
Added meta.title and meta.description for UI Library

### DIFF
--- a/Extending/UI Library/index.md
+++ b/Extending/UI Library/index.md
@@ -1,3 +1,8 @@
+---
+meta.Title: "UI Library"
+meta.Description: "A guide for getting started working with the Umbraco UI Library"
+---
+
 # UI Library
 
 The Umbraco UI Library is a set of web components that can be used to build Umbraco User Interface. The UI Library separates the user interface from Umbraco’s business logic and creates a unified user experience, with coherent styling and naming, across all the Umbraco platforms and projects including the ones developed by you.


### PR DESCRIPTION
Meta title and meta description was missing for this page.
This is especially a problem for the title in the browser, which now shows: "UI%20Library":
![Screen Shot 2021-12-06 at 09 02 42](https://user-images.githubusercontent.com/6122154/144810077-458c36fa-e396-4bb6-befb-ba0c0c113b06.png)