### PR TITLE
Backoffice tours updates

### DIFF
--- a/Extending/Backoffice-Tours/index.md
+++ b/Extending/Backoffice-Tours/index.md
@@ -230,7 +230,6 @@ namespace Umbraco.Docs.Samples.Web.BackofficeTours
 
             // Filter any tours in the file that is custom-tours.json
             // Found in App_Plugins/MyCustomBackofficeTour/backoffice/tours/
-            // OR at /Config/BackOfficeTours/
             builder.TourFilters()
                 .AddFilterByFile("custom-tours.json");
 

--- a/Extending/Backoffice-Tours/index.md
+++ b/Extending/Backoffice-Tours/index.md
@@ -15,13 +15,13 @@ They are managed in a JSON format and stored in files on disk. The filenames sho
 
 The tour functionality will load information from multiple locations.
 
-- **Core tours and custom tours**
+- **Core tours**
 
     The tour that ship with Umbraco are embedded into the CMS assemblies.
 
-- **Plugin tours**
+- **Custom tours**
 
-    When you want to include a tour with your custom plugin/package you can store the custom json tour file in `/App_Plugins/<YourPlugin>/backoffice/tours`. It is recommended that you place the tour files in this location when you are [creating a package](../Packages/Creating-a-Package/index.md).
+    Custom tours need to be added as custom plugin/package. The custom json tour file needs to be added in `/App_Plugins/<YourTourPlugin>/backoffice/tours`. The custom tours can be added independently, or [as part of a plugin/package](../Packages/Creating-a-Package/index.md).
 
 ## The JSON Format
 

--- a/Extending/Backoffice-Tours/index.md
+++ b/Extending/Backoffice-Tours/index.md
@@ -212,6 +212,12 @@ It is possible to hide/disable tours using a C# composer by adding to the TourFi
 
 Here is an example of disabling all the CMS core tours based on the alias, along with examples on how you could filter out tours by its JSON filename and how to disable tours from specific packages.
 
+:::note
+The option to filter tours based on the file names, `AddFilterByFile`, is currently not working.
+
+The [issue is reported](https://github.com/umbraco/Umbraco-CMS/issues/12667), and this document will be updated as soon as it has been resolved.
+:::
+
 ```c#
 using System.Text.RegularExpressions;
 using Umbraco.Cms.Core.Composing;


### PR DESCRIPTION
Made some small changes to the section about tours files. This applies for Umbraco 9 later versions.

At the bottom of the article, we have a section called [How to Filter/Disable Tours from being shown](https://our.umbraco.com/documentation/Extending/Backoffice-Tours/#how-to-filterdisable-tours-from-being-shown). 
The code meant to filter out tours based on the file name does not seem to work. It keeps showing the backoffice tour even though I am filtering by the file name used.

Lines 233-234:
```
builder.TourFilters()
    .AddFilterByFile("custom-tours.json");
```

The rest of the filters work fine.