### PR TITLE
Removing using statement from code example

### DIFF
--- a/Fundamentals/Setup/Upgrading/version-specific.md
+++ b/Fundamentals/Setup/Upgrading/version-specific.md
@@ -41,7 +41,6 @@ After updating the project through NuGet, you will need to update your project f
 Additionally, you will need to update the `Program.cs` to the following:
 
 ```csharp
-using Umbraco.Cms.Web.Common.Hosting;
 public class Program
     {
         public static void Main(string[] args)


### PR DESCRIPTION
Removed this statement:
using Umbraco.Cms.Web.Common.Hosting

After testing the upgrade from 9 -> 10  I discovered that this using statement wasn't being used at all.