### PR TITLE
Rename in Scheduling documentation

### DIFF
--- a/Reference/Scheduling/index.md
+++ b/Reference/Scheduling/index.md
@@ -29,7 +29,7 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.HostedServices;
 
-namespace MySite
+namespace Umbraco.Docs.Samples.Web.RecurringHostedService
 {
     public class CleanUpYourRoom : RecurringHostedServiceBase
     {
@@ -102,9 +102,9 @@ First we need to create our extension method where we register the hosted servic
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.DependencyInjection;
 
-namespace MySite
+namespace Umbraco.Docs.Samples.Web.RecurringHostedService
 {
-    public static class BuilderExtensions
+    public static class UmbracoBuilderHostedServiceExtensions
     {
         public static IUmbracoBuilder AddCustomHostedServices(this IUmbracoBuilder builder)
         {
@@ -140,7 +140,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 
-namespace MySite
+namespace Umbraco.Docs.Samples.Web.RecurringHostedService
 {
     public class CleanUpYourRoomComposer : IComposer
     {

--- a/Reference/Scheduling/index.md
+++ b/Reference/Scheduling/index.md
@@ -29,7 +29,7 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.HostedServices;
 
-namespace Umbraco.Cms.Web.UI
+namespace MySite
 {
     public class CleanUpYourRoom : RecurringHostedServiceBase
     {
@@ -102,11 +102,11 @@ First we need to create our extension method where we register the hosted servic
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.DependencyInjection;
 
-namespace Umbraco.Cms.Web.UI
+namespace MySite
 {
     public static class BuilderExtensions
     {
-        public static IUmbracoBuilder AddHostedServices(this IUmbracoBuilder builder)
+        public static IUmbracoBuilder AddCustomHostedServices(this IUmbracoBuilder builder)
         {
             builder.Services.AddHostedService<CleanUpYourRoom>();
             return builder;
@@ -125,7 +125,7 @@ public void ConfigureServices(IServiceCollection services)
         .AddBackOffice()
         .AddWebsite()
         .AddComposers()
-        .AddHostedServices() // Register CleanUpYourRoom
+        .AddCustomHostedServices() // Register CleanUpYourRoom
         .Build();
 #pragma warning restore IDE0022 // Use expression body for methods
 }
@@ -140,7 +140,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 
-namespace Umbraco.Cms.Web.UI
+namespace MySite
 {
     public class CleanUpYourRoomComposer : IComposer
     {


### PR DESCRIPTION
I have changed the namespace to MySite. This will make it clear that it is custom code you will need to add to your site. I have choosen MySite since it is used already: https://our.umbraco.com/Documentation/Reference/Notifications/MemberService-Notifications/

I have renamed the extension method AddCustomHostedServices. This is to avoid confusion with Umbraco.Extensions.UmbracoBuilderExtensions.AddHostedServices