### PR TITLE
Added v9-v10 version of Declaring-your-property-editor.

### DIFF
--- a/Extending/Property-Editors/Declaring-your-property-editor-v8.md
+++ b/Extending/Property-Editors/Declaring-your-property-editor-v8.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+versionFrom: 8.0.0
+needsv9Update: "true"
 ---
 
 # Declaring your property editor
@@ -58,71 +58,71 @@ The actual **Sir Trevor** property editor has some additional configuration. It'
 
 ```json
 {
-  "propertyEditors": [
-    {
-      "alias": "Sir.Trevor",
-      "name": "Sir Trevor",
-      "editor": {
-        "view": "/App_Plugins/SirTrevor/SirTrevor.html",
-        "hideLabel": true,
-        "valueType": "JSON"
-      },
-      "prevalues": {
-        "fields": [
-          {
-            "label": "Maximum number of blocks",
-            "description": "The total maximum number of blocks (of any type) that can be displayed (0 = infinite).",
-            "key": "blockLimit",
-            "view": "requiredfield",
-            "validation": [
-              {
-                "type": "Required"
-              }
-            ]
-          },
-          {
-            "label": "Align editor centered",
-            "description": "If the editor doesn't span the entire width of the content editing area, center it. Otherwise left aligned.",
-            "key": "editorAlignCentered",
-            "view": "boolean"
-          },
-          {
-            "label": "Editor width",
-            "description": "The width the Sir Trevor editor will expand to, most likely 100%.",
-            "key": "editorWidth",
-            "view": "requiredfield",
-            "validation": [
-              {
-                "type": "Required"
-              }
-            ]
-          },
-          {
-            "label": "Maximum editor width",
-            "description": "The maximum width the Sir Trevor editor will expand to, i.e. 500px or 80%.",
-            "key": "editorMaxWidth",
-            "view": "requiredfield",
-            "validation": [
-              {
-                "type": "Required"
-              }
-            ]
-          },
-          {
-            "label": "Block types",
-            "description": "Configure the block types available to the user.",
-            "key": "blocktypes",
-            "view": "~/App_Plugins/SirTrevor/settings/blocktypes.html"
-          }
-        ]
-      }
-    }
-  ],
-  "javascript": [
-    "/App_Plugins/SirTrevor/SirTrevor.controller.js",
-    "/App_Plugins/SirTrevor/settings/settings.blocktypes.controller.min.js",
-    "/App_Plugins/SirTrevor/settings/settings.resource.min.js"
-  ]
+    "propertyEditors": [
+        {
+            "alias": "Sir.Trevor",
+            "name": "Sir Trevor",
+            "editor": {
+                "view": "/App_Plugins/SirTrevor/SirTrevor.html",
+                "hideLabel": true,
+                "valueType": "JSON"
+            },
+            "prevalues": {
+                "fields": [
+                    {
+                        "label": "Maximum number of blocks",
+                        "description": "The total maximum number of blocks (of any type) that can be displayed (0 = infinite).",
+                        "key": "blockLimit",
+                        "view": "requiredfield",
+                        "validation": [
+                            {
+                                "type": "Required"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "Align editor centered",
+                        "description": "If the editor doesn't span the entire width of the content editing area, center it. Otherwise left aligned.",
+                        "key": "editorAlignCentered",
+                        "view": "boolean"
+                    },
+                    {
+                        "label": "Editor width",
+                        "description": "The width the Sir Trevor editor will expand to, most likely 100%.",
+                        "key": "editorWidth",
+                        "view": "requiredfield",
+                        "validation": [
+                            {
+                                "type": "Required"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "Maximum editor width",
+                        "description": "The maximum width the Sir Trevor editor will expand to, i.e. 500px or 80%.",
+                        "key": "editorMaxWidth",
+                        "view": "requiredfield",
+                        "validation": [
+                            {
+                                "type": "Required"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "Block types",
+                        "description": "Configure the block types available to the user.",
+                        "key": "blocktypes",
+                        "view": "~/App_Plugins/SirTrevor/settings/blocktypes.html"
+                    }
+                ]
+            }
+        }
+    ],
+    "javascript": [
+        "/App_Plugins/SirTrevor/SirTrevor.controller.js",
+        "/App_Plugins/SirTrevor/settings/settings.blocktypes.controller.min.js",
+        "/App_Plugins/SirTrevor/settings/settings.resource.min.js"
+    ]
 }
 ```
 
@@ -131,29 +131,25 @@ The actual **Sir Trevor** property editor has some additional configuration. It'
 The same property editor can be declared using C# instead using the `DataEditor` class and decorating the class with the `DataEditor` attribute:
 
 ```csharp
-using Umbraco.Cms.Core.PropertyEditors;
-using Umbraco.Cms.Core.WebAssets;
-using Umbraco.Cms.Infrastructure.WebAssets;
+using ClientDependency.Core;
+using Umbraco.Core.Logging;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Web.PropertyEditors;
 
 namespace UmbracoEightExamples.PropertyEditors
 {
-    [DataEditor(
-        "Sir.Trevor",
-        EditorType.PropertyValue,
-        "Sir Trevor",
-        "/App_Plugins/SirTrevor/SirTrevor.html",
+
+    [DataEditor("Sir.Trevor", EditorType.PropertyValue, "Sir Trevor", "/App_Plugins/SirTrevor/SirTrevor.html",
         ValueType = ValueTypes.Json,
         HideLabel = true)]
-    [PropertyEditorAsset(AssetType.Javascript, "/App_Plugins/SirTrevor/SirTrevor.controller.js")]
+    [PropertyEditorAsset(ClientDependencyType.Javascript, "/App_Plugins/SirTrevor/SirTrevor.controller.js")]
     public class SirTrevorEditor : DataEditor
     {
-        public SirTrevorEditor(
-            IDataValueEditorFactory dataValueEditorFactory,
-            EditorType type = EditorType.PropertyValue)
-            : base(dataValueEditorFactory, type)
-        {
-        }
+
+        public SitTrevorEditor(ILogger logger) : base(logger) { }
+
     }
+
 }
 ```
 
@@ -179,8 +175,9 @@ The [DataEditor](https://our.umbraco.com/apidocs/v8/csharp/api/Umbraco.Core.Prop
 
 As shown in the C# example, the [PropertyEditorAsset](https://our.umbraco.com/apidocs/v8/csharp/api/Umbraco.Web.PropertyEditors.PropertyEditorAssetAttribute.html) attribute was used to make Umbraco load the specified JavaScript file.
 
-The constructor of the attribute takes the type of the assets as the first parameter.
-Possible values are either `AssetType.Javascript` or `AssetType.Css`. The second parameter is the URL of the asset.
+The constructor of the attribute takes the type of the assets as the first parameter. Possible values are either `ClientDependencyType.Javascript` or `ClientDependencyType.Css`. The second parameter is the URL of the asset.
+
+Optionally one may also specify a third parameter, which is the priority of the asset. This enables you to include your asset either before or after other assets, all depending on their respective priorities.
 
 ### DataEditor class
 
@@ -191,153 +188,148 @@ The [DataEditor](https://our.umbraco.com/apidocs/v8/csharp/api/Umbraco.Core.Prop
 Virtual methods are methods declared in a parent class, and they have a default implementation that can be overridden in classes that inherit from the parent class. For instance in the example below, we can override the method and provide our own `SirTrevorConfigurationEditor` instead of what Umbraco returns by default.
 
 ```csharp
-using Umbraco.Cms.Core.PropertyEditors;
-using Umbraco.Cms.Core.WebAssets;
-using Umbraco.Cms.Infrastructure.WebAssets;
+using ClientDependency.Core;
+using Umbraco.Core.Logging;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Web.PropertyEditors;
 
 namespace UmbracoEightExamples.PropertyEditors
 {
-    [DataEditor(
-        "Sir.Trevor",
-        EditorType.PropertyValue,
-        "Sir Trevor",
-        "/App_Plugins/SirTrevor/SirTrevor.html",
+
+    [DataEditor("Sir.Trevor", EditorType.PropertyValue, "Sir Trevor", "/App_Plugins/SirTrevor/SirTrevor.html",
         ValueType = ValueTypes.Json,
         HideLabel = true)]
-    [PropertyEditorAsset(AssetType.Javascript, "/App_Plugins/SirTrevor/SirTrevor.controller.js")]
-    public class SirTrevorEditor : DataEditor
+    [PropertyEditorAsset(ClientDependencyType.Javascript, "/App_Plugins/SirTrevor/SirTrevor.controller.js")]
+    public class SitTrevorEditor : DataEditor
     {
-        public SirTrevorEditor(
-            IDataValueEditorFactory dataValueEditorFactory,
-            EditorType type = EditorType.PropertyValue)
-            : base(dataValueEditorFactory, type)
-        {
-        }
+
+        public SitTrevorEditor(ILogger logger) : base(logger) { }
 
         protected override IConfigurationEditor CreateConfigurationEditor() => new SirTrevorConfigurationEditor();
 
     }
+
 }
 ```
 
 In this case, the `SirTrevorConfigurationEditor` class doesn't do much either - but notice that it inherits from `ConfigurationEditor<SirTrevorConfiguration>`, meaning the configuration will be of type `SirTrevorConfiguration`:
 
 ```csharp
-using Umbraco.Cms.Core.IO;
-using Umbraco.Cms.Core.PropertyEditors;
-using Umbraco.Cms.Core.Services;
+using Umbraco.Core.PropertyEditors;
 
 namespace UmbracoEightExamples.PropertyEditors
 {
+
     public class SirTrevorConfigurationEditor : ConfigurationEditor<SirTrevorConfiguration>
     {
-        public SirTrevorConfigurationEditor(IIOHelper ioHelper, IEditorConfigurationParser editorConfigurationParser) : base(ioHelper, editorConfigurationParser)
-        {
-        }
+
     }
+
 }
 ```
 
 The referenced `SirTrevorConfiguration` class is then what declares the configuration fields of when editing a data type using the Sir Trevor property editor:
 
 ```csharp
-using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Core.PropertyEditors;
 
 namespace UmbracoEightExamples.PropertyEditors
 {
+
     public class SirTrevorConfiguration
     {
+
         [ConfigurationField("blockLimit", "Maximum number of blocks", "requiredfield",
             Description = "The total maximum number of blocks (of any type) that can be displayed (0 = infinite).")]
         public int BlockLimit { get; set; }
 
         [ConfigurationField("editorAlignCentered", "Align editor centered", "boolean",
-            Description =
-                "If the editor doesn't span the entire width of the content editing area, center it. Otherwise left aligned.")]
+            Description = "If the editor doesn't span the entire width of the content editing area, center it. Otherwise left aligned.")]
         public bool EditorAlignCentered { get; set; }
+
 
         [ConfigurationField("editorWidth", "Editor width", "requiredfield",
             Description = "The width the Sir Trevor editor will expand to, most likely 100%.")]
         public int EditorWidth { get; set; }
 
+
         [ConfigurationField("editorMaxWidth", "Maximum editor width", "requiredfield",
             Description = "The maximum width the Sir Trevor editor will expand to, i.e. 500px or 80%.")]
         public int EditorMaxWidth { get; set; }
 
+
         [ConfigurationField("blocktypes", "Block types", "/App_Plugins/SirTrevor/settings/blocktypes.html",
             Description = "Configure the block types available to the user.")]
         public object BlockTypes { get; set; }
+
     }
+
 }
 ```
 
 A benefit of this approach (opposed to `package.manifest` files) is that we can now refer to the configuration using a strongly typed model - eg. as in this example Razor view:
 
 ```csharp
-@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
-@using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
-@using Umbraco.Cms.Core.Services
-@using UmbracoEightExamples.PropertyEditors
-@inject IDataTypeService DataTypeService
-
+@using Umbraco.Core.Composing
+@using UmbracoEightZeroZero.Controllers
+@inherits UmbracoViewPage
 @{
-    var dt = DataTypeService.GetDataType(1234);
 
-    if (dt is not null)
-    {
-        <pre>@dt.Name</pre>
+    IDataType dt = Current.Services.DataTypeService.GetDataType(1234);
 
-        <pre>@(dt.Configuration as SirTrevorConfiguration)</pre>
+    <pre>@dt.Name</pre>
 
-        <pre>@(dt.ConfigurationAs<SirTrevorConfiguration>())</pre>
-    }
+    <pre>@(dt.Configuration as SirTrevorConfiguration)</pre>
+
+    <pre>@(dt.ConfigurationAs<SirTrevorConfiguration>())</pre>
+
 }
 ```
 
-Both instances of `IDataType` and `PublishedDataType` have a `Configuration` property.
-When looking across all data types and property editors, there is no common type for the configuration, so the return value is `object`.
-To get the strongly typed model, you can either cast the configuration value on your own, or use the generic `ConfigurationAs` extension method as shown above.
+Both instances of `IDataType` and `PublishedDataType` have a `Configuration` property. When looking across all data types and property editors, there is no common type for the configuration, so the return value is `object`. To get the strongly typed model, you can either cast the configuration value on your own, or use the generic `ConfigurationAs` extension method as shown above.
 
 Like mentioned before, the `SirTrevorConfigurationEditor` class doesn't really do much in this example with the Sir Trevor property editor. But the **Multi Node Tree Picker** and others of Umbraco's build in property editors also override the `ToValueEditor` method.
 
 This method is used when the strongly typed configuration value is converted to the model used by the Angular logic in the backoffice. So with the implementation of the [MultiNodePickerConfigurationEditor]( https://github.com/umbraco/Umbraco-CMS/blob/ade9bb73246caf25a7073f2b9e5262641a201863/src/Umbraco.Web/PropertyEditors/MultiNodePickerConfigurationEditor.cs) class, some additional configuration fields are sent along - for instance that it's a multi picker and that the ID type should be URI's. These are configuration values that the user should not be able to edit, but the property editor may still rely on them.
 
 ```csharp
-using Umbraco.Cms.Core.IO;
-using Umbraco.Cms.Core.Services;
+using System.Collections.Generic;
+using Umbraco.Core.PropertyEditors;
 
-namespace Umbraco.Cms.Core.PropertyEditors;
-
-/// <summary>
-///     Represents the configuration for the multinode picker value editor.
-/// </summary>
-public class MultiNodePickerConfigurationEditor : ConfigurationEditor<MultiNodePickerConfiguration>
+namespace Umbraco.Web.PropertyEditors
 {
-    public MultiNodePickerConfigurationEditor(IIOHelper ioHelper, IEditorConfigurationParser editorConfigurationParser)
-        : base(ioHelper, editorConfigurationParser) =>
-        Field(nameof(MultiNodePickerConfiguration.TreeSource))
-            .Config = new Dictionary<string, object> { { "idType", "udi" } };
-
-    /// <inheritdoc />
-    public override Dictionary<string, object> ToConfigurationEditor(MultiNodePickerConfiguration? configuration)
+    /// <summary>
+    /// Represents the configuration for the multinode picker value editor.
+    /// </summary>
+    public class MultiNodePickerConfigurationEditor : ConfigurationEditor<MultiNodePickerConfiguration>
     {
-        // sanitize configuration
-        Dictionary<string, object> output = base.ToConfigurationEditor(configuration);
+        public MultiNodePickerConfigurationEditor()
+        {
+            Field(nameof(MultiNodePickerConfiguration.TreeSource))
+                .Config = new Dictionary<string, object> { { "idType", "udi" } };
+        }
 
-        output["multiPicker"] = configuration?.MaxNumber > 1;
+        /// <inheritdoc />
+        public override Dictionary<string, object> ToConfigurationEditor(MultiNodePickerConfiguration configuration)
+        {
+            // sanitize configuration
+            var output = base.ToConfigurationEditor(configuration);
 
-        return output;
-    }
+            output["multiPicker"] = configuration.MaxNumber > 1;
 
-    /// <inheritdoc />
-    public override IDictionary<string, object> ToValueEditor(object? configuration)
-    {
-        IDictionary<string, object> d = base.ToValueEditor(configuration);
-        d["multiPicker"] = true;
-        d["showEditButton"] = false;
-        d["showPathOnHover"] = false;
-        d["idType"] = "udi";
-        return d;
+            return output;
+        }
+
+        /// <inheritdoc />
+        public override IDictionary<string, object> ToValueEditor(object configuration)
+        {
+            var d = base.ToValueEditor(configuration);
+            d["multiPicker"] = true;
+            d["showEditButton"] = false;
+            d["showPathOnHover"] = false;
+            d["idType"] = "udi";
+            return d;
+        }
     }
 }
 ```


### PR DESCRIPTION
Most C# is different. Also fixed a few bugs in the v8 version. The `ddd` class was not mentioned and changed "Get get" to "To get"...