### PR TITLE
Added information about the Package Script Writer tool

### DIFF
--- a/Fundamentals/Setup/Install/index.md
+++ b/Fundamentals/Setup/Install/index.md
@@ -32,6 +32,8 @@ Learn how to run an already installed local installation of Umbraco.
 
 .NET CLI, included with the .NET SDK, can be used to install or uninstall .NET templates from NuGet using the `dotnet new` command on any OS. The underlying Template Engine enables the creation of custom templates which make new project bootstrapping much faster. With a few steps you can have an Umbraco project running without the need for a code editor.
 
+There is a useful website which makes installation of Umbraco and the associated packages a lot easier for you. Go to [https://psw.codeshare.co.uk](https://psw.codeshare.co.uk), configure your options and click on the `Install Script` tab to get the commands you need to paste into the terminal. This even includes the commands for unattended install, which creates the database for you and can install a starter kit too, if you wish.
+
 ## [Visual Studio installation](visual-studio.md)
 
 Visual Studio is used to write native code and managed code supported by .NET and many others.


### PR DESCRIPTION
Package Script Writer is a tool made by the Umbraco Community, for the Umbraco Community. It was created to make installation of Umbraco and the associated packages super easy. It would be great to add a link to it in the documentation so more people can benefit from it.