### PR TITLE
V10: Update the upgrade page to show how to re-enable appsettings intellisense in v10

### DIFF
--- a/Fundamentals/Setup/Upgrading/version-specific.md
+++ b/Fundamentals/Setup/Upgrading/version-specific.md
@@ -57,7 +57,19 @@ Finally, remove the following files and folders:
 - `/umbraco/UmbracoInstall`
 - `/umbraco/UmbracoWebsite`
 - `/umbraco/config/lang`
-- 
+
+To re-enable the appsettings intellisense you must update your schema reference from: 
+
+```json
+"$schema": "./umbraco/config/appsettings-schema.json",
+```
+
+To:
+
+```json
+"$schema": "./appsettings-schema.json",
+```
+
 :::note
 To upgrade to Umbraco 10, your database needs to be at least on Umbraco 8.18.
 :::

--- a/Fundamentals/Setup/Upgrading/version-specific.md
+++ b/Fundamentals/Setup/Upgrading/version-specific.md
@@ -58,7 +58,7 @@ Finally, remove the following files and folders:
 - `/umbraco/UmbracoWebsite`
 - `/umbraco/config/lang`
 
-To re-enable the appsettings intellisense you must update your schema reference from: 
+To re-enable the appsettings IntelliSense, you must update your schema reference in the **appsettings.json** file from: 
 
 ```json
 "$schema": "./umbraco/config/appsettings-schema.json",


### PR DESCRIPTION
In RC2 of v10 the intellisense for the appsettings file has been re-introduced, but requires a small change for existing sites.

I've updated the upgrade docs to show how you re-enable the intellisense :) 