### PR TITLE
Eye Dropper Color Picker value type in v9

### DIFF
--- a/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Eye-Dropper-Color-Picker/index.md
+++ b/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Eye-Dropper-Color-Picker/index.md
@@ -6,7 +6,7 @@ versionFrom: 9.0.0
 
 `Alias: Umbraco.ColorPicker.EyeDropper`
 
-`Returns: object`
+`Returns: string`
 
 The Eye Dropper Color picker allows you to choose a color from the full color spectrum using HEX and RGBA.
 


### PR DESCRIPTION
In v9 we updated the value type of Eye Dropper Color Picker to return a `string` instead of a generic `object`, which is also the default generated value type using in ModelsBuilder if no value converter is found.
https://github.com/umbraco/Umbraco-CMS/pull/10853