### PR TITLE
Update blob version number in Cloud 9 to 10 guide

### DIFF
--- a/Umbraco-Cloud/Upgrades/Migrating-from-9-to-10/index.md
+++ b/Umbraco-Cloud/Upgrades/Migrating-from-9-to-10/index.md
@@ -86,7 +86,7 @@ Follow the steps 9-12 to update the following packages as well:
 |Umbraco Forms                            |10.0.0          |
 |Umbraco Deploy Forms                     |10.0.0          |
 |Umbraco Cloud Identity                   |10.0.2          |
-|Umbraco Cloud StorageProviders AzureBlob |5.0.0           |
+|Umbraco Cloud StorageProviders AzureBlob |10.0.0          |
 
 :::note
 If you have more projects in your solution or other packages, make sure that these are also updated to support .NET 6 framework.


### PR DESCRIPTION
When I build I get the message that Umbraco.Cloud.StorageProviders.AzureBlob version 5.0.0 doesn't exist, and it will use 10.0.0 instead.