### PR TITLE
Use hardcoded language

### DIFF
--- a/Reference/Notifications/EditorModel-Notifications/Customizing-the-links-box.md
+++ b/Reference/Notifications/EditorModel-Notifications/Customizing-the-links-box.md
@@ -16,7 +16,7 @@ public void Handle(SendingContentNotification notification)
 {
     notification.Content.Urls = new[]
     {
-        new UrlInfo($"/products/?id={notification.Content.Id}", true, CultureInfo.CurrentCulture.Name)
+        new UrlInfo($"/products/?id={notification.Content.Id}", true, "en-US")
     };
 }
 ```


### PR DESCRIPTION
While it makes sense to get this from the CurrentCulture, this IS NOT related to the culture which is linked to the variant. Even more, your backoffice user can work in dk while the website is only available in en-US...  which would never show this link.

I think it makes more sense to use a hardcoded string to make sure people will change it before raising support requests.

Or maybe it should be something like `notification.UmbracoContext.PublishedRequest.Culture`