### PR TITLE
Update storage providers docs for v10

### DIFF
--- a/Extending/FileSystemProviders/Azure-Blob-Storage/index.md
+++ b/Extending/FileSystemProviders/Azure-Blob-Storage/index.md
@@ -82,33 +82,6 @@ Invoke the `.AddAzureBlobMediaFileSystem()` extention method in the `ConfigureSe
         }
 ```
 
-Next invoke `UseAzureBlobMediaFileSystem();` in the `.WithMiddleware` call, like so:
-
-```C#
-public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-{
-    if (env.IsDevelopment())
-    {
-        app.UseDeveloperExceptionPage();
-    }
-
-    app.UseUmbraco()
-        .WithMiddleware(u =>
-        {
-            u.UseBackOffice();
-            u.UseWebsite();
-            // This enables the Azure Blob storage middleware for media.
-            u.UseAzureBlobMediaFileSystem();
-        })
-        .WithEndpoints(u =>
-        {
-            u.UseInstallerEndpoints();
-            u.UseBackOfficeEndpoints();
-            u.UseWebsiteEndpoints();
-        });
-}
-```
-
 Now when you launch your site again, the blob storage will be used to store media items as well as the ImageSharp cache. Do note though that the `/media` and `/cache` folders do not get created until a piece of media is uploaded.
 
 


### PR DESCRIPTION
Updating for v10 based on changes to readme it looks like this section isn't needed now: https://github.com/umbraco/Umbraco.StorageProviders#umbracostorageproviders

Do you also want me to create a v9 specific page for the v9 way to work with this? or a note on this same page?

Thanks,
Carole