### PR TITLE
Update v9-config index.md, for ref to RTE

### DIFF
--- a/Reference/V9-Config/index.md
+++ b/Reference/V9-Config/index.md
@@ -143,6 +143,7 @@ A complete list of all the configuration sections included in Umbraco, by defaul
 * [Umbraco settings](umbracoSettings/index.md)
 * [Unattended settings](UnattendedSettings/index.md)
 * [Web routing settings](WebRoutingSettings/index.md)
+* [RichTextEditor settings](RichTextEditorSettings/index.md)
 
 ## Configured by code
 


### PR DESCRIPTION
https://our.umbraco.com/documentation/Reference/V9-Config/RichTextEditorSettings/ Based on this forum post, the config explain was missing, i only found the page in the docs GIT, but let´s embress that page