### PR TITLE
Added reference to Services and Helpers

### DIFF
--- a/Reference/Scheduling/index-v8.md
+++ b/Reference/Scheduling/index-v8.md
@@ -100,7 +100,7 @@ namespace Umbraco.Web.UI
 ```
 
 :::tip
-Trying to inject services or helpers that rely on `UmbracoContext` such as `UmbracoHelper` or `MembershipHelper` will trigger a boot failed error on startup. See the [Services and Helpers](../../Implementation/Services/index-v8.md#accessing-published-content-outside-of-a-http-request) article on how to get around this by using the `UmbracoContextFactory`.
+Trying to inject services or helpers that rely on `UmbracoContext` such as `UmbracoHelper` or `MembershipHelper` will trigger a boot failed error on startup. See the [Accessing Published Content outside of a Http Request](../../Implementation/Services/index-v8.md#accessing-published-content-outside-of-a-http-request) article to query the Umbraco Published Content using `UmbracoContextFactory`.
 :::
 
 ## RecurringTaskBase

--- a/Reference/Scheduling/index-v8.md
+++ b/Reference/Scheduling/index-v8.md
@@ -99,6 +99,10 @@ namespace Umbraco.Web.UI
 
 ```
 
+:::tip
+Trying to inject services or helpers that rely on `UmbracoContext` such as `UmbracoHelper` or `MembershipHelper` will trigger a boot failed error on startup. See the [Services and Helpers](../../Implementation/Services/index-v8.md#accessing-published-content-outside-of-a-http-request) article on how to get around this by using the `UmbracoContextFactory`.
+:::
+
 ## RecurringTaskBase
 
 This class provides the base class for any recurring task. You can override the `PerformRun` method to implement the class. Tasks can also be run asynchronously. In this case, the property `IsAsync` must be overridden and set to `true` and the `PerformRunAsync` must be overridden to implement the class.


### PR DESCRIPTION
This updates the documentation section on scheduling by adding a reference to the Services and Helpers article explaining how and when to use `UmbracoContextFactory` as discussed in issue #3682.