### PR TITLE
V10 system requirements require VS2022 for .NET 6 support

### DIFF
--- a/Fundamentals/Setup/Requirements/index.md
+++ b/Fundamentals/Setup/Requirements/index.md
@@ -21,7 +21,7 @@ The Umbraco UI should work in all modern browsers:
   * Linux (Ubuntu, Alpine, CentOS, Debian, Fedora, openSUSE and other major distributions)
 * One of the following .NET Tools or Editors:
   * [Visual Studio Code](https://code.visualstudio.com/) with the [IISExpress extension](https://marketplace.visualstudio.com/items?itemName=warren-buckley.iis-express)
-  * [Microsoft Visual Studio](https://www.visualstudio.com/) 2019 **version 16.8 and higher**
+  * [Microsoft Visual Studio](https://www.visualstudio.com/) 2022
   * [JetBrains Rider](https://www.jetbrains.com/rider) **version 2020.3 and higher**
   * .NET Core CLI
 * .NET 6.0.5+

--- a/Umbraco-Cloud/Upgrades/Upgrading-from-9-to-10/index.md
+++ b/Umbraco-Cloud/Upgrades/Upgrading-from-9-to-10/index.md
@@ -129,12 +129,12 @@ With the packages and projects updated, it is time to make some changes to some 
     "$schema": "./appsettings-schema.json",
     ```
 
-3. Follow step 2 for the following files as well:
+Apply this change to the following files as well:
   - **appsettings.Development.json**
   - **appsettings.Production.json**
   - **appsettings.Staging.json**
 
-The final thing you need to do before testing the upgrade locally, is to remove a series of files no longer needed in your project.
+3. The final thing you need to do before testing the upgrade locally, is to remove a series of files no longer needed in your project.
 
 Remove the following files and folders *manually* from your local project:
 


### PR DESCRIPTION
The system requirements for Umbraco 10 currently list Visual Studio 2019.

However, VS2019 does not include support for C# 10 and any of the modern C# features being used in Umbraco including:

- Global usings
- File scoped namespaces

Some of these features are used within the Umbraco templates by default, meaning you can't built your solution in VS2019.

Confirmation of this can be found in the .NET 6 launch blog post: https://devblogs.microsoft.com/dotnet/announcing-net-6/#support

This PR bumps the minimum recommended Visual Studio version to VS2022.