### PR TITLE
v9 & v10: Examine custom indexing

### DIFF
--- a/Reference/Searching/Examine/Indexing/index-v8.md
+++ b/Reference/Searching/Examine/Indexing/index-v8.md
@@ -11,20 +11,20 @@ This document has been verified for Umbraco 8.
 If you are using Umbraco 9 or later versions, please refer to the note on the [Examine documentation landing page](../index.md) for more details.
 :::
 
-Examine has changed quite a bit in Umbraco 8 (and by "a bit" we really mean a lot). In Umbraco 7 everything was configured in the two Examine config files - in Umbraco 8 everything happens through C#.
+Examine has changed a bit in Umbraco 8 (and by "a bit" we mean a lot). In Umbraco 7 everything was configured in the two Examine config files - in Umbraco 8 everything happens through C#.
 
 ## Customizing the built in indexes
 
-You can modify the built in indexes in several ways:
+You can modify the built-in indexes in the following ways:
 
 * Events - giving you control over exactly what data goes into them and how the fields are configured
 * Changing the field value types to change how values are stored in the index
 * Changing the `IValueSetValidator` to change what goes into the index
-* Take control of the entire index creation pipeline to completely change the implementation
+* Take control of the entire index creation pipeline to change the implementation
 
 ### Changing field value types
 
-By default Examine will store values into the Lucene index as "Full Text", meaning it will be indexed and analyzed for a textual search. However, if a value that you are storing in a field is numerical, a date/time or another specific value type then you might want to change how this is stored in the index. This way you will be able to take advantage of some features such as numerical range or date features, etc...
+By default, Examine will store values into the Lucene index as "Full Text", meaning it will be indexed and analyzed for a textual search. However, if a value that you are storing in a field is numerical, a date/time, or another specific value type then you might want to change how this is stored in the index. This way you will be able to take advantage of some features such as numerical range or date features, etc...
 
 There is some documentation about this in the [Examine documentation](https://shazwazza.github.io/Examine/configuration).
 
@@ -70,7 +70,7 @@ public class CustomizeIndexComponent : IComponent
 
 An `IValueSetValidator` is responsible for validating a `ValueSet` to see if it should be included in the index and/or filtering the data in the `ValueSet`. For example, by default the validation process for the ExternalIndex checks if a `ValueSet` has a category type of either "media" or "content" (not member). If a `ValueSet` was passed to the ExternalIndex and it did not pass this requirement it would be ignored.
 
-Starting in Umbraco 8.4.0, the `IValueSetValidator` implementation for the built in indexes, can be changed like this:
+Starting in Umbraco 8.4.0, the `IValueSetValidator` implementation for the built-in indexes, can be changed like this:
 
 ```c#
 using Examine;
@@ -116,7 +116,7 @@ If you are using a version of Umbraco before 8.4.0 then to do this you will need
 
 ### Overriding index creation
 
-You can completely take control of the whole Umbraco index creation logic by replacing the default implementation of `IUmbracoIndexesCreator`.
+You can take control of the whole Umbraco index creation logic by replacing the default implementation of `IUmbracoIndexesCreator`.
 
 A few examples of why you might want to override the index creation:
 
@@ -124,7 +124,7 @@ A few examples of why you might want to override the index creation:
 * Change the `IValueSetValidator`
 * Modify field definitions
 * Change the location of where the indexes are stored, or
-* Completely replace the indexes with your own entirely custom implementation
+* Replace the indexes with your own entirely custom implementation
 
 As an example, to change the `IValueSetValidator` for the MemberIndex in the above example:
 
@@ -232,16 +232,16 @@ public class CustomUmbracoIndexesCreator : UmbracoIndexesCreator
 The following example will show how to create an index that will only include nodes based on the document type _product_.
 
 :::note
-We always recommend that you use the existing built in ExternalIndex. You should then query based on the NodeTypeAlias instead of creating a new separate index based on that particular node type. However, should the need arise, the example below will show you how to do it.
+We always recommend that you use the existing built-in ExternalIndex. You should then query based on the NodeTypeAlias instead of creating a new separate index based on that particular node type. However, should the need arise, the example below will show you how to do it.
 
 Take a look at our [Examine Quick Start](../quick-start/index.md) to see some examples of how to search the ExternalIndex.
 :::
 
-In order to create this index we need three things:
+To create this index we need three things:
 
 1. An IndexCreator to create a definition for the configuration of the index(s)
 2. A Component to register the created index(s) with Examine
-3. A Composer to append this Component to the list of Components Umbraco initializes during start up and to register our IndexCreator service with the underlying dependency injection framework, so it can be injected into our Component constructor.
+3. A Composer to append this Component to the list of Components Umbraco initializes during start-up and to register our IndexCreator service with the underlying dependency injection framework, so it can be injected into our Component constructor.
 
 (Read more about [using Composition and Components to modify Umbraco's default behaviour](../../../../Implementation/Composing/) and [Registering dependencies with Umbraco's underlying IoC framework](../../../Using-Ioc/)).
 

--- a/Reference/Searching/Examine/Indexing/index.md
+++ b/Reference/Searching/Examine/Indexing/index.md
@@ -13,6 +13,54 @@ You can modify the built in indexes in several ways:
 * Changing the `IValueSetValidator` to change what goes into the index
 * Take control of the entire index creation pipeline to completely change the implementation
 
+We can do all this by using the `ConfigureNamedOptions` pattern.
+
+## Creating a ConfigureOptions class
+
+We will start by creating a ConfigureExamineOptions class, that derives from `IConfigureNamedOptions<LuceneDirectoryIndexOptions>`:
+```c#
+using Examine.Lucene;
+using Microsoft.Extensions.Options;
+
+namespace MySite
+{
+    public class ConfigureExamineOptions : IConfigureNamedOptions<LuceneDirectoryIndexOptions>
+    {
+        public void Configure(string name, LuceneDirectoryIndexOptions options)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void Configure(LuceneDirectoryIndexOptions options)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}
+```
+
+:::note
+In this documentation we will use the `ConfigureExamineOptions` class for everything, it is recommended that you seperate this class out per filter for simplicity, for example if you do a lot of configuring for the ExternalIndex class, you would have a `ConfigureExternalIndex` class
+:::
+
+When using the `ConfigureNamedOptions` pattern, we have to register this in a composer for it to configure our indexes, this can be done like this:
+
+```c#
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+
+namespace MySite
+{
+    public class ExamineComposer : IComposer
+    {
+        public void Compose(IUmbracoBuilder builder)
+        {
+            builder.Services.ConfigureOptions<ConfigureExamineOptions>();
+        }
+    }
+}
+```
 ### Changing field value types
 
 By default Examine will store values into the Lucene index as "Full Text", meaning it will be indexed and analyzed for a textual search. However, if a value that you are storing in a field is numerical, a date/time or another specific value type then you might want to change how this is stored in the index. This way you will be able to take advantage of some features such as numerical range or date features, etc...
@@ -26,19 +74,11 @@ using Examine;
 using Examine.Lucene;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Configuration.Models;
 
 namespace MySite
 {
     public class ConfigureExamineOptions : IConfigureNamedOptions<LuceneDirectoryIndexOptions>
     {
-        private readonly IOptions<IndexCreatorSettings> _settings;
-
-        public ConfigureExamineOptions(IOptions<IndexCreatorSettings> settings)
-        {
-            _settings = settings;
-        }
-
         public void Configure(string name, LuceneDirectoryIndexOptions options)
         {
             if (name.Equals(Constants.UmbracoIndexes.ExternalIndexName))
@@ -57,187 +97,39 @@ namespace MySite
 ```
 This will either add the `price` field to the index, or if the field already exists, update date its type to double.
 
-Remember to register this using a composer!
+## Changing IValueSetValidator
+
+An `IValueSetValidator` is responsible for validating a `ValueSet` to see if it should be included in the index and/or filtering the data in the `ValueSet`. For example, by default the validation process for the ExternalIndex checks if a `ValueSet` has a category type of either "media" or "content" (not member). If a `ValueSet` was passed to the ExternalIndex and it did not pass this requirement it would be ignored.
+
+The `IValueSetValidator` implementation for the built in indexes, can be changed like this:
 
 ```c#
-using Microsoft.Extensions.DependencyInjection;
-using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Core.DependencyInjection;
+using Examine.Lucene;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Examine;
 
 namespace MySite
 {
-    public class ExamineComposer : IComposer
+    public class ConfigureExamineOptions : IConfigureNamedOptions<LuceneDirectoryIndexOptions>
     {
-        public void Compose(IUmbracoBuilder builder)
+        public void Configure(string name, LuceneDirectoryIndexOptions options)
         {
-            builder.Services.ConfigureOptions<ConfigureExamineOptions>();
+            if (name.Equals(Constants.UmbracoIndexes.MembersIndexName))
+            {
+                options.Validator = new MemberValueSetValidator(null, null, new[] {"email"}, null);
+            }
+        }
+
+        public void Configure(LuceneDirectoryIndexOptions options)
+        {
+            throw new System.NotImplementedException("This is never called and is just part of the interface");
         }
     }
 }
 ```
 
-## Changing IValueSetValidator
-
-An `IValueSetValidator` is responsible for validating a `ValueSet` to see if it should be included in the index and/or filtering the data in the `ValueSet`. For example, by default the validation process for the ExternalIndex checks if a `ValueSet` has a category type of either "media" or "content" (not member). If a `ValueSet` was passed to the ExternalIndex and it did not pass this requirement it would be ignored.
-
-Starting in Umbraco 8.4.0, the `IValueSetValidator` implementation for the built in indexes, can be changed like this:
-
-```c#
-using Examine;
-using Umbraco.Core;
-using Umbraco.Core.Composing;
-using Umbraco.Core.Services;
-using Umbraco.Examine;
-
-public class CustomizeIndexComposer : IUserComposer
-{
-    public void Compose(Composition composition)
-    {
-        // replace the default IUmbracoIndexConfig definition
-        composition.RegisterUnique<IUmbracoIndexConfig, CustomIndexConfig>();
-    }
-}
-
-// inherit from the default
-public class CustomIndexConfig : UmbracoIndexConfig, IUmbracoIndexConfig
-{
-    public CustomIndexConfig(IPublicAccessService publicAccessService) : base(publicAccessService)
-    {
-    }
-
-    // explicit implementation - overrides base class.
-    // GetMemberValueSetValidator is used for the MemberIndex.
-    IValueSetValidator IUmbracoIndexConfig.GetMemberValueSetValidator()
-    {
-        // NOTE - by default Umbraco only includes a small subset of fields for the member index for
-        // security reasons, however you may want to include a larger set of data in the member index.
-        // This example will include all data for a member excluding the built in property values.
-
-        // all built in member properties to exclude (i.e. Password question, etc...)
-        var excludeFields = Constants.Conventions.Member.GetStandardPropertyTypeStubs().Keys;
-
-        // include everything except the above
-        return new MemberValueSetValidator(null, null, null, excludeFields);
-    }
-}
-```
-
-If you are using a version of Umbraco before 8.4.0 then to do this you will need to modify the index creation (see below).
-
-### Overriding index creation
-
-You can completely take control of the whole Umbraco index creation logic by replacing the default implementation of `IUmbracoIndexesCreator`.
-
-A few examples of why you might want to override the index creation:
-
-* To customize the default analyzer used in the built in indexes
-* Change the `IValueSetValidator`
-* Modify field definitions
-* Change the location of where the indexes are stored, or
-* Completely replace the indexes with your own entirely custom implementation
-
-As an example, to change the `IValueSetValidator` for the MemberIndex in the above example:
-
-```c#
-using Examine;
-using Umbraco.Core;
-using Umbraco.Core.Composing;
-using Umbraco.Core.Logging;
-using Umbraco.Core.Services;
-using Umbraco.Examine;
-using Umbraco.Web.Search;
-
-public class CustomizeIndexComposer : IUserComposer
-{
-    public void Compose(Composition composition)
-    {
-        // replace the default IUmbracoIndexesCreator definition
-        composition.RegisterUnique<IUmbracoIndexesCreator, CustomUmbracoIndexesCreator>();
-    }
-}
-
-// override the default creator
-public class CustomUmbracoIndexesCreator : UmbracoIndexesCreator
-{
-    public CustomUmbracoIndexesCreator(IProfilingLogger profilingLogger, ILocalizationService languageService, IPublicAccessService publicAccessService, IMemberService memberService, IUmbracoIndexConfig umbracoIndexConfig)
-        : base(profilingLogger, languageService, publicAccessService, memberService, umbracoIndexConfig)
-    {
-    }
-
-    // note - in Umbraco 8.4 this method is obsoleted and it's advised to replace the
-    // IUmbracoIndexConfig as in the above example.
-    public override IValueSetValidator GetMemberValueSetValidator()
-    {
-        // all built in member properties to exclude (i.e. Password question, etc...)
-        var excludeFields = Constants.Conventions.Member.GetStandardPropertyTypeStubs().Keys;
-
-        // include everything except the above
-        return new MemberValueSetValidator(null, null, null, excludeFields);
-    }
-}
-```
-
-Another example could be to replace the default Lucene analyzer for the ExternalIndex:
-
-```c#
-using System.Collections.Generic;
-using Examine;
-using Lucene.Net.Analysis;
-using Umbraco.Core;
-using Umbraco.Core.Logging;
-using Umbraco.Core.Services;
-using Umbraco.Examine;
-using Umbraco.Web.Search;
-
-// override the default creator
-public class CustomUmbracoIndexesCreator : UmbracoIndexesCreator
-{
-    // ctor
-    public CustomUmbracoIndexesCreator(IProfilingLogger profilingLogger, ILocalizationService languageService, IPublicAccessService publicAccessService, IMemberService memberService, IUmbracoIndexConfig umbracoIndexConfig)
-        : base(profilingLogger, languageService, publicAccessService, memberService, umbracoIndexConfig)
-    {
-    }
-
-    // override the Create method
-    public override IEnumerable<IIndex> Create()
-    {
-        // create the default index definitions
-        var defaultIndexes = base.Create().ToDictionary(x => x.Name, x => x);
-        var internalIndex = defaultIndexes[Constants.UmbracoIndexes.InternalIndexName];
-        var memberIndex = defaultIndexes[Constants.UmbracoIndexes.MembersIndexName];
-
-        // create a custom external index
-        var externalIndex = CreateExternalIndex();
-
-        // return the Umbraco indexes - all 3 must be here with the correct names!
-        return new IIndex[]
-        {
-            internalIndex,
-            externalIndex,
-            memberIndex
-        };
-    }
-
-    private IIndex CreateExternalIndex()
-    {
-        var index = new UmbracoContentIndex(
-            Constants.UmbracoIndexes.ExternalIndexName, // default
-            CreateFileSystemLuceneDirectory(Constants.UmbracoIndexes.ExternalIndexPath), // default
-            new UmbracoFieldDefinitionCollection(), // default
-
-            // change the default analyzer from StandardAnalyzer
-            new WhitespaceAnalyzer(),
-
-            ProfilingLogger, // default
-            LanguageService, // default
-            UmbracoIndexConfig.GetPublishedContentValueSetValidator()); // default
-
-        return index;
-    }
-}
-```
-
-## Index based on document types
+## Creating your own index
 
 The following example will show how to create an index that will only include nodes based on the document type _product_.
 
@@ -247,114 +139,194 @@ We always recommend that you use the existing built in ExternalIndex. You should
 Take a look at our [Examine Quick Start](../quick-start/index.md) to see some examples of how to search the ExternalIndex.
 :::
 
-In order to create this index we need three things:
+In order to create this index we need five things:
 
-1. An IndexCreator to create a definition for the configuration of the index(s)
-2. A Component to register the created index(s) with Examine
-3. A Composer to append this Component to the list of Components Umbraco initializes during start up and to register our IndexCreator service with the underlying dependency injection framework, so it can be injected into our Component constructor.
+1. A definition of the index
+2. A ConfigureNamedOptions to configure all the fields of the index
+3. A ValueSetBuilder to build the value sets for the index
+4. A IndexPopulator to populate the index with the value sets
+5. A composer to add all these services to the runtime.
 
-(Read more about [using Composition and Components to modify Umbraco's default behaviour](../../../../Implementation/Composing/) and [Registering dependencies with Umbraco's underlying IoC framework](../../../Using-Ioc/)).
 
-### ProductIndexCreator
+### ProductIndex
+
+```c#
+using Examine.Lucene;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Examine;
+
+namespace MySite.MyCustomIndex
+{
+    public class ProductIndex : UmbracoExamineIndex
+    {
+        public ProductIndex(
+            ILoggerFactory loggerFactory,
+            string name,
+            IOptionsMonitor<LuceneDirectoryIndexOptions> indexOptions,
+            IHostingEnvironment hostingEnvironment,
+            IRuntimeState runtimeState) : base(loggerFactory,
+            name,
+            indexOptions,
+            hostingEnvironment,
+            runtimeState)
+        {
+        }
+    }
+}
+```
+
+### ConfigureCustomIndexOptions
+
+```c#
+using Examine;
+using Examine.Lucene;
+using Lucene.Net.Analysis.Standard;
+using Lucene.Net.Index;
+using Lucene.Net.Util;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Examine;
+
+namespace MySite.MyCustomIndex
+{
+    public class ConfigureCustomIndexOptions : IConfigureNamedOptions<LuceneDirectoryIndexOptions>
+    {
+        private readonly IOptions<IndexCreatorSettings> _settings;
+        private readonly IPublicAccessService _publicAccessService;
+        private readonly IScopeProvider _scopeProvider;
+
+        public ConfigureCustomIndexOptions(
+            IOptions<IndexCreatorSettings> settings,
+            IPublicAccessService publicAccessService,
+            IScopeProvider scopeProvider)
+        {
+            _settings = settings;
+            _publicAccessService = publicAccessService;
+            _scopeProvider = scopeProvider;
+        }
+
+        public void Configure(string name, LuceneDirectoryIndexOptions options)
+        {
+            if (name.Equals("ProductIndex"))
+            {
+                options.Analyzer = new StandardAnalyzer(LuceneVersion.LUCENE_48);
+                options.FieldDefinitions = new(
+                    new("id", FieldDefinitionTypes.Integer),
+                    new("name", FieldDefinitionTypes.FullText)
+                    );
+                options.UnlockIndex = true;
+                options.Validator = new ContentValueSetValidator(true, false, _publicAccessService, _scopeProvider, includeItemTypes: new[] {"product"});
+                if (_settings.Value.LuceneDirectoryFactory == LuceneDirectoryFactory.SyncedTempFileSystemDirectoryFactory)
+                {
+                    // if this directory factory is enabled then a snapshot deletion policy is required
+                    options.IndexDeletionPolicy = new SnapshotDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy());
+                }
+            }
+        }
+
+        public void Configure(LuceneDirectoryIndexOptions options)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}
+```
+
+### ProductIndexValueSetBuilder
 
 ```c#
 using System.Collections.Generic;
 using Examine;
-using Lucene.Net.Analysis.Standard;
-using Lucene.Net.Util;
-using Umbraco.Core.Logging;
-using Umbraco.Core.Services;
-using Umbraco.Examine;
-using Umbraco.Web.Search;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Infrastructure.Examine;
 
-public class ProductIndexCreator : LuceneIndexCreator, IUmbracoIndexesCreator
+namespace MySite.MyCustomIndex
 {
-    private readonly IProfilingLogger _profilingLogger;
-    private readonly ILocalizationService _localizationService;
-    private readonly IPublicAccessService _publicAccessService;
-    private readonly IScopeProvider _scopeProvider;
-
-    // Since Umbraco 8 has dependency injection out of the box, we can use it to inject
-    // the different services that we need.
-    public ProductIndexCreator(IProfilingLogger profilingLogger,
-        ILocalizationService localizationService,
-        IPublicAccessService publicAccessService,
-        IScopeProvider scopeProvider
-    )
+    public class ProductIndexValueSetBuilder : IValueSetBuilder<IContent>
     {
-        _profilingLogger = profilingLogger;
-        _localizationService = localizationService;
-        _publicAccessService = publicAccessService;
-        _scopeProvider = scopeProvider;
-    }
-
-        // Noticed that we return a collection of indexes? Technically you
-        // can create multiple indexes in an indexCreator :) You can have a look at
-        // UmbracoIndexesCreator.cs in the CMS core and see how the CMS does that.
-        public override IEnumerable<IIndex> Create()
+        public IEnumerable<ValueSet> GetValueSets(params IContent[] contents)
         {
-            var index = new UmbracoContentIndex("ProductIndex",
-                CreateFileSystemLuceneDirectory("ProductIndex"),
-                new UmbracoFieldDefinitionCollection(),
-                new StandardAnalyzer(Version.LUCENE_30),
-                _profilingLogger,
-                _localizationService,
-                // We can use the ContentValueSetValidator to set up rules for the content we
-                // want to have indexed. In our case we want published, non-protected nodes of the type "product".
-                new ContentValueSetValidator(true, false, _publicAccessService, _scopeProvider, includeItemTypes: new string[] { "product" }));
-
-            return new[] { index };
+            foreach (var content in contents)
+            {
+                var indexValues = new Dictionary<string, object>
+                {
+                    ["name"] = content.Name,
+                    ["id"] = content.Id,
+                };
+                yield return new ValueSet(content.Id.ToString(), "content", indexValues);
+            }
         }
+    }
+}
+```
+### ProductIndexPopulator
+```c#
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Examine;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Examine;
+
+namespace MySite.MyCustomIndex
+{
+    public class ProductIndexPopulator : IndexPopulator
+    {
+        private readonly IContentService _contentService;
+        private readonly ProductIndexValueSetBuilder _productIndexValueSetBuilder;
+
+        public ProductIndexPopulator(IContentService contentService, ProductIndexValueSetBuilder productIndexValueSetBuilder)
+        {
+            _contentService = contentService;
+            _productIndexValueSetBuilder = productIndexValueSetBuilder;
+            RegisterIndex("ProductIndex");
+        }
+        protected override void PopulateIndexes(IReadOnlyList<IIndex> indexes)
+        {
+            foreach (var index in indexes)
+            {
+                var roots = _contentService.GetRootContent();
+                index.IndexItems(_productIndexValueSetBuilder.GetValueSets(roots.ToArray()));
+
+                foreach (var root in roots)
+                {
+                   var valueSets = _productIndexValueSetBuilder.GetValueSets(_contentService.GetPagedDescendants(root.Id, 0, Int32.MaxValue, out _).ToArray());
+                   index.IndexItems(valueSets);
+                }
+            }
+
+        }
+    }
 }
 ```
 
-### ProductComponent
-
+### ExamineComposer
 ```c#
 using Examine;
-using Umbraco.Core.Composing;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Infrastructure.Examine;
 
-public class ProductComponent : IComponent
+namespace MySite.MyCustomIndex
 {
-    private readonly IExamineManager _examineManager;
-    private readonly ProductIndexCreator _productIndexCreator;
-
-    public ProductComponent(IExamineManager examineManager, ProductIndexCreator productIndexCreator)
+    public class ExamineComposer : IComposer
     {
-        _examineManager = examineManager;
-        _productIndexCreator = productIndexCreator;
-    }
-
-    public void Initialize()
-    {
-        // Because the Create method returns a collection of indexes,
-        // we have to loop through them.
-        foreach (var index in _productIndexCreator.Create())
+        public void Compose(IUmbracoBuilder builder)
         {
-            _examineManager.AddIndex(index);
+            builder.Services.AddExamineLuceneIndex<ProductIndex, ConfigurationEnabledDirectoryFactory>("ProductIndex");
+            builder.Services.ConfigureOptions<ConfigureCustomIndexOptions>();
+            builder.Services.AddSingleton<ProductIndexValueSetBuilder>();
+            builder.Services.AddSingleton<ProductIndexPopulator>();
         }
     }
-
-    public void Terminate() { }
 }
 ```
-
-### ProductComposer
-
-```c#
-using Umbraco.Core;
-using Umbraco.Core.Composing;
-
-public class ProductComposer : IUserComposer
-{
-    public void Compose(Composition composition)
-    {
-        composition.Components().Append<ProductComponent>();
-        composition.RegisterUnique<ProductIndexCreator>();
-    }
-}
-```
-
 ### Result
 
 ![Custom product index](images/examine-management-product-index.png)

--- a/Reference/Searching/Examine/Indexing/index.md
+++ b/Reference/Searching/Examine/Indexing/index.md
@@ -99,7 +99,12 @@ This will ensure that the `price` field in the index is treated as a `double` ty
 
 ## Changing IValueSetValidator
 
-An `IValueSetValidator` is responsible for validating a `ValueSet` to see if it should be included in the index and/or filtering the data in the `ValueSet`. For example, by default the validation process for the ExternalIndex checks if a `ValueSet` has a category type of either "media" or "content" (not member). If a `ValueSet` was passed to the ExternalIndex and it did not pass this requirement it would be ignored.
+An `IValueSetValidator` is responsible for validating a `ValueSet` to see if it should be included in the index.
+For example, by default the validation process for the ExternalIndex checks if a `ValueSet` has a category type of either "media" or "content" (not member).
+If a `ValueSet` was passed to the ExternalIndex and it did not pass this requirement it would be ignored.
+
+The `IValueSetValidator` is also responsible for filtering the data in the `ValueSet`. For example, by default the validator for the MemberIndex will validate on all the default member properties, so an extra property "PhoneNumber", would not pass validation, and therefore not be included.
+
 
 The `IValueSetValidator` implementation for the built in indexes, can be changed like this:
 

--- a/Reference/Searching/Examine/Indexing/index.md
+++ b/Reference/Searching/Examine/Indexing/index.md
@@ -6,12 +6,12 @@ versionTo: 10.0.0
 # Custom indexing
 ## Customizing the built in indexes
 
-You can modify the built in indexes in several ways:
+You can modify the built-in indexes in the following ways:
 
 * Events - giving you control over exactly what data goes into them and how the fields are configured
 * Changing the field value types to change how values are stored in the index
 * Changing the `IValueSetValidator` to change what goes into the index
-* Take control of the entire index creation pipeline to completely change the implementation
+* Take control of the entire index creation pipeline to change the implementation
 
 We can do all this by using the `ConfigureNamedOptions` pattern.
 
@@ -63,7 +63,7 @@ namespace MySite
 ```
 ### Changing field value types
 
-By default Examine will store values into the Lucene index as "Full Text" fields, meaning the values will be indexed and analyzed for a textual search. However, if a field value is numerical, date/time or another non-textual value type, you might want to change how the value is stored in the index. This will let you take advantage of some value type specific search features such as numerical or date range.
+By default, Examine will store values into the Lucene index as "Full Text" fields, meaning the values will be indexed and analyzed for a textual search. However, if a field value is numerical, date/time, or another non-textual value type, you might want to change how the value is stored in the index. This will let you take advantage of some value type-specific search features such as numerical or date range.
 
 There is some documentation about this in the [Examine documentation](https://shazwazza.github.io/Examine/configuration).
 
@@ -106,7 +106,7 @@ If a `ValueSet` was passed to the ExternalIndex and it did not pass this require
 The `IValueSetValidator` is also responsible for filtering the data in the `ValueSet`. For example, by default the validator for the MemberIndex will validate on all the default member properties, so an extra property "PhoneNumber", would not pass validation, and therefore not be included.
 
 
-The `IValueSetValidator` implementation for the built in indexes, can be changed like this:
+The `IValueSetValidator` implementation for the built-in indexes, can be changed like this:
 
 ```c#
 using Examine.Lucene;
@@ -149,7 +149,7 @@ We always recommend that you use the existing built in ExternalIndex. You should
 Take a look at our [Examine Quick Start](../quick-start/index.md) to see some examples of how to search the ExternalIndex.
 :::
 
-In order to create this index we need five things:
+To create this index we need five things:
 
 1. An `UmbracoExamineIndex` implementation that defines the index
 2. An `IConfigureNamedOptions` implementation that configures the fields of the index


### PR DESCRIPTION
This is still a draft because a lot of this section cannot actually be completed before an Examine bug has been fixed.
When the bug has been fixed this should be ready for an internal D-team review 💪 
# Notes
- Revamped the custom indexing section for v9 & 10
- This now used the `ConfiguredNamedOptions` pattern instead of the `UmbracoIndexConfig` pattern

