### PR TITLE
Update backoffice search documentation

### DIFF
--- a/Extending/Backoffice-Search/index.md
+++ b/Extending/Backoffice-Search/index.md
@@ -72,29 +72,33 @@ namespace Umbraco.Docs.Samples.Web.BackofficeSearch
         //Adding custom field to search in all nodes
         public new IEnumerable<string> GetBackOfficeFields()
         {
-            return new List<string>(base.GetBackOfficeFields()) { "parentID" };
+            return new List<string>(base.GetBackOfficeFields()) { "nodeType" };
         }
 
         //Adding custom field to search in document types
         public new IEnumerable<string> GetBackOfficeDocumentFields()
         {
-            return new List<string>(base.GetBackOfficeDocumentFields()) { "parentID" };
+            return new List<string>(base.GetBackOfficeDocumentFields()) { "nodeType" };
         }
 
         //Adding custom field to search in media
         public new IEnumerable<string> GetBackOfficeMediaFields()
         {
-            return new List<string>(base.GetBackOfficeMediaFields()) { "parentID" };
+            return new List<string>(base.GetBackOfficeMediaFields()) { "nodeType" };
         }
 
         //Adding custom field to search in members
         public new IEnumerable<string> GetBackOfficeMembersFields()
         {
-            return new List<string>(base.GetBackOfficeMembersFields()) { "parentID" };
+            return new List<string>(base.GetBackOfficeMembersFields()) { "nodeType" };
         }
     }
 }
 ```
+
+:::warning
+You cannot use this to search on integer types in the index, as an example `parentID` does not work.
+:::
 
 ## More advanced extensions
 


### PR DESCRIPTION
# Notes
- using `parentID` was not working, so this has been changed to `nodeType`
- added warning about integers not being searchable this way