### PR TITLE
v9: Maximum Upload Size documentation

### DIFF
--- a/Reference/V9-Config/MaximumUploadSizeSettings/index.md
+++ b/Reference/V9-Config/MaximumUploadSizeSettings/index.md
@@ -4,6 +4,8 @@ meta.Title: "Umbraco Maximum upload size settingsg"
 meta.Description: "Information on how to change the default cap of upload size"
 ---
 
+Umbraco does not touch the default maximum allowed content size of the different services, but you can configure this yourself.
+
 # Using IIS
 
 To configure the default 28.6mb upload limit using IIS, we have to create a web.config file in the root of the project. It should contain this:
@@ -41,3 +43,13 @@ An example of a configuration could look something like:
 ```
 
 `MaxRequestLength` is specified in kilobytes, so this configuration would limit requests, and therefore uploaded files, to 2 megabytes, and a maximum query string length of 90 characters.
+
+# Using nginx
+
+Here's the documentation link to nginx: 
+https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+
+# Using apache
+
+Here's the documentation link to apache:
+https://httpd.apache.org/docs/2.2/mod/core.html#limitrequestbody

--- a/Reference/V9-Config/MaximumUploadSizeSettings/index.md
+++ b/Reference/V9-Config/MaximumUploadSizeSettings/index.md
@@ -8,7 +8,7 @@ Umbraco does not touch the default maximum allowed content size of the different
 
 # Using IIS
 
-To configure the default 28.6mb upload limit using IIS, we have to create a web.config file in the root of the project. It should contain this:
+To configure the default 28.6MB upload limit using IIS, we have to create a web.config file at the root of the project. It should contain this:
 ```
 <?xml version="1.0"?>
 <configuration>
@@ -27,9 +27,9 @@ To configure the default 28.6mb upload limit using IIS, we have to create a web.
 
 # Using Kestrel
 
-Runtime settings allows you to configure the `MaxRequestLength` and `MaxQueryStringLength` for kestrel. If you want to upload files larger than 28.6mb, then you have to configure these seetings. If nothing is configured reqests and query string can only be the default size and smaller.
+Runtime settings allow you to configure the `MaxRequestLength` and `MaxQueryStringLength` for kestrel. If you want to upload files larger than 28.6MB, then you have to configure these settings. If nothing is configured requests and query strings can only be the default size and smaller.
 
-An example of a configuration could look something like: 
+An example of a configuration could look something like this: 
 
 ```json
 "Umbraco": {
@@ -44,9 +44,9 @@ An example of a configuration could look something like:
 
 `MaxRequestLength` is specified in kilobytes, so this configuration would limit requests, and therefore uploaded files, to 2 megabytes, and a maximum query string length of 90 characters.
 
-# Using nginx
+# Using Nginx
 
-Here's the documentation link to nginx: 
+Here's the documentation link to Nginx: 
 https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
 
 # Using apache

--- a/Reference/V9-Config/MaximumUploadSizeSettings/index.md
+++ b/Reference/V9-Config/MaximumUploadSizeSettings/index.md
@@ -1,0 +1,43 @@
+---
+versionFrom: 9.0.0
+meta.Title: "Umbraco Maximum upload size settingsg"
+meta.Description: "Information on how to change the default cap of upload size"
+---
+
+# Using IIS
+
+To configure the default 28.6mb upload limit using IIS, we have to create a web.config file in the root of the project. It should contain this:
+```
+<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <security>
+      <requestFiltering>
+        <!-- ~ Below is the number of bytes allowed, 4GB is the maximum -->
+        <requestLimits maxAllowedContentLength="2000000" />
+      </requestFiltering>
+    </security>
+  </system.webServer>
+</configuration>
+```
+
+`maxAllowedContentLength` is specified in bytes, so this configuration would limit requests, and therefore uploaded files, to 2 megabytes
+
+# Using Kestrel
+
+Runtime settings allows you to configure the `MaxRequestLength` and `MaxQueryStringLength` for kestrel. If you want to upload files larger than 28.6mb, then you have to configure these seetings. If nothing is configured reqests and query string can only be the default size and smaller.
+
+An example of a configuration could look something like: 
+
+```json
+"Umbraco": {
+  "CMS": {
+    "Runtime": {
+      "MaxQueryStringLength": 90,
+      "MaxRequestLength": 2000
+    }
+  }
+}
+```
+
+`MaxRequestLength` is specified in kilobytes, so this configuration would limit requests, and therefore uploaded files, to 2 megabytes, and a maximum query string length of 90 characters.

--- a/Reference/V9-Config/index.md
+++ b/Reference/V9-Config/index.md
@@ -106,6 +106,7 @@ A complete list of all the configuration sections included in Umbraco by default
 * [Imaging settings](ImagingSettings/index.md)
 * [Keep alive settings](KeepAliveSettings/index.md)
 * [Logging settings](LoggingSettings/index.md)
+* [Maximum upload size settings](MaximumUploadSizeSettings/index.md)
 * [Models builder settings](ModelsBuilderSettings/index.md)
 * [NuCache settings](NuCacheSettings/index.md)
 * [Package migration settings](PackageMigrationSettings/index.md)


### PR DESCRIPTION
So this comes from a number of issues raised on the CMS, where you cannot upload a file larger than 28.6MB, so I thought some documentation on how to do so would be appreciated!

This contains a how-to of the 2 most used services with .net core (kestrel & IIS) but also links to documentation on how to change this with apache and nginx 👍 