### PR TITLE
Docs updates for upcoming 4.6.0/9.4.0 release of Umbraco Deploy.

### DIFF
--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
@@ -197,7 +197,7 @@ Culture and hostname settings, defined per content item for culture invariant co
 To enable this, set the configuration value as appropriate for the types of domains you want to allow:
 
 - *Wildcard* - the language setting for the content, defined under "Culture"
-- *AbsolutePath* - values defined under "Domains" with a root relative path, e.g. "/en"
+- *AbsolutePath* - values defined under "Domains" with an absolute path, e.g. "/en"
 - *Hostname* - values defined under "Domains" with a full host name, e.g. "en.mysite.com"
 
 Combinations of settings can be applied, e.g. `Hostname,AbsolutePath`.

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
@@ -174,7 +174,7 @@ For example, using the following settings, you will have an installation that ig
 
 ## Memory cache reload
 
-Some customers have reported intermittent issues related to Umbraco's memory cache following deployments, that are resolved by a manual reload of the cache via the _Settings > Published Status > Caches_ dashboard.  If you are running into to such issues and have no issues with a cache clear after deployment, this workaround can be automated via the following setting:
+Some customers have reported intermittent issues related to Umbraco's memory cache following deployments, which are resolved by a manual reload of the cache via the _Settings > Published Status > Caches_ dashboard.  If you are running into such issues and have no issues with a cache clear after deployment, this workaround can be automated via the following setting:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -185,7 +185,7 @@ Some customers have reported intermittent issues related to Umbraco's memory cac
 
 ## Deployment of culture & hostnames settings
 
-Culture and hostname settings, defined per content item, are not deployed between environments by default, but can be opted into via configuration.
+Culture and hostname settings, defined per content item, are not deployed between environments by default but can be opted into via configuration.
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
@@ -183,7 +183,7 @@ Some customers have reported intermittent issues related to Umbraco's memory cac
 </settings>
 ```
 
-By upgrading to the most recent available version of the CMS major you are running, you'll be able to benefit from the latest bug fixes and optimizations in this area.  That should be your first option if encountering cache related issues. Failing that, or if a CMS upgrade it not an option, then this workaround can be considered.
+By upgrading to the most recent available version of the CMS major you are running, you'll be able to benefit from the latest bug fixes and optimizations in this area.  That should be your first option if encountering cache related issues. Failing that, or if a CMS upgrade is not an option, then this workaround can be considered.
 
 ## Deployment of culture & hostnames settings
 

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
@@ -174,7 +174,7 @@ For example, using the following settings, you will have an installation that ig
 
 ## Memory cache reload
 
-Some customers have reported intermittent issues related to Umbraco's memory cache following deployments, which are resolved by a manual reload of the cache via the _Settings > Published Status > Caches_ dashboard.  If you are running into such issues and have no issues with a cache clear after deployment, this workaround can be automated via the following setting:
+Some customers have reported intermittent issues related to Umbraco's memory cache following deployments, which are resolved by a manual reload of the cache via the _Settings > Published Status > Caches_ dashboard.  If you are running into such issues and are able to accomodate a cache clear after deployment, this workaround can be automated via the following setting:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
@@ -190,13 +190,13 @@ Culture and hostname settings, defined per content item for culture invariant co
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <settings xmlns="urn:umbracodeploy-settings">
-    <deploy allowDomainsDeploymentOperations="None|Wildcard|Absolute|Hostname|All" />
+    <deploy allowDomainsDeploymentOperations="None|Culture|Absolute|Hostname|All" />
 </settings>
 ```
 
 To enable this, set the configuration value as appropriate for the types of domains you want to allow:
 
-- *Wildcard* - the language setting for the content, defined under "Culture"
+- *Culture* - the language setting for the content, defined under "Culture"
 - *AbsolutePath* - values defined under "Domains" with an absolute path, e.g. "/en"
 - *Hostname* - values defined under "Domains" with a full host name, e.g. "en.mysite.com"
 

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
@@ -172,4 +172,32 @@ For example, using the following settings, you will have an installation that ig
 </settings>
 ```
 
+## Memory cache reload
+
+Some customers have reported intermittent issues related to Umbraco's memory cache following deployments, that are resolved by a manual reload of the cache via the _Settings > Published Status > Caches_ dashboard.  If you are running into to such issues and have no issues with a cache clear after deployment, this workaround can be automated via the following setting:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<settings xmlns="urn:umbracodeploy-settings">
+    <deploy reloadMemoryCacheFollowingDiskReadOperation="true" />
+</settings>
+```
+
+## Deployment of culture & hostnames settings
+
+Culture and hostname settings, defined per content item, are not deployed between environments by default, but can be opted into via configuration.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<settings xmlns="urn:umbracodeploy-settings">
+    <deploy allowDomainsDeploymentOperations="None|Wildcard|Absolute|Hostname|WildcardAndAbsolute|WildcardAndHostname|AbsoluteAndHostName|All" />
+</settings>
+```
+
+To enable this, set the configuration value as appropriate for the types of domains you want to allow:
+
+- *Wildcard* - the language setting for the content, defined under "Culture"
+- *Absolute* - values defined under "Domains" with a root relative path, e.g. "/en"
+- *Hostname* - values defined under "Domains" with a full host name, e.g. "en.mysite.com"
+
 

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
@@ -183,6 +183,8 @@ Some customers have reported intermittent issues related to Umbraco's memory cac
 </settings>
 ```
 
+By upgrading to the most recent available version of the CMS major you are running, you'll be able to benefit from the latest bug fixes and optimizations in this area.  That should be your first option if encountering cache related issues. Failing that, or if a CMS upgrade it not an option, then this workaround can be considered.
+
 ## Deployment of culture & hostnames settings
 
 Culture and hostname settings, defined per content item for culture invariant content, are not deployed between environments by default but can be opted into via configuration.

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
@@ -185,7 +185,7 @@ Some customers have reported intermittent issues related to Umbraco's memory cac
 
 ## Deployment of culture & hostnames settings
 
-Culture and hostname settings, defined per content item, are not deployed between environments by default but can be opted into via configuration.
+Culture and hostname settings, defined per content item for culture invariant content, are not deployed between environments by default but can be opted into via configuration.
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
@@ -190,14 +190,16 @@ Culture and hostname settings, defined per content item, are not deployed betwee
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <settings xmlns="urn:umbracodeploy-settings">
-    <deploy allowDomainsDeploymentOperations="None|Wildcard|Absolute|Hostname|WildcardAndAbsolute|WildcardAndHostname|AbsoluteAndHostName|All" />
+    <deploy allowDomainsDeploymentOperations="None|Wildcard|Absolute|Hostname|All" />
 </settings>
 ```
 
 To enable this, set the configuration value as appropriate for the types of domains you want to allow:
 
 - *Wildcard* - the language setting for the content, defined under "Culture"
-- *Absolute* - values defined under "Domains" with a root relative path, e.g. "/en"
+- *AbsolutePath* - values defined under "Domains" with a root relative path, e.g. "/en"
 - *Hostname* - values defined under "Domains" with a full host name, e.g. "en.mysite.com"
+
+Combinations of settings can be applied, e.g. `Hostname,AbsolutePath`.
 
 

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -184,6 +184,8 @@ Some customers have reported intermittent issues related to Umbraco's memory cac
     "ReloadMemoryCacheFollowingDiskReadOperation": true,
 ```
 
+By upgrading to the most recent available version of the CMS major you are running, you'll be able to benefit from the latest bug fixes and optimizations in this area.  That should be your first option if encountering cache related issues. Failing that, or if a CMS upgrade it not an option, then this workaround can be considered.
+
 ## Deployment of culture & hostnames settings
 
 Culture and hostname settings, defined per content item for culture invariant content, are not deployed between environments by default but can be opted into via configuration.

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -178,7 +178,7 @@ For example, using the following settings, you will have an installation that ig
 
 ## Memory cache reload
 
-Some customers have reported intermittent issues related to Umbraco's memory cache following deployments, which are resolved by a manual reload of the cache via the _Settings > Published Status > Caches_ dashboard.  If you are running into such issues and have no issues with a cache clear after deployment, this workaround can be automated via the following setting:
+Some customers have reported intermittent issues related to Umbraco's memory cache following deployments, which are resolved by a manual reload of the cache via the _Settings > Published Status > Caches_ dashboard.  If you are running into such issues and are able to accomodate a cache clear after deployment, this workaround can be automated via the following setting:
 
 ```json
     "ReloadMemoryCacheFollowingDiskReadOperation": true,

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -195,7 +195,7 @@ Culture and hostname settings, defined per content item for culture invariant co
 To enable this, set the configuration value as appropriate for the types of domains you want to allow:
 
 - *Wildcard* - the language setting for the content, defined under "Culture"
-- *AbsolutePath* - values defined under "Domains" with a root relative path, e.g. "/en"
+- *AbsolutePath* - values defined under "Domains" with an absolute path, e.g. "/en"
 - *Hostname* - values defined under "Domains" with a full host name, e.g. "en.mysite.com"
 
 Combinations of settings can be applied, e.g. `Hostname,AbsolutePath`.

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -55,6 +55,8 @@ For illustration purposes, the following structure represents the full set of op
             "AllowMembersDeploymentOperations": "None",
             "TransferMemberGroupsAsContent": false,
             "ExportMemberGroups": true,
+            "ReloadMemoryCacheFollowingDiskReadOperation": false,
+            "AllowDomainsDeploymentOperations": "None",
         }
     }
   }
@@ -173,6 +175,29 @@ For example, using the following settings, you will have an installation that ig
     "IgnoreBrokenDependencies": true,
     "IgnoreBrokenDependenciesBehavior": "Restore",
 ```
+
+## Memory cache reload
+
+Some customers have reported intermittent issues related to Umbraco's memory cache following deployments, that are resolved by a manual reload of the cache via the _Settings > Published Status > Caches_ dashboard.  If you are running into to such issues and have no issues with a cache clear after deployment, this workaround can be automated via the following setting:
+
+```json
+    "ReloadMemoryCacheFollowingDiskReadOperation": true,
+```
+
+## Deployment of culture & hostnames settings
+
+Culture and hostname settings, defined per content item, are not deployed between environments by default, but can be opted into via configuration.
+
+```json
+    "AllowDomainsDeploymentOperations": "None|Wildcard|Absolute|Hostname|WildcardAndAbsolute|WildcardAndHostname|AbsoluteAndHostName|All",
+```
+
+To enable this, set the configuration value as appropriate for the types of domains you want to allow:
+
+- *Wildcard* - the language setting for the content, defined under "Culture"
+- *Absolute* - values defined under "Domains" with a root relative path, e.g. "/en"
+- *Hostname* - values defined under "Domains" with a full host name, e.g. "en.mysite.com"
+
 
 
 

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -186,7 +186,7 @@ Some customers have reported intermittent issues related to Umbraco's memory cac
 
 ## Deployment of culture & hostnames settings
 
-Culture and hostname settings, defined per content item, are not deployed between environments by default but can be opted into via configuration.
+Culture and hostname settings, defined per content item for culture invariant content, are not deployed between environments by default but can be opted into via configuration.
 
 ```json
     "AllowDomainsDeploymentOperations": "None|Wildcard|AbsolutePath|Hostname|All",

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -184,7 +184,7 @@ Some customers have reported intermittent issues related to Umbraco's memory cac
     "ReloadMemoryCacheFollowingDiskReadOperation": true,
 ```
 
-By upgrading to the most recent available version of the CMS major you are running, you'll be able to benefit from the latest bug fixes and optimizations in this area.  That should be your first option if encountering cache related issues. Failing that, or if a CMS upgrade it not an option, then this workaround can be considered.
+By upgrading to the most recent available version of the CMS major you are running, you'll be able to benefit from the latest bug fixes and optimizations in this area.  That should be your first option if encountering cache related issues. Failing that, or if a CMS upgrade is not an option, then this workaround can be considered.
 
 ## Deployment of culture & hostnames settings
 

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -189,14 +189,16 @@ Some customers have reported intermittent issues related to Umbraco's memory cac
 Culture and hostname settings, defined per content item, are not deployed between environments by default but can be opted into via configuration.
 
 ```json
-    "AllowDomainsDeploymentOperations": "None|Wildcard|Absolute|Hostname|WildcardAndAbsolute|WildcardAndHostname|AbsoluteAndHostName|All",
+    "AllowDomainsDeploymentOperations": "None|Wildcard|AbsolutePath|Hostname|All",
 ```
 
 To enable this, set the configuration value as appropriate for the types of domains you want to allow:
 
 - *Wildcard* - the language setting for the content, defined under "Culture"
-- *Absolute* - values defined under "Domains" with a root relative path, e.g. "/en"
+- *AbsolutePath* - values defined under "Domains" with a root relative path, e.g. "/en"
 - *Hostname* - values defined under "Domains" with a full host name, e.g. "en.mysite.com"
+
+Combinations of settings can be applied, e.g. `Hostname,AbsolutePath`.
 
 
 

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -178,7 +178,7 @@ For example, using the following settings, you will have an installation that ig
 
 ## Memory cache reload
 
-Some customers have reported intermittent issues related to Umbraco's memory cache following deployments, that are resolved by a manual reload of the cache via the _Settings > Published Status > Caches_ dashboard.  If you are running into to such issues and have no issues with a cache clear after deployment, this workaround can be automated via the following setting:
+Some customers have reported intermittent issues related to Umbraco's memory cache following deployments, which are resolved by a manual reload of the cache via the _Settings > Published Status > Caches_ dashboard.  If you are running into such issues and have no issues with a cache clear after deployment, this workaround can be automated via the following setting:
 
 ```json
     "ReloadMemoryCacheFollowingDiskReadOperation": true,
@@ -186,7 +186,7 @@ Some customers have reported intermittent issues related to Umbraco's memory cac
 
 ## Deployment of culture & hostnames settings
 
-Culture and hostname settings, defined per content item, are not deployed between environments by default, but can be opted into via configuration.
+Culture and hostname settings, defined per content item, are not deployed between environments by default but can be opted into via configuration.
 
 ```json
     "AllowDomainsDeploymentOperations": "None|Wildcard|Absolute|Hostname|WildcardAndAbsolute|WildcardAndHostname|AbsoluteAndHostName|All",

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -189,12 +189,12 @@ Some customers have reported intermittent issues related to Umbraco's memory cac
 Culture and hostname settings, defined per content item for culture invariant content, are not deployed between environments by default but can be opted into via configuration.
 
 ```json
-    "AllowDomainsDeploymentOperations": "None|Wildcard|AbsolutePath|Hostname|All",
+    "AllowDomainsDeploymentOperations": "None|Culture|AbsolutePath|Hostname|All",
 ```
 
 To enable this, set the configuration value as appropriate for the types of domains you want to allow:
 
-- *Wildcard* - the language setting for the content, defined under "Culture"
+- *Culture* - the language setting for the content, defined under "Culture"
 - *AbsolutePath* - values defined under "Domains" with an absolute path, e.g. "/en"
 - *Hostname* - values defined under "Domains" with a full host name, e.g. "en.mysite.com"
 

--- a/Add-ons/Umbraco-Deploy/Extending/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index-v8.md
@@ -422,7 +422,7 @@ And then for the rider:
 
 Finally, the `remoteTree` optional parameter adds support for plugins to implement Deploy's "partial restore" feature.  This gives the editor the option to select an item to restore, from a tree picker displaying details from a remote environment.  The parameter is of type `DeployRegisteredEntityTypeDetail.RemoteTreeDetail` that defines three pieces of information:
 
-- A function responsible for returing a level of a tree.
+- A function responsible for returning a level of a tree.
 - The name of the entity (or entities) that can be restored from the remote tree.
 - The remote tree alias.
 

--- a/Add-ons/Umbraco-Deploy/Extending/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index-v8.md
@@ -334,6 +334,29 @@ In order to deploy the entity as schema, via disk based representations held in 
     }
 ```
 
+#### Including Plugin Registered Disk Entities in the Schema Comparison Dashboard
+
+In Umbraco Deploy 4.6 a schema comparison feature was added to the dashboard available under _Settings > Deploy_.  This lists the Deploy managed entities held in Umbraco and shows a comparison with the data held in the `.uda` files on disk.
+
+All core Umbraco entities, such as document types and data types, will be shown.
+
+To include entities from plugins, they need to be registered using an overload of the method shown above, that allows you to provide additional detail, e.g.:
+
+```C#
+_diskEntityService.RegisterDiskEntityType(
+    "mypackage-example",
+    "Examples",
+    false,
+    _exampleDataService.GetAll().Select(x => new DeployDiskRegisteredEntityTypeDetail.InstalledEntityDetail(x.GetUdi(), x.Name, x))));
+```
+
+The parameters are as follows:
+
+- The system name of the entity type (as used in the `UdiDefinition` attribute).
+- A human readable, pluralized name for display in the schema comparison dashboard user interface.
+- A flag indicating whether the entity is an Umbraco one, which should be set to `false`.
+- A function that returns all entities of the type installed in Umbraco, mapped to an object exposing the Udi and name of the entity.
+
 ### Backoffice Integrated Transfers
 
 If the optimal deployment workflow for your entity is to have editors control the deployment operations, instead of registering with the disk entity service, the transfer entity service should be used.  The process is similar, but a bit more involved, as there's a need to also register details of the tree that's being used for editing the entities.  In more complex cases, we also need to be able handle the situation where multiple entity types are managed within a single tree.

--- a/Add-ons/Umbraco-Deploy/Extending/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index-v8.md
@@ -372,7 +372,8 @@ The following code shows the registration of an entity for backoffice deployment
                 "exampleTreeAlias",
                 (string routePath) => true,
                 (string nodeId) => true,
-                (string nodeId, out Guid entityId) => Guid.TryParse(nodeId, out entityId));
+                (string nodeId, out Guid entityId) => Guid.TryParse(nodeId, out entityId),
+                new DeployRegisteredEntityTypeDetail.RemoteTreeDetail(FormsTreeHelper.GetExampleTree, "example", "externalExampleTree"));
         }
 
         public void Terminate()
@@ -417,6 +418,45 @@ And then for the rider:
         (string routePath) => routePath.Contains($"/riderEdit/"),
         (string nodeId) => nodeId.StartsWith("rider-"),
         (string nodeId, out Guid entityId) => Guid.TryParse(nodeId.Substring("rider-".Length), out entityId);
+```
+
+Finally, the `remoteTree` optional parameter adds support for plugins to implement Deploy's "partial restore" feature.  This gives the editor the option to select an item to restore, from a tree picker displaying details from a remote environment.  The parameter is of type `DeployRegisteredEntityTypeDetail.RemoteTreeDetail` that defines three pieces of information:
+
+- A function responsible for returing a level of a tree.
+- The name of the entity (or entities) that can be restored from the remote tree.
+- The remote tree alias.
+
+An example function that returns a level of a remote tree may look like this:
+
+```C#
+    public static IEnumerable<RemoteTreeNode> GetExampleTree(string parentId)
+    {
+        var exampleDataService = Current.Factory.GetInstance<IExampleDataService>();
+        var items = exampleDataService.GetItems(parentId);
+        return items
+            .Select(x => new RemoteTreeNode
+            {
+                Id = x.Id,,
+                Title = x.Name,
+                Icon = "icon-box",
+                ParentId = parentId,
+                HasChildren = true,
+            })
+            .ToList();
+    }
+```
+
+To complete the setup for partial restore support, an external tree controller needs to be added, attributed to match the registered tree alias.  Using a base class available in `Umbraco.Deploy.Forms.Tree`, this can look like the following:
+
+```C#
+    [Tree(DeployConstants.SectionAlias, "externalExampleTree", TreeUse = TreeUse.Dialog)]
+    public class ExternalExampleTreeController : ExternalTreeControllerBase
+    {
+        public ExternalExampleTreeController(IExtractEnvironmentInfo environmentInfoExtractor)
+            : base(environmentInfoExtractor, "mypackage-example")
+        {
+        }
+    }
 ```
 
 #### Client-Side Registration

--- a/Add-ons/Umbraco-Deploy/Extending/index.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index.md
@@ -345,7 +345,7 @@ In order to deploy the entity as schema, via disk based representations held in 
 
 #### Including Plugin Registered Disk Entities in the Schema Comparison Dashboard
 
-In Umbraco Deploy 4.6 and 9.4 a schema comparison feature was added to the dashboard available under _Settings > Deploy_.  This lists the Deploy managed entities held in Umbraco and shows a comparison with the data held in the `.uda` files on disk.
+In Umbraco Deploy 9.4 a schema comparison feature was added to the dashboard available under _Settings > Deploy_.  This lists the Deploy managed entities held in Umbraco and shows a comparison with the data held in the `.uda` files on disk.
 
 All core Umbraco entities, such as document types and data types, will be shown.
 

--- a/Add-ons/Umbraco-Deploy/Extending/index.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index.md
@@ -437,7 +437,7 @@ var localizationService = httpContext.RequestServices.GetRequiredService<ILocali
 
 Finally, the `remoteTree` optional parameter adds support for plugins to implement Deploy's "partial restore" feature.  This gives the editor the option to select an item to restore, from a tree picker displaying details from a remote environment.  The parameter is of type `DeployRegisteredEntityTypeDetail.RemoteTreeDetail` that defines three pieces of information:
 
-- A function responsible for returing a level of a tree.
+- A function responsible for returning a level of a tree.
 - The name of the entity (or entities) that can be restored from the remote tree.
 - The remote tree alias.
 

--- a/Add-ons/Umbraco-Deploy/Extending/index.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index.md
@@ -343,6 +343,29 @@ In order to deploy the entity as schema, via disk based representations held in 
     }
 ```
 
+#### Including Plugin Registered Disk Entities in the Schema Comparison Dashboard
+
+In Umbraco Deploy 4.6 and 9.4 a schema comparison feature was added to the dashboard available under _Settings > Deploy_.  This lists the Deploy managed entities held in Umbraco and shows a comparison with the data held in the `.uda` files on disk.
+
+All core Umbraco entities, such as document types and data types, will be shown.
+
+To include entities from plugins, they need to be registered using an overload of the method shown above, that allows you to provide additional detail, e.g.:
+
+```C#
+_diskEntityService.RegisterDiskEntityType(
+    "mypackage-example",
+    "Examples",
+    false,
+    _exampleDataService.GetAll().Select(x => new DeployDiskRegisteredEntityTypeDetail.InstalledEntityDetail(x.GetUdi(), x.Name, x))));
+```
+
+The parameters are as follows:
+
+- The system name of the entity type (as used in the `UdiDefinition` attribute).
+- A human readable, pluralized name for display in the schema comparison dashboard user interface.
+- A flag indicating whether the entity is an Umbraco one, which should be set to `false`.
+- A function that returns all entities of the type installed in Umbraco, mapped to an object exposing the Udi and name of the entity.
+
 ### Backoffice Integrated Transfers
 
 If the optimal deployment workflow for your entity is to have editors control the deployment operations, instead of registering with the disk entity service, the transfer entity service should be used.  The process is similar, but a bit more involved, as there's a need to also register details of the tree that's being used for editing the entities.  In more complex cases, we also need to be able handle the situation where multiple entity types are managed within a single tree.


### PR DESCRIPTION
I'm not sure exactly when this will be needed yet, but earliest would be 5th April for the release candidate - which is when we should update the docs.