### PR TITLE
Update to use Url extension method

### DIFF
--- a/Reference/Templating/Mvc/views.md
+++ b/Reference/Templating/Mvc/views.md
@@ -42,7 +42,8 @@ Looping over a selection works in a similar way. If you have a property that con
 }
 
 <ul>
-    @foreach(var item in collection){
+    @foreach(var item in collection)
+    {
         <p>@item.Name</p>
     }
 </ul>
@@ -50,11 +51,11 @@ Looping over a selection works in a similar way. If you have a property that con
 If you want to convert a type and it's possible, you can do that by typing a variable and assigning the value from your property to it. This could look like the example below.
 ```csharp
 @foreach (TeamMember person in Model.TeamMembers)
-   {
-     <a href="@person.Url">
-        <p>@person.Name</p>
-     </a>
-   }
+{
+    <a href="@person.Url()">
+       <p>@person.Name</p>
+    </a>
+}
  ```
 
 In this example, we are looping through a list of items with the custom made type TeamMember assigned. This means we are able to access the strongly typed properties on the TeamMember item.
@@ -92,13 +93,13 @@ This renders a macro with some parameters using a dictionary
 @inject IMemberManager _memberManager;
 
 @if(_memberManager.IsLoggedIn())
-    {
-        <p>A Member is logged in</p>
-    }
-    else
-    {
-        <p>No member is logged in</p>
-    }
+{
+    <p>A Member is logged in</p>
+}
+else
+{
+    <p>No member is logged in</p>
+}
 ```
 
 ## Models Builder


### PR DESCRIPTION
The `Url` property has been obsolete for a while in v8 and in v9 I believe it has been removed and instead `Url()` extension method should be used.