### PR TITLE
Added missing detail about configuration for Umbraco Deploy on-premises

### DIFF
--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/Install-Configure/index.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/Install-Configure/index.md
@@ -92,24 +92,31 @@ An example configuration with a single upstream environment file will look like 
 
 ```json
 {
-  "Umbraco": {
-    "Deploy": {
-        "Settings": {
-            "ApiKey": "<your API key here>",
-        },
-        "Project": {
-            "Workspaces": [
-                {
-                    "Id": "efef5e89-a19b-434b-b68a-26e022a0ad52",
-                    "Name": "Live",
-                    "Url": "https://localhost:44307"
-                }
+   "Umbraco":{
+      "Deploy":{
+         "Settings":{
+            "ApiKey":"<your API key here>"
+         },
+         "Debug":{
+            "EnvironmentName":"Live"
+         },
+         "Project":{
+            "Workspaces":[
+               {
+                  "Id":"efef5e89-a19b-434b-b68a-26e022a0ad52",
+                  "Name":"Live",
+                  "Url":"https://localhost:44307"
+               }
             ]
-        },
-    }
-  }
+         }
+      }
+   }
 }
 ```
+
+The setting under _Debug:EnvironmentName_ should match the _Name_ provided in the list of _Workspaces_ that matches the current environment.  Using this Umbraco Deploy will indicate the correct current environment on the "Workspaces" dashboard.
+
+_Note:_ Although included under a "Debug" section, this setting is required for the installations of Umbraco Deploy on-premises (i.e. other than on Umbraco Cloud). It will likely be moved to the "Project" section in Umbraco Deploy 10.
 
 You will need to generate a unique GUID for each environment. This can be done in Visual Studio:
 


### PR DESCRIPTION
I realised that this had been missed off the V9 version of this page, and is necessary for Umbraco Deploy on-premises (i,e, when not installed on Cloud).

Came up in [this support request](https://umbraco.slack.com/archives/C0968J7PU/p1645807938426169) for background.