### PR TITLE
Remove note about documentation only being tested in v8

### DIFF
--- a/Reference/Searching/Examine/index.md
+++ b/Reference/Searching/Examine/index.md
@@ -1,23 +1,11 @@
 ---
 versionFrom: 8.0.0
-versionTo: 8.0.0
+versionTo: 10.0.0
 ---
 
 # Examine
 
 _Examine uses Lucene as its search and index engine. Searching using Examine with Lucene can be very powerful and fast._
-
-:::note
-The majority of the Examine documentation in this section, is last verified for Umbraco 8 or 7.
-
-We recommend that you refer to the official [Examine](https://shazwazza.github.io/Examine/) and [Lucene](https://lucenenet.apache.org/) documentation when using Umbraco 9 or later versions.
-
-Since Examine 1.2.1, special characters (like æ, ø, å etc.) are now indexed by default.
-This version of Examine ships with Umbraco CMS 8.18 and above.
-For more information, you can refer to the [Github Issue](https://github.com/umbraco/Umbraco-CMS/issues/11871#issuecomment-1153923424). 
-
-Do you have any specific questions or queries regarding the above, please feel free to report on the official [UmbracoDocs Github Issue Tracker](https://github.com/umbraco/UmbracoDocs/issues).
-:::
 
 ## What is Examine?
 

--- a/Reference/Searching/Examine/index.md
+++ b/Reference/Searching/Examine/index.md
@@ -5,7 +5,7 @@ versionTo: 10.0.0
 
 # Examine
 
-_Examine uses Lucene as its search and index engine. Searching using Examine with Lucene can be very powerful and fast._
+_Examine uses Lucene as its search and index engine. Searching using Examine with Lucene can be powerful and fast._
 
 ## What is Examine?
 


### PR DESCRIPTION
I think after the revamp of the Examine documentation for v10, we can safely remove the note about it only being tested on v8 💪 