### PR TITLE
Add missing HttpContext passed into GetPostFieldValue method

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-an-Event-Handler.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-an-Event-Handler.md
@@ -43,7 +43,7 @@ namespace MyFormsExtensions
                 // If the validation fails, return a ModelError
                 if (email.ToLower() != emailConfirm.ToLower())
                 {
-                    notification.ModelState.AddModelError(GetPostField(e, "verifyEmail").Id.ToString(), "Email does not match");
+                    notification.ModelState.AddModelError(GetPostField(notification.Form, "verifyEmail").Id.ToString(), "Email does not match");
                 }
             }
         }

--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-an-Event-Handler.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-an-Event-Handler.md
@@ -37,7 +37,7 @@ namespace MyFormsExtensions
                 }
 
                 // A sample validation
-                var email = GetPostFieldValue(notification.Form, "email");
+                var email = GetPostFieldValue(notification.Form, notification.Context, "email");
                 var emailConfirm = GetPostFieldValue(notification.Form, notification.Context, "verifyEmail");
 
                 // If the validation fails, return a ModelError


### PR DESCRIPTION
The method `GetPostFieldValue(Form form, HttpContext context, string key)` need `HttpContext` passed in as second parameter.

Furthermore there is no `e` at use of `GetPostField()` method - it takes `Form` as first parameter.

Not sure how the docs should be handled regarding .NET5 vs .NET6.

In Umbraco 10 / Umbraco Forms 10 `GetPostField()` returns a possible nullable `Field`:

```
using Microsoft.AspNetCore.Http;
using Umbraco.Cms.Core.Events;
using Umbraco.Forms.Core.Models;
using Umbraco.Forms.Core.Services.Notifications;

namespace MyProject.Core.Notifications
{
    /// <summary>
    /// Catch form submissions before being saved and perform custom validation.
    /// </summary>
    public class FormValidateNotificationHandler : INotificationHandler<FormValidateNotification>
    {
        public void Handle(FormValidateNotification notification)
        {
            // If needed, be selective about which form submissions you affect.
            if (notification.Form.Name == "Form Name")
            {
                // Check the ModelState
                if (notification.ModelState.IsValid == false)
                {
                    return;
                }

                // A sample validation
                var email = GetPostFieldValue(notification.Form, notification.Context, "email");
                var emailConfirm = GetPostFieldValue(notification.Form, notification.Context, "verifyEmail");

                // If the validation fails, return a ModelError
                if (email.ToLower() != emailConfirm.ToLower())
                {
                    var field = GetPostField(notification.Form, "verifyEmail");
                    if (field != null)
                    {
                        notification.ModelState.AddModelError(field.Id.ToString(), "Email does not match");
                    }
                }
            }
        }

        private static string GetPostFieldValue(Form form, HttpContext context, string key)
        {
            Field? field = GetPostField(form, key);
            if (field == null)
            {
                return string.Empty;
            }

            return context.Request.HasFormContentType && context.Request.Form.Keys.Contains(field.Id.ToString())
                ? context.Request.Form[field.Id.ToString()].ToString().Trim()
                : string.Empty;
        }

        private static Field? GetPostField(Form form, string key) => form.AllFields.SingleOrDefault(f => f.Alias == key);
    }
}
```