### PR TITLE
Fix Constructor name

### DIFF
--- a/Reference/Notifications/EditorModel-Notifications/index.md
+++ b/Reference/Notifications/EditorModel-Notifications/index.md
@@ -74,7 +74,7 @@ namespace Umbraco.Docs.Samples.Web.Notifications
     {
         private readonly IMemberGroupService _memberGroupService;
 
-        public EditorModelNotificationHandler(IMemberGroupService memberGroupService)
+        public EditorSendingMemberNotificationHandler(IMemberGroupService memberGroupService)
         {
             _memberGroupService = memberGroupService;
         }


### PR DESCRIPTION
The name of the constructor name was different than the class name. 