### PR TITLE
Advise against Explicit Scheduling Publisher role on Azure App Service

### DIFF
--- a/Fundamentals/Setup/Server-Setup/Load-Balancing/flexible-advanced-v8.md
+++ b/Fundamentals/Setup/Server-Setup/Load-Balancing/flexible-advanced-v8.md
@@ -11,6 +11,10 @@ _This describes some more advanced techniques that you could achieve with flexib
 It is recommended to configure an explicit master scheduling server since this reduces the amount
 complexity that the [master election](flexible.md#scheduling-and-master-election) process performs.
 
+:::note
+Explicitly registering the Master Scheduling Server is advised against when using the deployment slots feature on Azure Web Apps.
+This is because both the staging and production slot would be master scheduling servers, this can result in data corruption when using scheduled publishing/unpublishing is used.
+
 The first thing to do is create a couple classes for your front-end servers and master server to use:
 
 ```csharp

--- a/Fundamentals/Setup/Server-Setup/Load-Balancing/flexible-advanced.md
+++ b/Fundamentals/Setup/Server-Setup/Load-Balancing/flexible-advanced.md
@@ -22,6 +22,10 @@ These new terms replace 'Master and Replica', in Umbraco versions 7 and 8.
 It is recommended to configure an explicit SchedulingPublisher server since this reduces the amount
 of complexity that the election process performs.
 
+:::note
+Explicitly registering the SchedulingPublisher Server is advised against when using the deployment slots feature on Azure Web Apps.
+This is because both the staging and production slot would be scheduling publisher servers, this can result in data corruption when using scheduled publishing/unpublishing is used.
+
 The first thing to do is create a couple of small classes that implement `IServerRoleAccessor` one for each of the different server roles:
 
 ```csharp


### PR DESCRIPTION
Add note advising against explicit scheduling publisher on azure appservice with deployment slots.

Reason:
Explicitly registering the SchedulingPublisher Server is advised against when using the deployment slots feature on Azure Web Apps.
This is because both the staging and production slot would be scheduling publisher servers, this can result in data corruption when using scheduled publishing/unpublishing is used as both slots will try execute the scheduled publishing task.