### PR TITLE
Correct typo in MaximumUploadSizeSettings meta title

### DIFF
--- a/Reference/Configuration/MaximumUploadSizeSettings/index.md
+++ b/Reference/Configuration/MaximumUploadSizeSettings/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 versionTo: 10.0.0
-meta.Title: "Umbraco Maximum upload size settingsg"
+meta.Title: "Umbraco Maximum upload size settings"
 meta.Description: "Information on how to change the default cap of upload size"
 ---
 


### PR DESCRIPTION
I found this typo when Googling for some docs, so thought I would correct it!