### PR TITLE
Update Logging page with Microsoft App Store Badge

### DIFF
--- a/Fundamentals/Code/Debugging/Logging/index-v8.md
+++ b/Fundamentals/Code/Debugging/Logging/index-v8.md
@@ -209,7 +209,9 @@ Learn more about the [logviewer dashboard](../../../Backoffice/LogViewer/) in th
 
 This is a tool for viewing & querying JSON log files from disk in the same way as the built in log viewer dashboard.
 
-<a href='//www.microsoft.com/store/apps/9N8RV8LKTXRJ?cid=storebadge&ocid=badge'><img src='https://assets.windowsphone.com/85864462-9c82-451e-9355-a3d5f874397a/English_get-it-from-MS_InvariantCulture_Default.png' alt='English badge' style='height: 38px;' height="38" /></a> <a href="https://itunes.apple.com/gb/app/compact-log-viewer/id1456027499"><img src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-mac-app-store.svg" /></a>
+<script type="module" src="https://getbadgecdn.azureedge.net/ms-store-badge.bundled.js"></script>
+<ms-store-badge productid="9n8rv8lktxrj" size="small"></ms-store-badge>
+<a href="https://itunes.apple.com/gb/app/compact-log-viewer/id1456027499"><img src="https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-mac-app-store.svg" /></a>
 
 ## Serilog project/references shipped
 


### PR DESCRIPTION
Hoping the badge works once rendered in the browser. Looks like Microsoft have changed the way badges are displayed. This should fix it. 

Badges page from Microsoft: https://developer.microsoft.com/en-us/microsoft-store/badges/