### PR TITLE
Added a note in an attempt to avoid confusion

### DIFF
--- a/Reference/Querying/MemberShipHelper/index.md
+++ b/Reference/Querying/MemberShipHelper/index.md
@@ -1,7 +1,14 @@
 ---
 versionFrom: 8.0.0
+versionTo: 8.0.0
 versionRemoved: 9.0.0
 ---
+
+:::warning
+The topic covered in this article is only relevant to you if you are using Umbraco 8 or below.
+
+This article is not relevant to you if you are using Umbraco 9 or above.
+:::
 
 # Membershiphelper
 

--- a/Reference/Querying/MemberShipHelper/index.md
+++ b/Reference/Querying/MemberShipHelper/index.md
@@ -7,7 +7,7 @@ versionRemoved: 9.0.0
 :::warning
 The topic covered in this article is only relevant to you if you are using Umbraco 8 or below.
 
-This article is not relevant to you if you are using Umbraco 9 or above.
+If you are using Umbraco 9 or above, see the [IMemberManager](../IMemberManager/index.md) article.
 :::
 
 # Membershiphelper

--- a/Reference/Querying/MemberShipHelper/index.md
+++ b/Reference/Querying/MemberShipHelper/index.md
@@ -1,6 +1,6 @@
 ---
 versionFrom: 8.0.0
-versionTo: 8.0.0
+versionTo: 8.18.0
 versionRemoved: 9.0.0
 ---
 


### PR DESCRIPTION
When visiting this article right now, it looks like it should be valid for Umbraco 9 as well.

However, in the YAML tags is says `versionRemoved: 9.0.0`.
I've added a note to the article, to make it clear that this article is not valid for v9 or above.
Also added a `versionTo` tag, to make it a little clearer.