### PR TITLE
Updated backoffice user manager docs

### DIFF
--- a/Reference/Security/backoffice-user-manager.md
+++ b/Reference/Security/backoffice-user-manager.md
@@ -1,5 +1,6 @@
 ---
 versionFrom: 9.0.0
+versionTo: 10.0.0
 meta.Title: "BackOfficeUserManager and Notifications"
 meta.Description: "The BackOfficeUserManager is the ASP.NET Core Identity UserManager implementation in Umbraco. It exposes APIs for working with Umbraco User's via the ASP.NET Core Identity including password handling."
 ---
@@ -52,11 +53,12 @@ Note the constructor minimum needs to inject what is required for the base `Back
         BackOfficeErrorDescriber errors,
         IServiceProvider services,
         IHttpContextAccessor httpContextAccessor,
-        ILogger<UserManager<BackOfficeIdentityUser>> logger,
+        ILogger<CustomBackOfficeUserManager> logger,
         IOptions<UserPasswordConfigurationSettings> passwordConfiguration,
         IEventAggregator eventAggregator,
         IBackOfficeUserPasswordChecker backOfficeUserPasswordChecker)
-        : base(ipResolver,
+        : base(
+            ipResolver,
             store,
             optionsAccessor,
             passwordHasher,
@@ -73,7 +75,7 @@ Note the constructor minimum needs to inject what is required for the base `Back
     }
 
     //Override whatever you need, e.g. SupportsUserTwoFactor.
-    public override bool SupportsUserTwoFactor => true;
+    public override bool SupportsUserTwoFactor => false;
 }
 ```
 


### PR DESCRIPTION
The page is still valid for v9 and since 9.5 it make sense to change `true` to `false ` in the example.