### PR TITLE
Verify Content Apps article for v10

### DIFF
--- a/Extending/Content-Apps/index.md
+++ b/Extending/Content-Apps/index.md
@@ -1,5 +1,6 @@
 ---
 versionFrom: 9.2.0
+versionTo: 10.0.0
 meta.Title: "Content Apps"
 meta.Description: "A guide configuring content apps in Umbraco"
 ---
@@ -209,6 +210,8 @@ This is an example of how to create a Content App with C# and perform your own c
 ```csharp
 using System.Collections.Generic;
 using System.Linq;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Models.Membership;

--- a/Extending/Content-Apps/index.md
+++ b/Extending/Content-Apps/index.md
@@ -229,7 +229,7 @@ namespace My.Website
 
     public class WordCounterApp : IContentAppFactory
     {
-        public ContentApp GetContentAppFor(object source, IEnumerable<IReadOnlyUserGroup> userGroups)
+        public ContentApp? GetContentAppFor(object source, IEnumerable<IReadOnlyUserGroup> userGroups)
         {
             // Can implement some logic with userGroups if needed
             // Allowing us to display the content app with some restrictions for certain groups


### PR DESCRIPTION
Adding a couple of `@using` statements that was missing from the C# sample - this also applies to the latest version of 9.

There is one difference between v10 and v9 when testing this article.
For v10, VS suggests adding a `?` to the ContentApp method in the C# sample:

```
public ContentApp? GetContentAppFor(object source, IEnumerable<IReadOnlyUserGroup> userGroups)
        {
```

It seems to be related to the nullable references.
When adding the same to the v9 code, it still works, only gives a warning.