### PR TITLE
Fix syntax highlighting in Localization samples 

### DIFF
--- a/Extending/Language-Files/index.md
+++ b/Extending/Language-Files/index.md
@@ -69,11 +69,11 @@ By default, these files are empty but you can add any new keys you want or overr
 
 In order for these files to deploy when you do a `dotnet publish`, you need to add the following to your `.csproj` file:
 
-    ```xml
-    <ItemGroup>
-        <Content Include="config/**" CopyToOutputDirectory="Always" />
-    </ItemGroup>
-    ``` 
+```xml
+<ItemGroup>
+    <Content Include="config/**" CopyToOutputDirectory="Always" />
+</ItemGroup>
+``` 
 
 ## Using the language keys
 
@@ -83,38 +83,38 @@ Using core or custom language keys from your code:
 
 `ILocalizedTextService` is used to localize strings, and is available through dependency injection. First, inject the service, and then use the `Localize()` method available in the namespace `Umbraco.Extensions` to localize the string with the format [area]/[key]:
 
-    ```csharp
-    public MyClass(ILocalizedTextService textservice)
-    {
-        var localizedLabel = textservice.Localize("dialog/mykey");
-    }
-    ```
+```csharp
+public MyClass(ILocalizedTextService textservice)
+{
+    var localizedLabel = textservice.Localize("dialog/mykey");
+}
+```
 
 ### From Angular
 
 In the Umbraco backoffice UI, labels can be localized with the `localize` directive:
 
-    ```xml
-    <button>
-        <localize key="dialog_myKey">Default value</localize>
-    </button>
-    ```
+```xml
+<button>
+    <localize key="dialog_myKey">Default value</localize>
+</button>
+```
 
 The localize directive can also be used as an attribute like below where the value of the title attribute is then populated with the dictionary key "title_name" from the language file using "@title_name".
 
-    ```xml
-    <button localize="title" title="@title_name">
-        <localize key="dialog_myKey">Default value</localize>
-    </button>
-    ```
+```xml
+<button localize="title" title="@title_name">
+    <localize key="dialog_myKey">Default value</localize>
+</button>
+```
 
 Or from a controller by using the `LocalizationService` which returns an async translation in a promise:
 
-    ```javascript
-        localizationService.localize("dialog_myKey").then(function(value){
-                        element.html(value);
-        });
-    ```
+```javascript
+localizationService.localize("dialog_myKey").then(function(value){
+                element.html(value);
+});
+```
 
 ## Help keep the language files up to date
 
@@ -126,38 +126,38 @@ If a translation is missing, the key "alias" used will be shown within the user 
 
 The language files are XML files with a straight-forward layout as seen below.
 
-    ```xml
-    <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-    <language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
-        <creator>
-            <name>The Umbraco community</name>
-            <link>https://our.umbraco.com</link>
-        </creator>
-        <area alias="actions">
-            <key alias="assignDomain">Culture and Hostnames</key>
-            <key alias="auditTrail">Audit Trail</key>
-            ...
-        </area>
+```xml
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
+    <creator>
+        <name>The Umbraco community</name>
+        <link>https://our.umbraco.com</link>
+    </creator>
+    <area alias="actions">
+        <key alias="assignDomain">Culture and Hostnames</key>
+        <key alias="auditTrail">Audit Trail</key>
         ...
-    </language>
-    ```
+    </area>
+    ...
+</language>
+```
 
 In the above example of a missing translation for "assignDomain", locate this string in the en.xml file and then copy the whole "Key" element into the relevant language file. Then you can translate the text, as an example here is the Spanish version of the above snippet:
 
-    ```xml
-    <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-    <language alias="es" intName="Spanish" localName="español" lcid="10" culture="es-ES">
-        <creator>
-            <name>The Umbraco community</name>
-            <link>https://our.umbraco.com</link>
-        </creator>
-        <area alias="actions">
-            <key alias="assignDomain">Administrar hostnames</key>
-            <key alias="auditTrail">Auditoría</key>
-            ...
-        </area>
+```xml
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="es" intName="Spanish" localName="español" lcid="10" culture="es-ES">
+    <creator>
+        <name>The Umbraco community</name>
+        <link>https://our.umbraco.com</link>
+    </creator>
+    <area alias="actions">
+        <key alias="assignDomain">Administrar hostnames</key>
+        <key alias="auditTrail">Auditoría</key>
         ...
-    </language>
-    ```
+    </area>
+    ...
+</language>
+```
 
 If you do update any of the core language files or you add a new language, don't forget to help the rest of the community by [submitting a pull request](../../Contribute/index.md) so that your changes are merged into the core.


### PR DESCRIPTION
Small, un-indenting fix for the code samples to reinstate the syntax-highlighting.