### PR TITLE
Noted auto addition of  request verification token

### DIFF
--- a/Reference/Routing/surface-controllers.md
+++ b/Reference/Routing/surface-controllers.md
@@ -188,6 +188,8 @@ Whenever you render an Umbraco form within your view using `Html.BeginUmbracoFor
 
 Note this doesn't protect against Cross-Site Request Forgery (CSRF) attacks, there is a `__RequestVerificationToken` you can use to protect you from this.
 
+In Umbraco 9 the `__RequestVerificationToken` token is automatically added to forms for you, so you no longer need to add `@Html.AntiForgeryToken()` to your forms.
+
 ### Surface Controller Actions
 
 You can read more about the surface controller [action result helpers](surface-controllers-actions.md).


### PR DESCRIPTION
Added a note to document the fact that the request verification token is automatically added to forms, so you no longer need to do it yourself.