### PR TITLE
Update scheduling article

### DIFF
--- a/Reference/Scheduling/index.md
+++ b/Reference/Scheduling/index.md
@@ -92,7 +92,7 @@ namespace Umbraco.Docs.Samples.Web.RecurringHostedService
 
 ```
 :::note
-If you are using an Umbraco version before v9.4 you don't have to pass in an instance of Ilogger in to the base constructor. See the code example below:
+If you are using an Umbraco version before v9.4 you don't have to pass in an instance of `ILogger` in to the base constructor. See the code example below:
 
 ```C#
 public CleanUpYourRoom(

--- a/Reference/Scheduling/index.md
+++ b/Reference/Scheduling/index.md
@@ -92,7 +92,7 @@ namespace Umbraco.Docs.Samples.Web.RecurringHostedService
 
 ```
 :::note
-If you are using an Umbraco version before v9.4 you don't have to pass in an instance of `ILogger` in to the base constructor. See the code example below:
+If you are using an Umbraco version before v9.4 you can't pass in an instance of `ILogger` in to the base constructor. See the code example below:
 
 ```C#
 public CleanUpYourRoom(

--- a/Reference/Scheduling/index.md
+++ b/Reference/Scheduling/index.md
@@ -48,7 +48,7 @@ namespace Umbraco.Docs.Samples.Web.RecurringHostedService
             IProfilingLogger profilingLogger,
             ILogger<CleanUpYourRoom> logger,
             IScopeProvider scopeProvider)
-            : base(HowOftenWeRepeat, DelayBeforeWeStart)
+            : base(logger, HowOftenWeRepeat, DelayBeforeWeStart)
         {
             _runtimeState = runtimeState;
             _contentService = contentService;

--- a/Reference/Scheduling/index.md
+++ b/Reference/Scheduling/index.md
@@ -91,6 +91,18 @@ namespace Umbraco.Docs.Samples.Web.RecurringHostedService
 }
 
 ```
+:::note
+If you are using an Umbraco version before v9.4 you don't have to pass in an instance of Ilogger in to the base constructor. See the code example below:
+
+```C#
+public CleanUpYourRoom(
+    ...)
+    : base(HowOftenWeRepeat, DelayBeforeWeStart)
+{
+    ...
+}
+```
+:::
 
 ### Registering with extension method
 


### PR DESCRIPTION
Update the code sample. Pass in an instance of `ILogger` in to the base constructor as suggested in https://github.com/umbraco/UmbracoDocs/issues/3883.  Added a note instead of creating a specific file targeting versions before 9.4 as @sofietoft suggested here: https://github.com/umbraco/UmbracoDocs/issues/3883#issuecomment-1081739309

Fixes: https://github.com/umbraco/UmbracoDocs/issues/3883