### PR TITLE
Documented Umbraco Deploy's BackOfficeOnly setting.

### DIFF
--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
@@ -10,13 +10,13 @@ The UmbracoDeploy.Settings.config file is empty by default, but there are some o
 
 ## Edition
 
-The default value for this setting is `Default`, which configures Umbraco Deploy to work according to how we expect most customers to use the product. Umbraco schema, such as document and data types, are serialzed to disk as `.uda` files in save operations. These are checked into source control and used to update the schema in the upstream environments via a trigger from your CI/CD pipeline, or automatically if using Umbraco Cloud.
+The default value for this setting is `Default`, which configures Umbraco Deploy to work according to how we expect most customers to use the product. Umbraco schema, such as document and data types, are serialized to disk as `.uda` files in save operations. These are checked into source control and used to update the schema in the upstream environments via a trigger from your CI/CD pipeline, or automatically if using Umbraco Cloud.
 
 Items managed by editors - content, media and optionally forms, dictionary items and members - are deployed between environments using the transfer and restore options available in the backoffice.
 
 It's possible to use this method for all Umbraco data, by setting the value of this setting to `BackOfficeOnly`. With this in place, all data, including what is typically considered as schema, are available for transfer via the backoffice.
 
-Our recommended approach is to leave this setting as `Default` and use source control and a deployment pipeline to ensure that structural changes to Umbraco are alwaya aligned with the code and template amends that use them.
+Our recommended approach is to leave this setting as `Default` and use source control and a deployment pipeline to ensure that structural changes to Umbraco are always aligned with the code and template amends that use them.
 
 However, we are aware that some customers prefer the option to use the backoffice for all data transfers. If that's the case, the `BackOfficeOnly` setting will allow this.
 

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
@@ -8,6 +8,25 @@ meta.Description: "Various settings for Umbraco Deploy"
 
 The UmbracoDeploy.Settings.config file is empty by default, but there are some optional settings you can set in the file to ignore certain types of file, increase timeout limits, etc.
 
+## Edition
+
+The default value for this setting is `Default`, which configures Umbraco Deploy for operation according to how we expect most customers to use the product. Umbraco schema, such as document and data types, are serialzed to disk as `.uda` files in save operations. These are checked into source control and used to update the schema in the upstream environments via a trigger from your CI/CD pipeline, or automatically if using Umbraco Cloud.
+
+Items managed by editors - content, media and optionally forms, dictionary items and members - are deployed between environments using the transfer and restore options available in the backoffice.
+
+It's possible to use this method for all Umbraco data, by setting the value of this setting to `BackOfficeOnly`. With this in place, all data, including what is typically considered as schema like document types, are available for transfer via the backoffice.
+
+Our recommended approach is to leave this setting as `Default` and use source control and a deployment pipeline to ensure that structural changes to Umbraco are alwaya aligned with the code and template amends that use them. However, we are aware that some customers prefer the option to use the backoffice for all data transfers. If that's the case, the `BackOfficeOnly` setting will allow this.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<settings xmlns="urn:umbracodeploy-settings">
+    <deploy edition="Default|BackOfficeOnly" />
+</settings>
+```
+
+
+
 ## ExcludedEntityTypes
 
 This setting allows you to exclude a certain type of entity from being deployed. This is **not** recommended to set, but sometimes there may be issues with the way a custom media fileprovider works with your site and you will need to set it for media files. Here is an example:

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
@@ -10,15 +10,15 @@ The UmbracoDeploy.Settings.config file is empty by default, but there are some o
 
 ## Edition
 
-The default value for this setting is `Default`, which configures Umbraco Deploy to work according to how we expect most customers to use the product. Umbraco schema, such as document and data types, are serialized to disk as `.uda` files in save operations. These are checked into source control and used to update the schema in the upstream environments via a trigger from your CI/CD pipeline, or automatically if using Umbraco Cloud.
+The default value for this setting is `Default`, which configures Umbraco Deploy to work according to how we expect most customers to use the product. Umbraco schema, such as Document and Data Types, are serialized to disk as `.uda` files in save operations. These are checked into source control and used to update the schema in the upstream environments via a trigger from your CI/CD pipeline, or automatically if using Umbraco Cloud.
 
 Items managed by editors - content, media and optionally forms, dictionary items and members - are deployed between environments using the transfer and restore options available in the backoffice.
 
-It's possible to use this method for all Umbraco data, by setting the value of this setting to `BackOfficeOnly`. With this in place, all data, including what is typically considered as schema, are available for transfer via the backoffice.
+It is possible to use this method for all Umbraco data, by setting the value of this setting to `BackOfficeOnly`. With this in place, all data, including what is typically considered as schema, are available for transfer via the backoffice.
 
 Our recommended approach is to leave this setting as `Default` and use source control and a deployment pipeline to ensure that structural changes to Umbraco are always aligned with the code and template amends that use them.
 
-However, we are aware that some customers prefer the option to use the backoffice for all data transfers. If that's the case, the `BackOfficeOnly` setting will allow this.
+However, we are aware that some customers prefer the option to use the backoffice for all data transfers. If that is the case, the `BackOfficeOnly` setting will allow this.
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
@@ -10,13 +10,15 @@ The UmbracoDeploy.Settings.config file is empty by default, but there are some o
 
 ## Edition
 
-The default value for this setting is `Default`, which configures Umbraco Deploy for operation according to how we expect most customers to use the product. Umbraco schema, such as document and data types, are serialzed to disk as `.uda` files in save operations. These are checked into source control and used to update the schema in the upstream environments via a trigger from your CI/CD pipeline, or automatically if using Umbraco Cloud.
+The default value for this setting is `Default`, which configures Umbraco Deploy to work according to how we expect most customers to use the product. Umbraco schema, such as document and data types, are serialzed to disk as `.uda` files in save operations. These are checked into source control and used to update the schema in the upstream environments via a trigger from your CI/CD pipeline, or automatically if using Umbraco Cloud.
 
 Items managed by editors - content, media and optionally forms, dictionary items and members - are deployed between environments using the transfer and restore options available in the backoffice.
 
-It's possible to use this method for all Umbraco data, by setting the value of this setting to `BackOfficeOnly`. With this in place, all data, including what is typically considered as schema like document types, are available for transfer via the backoffice.
+It's possible to use this method for all Umbraco data, by setting the value of this setting to `BackOfficeOnly`. With this in place, all data, including what is typically considered as schema, are available for transfer via the backoffice.
 
-Our recommended approach is to leave this setting as `Default` and use source control and a deployment pipeline to ensure that structural changes to Umbraco are alwaya aligned with the code and template amends that use them. However, we are aware that some customers prefer the option to use the backoffice for all data transfers. If that's the case, the `BackOfficeOnly` setting will allow this.
+Our recommended approach is to leave this setting as `Default` and use source control and a deployment pipeline to ensure that structural changes to Umbraco are alwaya aligned with the code and template amends that use them.
+
+However, we are aware that some customers prefer the option to use the backoffice for all data transfers. If that's the case, the `BackOfficeOnly` setting will allow this.
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -24,8 +26,6 @@ Our recommended approach is to leave this setting as `Default` and use source co
     <deploy edition="Default|BackOfficeOnly" />
 </settings>
 ```
-
-
 
 ## ExcludedEntityTypes
 

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -70,13 +70,13 @@ The API key is a 10 character random string applied with the same value to all e
 
 ## Edition
 
-The default value for this setting is `Default`, which configures Umbraco Deploy to work according to how we expect most customers to use the product. Umbraco schema, such as document and data types, are serialzed to disk as `.uda` files in save operations. These are checked into source control and used to update the schema in the upstream environments via a trigger from your CI/CD pipeline, or automatically if using Umbraco Cloud.
+The default value for this setting is `Default`, which configures Umbraco Deploy to work according to how we expect most customers to use the product. Umbraco schema, such as document and data types, are serialized to disk as `.uda` files in save operations. These are checked into source control and used to update the schema in the upstream environments via a trigger from your CI/CD pipeline, or automatically if using Umbraco Cloud.
 
 Items managed by editors - content, media and optionally forms, dictionary items and members - are deployed between environments using the transfer and restore options available in the backoffice.
 
 It's possible to use this method for all Umbraco data, by setting the value of this setting to `BackOfficeOnly`. With this in place, all data, including what is typically considered as schema, are available for transfer via the backoffice.
 
-Our recommended approach is to leave this setting as `Default` and use source control and a deployment pipeline to ensure that structural changes to Umbraco are alwaya aligned with the code and template amends that use them.
+Our recommended approach is to leave this setting as `Default` and use source control and a deployment pipeline to ensure that structural changes to Umbraco are always aligned with the code and template amends that use them.
 
 However, we are aware that some customers prefer the option to use the backoffice for all data transfers. If that's the case, the `BackOfficeOnly` setting will allow this.
 

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -70,15 +70,15 @@ The API key is a 10 character random string applied with the same value to all e
 
 ## Edition
 
-The default value for this setting is `Default`, which configures Umbraco Deploy to work according to how we expect most customers to use the product. Umbraco schema, such as document and data types, are serialized to disk as `.uda` files in save operations. These are checked into source control and used to update the schema in the upstream environments via a trigger from your CI/CD pipeline, or automatically if using Umbraco Cloud.
+The default value for this setting is `Default`, which configures Umbraco Deploy to work according to how we expect most customers to use the product. Umbraco schema, such as Document and Data Types, are serialized to disk as `.uda` files in save operations. These are checked into source control and used to update the schema in the upstream environments via a trigger from your CI/CD pipeline, or automatically if using Umbraco Cloud.
 
 Items managed by editors - content, media and optionally forms, dictionary items and members - are deployed between environments using the transfer and restore options available in the backoffice.
 
-It's possible to use this method for all Umbraco data, by setting the value of this setting to `BackOfficeOnly`. With this in place, all data, including what is typically considered as schema, are available for transfer via the backoffice.
+It is possible to use this method for all Umbraco data, by setting the value of this setting to `BackOfficeOnly`. With this in place, all data, including what is typically considered as schema, are available for transfer via the backoffice.
 
 Our recommended approach is to leave this setting as `Default` and use source control and a deployment pipeline to ensure that structural changes to Umbraco are always aligned with the code and template amends that use them.
 
-However, we are aware that some customers prefer the option to use the backoffice for all data transfers. If that's the case, the `BackOfficeOnly` setting will allow this.
+However, we are aware that some customers prefer the option to use the backoffice for all data transfers. If that is the case, the `BackOfficeOnly` setting will allow this.
 
 ## ExcludedEntityTypes
 

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -36,6 +36,7 @@ For illustration purposes, the following structure represents the full set of op
     "Deploy": {
         "Settings": {
             "ApiKey": "<your API key here>",
+            "Edition": "Default",
             "DefaultTimeoutSeconds": 60,
             "ExcludedEntityTypes": [],
             "RelationTypes" : [],
@@ -66,6 +67,18 @@ For illustration purposes, the following structure represents the full set of op
 ## ApiKey
 
 The API key is a 10 character random string applied with the same value to all environments in order to authenticate HTTP requests between them.
+
+## Edition
+
+The default value for this setting is `Default`, which configures Umbraco Deploy to work according to how we expect most customers to use the product. Umbraco schema, such as document and data types, are serialzed to disk as `.uda` files in save operations. These are checked into source control and used to update the schema in the upstream environments via a trigger from your CI/CD pipeline, or automatically if using Umbraco Cloud.
+
+Items managed by editors - content, media and optionally forms, dictionary items and members - are deployed between environments using the transfer and restore options available in the backoffice.
+
+It's possible to use this method for all Umbraco data, by setting the value of this setting to `BackOfficeOnly`. With this in place, all data, including what is typically considered as schema, are available for transfer via the backoffice.
+
+Our recommended approach is to leave this setting as `Default` and use source control and a deployment pipeline to ensure that structural changes to Umbraco are alwaya aligned with the code and template amends that use them.
+
+However, we are aware that some customers prefer the option to use the backoffice for all data transfers. If that's the case, the `BackOfficeOnly` setting will allow this.
 
 ## ExcludedEntityTypes
 


### PR DESCRIPTION
This adds details of a currently undocumented setting that allows Umbraco Deploy to be used 

There's a couple of issues being fixed in the next patch release that makes this available, so should be held until they are out (likely 16/8/2022).