### PR TITLE
Do not use NText anymore, nvarchar(max)

### DIFF
--- a/Extending/Database/index.md
+++ b/Extending/Database/index.md
@@ -125,7 +125,7 @@ namespace MyNamespace
             public string Website { get; set; }
 
             [Column("Message")]
-            [SpecialDbType(SpecialDbTypes.NTEXT)]
+            [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
             public string Message { get; set; }
         }
     }


### PR DESCRIPTION
Ntext is deprecated in favor of nvarchar(max)

[quote from the microsoft docs](https://docs.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql?view=sql-server-ver16)

> The ntext, text, and image data types will be removed in a future version of SQL Server. Avoid using these data types in new development work, and plan to modify applications that currently use them. Use [nvarchar(max)](https://docs.microsoft.com/en-us/sql/t-sql/data-types/nchar-and-nvarchar-transact-sql?view=sql-server-ver16), [varchar(max)](https://docs.microsoft.com/en-us/sql/t-sql/data-types/char-and-varchar-transact-sql?view=sql-server-ver16), and [varbinary(max)](https://docs.microsoft.com/en-us/sql/t-sql/data-types/binary-and-varbinary-transact-sql?view=sql-server-ver16) instead.
