### PR TITLE
Return if `ModelState` is valid

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-an-Event-Handler.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-an-Event-Handler.md
@@ -31,7 +31,7 @@ namespace MyFormsExtensions
             if (notification.Form.Name == "Form Name")
             {
                 // Check the ModelState
-                if (notification.ModelState.IsValid == false)
+                if (notification.ModelState.IsValid)
                 {
                     return;
                 }


### PR DESCRIPTION
Testing this in a project, but it doesn't continue in code because `ModelState.IsValid`  is `true`.

With this change it works as expected and shows the ModelState error when `email` and `verifyEmail` fields doesn't match - otherwise it doesn't add the modelstate error.

I wonder if this is possible to archive as well with a custom field and a setting to specify field to compare e.g. using alias `email`.
My attempt was something like the following, which seems to work as well.

```
public class ConfirmEmailField : Umbraco.Forms.Core.FieldType
{
    [Setting("Compare Field",
        Description = "Compare field",
        View = "TextField")]
    public string CompareField { get; set; }

    public ConfirmEmailField()
    {
        this.Id = new Guid("79201eb2-71c5-4ee7-8bd4-5fd59fc61553");
        this.Name = "Email Confirm";
        this.Description = "Render input to confirm email.";
        this.Icon = "icon-message";
        this.FieldTypeViewName = "FieldType.Textfield.cshtml";
        this.DataType = FieldDataType.String;
        this.SortOrder = 10;
        this.SupportsRegex = true;
    }

    public override string GetDesignView() =>
        "~/App_Plugins/UmbracoForms/backoffice/Common/FieldTypes/Textfield.html";

    public override IEnumerable<string> ValidateField(Form form, Field field, IEnumerable<object> postedValues, HttpContext context, IPlaceholderParsingService placeholderParsingService)
    {
        var baseValidation = base.ValidateField(form, field, postedValues, context, placeholderParsingService);
        var value = postedValues.FirstOrDefault();

        var compareField = GetPostFieldValue(form, context, CompareField);

        if (compareField == null)
            return baseValidation;

        if (value != null && value.ToString() == compareField)
        {
            return baseValidation;
        }

        var custom = new List<string>();
        custom.AddRange(baseValidation);
        custom.Add("Email does not match.");

        return custom;
    }

    private static string GetPostFieldValue(Form form, HttpContext context, string key)
    {
        Field? field = GetPostField(form, key);
        if (field == null)
        {
            return string.Empty;
        }

        return context.Request.HasFormContentType && context.Request.Form.Keys.Contains(field.Id.ToString())
            ? context.Request.Form[field.Id.ToString()].ToString().Trim()
            : string.Empty;
    }

    private static Field? GetPostField(Form form, string key) => form.AllFields.SingleOrDefault(f => f.Alias == key);
}
```

![image](https://user-images.githubusercontent.com/2919859/178668203-f9527c2c-65b7-4a3d-91f1-fd7131e19d50.png)
