### PR TITLE
Updated signature of SetValue overload method

### DIFF
--- a/Reference/Management/Services/MediaService/Index.md
+++ b/Reference/Management/Services/MediaService/Index.md
@@ -99,6 +99,7 @@ Note that you will need to inject the following services:
 - `IShortStringHelper _shortStringHelper`
 - `IContentTypeBaseServiceProvider _contentTypeBaseServiceProvider`
 - `IJsonSerializer _serializer`
+- `MediaUrlGeneratorCollection _mediaUrlGeneratorCollection`
 
 ```csharp
 // Open a new stream to the file
@@ -107,7 +108,7 @@ using (Stream stream = File.OpenRead("C:/path/to/my-image.jpg"))
     // Initialize a new image at the root of the media archive
     IMedia media = _mediaService.CreateMedia("My image", Constants.System.Root, Constants.Conventions.MediaTypes.Image);
     // Set the property value (Umbraco will handle the underlying magic)
-    media.SetValue(_mediaFileManager, _shortStringHelper, _contentTypeBaseServiceProvider, _serializer, Constants.Conventions.MediaTypes.File, "my-image.jpg", stream);
+    media.SetValue(_mediaFileManager, _mediaUrlGeneratorCollection, _shortStringHelper, _contentTypeBaseServiceProvider, "umbracoFile", fileName, stream)
     // Save the media
     _mediaService.Save(media);
 }


### PR DESCRIPTION
The  overload method mentioned in the doc throws an error 'No overload for method 'SetValue' takes 7 arguments' as the method signature is different than what is expected. I've updated it to the correct one, hope this helps others. 

@UmbracoHQ 