### PR TITLE
ARRAffinity cookie update

### DIFF
--- a/Umbraco-Cloud/Security/index.md
+++ b/Umbraco-Cloud/Security/index.md
@@ -82,7 +82,7 @@ Umbraco Cloud offers a multitude of features allowing you to block access to dif
 
 ## Cookies and security
 
-On all Umbraco Cloud sites, you will find an ARRAffinity cookie. This is not sent over HTTPS, and might to some, look like a security risk.
+On Umbraco Cloud sites, you will find an ARRAffinity cookie. This is not sent over HTTPS, and might to some, look like a security risk.
 
 It is **not** a security risk. This cookie is set by the load balancer (LB) and only used by the LB to track which server your site is on. It is set by the software we use (Azure App Service) and only useful when your website is being scaled to multiple servers. In Umbraco Cloud we cannot scale your site to multiple servers so the cookie is effectively unused.
 


### PR DESCRIPTION
The ARRAffinity cookie has been removed for all Cloud projects created after the 25th of February 2022. 

The old projects still have the ARRAffinity cookie enabled.