### PR TITLE
UmbracoPath is no longer configurable

### DIFF
--- a/Reference/Configuration/GlobalSettings/index.md
+++ b/Reference/Configuration/GlobalSettings/index.md
@@ -21,7 +21,6 @@ The following snippet contains all the available options, with default values, a
       "HideTopLevelNodeFromPath": false,
       "UseHttps": false,
       "VersionCheckPeriod": 7,
-      "UmbracoPath": "~/umbraco",
       "IconsPath": "~/umbraco/assets/icons",
       "UmbracoCssPath": "~/css",
       "UmbracoScriptsPath": "~/css",
@@ -94,10 +93,6 @@ Makes sure that all of the requests in the backoffice are called over HTTPS inst
 ### Version check period
 
 When this value is set above 0, the backoffice will check for a new version of Umbraco every 'x' number of days where 'x' is the value defined for this setting. Set this value to 0 to never check for a new version.
-
-### Umbraco path
-
-The URL pointing to the Umbraco backoffice, if you change this value you also need to rename the `/umbraco` and `wwwroot/umbraco` folders to match this new name. Be aware that if you run your site on linux the casing needs to be identical.
 
 ### Icons path
 

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -1,0 +1,84 @@
+---
+versionFrom: 9.0.0
+---
+
+# Umbraco Security Hardening
+
+Here you find some tips and trick for hardening the security of your Umbraco installation.
+
+## Lock down access to your Umbraco-folders (IIS)
+
+By default there are some folders in your Umbraco installation that should be only used by authenticated users. It’s considered a good practice to lock down these folders to specific IP-addresses and/or IP-ranges to make sure not everyone can access these.
+The folders we want to lock down are App_Plugins, Config and Umbraco.
+The prerequisite of this to work is that you’re using [IISRewrite](../../Routing/IISRewriteRules/index.md)
+
+If you’ve made sure that you’ve installed this on your server we can start locking down our Umbraco-folders. This can be down by following these three steps.
+
+1. We are going to lock down /Umbraco/, but because API-controllers and Surface-controller will use the path /umbraco/api/ and /umbraco/surface/ these will also be locked down. Our first rule in the IISRewrite.config will be used to make sure that these are not locked by IP-address.
+
+```xml
+<rule name="Ignore" stopProcessing="true">
+    <match url="^(?:umbraco/api|umbraco/surface)/" />
+    <action type="None" />
+</rule>
+```
+
+Some older versions of Umbraco also relied on /umbraco/webservices/ for loadbalancing purposes. If you're loadbalancing you should also add umbraco/webservices to the rule.
+
+```xml
+<rule name="Ignore" stopProcessing="true">
+    <match url="^(?:umbraco/api|umbraco/surface|umbraco/webservices)/" />
+    <action type="None" />
+</rule>
+```
+
+2. Get the IP-addresses of your client and write these down like a regular expression. If the IP-addresses are for example 213.3.10.8 and 88.4.43.108 the regular expression would be "213.3.10.8|88.4.43.108".
+
+3. Lock down the folders App_Plugins, Config and Umbraco (or the renamed version of this folder) by putting this rule into your IISRewrite-rules
+
+```xml
+<rule name="Allowed IPs" stopProcessing="true">
+    <match url="^(?:app_plugins|config|umbraco)(?:/|$)" />
+    <conditions>
+        <add input="{REMOTE_ADDR}" negate="true" pattern="213.3.10.8|88.4.43.108" />
+    </conditions>
+    <action type="AbortRequest" />
+</rule>
+```
+
+If your server is behind a load balancer, you should use `{HTTP_X_FORWARDED_FOR}` instead of `{REMOTE_ADDR}` as the input for the rule.
+
+If you now go to /umbraco/ for example from a different IP-address the login screen will not be rendered.
+
+## Rename your Umbraco-folder
+
+:::Note
+*Important note*: Renaming your Umbraco folder is currently not supported on Umbraco Cloud.
+
+*Important note 2*: Not all packages will keep working if you rename your Umbraco folder. Please be aware of this risk and test it at your local environment first.
+:::
+
+By default the login page of Umbraco is available at the path /umbraco/. This page is the entrance to your installation and it’s considered a good practice to rename your path to a more secure path.
+This can be done by following these steps.
+
+1. Clean solution - This will delete the `wwwroot/umbraco` folder
+2. Add the following line into a property group element of your `csproj`-file
+   - `<UmbracoWwwrootName>my-secret-loginpanel</UmbracoWwwrootName>`
+3. Build sulution - This will copy umbraco content into `wwwroot/my-secret-loginpanel`
+4. Change the three keys in your configuration “Umbraco:CMS:Global:ReservedPaths”,“Umbraco:CMS:Global:UmbracoPath” and “Umbraco:CMS:Global:IconsPath” to your new path.
+
+```json
+{
+    "Umbraco": {
+        "CMS": {
+            "Global": {
+                "ReservedPaths": "~/app_plugins/,~/install/,~/mini-profiler-resources/,~/my-secret-loginpanel/,",
+                "UmbracoPath": "~/my-secret-loginpanel",
+                "IconsPath": "~/my-secret-loginpanel/assets/icons"
+            }
+        }
+    }
+}
+```
+
+From now on, you can only get access to the login screen by going to this path and no longer by going to /umbraco/.

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -34,7 +34,7 @@ Some older versions of Umbraco also relied on `/umbraco/webservices/`  for load-
 
 2. Get the IP addresses of your client and write these down like a regular expression. If the IP addresses are for example `213.3.10.8` and `88.4.43.108`, the regular expression would be: "`213.3.10.8|88.4.43.108`".
 
-3. Lock down the folders App_Plugins, Config and Umbraco (or the renamed version of this folder) by putting this rule into your IISRewrite-rules
+3. Lock down the folders `App_Plugins`, `Config`, and `Umbraco` (or the renamed version of this folder) by putting this rule into your IISRewrite-rules
 
 ```xml
 <rule name="Allowed IPs" stopProcessing="true">

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -32,7 +32,7 @@ Some older versions of Umbraco also relied on `/umbraco/webservices/`  for load-
 </rule>
 ```
 
-2. Get the IP-addresses of your client and write these down like a regular expression. If the IP-addresses are for example 213.3.10.8 and 88.4.43.108 the regular expression would be "213.3.10.8|88.4.43.108".
+2. Get the IP addresses of your client and write these down like a regular expression. If the IP addresses are for example `213.3.10.8` and `88.4.43.108`, the regular expression would be: "`213.3.10.8|88.4.43.108`".
 
 3. Lock down the folders App_Plugins, Config and Umbraco (or the renamed version of this folder) by putting this rule into your IISRewrite-rules
 

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -65,7 +65,7 @@ This can be done by following these steps:
 2. Add the following line into a property group element of your `csproj`-file
    - `<UmbracoWwwrootName>my-secret-loginpanel</UmbracoWwwrootName>`
 3. Build sulution - This will copy umbraco content into `wwwroot/my-secret-loginpanel`
-4. Change the three keys in your configuration “Umbraco:CMS:Global:ReservedPaths”,“Umbraco:CMS:Global:UmbracoPath” and “Umbraco:CMS:Global:IconsPath” to your new path.
+4. Change the three keys in your configuration `Umbraco:CMS:Global:ReservedPaths`,`Umbraco:CMS:Global:UmbracoPath`, and `Umbraco:CMS:Global:IconsPath` to your new path:
 
 ```json
 {

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -8,7 +8,7 @@ Here you can find some tips and tricks for hardening the security of your Umbrac
 
 ## Lock down access to your Umbraco-folders (IIS)
 
-By default there are some folders in your Umbraco installation that should be only used by authenticated users. It’s considered a good practice to lock down these folders to specific IP-addresses and/or IP-ranges to make sure not everyone can access these.
+By default, there are some folders in your Umbraco installation that should only be used by authenticated users. It’s considered a good practice to lock down these folders to specific IP addresses and/or IP ranges to make sure not everyone can access these.
 The folders we want to lock down are App_Plugins, Config and Umbraco.
 The prerequisite of this to work is that you’re using [IISRewrite](../../Routing/IISRewriteRules/index.md)
 

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -10,7 +10,7 @@ Here you can find some tips and tricks for hardening the security of your Umbrac
 
 By default, there are some folders in your Umbraco installation that should only be used by authenticated users. It’s considered a good practice to lock down these folders to specific IP addresses and/or IP ranges to make sure not everyone can access these.
 The folders we want to lock down are `App_Plugins`, `Config`, and `Umbraco`.
-The prerequisite of this to work is that you’re using [IISRewrite](../../Routing/IISRewriteRules/index.md)
+The prerequisite for this to work is that you’re using [IISRewrite](../../Routing/IISRewriteRules/index.md).
 
 If you’ve made sure that you’ve installed this on your server we can start locking down our Umbraco-folders. This can be down by following these three steps.
 

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -59,7 +59,7 @@ Not all packages will keep working if you rename your Umbraco folder. Please be 
 :::
 
 By default, the login page of Umbraco is available at the path `/umbraco/`. This page is the entrance to your installation and it’s considered good practice to rename your path to a more secure path.
-This can be done by following these steps.
+This can be done by following these steps:
 
 1. Clean solution - This will delete the `wwwroot/umbraco` folder
 2. Add the following line into a property group element of your `csproj`-file

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -14,7 +14,7 @@ The prerequisite for this to work is that you’re using [IISRewrite](../../Rout
 
 If you’ve made sure that you’ve installed this on your server we can start locking down our Umbraco folders. This can be done by following these three steps:
 
-1. We are going to lock down /Umbraco/, but because API-controllers and Surface-controller will use the path /umbraco/api/ and /umbraco/surface/ these will also be locked down. Our first rule in the IISRewrite.config will be used to make sure that these are not locked by IP-address.
+1. We are going to lock down `/Umbraco/`, but because API-controllers and Surface-controller will use the path `/umbraco/api/` and `/umbraco/surface/` these will also be locked down. Our first rule in the `IISRewrite.config` file will be used to make sure that these are not locked by IP address.
 
 ```xml
 <rule name="Ignore" stopProcessing="true">

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -4,7 +4,7 @@ versionFrom: 9.0.0
 
 # Umbraco Security Hardening
 
-Here you find some tips and trick for hardening the security of your Umbraco installation.
+Here you can find some tips and tricks for hardening the security of your Umbraco installation.
 
 ## Lock down access to your Umbraco-folders (IIS)
 

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -6,7 +6,7 @@ versionFrom: 9.0.0
 
 Here you can find some tips and tricks for hardening the security of your Umbraco installation.
 
-## Lock down access to your Umbraco-folders (IIS)
+## Lock down access to your Umbraco folders (IIS)
 
 By default, there are some folders in your Umbraco installation that should only be used by authenticated users. It’s considered a good practice to lock down these folders to specific IP addresses and/or IP ranges to make sure not everyone can access these.
 The folders we want to lock down are `App_Plugins`, `Config`, and `Umbraco`.

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -9,7 +9,7 @@ Here you can find some tips and tricks for hardening the security of your Umbrac
 ## Lock down access to your Umbraco-folders (IIS)
 
 By default, there are some folders in your Umbraco installation that should only be used by authenticated users. It’s considered a good practice to lock down these folders to specific IP addresses and/or IP ranges to make sure not everyone can access these.
-The folders we want to lock down are App_Plugins, Config and Umbraco.
+The folders we want to lock down are `App_Plugins`, `Config`, and `Umbraco`.
 The prerequisite of this to work is that you’re using [IISRewrite](../../Routing/IISRewriteRules/index.md)
 
 If you’ve made sure that you’ve installed this on your server we can start locking down our Umbraco-folders. This can be down by following these three steps.

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -58,7 +58,7 @@ Renaming your Umbraco folder is currently not supported on Umbraco Cloud.
 Not all packages will keep working if you rename your Umbraco folder. Please be aware of this risk and test it in your local environment first.
 :::
 
-By default the login page of Umbraco is available at the path /umbraco/. This page is the entrance to your installation and it’s considered a good practice to rename your path to a more secure path.
+By default, the login page of Umbraco is available at the path `/umbraco/`. This page is the entrance to your installation and it’s considered good practice to rename your path to a more secure path.
 This can be done by following these steps.
 
 1. Clean solution - This will delete the `wwwroot/umbraco` folder

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -81,4 +81,4 @@ This can be done by following these steps:
 }
 ```
 
-From now on, you can only get access to the login screen by going to this path and no longer by going to /umbraco/.
+From now on, you can only get access to the login screen by going to this path and no longer by going to `/umbraco/`.

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -23,7 +23,7 @@ If you’ve made sure that you’ve installed this on your server we can start l
 </rule>
 ```
 
-Some older versions of Umbraco also relied on /umbraco/webservices/ for loadbalancing purposes. If you're loadbalancing you should also add umbraco/webservices to the rule.
+Some older versions of Umbraco also relied on `/umbraco/webservices/`  for load-balancing purposes. If you're load-balancing you should also add `umbraco/webservices`  to the rule.
 
 ```xml
 <rule name="Ignore" stopProcessing="true">

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -55,7 +55,7 @@ If you now go to `/umbraco/` for example from a different IP address the login s
 :::Note
 Renaming your Umbraco folder is currently not supported on Umbraco Cloud.
 
-*Important note 2*: Not all packages will keep working if you rename your Umbraco folder. Please be aware of this risk and test it at your local environment first.
+Not all packages will keep working if you rename your Umbraco folder. Please be aware of this risk and test it in your local environment first.
 :::
 
 By default the login page of Umbraco is available at the path /umbraco/. This page is the entrance to your installation and it’s considered a good practice to rename your path to a more secure path.

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -12,7 +12,7 @@ By default, there are some folders in your Umbraco installation that should only
 The folders we want to lock down are `App_Plugins`, `Config`, and `Umbraco`.
 The prerequisite for this to work is that you’re using [IISRewrite](../../Routing/IISRewriteRules/index.md).
 
-If you’ve made sure that you’ve installed this on your server we can start locking down our Umbraco-folders. This can be down by following these three steps.
+If you’ve made sure that you’ve installed this on your server we can start locking down our Umbraco folders. This can be done by following these three steps:
 
 1. We are going to lock down /Umbraco/, but because API-controllers and Surface-controller will use the path /umbraco/api/ and /umbraco/surface/ these will also be locked down. Our first rule in the IISRewrite.config will be used to make sure that these are not locked by IP-address.
 

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -53,7 +53,7 @@ If you now go to `/umbraco/` for example from a different IP address the login s
 ## Rename your Umbraco-folder
 
 :::Note
-*Important note*: Renaming your Umbraco folder is currently not supported on Umbraco Cloud.
+Renaming your Umbraco folder is currently not supported on Umbraco Cloud.
 
 *Important note 2*: Not all packages will keep working if you rename your Umbraco folder. Please be aware of this risk and test it at your local environment first.
 :::

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -48,7 +48,7 @@ Some older versions of Umbraco also relied on `/umbraco/webservices/`  for load-
 
 If your server is behind a load balancer, you should use `{HTTP_X_FORWARDED_FOR}` instead of `{REMOTE_ADDR}` as the input for the rule.
 
-If you now go to /umbraco/ for example from a different IP-address the login screen will not be rendered.
+If you now go to `/umbraco/` for example from a different IP address the login screen will not be rendered.
 
 ## Rename your Umbraco-folder
 

--- a/Reference/Security/Security-hardening/index.md
+++ b/Reference/Security/Security-hardening/index.md
@@ -8,7 +8,7 @@ Here you find some tips and trick for hardening the security of your Umbraco ins
 
 ## Lock down access to your Umbraco folder (IIS)
 
-It’s considered a good practice to lock down the Umbraco folder to specific IP-addresses and/or IP-ranges to ensure this folder is not available to everyone.
+It’s considered a good practice to lock down the Umbraco folder to specific IP addresses and/or IP ranges to ensure this folder is not available to everyone.
 
 The prerequisite of this to work is that you’re using [IISRewrite](../../Routing/IISRewriteRules/index.md)
 

--- a/Reference/Security/Security-hardening/index.md
+++ b/Reference/Security/Security-hardening/index.md
@@ -50,4 +50,4 @@ Some older versions of Umbraco also relied on /umbraco/webservices/ for loadbala
 If your server is behind a load balancer, you should use `{HTTP_X_FORWARDED_FOR}` instead of `{REMOTE_ADDR}` as the input for the rule.
 :::
 
-If you now go to /umbraco/ from a different IP-address the login screen will not be rendered.
+If you now go to `/umbraco/` from a different IP-address the login screen will not be rendered.

--- a/Reference/Security/Security-hardening/index.md
+++ b/Reference/Security/Security-hardening/index.md
@@ -1,19 +1,18 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+versionFrom: 10.0.0
 ---
 
 # Umbraco Security Hardening
 
 Here you find some tips and trick for hardening the security of your Umbraco installation.
 
-## Lock down access to your Umbraco-folders (IIS)
+## Lock down access to your Umbraco folder (IIS)
 
-By default there are some folders in your Umbraco installation that should be only used by authenticated users. It’s considered a good practice to lock down these folders to specific IP-addresses and/or IP-ranges to make sure not everyone can access these.
-The folders we want to lock down are App_Plugins, Config and Umbraco.
+It’s considered a good practice to lock down the Umbraco folder to specific IP-addresses and/or IP-ranges to ensure this folder is not available to everyone.
+
 The prerequisite of this to work is that you’re using [IISRewrite](../../Routing/IISRewriteRules/index.md)
 
-If you’ve made sure that you’ve installed this on your server we can start locking down our Umbraco-folders. This can be down by following these three steps.
+If you’ve made sure that you’ve installed this on your server we can start locking down our Umbraco folder. This can be down by following these three steps.
 
 1. We are going to lock down /Umbraco/, but because API-controllers and Surface-controller will use the path /umbraco/api/ and /umbraco/surface/ these will also be locked down. Our first rule in the IISRewrite.config will be used to make sure that these are not locked by IP-address.
 
@@ -35,11 +34,11 @@ Some older versions of Umbraco also relied on /umbraco/webservices/ for loadbala
 
 2. Get the IP-addresses of your client and write these down like a regular expression. If the IP-addresses are for example 213.3.10.8 and 88.4.43.108 the regular expression would be "213.3.10.8|88.4.43.108".
 
-3. Lock down the folders App_Plugins, Config and Umbraco (or the renamed version of this folder) by putting this rule into your IISRewrite-rules
+3. Lock down the Umbraco folder by putting this rule into your IISRewrite-rules
 
 ```xml
 <rule name="Allowed IPs" stopProcessing="true">
-    <match url="^(?:app_plugins|config|umbraco)(?:/|$)" />
+    <match url="^(?:umbraco)(?:/|$)" />
     <conditions>
         <add input="{REMOTE_ADDR}" negate="true" pattern="213.3.10.8|88.4.43.108" />
     </conditions>
@@ -47,39 +46,8 @@ Some older versions of Umbraco also relied on /umbraco/webservices/ for loadbala
 </rule>
 ```
 
+:::note
 If your server is behind a load balancer, you should use `{HTTP_X_FORWARDED_FOR}` instead of `{REMOTE_ADDR}` as the input for the rule.
-
-If you now go to /umbraco/ for example from a different IP-address the login screen will not be rendered.
-
-## Rename your Umbraco-folder
-
-:::Note
-*Important note*: Renaming your Umbraco folder is currently not supported on Umbraco Cloud.
-
-*Important note 2*: Not all packages will keep working if you rename your Umbraco folder. Please be aware of this risk and test it at your local environment first.
 :::
 
-By default the login page of Umbraco is available at the path /umbraco/. This page is the entrance to your installation and it’s considered a good practice to rename your path to a more secure path.
-This can be done by following these steps.
-
-1. Clean solution - This will delete the `wwwroot/umbraco` folder
-2. Add the following line into a property group element of your `csproj`-file
-   - `<UmbracoWwwrootName>my-secret-loginpanel</UmbracoWwwrootName>`
-3. Build sulution - This will copy umbraco content into `wwwroot/my-secret-loginpanel`
-4. Change the three keys in your configuration “Umbraco:CMS:Global:ReservedPaths”,“Umbraco:CMS:Global:UmbracoPath” and “Umbraco:CMS:Global:IconsPath” to your new path.
-
-```json
-{
-    "Umbraco": {
-        "CMS": {
-            "Global": {
-                "ReservedPaths": "~/app_plugins/,~/install/,~/mini-profiler-resources/,~/my-secret-loginpanel/,",
-                "UmbracoPath": "~/my-secret-loginpanel",
-                "IconsPath": "~/my-secret-loginpanel/assets/icons"
-            }
-        }
-    }
-}
-```
-
-From now on, you can only get access to the login screen by going to this path and no longer by going to /umbraco/.
+If you now go to /umbraco/ from a different IP-address the login screen will not be rendered.


### PR DESCRIPTION
This PR removes all documentation of `UmbracoPath` being configurable, as the feature is broken for V10+ and will not be fixed. 

Changing `UmbracoPath` is a security-by-obscurity pattern. A much better option is using IP restrictions as documented in the "Security hardening" article. Said article has also been rewritten in this PR to reflect `UmbracoPath` no longer being configurable, as well as removing a few remnants from earlier versions.

See also https://github.com/umbraco/Umbraco-CMS/pull/13032