### PR TITLE
Moved link from codeblock to normal text

### DIFF
--- a/Reference/Cache/updating-cache-v8.md
+++ b/Reference/Cache/updating-cache-v8.md
@@ -21,9 +21,8 @@ public class MyClass
     }
 }
 
-[Read more about how to inject AppCaches](applicationcache-v8.md).
-
 ```
+[Read more about how to inject AppCaches](applicationcache-v8.md).
 
 ## Adding and retrieving items in the cache
 


### PR DESCRIPTION
Moved the link out of the codeblock as it gets wrongly interpreted (as seen in screenshot)
![image](https://user-images.githubusercontent.com/13347420/152048744-0d7189d0-d8c2-4d74-9aed-7ab540071b10.png)
