### PR TITLE
Updated Reference Routing Authorized to v10

### DIFF
--- a/Reference/Routing/Authorized/index.md
+++ b/Reference/Routing/Authorized/index.md
@@ -1,5 +1,6 @@
 ---
 versionFrom: 9.0.0
+versionTo: 10.0.0
 meta.Title: "Routing Requirements for Backoffice authentication"
 meta.Description: "Requirements for authenticating requests for the backoffice"
 ---
@@ -70,10 +71,10 @@ public static void MapUmbracoRoute<T>(
             this IEndpointRouteBuilder endpoints,
             string rootSegment,
             string areaName,
-            string prefixPathSegment,
+            string? prefixPathSegment,
             string defaultAction = "Index",
             bool includeControllerNameInRoute = true,
-            object constraints = null)
+            object? constraints = null)
 ```
 
 * The generic type argument is the contoller you wish to route, in this case `MyController`.


### PR DESCRIPTION
Opdated this page to v10. The only changes between v9 and v10 is the nullable reference types, so I still thing it is better to share the page for both v9 and v10, compared to copy paste every thing.