### PR TITLE
Removed Umbraco Courier section from the Add-Ons landing page

### DIFF
--- a/Add-ons/UmbracoCourier/index.md
+++ b/Add-ons/UmbracoCourier/index.md
@@ -4,11 +4,13 @@ versionRemoved: 8.0.0
 ---
 
 # Courier Documentation
-:::warning
-By March 2022 official support for Umbraco Courier has ended.
 
-It has been replaced with [Umbraco Deploy-on-premis.](https://umbraco.com/products/umbraco-deploy/umbraco-deploy-on-premises/)
+:::warning
+As of March 2022, official support for Umbraco Courier has ended.
+
+It has been replaced with [Umbraco Deploy On-premises](https://umbraco.com/products/umbraco-deploy/umbraco-deploy-on-premises/)
 :::
+
 Umbraco Courier is a tool that lets you deploy your schema and content from one Umbraco site to another.
 
 With Courier installed on your site, you can tell it to deploy an item from one site to another. Courier will then figure out what is needed for that specific item, package everything up, send it and finally extract it on the target site.
@@ -16,22 +18,29 @@ With Courier installed on your site, you can tell it to deploy an item from one 
 In this section you can find all the information you need in order to install, configure and work with Courier on a daily basis.
 
 ## [Install Courier](Installing)
+
 Thorough step-by-step documentation on how to install Courier and setup local test environments.
 
 ## [Upgrade Courier](Upgrade-Courier)
+
 Instructions on how to upgrade Umbraco Courier to the latest version.
 
 ## [Configuring a license](../The-Licensing-model)
+
 Configure the domains you need to be able to use Courier on.
 
 ## [Configuring Courier](Configuration)
+
 Learn about the various ways to configure Courier.
 
 ## [Using Courier](UsingCourier.md)
+
 How Courier is supposed to be used, to deploy content and developer assets from one site to another. Gives insight into how Courier is built.
 
 ## [Developer Documentation](Developer)
+
 These are the HOWTOs, which describes how you extend courier, and add new providers or hook into existing ones.
 
 ## [Common Issues](CommonIssues.md)
+
 For developers configuring or troubleshooting Courier.

--- a/Add-ons/index.md
+++ b/Add-ons/index.md
@@ -2,7 +2,9 @@
 meta.Title: "Add-ons for Umbraco CMS"
 meta.Description: "Learn about the Umbraco CMS add-ons; Umbraco Forms and Umbraco Courier. How to install them, what they do and how to extend functionality."
 versionFrom: 7.0.0
+versionTo: 10.0.0
 ---
+
 # Umbraco Products Documentation
 
 _Documentation for Umbraco Forms, Umbraco Deploy and Umbraco Courier products. These products are not standard parts of the Core, but
@@ -17,10 +19,6 @@ Umbraco Forms.
 
 Umbraco Deploy is the engine that runs behind the scenes on Umbraco Cloud and takes care of all the deployment processes of both code, schema and content on projects.
 With Umbraco Deploy (on-premises) you can use the Umbraco Cloud Deployment technology outside of Umbraco Cloud to ease deployment between multiple Umbraco environments.
-
-## [Umbraco Courier](UmbracoCourier/index.md)
-
-Architectural overview, extension and configuration guides, the intended audience is .NET developers who wish to configure, troubleshoot or extend Courier deployment functionality.
 
 ## [The Licensing Model](The-Licensing-model)
 


### PR DESCRIPTION
Since the official support for Umbraco Courier has ended, removing the section from the Add-Ons landing page.