### PR TITLE
Remove tilde (~) character from image locations

### DIFF
--- a/Reference/V9-Config/ContentSettings/index.md
+++ b/Reference/V9-Config/ContentSettings/index.md
@@ -24,8 +24,8 @@ To get an overview of the keys and values in the global section, the following s
       "DisallowedUploadFiles": ["ashx", "aspx", "ascx", "config", "cshtml", "vbhtml", "asmx", "air", "axd", "xamlx"],
       "AllowedUploadFiles": [],
       "ShowDeprecatedPropertyEditors": false,
-      "LoginBackgroundImage": "~/assets/img/login.jpg",
-      "LoginLogoImage": "~/assets/img/application/umbraco_logo_white.svg",
+      "LoginBackgroundImage": "/assets/img/login.jpg",
+      "LoginLogoImage": "/assets/img/application/umbraco_logo_white.svg",
       "Notifications": {
         "Email": "",
         "DisableHtmlEmail": false


### PR DESCRIPTION
Discovered when helping someone troubleshoot why the background image and logo were not showing in their Umbraco 9 installation.

[Issue #11830](https://github.com/umbraco/Umbraco-CMS/issues/11830)