### PR TITLE
Added clarity for deploy setting

### DIFF
--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -210,4 +210,12 @@ For Umbraco 10, by default, a SQLite database is created.
 
 If you would prefer to use SQL Server LocalDb when it's available on your local machine, set this value to `true`. If LocalDB isn't reported as being available by Umbraco, it will fallback to using a SQLite database instead.
 
-
+```json
+    "Umbraco": {
+        "Deploy": {
+            "Settings": {
+                "PreferLocalDbConnectionString": true
+            }
+        }
+    }
+```


### PR DESCRIPTION
Ran into a confusion scenario in the upgrade process.

Adding this into the documentation that we link to will give a direct overview of what you need in case you want to keep your old database when going from v9 -> v10