### PR TITLE
Styleguide updates

### DIFF
--- a/.github/styles/UmbracoDocs/ListStart.yml
+++ b/.github/styles/UmbracoDocs/ListStart.yml
@@ -1,7 +1,7 @@
 extends: existence
 message: "Start each option with a capital letter."
 link: https://github.com/testthedocs/vale-styles/blob/master/OpenStack/ListStart.yml
-level: error
+level: warning
 scope: list
 nonword: true
 tokens:

--- a/.github/styles/UmbracoDocs/SentenceLength.yml
+++ b/.github/styles/UmbracoDocs/SentenceLength.yml
@@ -2,5 +2,5 @@ message: "Write shorter sentences (less than 40 words)."
 extends: occurrence
 scope: sentence
 level: warning
-max: 40
+max: 25
 token: \b(\w+)\b

--- a/.github/styles/UmbracoDocs/SentenceLength.yml
+++ b/.github/styles/UmbracoDocs/SentenceLength.yml
@@ -1,4 +1,4 @@
-message: "Write shorter sentences (less than 40 words)."
+message: "Write shorter sentences (less than 25 words)."
 extends: occurrence
 scope: sentence
 level: warning


### PR DESCRIPTION
Made the following changes to the vale rules (styleguide):

- [ ] Change recommended sentence length from 40 to 25 words.
- [ ] Changed List Start rule from error to warning level.

Check running a vale check on the complete docs with the applied changes, this is the result:

> ✖ 3 errors, 5640 warnings and 0 suggestions in 1415 files.