### PR TITLE
Media Picker should be used instead of File Upload

### DIFF
--- a/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/File-Upload/index.md
+++ b/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/File-Upload/index.md
@@ -61,7 +61,7 @@ Example: `"/media/o01axaqu/guidelines-on-remote-working.pdf"`
 ## Add values programmatically
 
 :::note
-The samples in this section have not and will not be verified against the latest version of Umbraco.
+The samples in this section have not been verified against the latest version of Umbraco.
 
 Instead, we recommend using the [Media Picker](../Media-Picker-3/) for uploading files to your Umbraco website.
 :::

--- a/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/File-Upload/index.md
+++ b/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/File-Upload/index.md
@@ -61,7 +61,7 @@ Example: `"/media/o01axaqu/guidelines-on-remote-working.pdf"`
 ## Add values programmatically
 
 :::note
-The samples in this section has not and will not be verified against the latest version of Umbraco.
+The samples in this section have not and will not be verified against the latest version of Umbraco.
 
 Instead, we recommend using the [Media Picker](../Media-Picker-3/) for uploading files to your Umbraco website.
 :::

--- a/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/File-Upload/index.md
+++ b/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/File-Upload/index.md
@@ -61,7 +61,9 @@ Example: `"/media/o01axaqu/guidelines-on-remote-working.pdf"`
 ## Add values programmatically
 
 :::note
-The samples in this section has not been verified against the latest version of Umbraco.
+The samples in this section has not and will not be verified against the latest version of Umbraco.
+
+Instead, we recommend using the [Media Picker](../Media-Picker-3/) for uploading files to your Umbraco website.
 :::
 
 See the example below to see how a value can be added or changed programmatically. To update a value of this property editor you need the [Content Service](../../../../../Reference/Management/Services/ContentService/index.md) and the [Media Service](../../../../../Reference/Management/Services/MediaService/index.md).

--- a/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Media-Picker-3/index.md
+++ b/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Media-Picker-3/index.md
@@ -169,37 +169,54 @@ The global crops are configured on the DataType of the `umbracoFile` property on
 
 ### Add values programmatically
 
-:::warning
-Adding values programmatically for the Media Picker have not been verified for Umbraco 9 and 10 yet.
-:::
+See the example below to see how a value can be added or changed programmatically. To update a value of a property editor you need the [Content Service](../../../../../Reference/Management/Services/ContentService/index.md).
 
-This solution can be applied to both Media Picker 3 and Multi Media Picker 3
+The following sample will update a single image in a Media Picker.
+
+```csharp
+@using Umbraco.Cms.Core;
+@using Umbraco.Cms.Core.Services;
+@inject IContentService Services;
+@{
+    // Get access to ContentService
+    var contentService = Services;
+
+    // Create a variable for the GUID of the page you want to update
+    var guid = Guid.Parse("32e60db4-1283-4caa-9645-f2153f9888ef");
+
+    // Get the page using the GUID you've defined
+    var content = contentService.GetById(guid); // ID of your page
+
+    // Get the media you want to assign to the media picker 
+    var media = Umbraco.Media("bca8d5fa-de0a-4f2b-9520-02118d8329a8");
+
+    // Create an Udi of the media
+    var udi = Udi.Create(Constants.UdiEntityType.Media, media.Key);
+
+    // Set the value of the property with alias 'featuredBanner'. 
+    content.SetValue("featuredBanner", udi.ToString());
+
+    // Save the change
+    contentService.Save(content);
+}
+```
+
+Although the use of a GUID is preferable, you can also use the numeric ID to get the page:
 
 ```csharp
 @{
-                        //Get media by Id
-                        var media = mediaService.GetById(1150);
-                        
-                        //Initialize new list of dictionaries
-                        var dictionary = new List<Dictionary<string, string>>
-                        {
-                            new Dictionary<string, string>()
-                        {
-                            //Create new GUID for "key"
-                            { "key", Guid.NewGuid().ToString() },
-                            
-                            //Reference our media in "mediaKey"
-                            { "mediaKey", media.Key.ToString() },
-                            { "crops", null },
-                            { "focalPoint", null }
-                        }
-                        };
-
-                        //Serialize entire list of dictionaries
-                        var json = JsonConvert.SerializeObject(dictionary);
-                        
-                        //Assign JSON as the value of Media Picker 3 property
-                        content.SetValue("firstPic", json);
+    // Get the page using it's id
+    var content = contentService.GetById(1234); 
 }
+```
 
+If Modelsbuilder is enabled you can get the alias of the desired property without using a magic string:
+
+```csharp
+@using Umbraco.Cms.Core.PublishedCache;
+@inject IPublishedSnapshotAccessor _publishedSnapshotAccessor;
+@{
+    // Set the value of the property with alias 'featuredBanner'
+    content.SetValue(Home.GetModelPropertyType(_publishedSnapshotAccessor, x => x.FeaturedBanner).Alias, udi.ToString());
+}
 ```


### PR DESCRIPTION
I've made a few different things in this PR:

- Verified and updated the C# code sample for the Media Picker. Replaced the existing with the one from the legacy Media Picker article, as that worked for this Media picker as well. Not sure why the other sample was added to the Media Picker article - but I might be missing something.
- Noted that we're not going to update the C# sample in the File Upload article as we want people to be using the Media Picker for uploading media and files to their projects instead.