### PR TITLE
v10: Update articles with references to embedded resources

### DIFF
--- a/Extending/Backoffice-Tours/index.md
+++ b/Extending/Backoffice-Tours/index.md
@@ -1,5 +1,6 @@
 ---
 versionFrom: 9.0.0
+versionTo: 10.0.0
 meta.Title: "Backoffice Tours"
 meta.Description: "A guide configuring backoffice tours in Umbraco"
 ---
@@ -16,7 +17,9 @@ The tour functionality will load information from multiple locations.
 
 - **Core tours and custom tours**
 
-    The tour files that ship with Umbraco are stored in `/Config/BackofficeTours`. This is also the recommended location for storing your own tour files.
+    The tour that ship with Umbraco are embedded into the CMS.
+
+    When you want to implement custom tours into your website, we recommend that you create
 
 - **Plugin tours**
 

--- a/Extending/Backoffice-Tours/index.md
+++ b/Extending/Backoffice-Tours/index.md
@@ -17,9 +17,7 @@ The tour functionality will load information from multiple locations.
 
 - **Core tours and custom tours**
 
-    The tour that ship with Umbraco are embedded into the CMS.
-
-    When you want to implement custom tours into your website, we recommend that you create
+    The tour that ship with Umbraco are embedded into the CMS assemblies.
 
 - **Plugin tours**
 

--- a/Extending/Language-Files/index.md
+++ b/Extending/Language-Files/index.md
@@ -73,7 +73,7 @@ By default, these files are empty but you can add any new keys you want or overr
 
 In order for these files to deploy when you do a `dotnet publish`, you need to add the following to your `.csproj` file:
 
-```html
+```xml
 <ItemGroup>
     <Content Include="config/**" CopyToOutputDirectory="Always" />
 </ItemGroup>

--- a/Extending/Language-Files/index.md
+++ b/Extending/Language-Files/index.md
@@ -1,5 +1,6 @@
 ---
 versionFrom: 9.0.0
+versionTo: 10.0.0
 meta.Title: "Language Files & Localization"
 meta.Description: "Language files are used to translate the Umbraco backoffice user interface so that end users can use Umbraco in their native language."
 ---
@@ -42,7 +43,9 @@ Current languages that are included in the core are:
 
 The core Umbraco language files are found at the following location within the Umbraco source:
 
-    Umbraco-CMS/src/Umbraco.Web.UI.Netcore/umbraco/config/lang/
+```xml
+Umbraco-CMS/src/Umbraco.Core/EmbeddedResources/Lang/
+```
 
 These language files are the ones shipped with Umbraco and should not be modified.
 
@@ -50,8 +53,10 @@ These language files are the ones shipped with Umbraco and should not be modifie
 
 If you are a package developer, [see here for docs on how to include translations for your own package](../Packages/Language-Files-For-Packages/index.md), package language files are located in:
 
-    /App_Plugins/mypackage/Lang/{language}.xml
-    
+```xml
+/App_Plugins/mypackage/Lang/{language}.xml
+```
+
 :::note
 The `App_Plugins` version of the `Lang` directory is case sensitive on Linux systems, so make sure that it start with a capital `L`.
 :::
@@ -60,17 +65,19 @@ The `App_Plugins` version of the `Lang` directory is case sensitive on Linux sys
 
 If you want to override Umbraco core translations or translations shipped with packages, you can do that too, these files are located here:
 
-    /config/lang/{language}.user.xml
+```xml
+/config/lang/{language}.user.xml
+```
 
 By default, these files are empty but you can add any new keys you want or override existing ones with your own translations. The nice part about the user files is that they will not get overwritten by the installer when you upgrade your Umbraco versions.
 
 In order for these files to deploy when you do a `dotnet publish`, you need to add the following to your `.csproj` file:
 
-```xml
+```html
 <ItemGroup>
     <Content Include="config/**" CopyToOutputDirectory="Always" />
 </ItemGroup>
-``` 
+```
 
 ## Using the language keys
 
@@ -119,7 +126,9 @@ As Umbraco is a continually evolving product it is inevitable that new text is a
 
 If a translation is missing, the key "alias" used will be shown within the user interface, as an example:
 
-    [assignDomain]
+```xml
+[assignDomain]
+```
 
 The language files are XML files with a straight-forward layout as seen below.
 


### PR DESCRIPTION
Updated the Language Files article.

* [ ] Where do the `[LANG].user.xml` files need to be added in v10? (lines 65-81)

Updated the Backoffice Tours articles

* [ ] Where do the custom tour files need to be placed in v10? (lines 16-22)

Other related articles:
[Backoffice - Login](https://our.umbraco.com/documentation/Fundamentals/Backoffice/Login/)
[Custom Error Pages](https://our.umbraco.com/documentation/Tutorials/Custom-Error-Pages/#errors-with-booting-a-project)