### PR TITLE
Remove blob migration warning

### DIFF
--- a/Umbraco-Cloud/Set-Up/Media/index-v7.md
+++ b/Umbraco-Cloud/Set-Up/Media/index-v7.md
@@ -6,14 +6,6 @@ meta.Description: "All Media files for Umbraco Cloud projects are stored in Azur
 
 # Media on Umbraco Cloud
 
-:::warning
-We are currently migrating all media libraries on Umbraco Cloud projects to Azure Blob Storage. This is being done to optimize the performance of Umbraco Cloud sites, and as a part of the continuous improvements added to the service.
-
-You can follow the process on the [Umbraco Cloud Statuspage](https://status.umbraco.io/incidents/hfnq16mq7l1k).
-
-In the article below, you can find more information about Azure Blob Storage and how it works with your Umbraco Cloud project.
-:::
-
 All media files on your Umbraco Cloud projects are stored using Azure Blob Storage. This means that the media files are not stored with the rest of your project files but in an external storage system.
 
 In order to access the media files on your Umbraco Cloud project you can either

--- a/Umbraco-Cloud/Set-Up/Media/index.md
+++ b/Umbraco-Cloud/Set-Up/Media/index.md
@@ -6,14 +6,6 @@ meta.Description: "All Media files for Umbraco Cloud projects are stored in Azur
 
 # Media on Umbraco Cloud
 
-:::warning
-We are currently migrating all media libraries on Umbraco Cloud projects to Azure Blob Storage. This is being done to optimize the performance of Umbraco Cloud sites, and as a part of the continuous improvements added to the service.
-
-You can follow the process on the [Umbraco Cloud Statuspage](https://status.umbraco.io/incidents/hfnq16mq7l1k).
-
-In the article below, you can find more information about Azure Blob Storage and how it works with your Umbraco Cloud project.
-:::
-
 All media files on your Umbraco Cloud projects are stored using Azure Blob Storage. This means that the media files are not stored with the rest of your project files but in an external storage system.
 
 In order to access the media files on your Umbraco Cloud project you can either


### PR DESCRIPTION
Noticed that we were still showing a blob migration warning on the Setup/Media pages, even thoug the migrations have been done for quite some time now 🙈 