### PR TITLE
Updated 2FA article for v10

### DIFF
--- a/Reference/Security/Two-factor-authentication/index.md
+++ b/Reference/Security/Two-factor-authentication/index.md
@@ -201,6 +201,8 @@ Umbraco controls how the UI is for user login and user edits, but will still nee
 In the following example, we will use the [GoogleAuthenticator NuGet Package](https://www.nuget.org/packages/GoogleAuthenticator/).
 Despite the name, this package works for both Google and Microsoft authenticator apps and can be used to generate the QR code needed to activate the app for the website.
 
+**In Umbraco 9:**
+
 ```Csharp
 using System;
 using System.Runtime.Serialization;
@@ -220,6 +222,95 @@ namespace Umbraco9
 
         [DataMember(Name = "secret")]
         public string Secret { get; set; }
+    }
+
+    /// <summary>
+    /// App Authenticator implementation of the ITwoFactorProvider
+    /// </summary>
+    public class UmbracoUserAppAuthenticator : ITwoFactorProvider
+    {
+        private readonly IUserService _userService;
+
+        /// <summary>
+        /// The unique name of the ITwoFactorProvider. This is saved in a constant for reusability.
+        /// </summary>
+        public const string Name = "UmbracoUserAppAuthenticator";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoAppAuthenticator"/> class.
+        /// </summary>
+        public UmbracoUserAppAuthenticator(IUserService userService)
+        {
+            _userService = userService;
+
+        }
+
+        /// <summary>
+        /// The unique provider name of ITwoFactorProvider implementation.
+        /// </summary>
+        /// <remarks>
+        /// This value will be saved in the database to connect the member with this  ITwoFactorProvider.
+        /// </remarks>
+        public string ProviderName => Name;
+
+        /// <summary>
+        /// Returns the required data to setup this specific ITwoFactorProvider implementation. In this case it will contain the url to the QR-Code and the secret.
+        /// </summary>
+        /// <param name="userOrMemberKey">The key of the user or member</param>
+        /// <param name="secret">The secret that ensures only this user can connect to the authenticator app</param>
+        /// <returns>The required data to setup the authenticator app</returns>
+        public Task<object> GetSetupDataAsync(Guid userOrMemberKey, string secret)
+        {
+            var user = _userService.GetByKey(userOrMemberKey);
+
+            var twoFactorAuthenticator = new TwoFactorAuthenticator();
+            SetupCode setupInfo = twoFactorAuthenticator.GenerateSetupCode("My application name", user.Username, secret, false);
+            return Task.FromResult<object>(new TwoFactorAuthInfo()
+            {
+                QrCodeSetupImageUrl = setupInfo.QrCodeSetupImageUrl,
+                Secret = secret
+            });
+        }
+
+        /// <summary>
+        /// Validated the code and the secret of the user.
+        /// </summary>
+        public bool ValidateTwoFactorPIN(string secret, string code)
+        {
+            var twoFactorAuthenticator = new TwoFactorAuthenticator();
+            return twoFactorAuthenticator.ValidateTwoFactorPIN(secret, code);
+        }
+
+        /// <summary>
+        /// Validated the two factor setup
+        /// </summary>
+        /// <remarks>Called to confirm the setup of two factor on the user. In this case we confirm in the same way as we login by validating the PIN.</remarks>
+        public bool ValidateTwoFactorSetup(string secret, string token) => ValidateTwoFactorPIN(secret, token);
+    }
+}
+```
+
+**In Umbraco 10:**
+
+```Csharp
+using System;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Google.Authenticator;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco9
+{
+    [DataContract]
+    public class TwoFactorAuthInfo
+    {
+        [DataMember(Name = "qrCodeSetupImageUrl")]
+        public string? QrCodeSetupImageUrl { get; set; }
+
+        [DataMember(Name = "secret")]
+        public string? Secret { get; set; }
     }
 
     /// <summary>

--- a/Reference/Security/Two-factor-authentication/index.md
+++ b/Reference/Security/Two-factor-authentication/index.md
@@ -1,5 +1,6 @@
 ---
 versionFrom: 9.5.0
+versionTo: 10.0.0
 keywords: 2fa, security, members, users
 meta.Title: "Two-factor authentication"
 meta.Description: "Umbraco users and members support a two-factor authentication (2FA) abstraction for implementing a 2FA provider of your choice"
@@ -181,7 +182,7 @@ At this point, the 2FA is active, but no members have set up 2FA yet. The setup 
 }
 ```
 
-In this razor-code sample, we get the current members unique key and list all registered `ITwoFactorProvider` implementations.
+In this razor-code sample, we get the current member's unique key and list all registered `ITwoFactorProvider` implementations.
 
 If the `setupData` is `null` for the specified `providerName` it means the provider is already set up. In this case, we show a disable button. Otherwise, we check the type and show the UI for how to set up the App Authenticator, by showing the QR Code and an input field to validate the code from the App Authenticator.
 


### PR DESCRIPTION
The only difference between v10 and v9 in `UmbracoUserAppAuthenticator.cs` code:

```
public string? QrCodeSetupImageUrl { get; set; }
public string? Secret { get; set; }
```