### PR TITLE
v10: Created new article for Nullable reference types

### DIFF
--- a/Implementation/Nullable-Reference-Types/index.md
+++ b/Implementation/Nullable-Reference-Types/index.md
@@ -16,5 +16,5 @@ Nullable reference types includes three features that help you avoid these excep
 - Attributes that annotate APIs so that the flow analysis determines null-state.
 - Variable annotations that developers use to explicitly declare the intended null-state for a variable.
 
-To learn more about Nullable Reference Types, make sure to check out the [microsoft documentation](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references)
+To learn more about Nullable Reference Types, make sure to check out the [Microsoft Documentation](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references)
 

--- a/Implementation/Nullable-Reference-Types/index.md
+++ b/Implementation/Nullable-Reference-Types/index.md
@@ -1,0 +1,20 @@
+---
+versionFrom: 10.0.0
+Meta.Title: Nullable Reference Types
+Meta.Description: In this article we describe what Nullable reference types is.
+---
+
+# Nullable Reference Types
+
+Starting from Umbraco 10 Nullable Reference Typs is enabled by default in Umbraco.
+
+Nullable reference types is a group of features introduced in C# 8.0 that can be used to minimize the likelihood that your code causes the runtime to throw `System.NullReferenceException`.
+
+Nullable reference types includes three features that help you avoid these exceptions, including the ability to explicitly mark a reference type as nullable:
+
+- Improved static flow analysis that determines if a variable may be null before dereferencing it.
+- Attributes that annotate APIs so that the flow analysis determines null-state.
+- Variable annotations that developers use to explicitly declare the intended null-state for a variable.
+
+To learn more about Nullable Reference Types, make sure to check out the [microsoft documentation](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references)
+


### PR DESCRIPTION
Created a new article for nullable reference types.

Not sure if putting it in the Implementation tap is the right place to add the article.

Please let me know if it should be moved somewhere else.