### PR TITLE
Fixed a couple of layout and detail issues in Deploy's extending for custom entities documentation.

### DIFF
--- a/Add-ons/Umbraco-Deploy/Extending/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index-v8.md
@@ -73,14 +73,14 @@ The class is decorated with a `UdiDefinition` via which the name of the entity t
 
 The following example shows a service connector, responsible for handling the artifact shown above and it's related entity.  There are no dependencies to consider here.  More complex examples will involve collating the dependencies and potentially handling the extraction in more than one pass to ensure updates are made in the correct order.
 
-An illustrative data service is provided via dependency injection.  This will be whatever is appropriate for your solution to use for CRUD operations around reading and writing of entiries.
+An illustrative data service is provided via dependency injection.  This will be whatever is appropriate for your solution to use for CRUD operations around reading and writing of entities.
 
 :::note
 In Deploy 4.7, to improve performance on deploy operations, we introduced a cache. This change required the addition of new methods to interfaces, allowing the passing in of a cache parameter.  In order to introduce this without breaking changes, we created some new interfaces and base classes.
 
-In the example below, if instead we inherited from `ServiceConnectorBase2`, which has a type parameter of `IServiceConnector2`, we  would able to implement instead `IArtifact IServiceConnector2.GetArtifact(Udi udi, IContextCache contextCache)`. This would allow the connector to read and write to the cache and remove the use of the obsolete methods.
+In the example below, if instead we inherited from `ServiceConnectorBase2`, which has a type parameter of `IServiceConnector2`, we would be able to implement `IArtifact IServiceConnector2.GetArtifact(Udi udi, IContextCache contextCache)`. This would allow the connector to read and write to the cache and remove the use of the obsolete methods.
 
-There's no harm in what is listed below though.  It's just that the connectors won't be able to use the cache for any look-ups that are repeated in deploy operations.  The obsolete methods won't be removed until Deploy 11.  In that version we plan to return back to the original interface and class names and introduce the new method overloads (which will be a documented breaking change).
+There's no harm in what is listed below though.  It's only that the connectors won't be able to use the cache for any look-ups that are repeated in deploy operations.  The obsolete methods won't be removed until Deploy 11.  In that version we plan to return back to the original interface and class names and introduce the new method overloads (which will be a documented breaking change).
 :::
 
 ```C#

--- a/Add-ons/Umbraco-Deploy/Extending/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index-v8.md
@@ -80,7 +80,7 @@ In Deploy 4.7, to improve performance on deploy operations, we introduced a cach
 
 In the example below, if instead we inherited from `ServiceConnectorBase2`, which has a type parameter of `IServiceConnector2`, we would be able to implement `IArtifact IServiceConnector2.GetArtifact(Udi udi, IContextCache contextCache)`. This would allow the connector to read and write to the cache and remove the use of the obsolete methods.
 
-There's no harm in what is listed below though.  It's only that the connectors won't be able to use the cache for any look-ups that are repeated in deploy operations.  The obsolete methods won't be removed until Deploy 11.  In that version we plan to return back to the original interface and class names and introduce the new method overloads (which will be a documented breaking change).
+There's no harm in what is listed below though. It's only that the connectors won't be able to use the cache for any look-ups that are repeated in deploy operations. The obsolete methods won't be removed until Deploy 11. In that version we plan to return back to the original interface and class names. We also plan to introduce the new method overloads which will be a documented breaking change.
 :::
 
 ```C#
@@ -268,7 +268,7 @@ In the same way that Umbraco entities often have dependencies on one another, th
 
 If the dependent entity is also deployable, it will be included in the transfer.  Or if not, the deployment will be blocked and the reason presented to the user.
 
-In the following illustrative example, if deploying a representation of a "Person", we ensure their "Department" dependency is added, indicating that it must exist to allow the transfer.  We can also use `ArtifactDependencyMode.Match` to ensure the dependent entity not only exists but also matches in all properties.
+In the following illustrative example, if deploying a representation of a "Person", we ensure their "Department" dependency is added. This will indicate that it must exist to allow the transfer. We can also use `ArtifactDependencyMode.Match` to ensure the dependent entity not only exists but also matches in all properties.
 
 ```C#
         private PersonArtifact Map(GuidUdi udi, Person person, ICollection<ArtifactDependency> dependencies)

--- a/Add-ons/Umbraco-Deploy/Extending/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index-v8.md
@@ -260,7 +260,7 @@ In the same way that Umbraco entities often have dependencies on one another, th
 
 If the dependent entity is also deployable, it will be included in the transfer.  Or if not, the deployment will be blocked and the reason presented to the user.
 
-In the following illustrative example, if deploying a representation of a "Person", we ensure their "Department" dependency is added, indicating that it must exist to allow the transfer.  We can also use `ArtifactDependencyMode.Exist` to ensure the dependent entity not only exists but also matches in all properties.
+In the following illustrative example, if deploying a representation of a "Person", we ensure their "Department" dependency is added, indicating that it must exist to allow the transfer.  We can also use `ArtifactDependencyMode.Match` to ensure the dependent entity not only exists but also matches in all properties.
 
 ```C#
         private PersonArtifact Map(GuidUdi udi, Person person, ICollection<ArtifactDependency> dependencies)

--- a/Add-ons/Umbraco-Deploy/Extending/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index-v8.md
@@ -73,7 +73,15 @@ The class is decorated with a `UdiDefinition` via which the name of the entity t
 
 The following example shows a service connector, responsible for handling the artifact shown above and it's related entity.  There are no dependencies to consider here.  More complex examples will involve collating the dependencies and potentially handling the extraction in more than one pass to ensure updates are made in the correct order.
 
-Note that an illustrative data service is provided via dependency injection.  This will be whatever is appropriate for your solution to use for CRUD operations around reading and writing of entiries.
+An illustrative data service is provided via dependency injection.  This will be whatever is appropriate for your solution to use for CRUD operations around reading and writing of entiries.
+
+:::note
+In Deploy 4.7, to improve performance on deploy operations, we introduced a cache. This change required the addition of new methods to interfaces, allowing the passing in of a cache parameter.  In order to introduce this without breaking changes, we created some new interfaces and base classes.
+
+In the example below, if instead we inherited from `ServiceConnectorBase2`, which has a type parameter of `IServiceConnector2`, we  would able to implement instead `IArtifact IServiceConnector2.GetArtifact(Udi udi, IContextCache contextCache)`. This would allow the connector to read and write to the cache and remove the use of the obsolete methods.
+
+There's no harm in what is listed below though.  It's just that the connectors won't be able to use the cache for any look-ups that are repeated in deploy operations.  The obsolete methods won't be removed until Deploy 11.  In that version we plan to return back to the original interface and class names and introduce the new method overloads (which will be a documented breaking change).
+:::
 
 ```C#
     [UdiDefinition("mypackage-example", UdiType.GuidUdi)]

--- a/Add-ons/Umbraco-Deploy/Extending/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index-v8.md
@@ -73,7 +73,7 @@ The class is decorated with a `UdiDefinition` via which the name of the entity t
 
 The following example shows a service connector, responsible for handling the artifact shown above and it's related entity.  There are no dependencies to consider here.  More complex examples will involve collating the dependencies and potentially handling the extraction in more than one pass to ensure updates are made in the correct order.
 
-An illustrative data service is provided via dependency injection.  This will be whatever is appropriate for your solution to use for CRUD operations around reading and writing of entities.
+An illustrative data service is provided via dependency injection.  This will be whatever is appropriate for your solution to use for Create, Read, Update and Delete (CRUD) operations around reading and writing of entities.
 
 :::note
 In Deploy 4.7, to improve performance on deploy operations, we introduced a cache. This change required the addition of new methods to interfaces, allowing the passing in of a cache parameter.  In order to introduce this without breaking changes, we created some new interfaces and base classes.

--- a/Add-ons/Umbraco-Deploy/Extending/index.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index.md
@@ -74,14 +74,14 @@ The class is decorated with a `UdiDefinition` via which the name of the entity t
 
 The following example shows a service connector, responsible for handling the artifact shown above and it's related entity.  There are no dependencies to consider here.  More complex examples will involve collating the dependencies and potentially handling the extraction in more than one pass to ensure updates are made in the correct order.
 
-An illustrative data service is provided via dependency injection.  This will be whatever is appropriate for your solution to use for CRUD operations around reading and writing of entiries.
+An illustrative data service is provided via dependency injection.  This will be whatever is appropriate for your solution to use for CRUD operations around reading and writing of entities.
 
 :::note
 In Deploy 9.5/10.1, to improve performance on deploy operations, we introduced a cache. This change required the addition of new methods to interfaces, allowing the passing in of a cache parameter.  In order to introduce this without breaking changes, we created some new interfaces and base classes.
 
-In the example below, if instead we inherited from `ServiceConnectorBase2`, which has a type parameter of `IServiceConnector2`, we  would able to implement instead `IArtifact? IServiceConnector2.GetArtifact(Udi udi, IContextCache contextCache)`. This would allow the connector to read and write to the cache and remove the use of the obsolete methods.
+In the example below, if instead we inherited from `ServiceConnectorBase2`, which has a type parameter of `IServiceConnector2`, we would be able to implement `IArtifact? IServiceConnector2.GetArtifact(Udi udi, IContextCache contextCache)`. This would allow the connector to read and write to the cache and remove the use of the obsolete methods.
 
-There's no harm in what is listed below though.  It's just that the connectors won't be able to use the cache for any look-ups that are repeated in deploy operations.  The obsolete methods won't be removed until Deploy 11.  In that version we plan to return back to the original interface and class names and introduce the new method overloads (which will be a documented breaking change).
+There's no harm in what is listed below though.  It's only that the connectors won't be able to use the cache for any look-ups that are repeated in deploy operations.  The obsolete methods won't be removed until Deploy 11.  In that version we plan to return back to the original interface and class names and introduce the new method overloads (which will be a documented breaking change).
 :::
 
 ```C#

--- a/Add-ons/Umbraco-Deploy/Extending/index.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index.md
@@ -74,7 +74,15 @@ The class is decorated with a `UdiDefinition` via which the name of the entity t
 
 The following example shows a service connector, responsible for handling the artifact shown above and it's related entity.  There are no dependencies to consider here.  More complex examples will involve collating the dependencies and potentially handling the extraction in more than one pass to ensure updates are made in the correct order.
 
-Note that an illustrative data service is provided via dependency injection.  This will be whatever is appropriate for your solution to use for CRUD operations around reading and writing of entiries.
+An illustrative data service is provided via dependency injection.  This will be whatever is appropriate for your solution to use for CRUD operations around reading and writing of entiries.
+
+:::note
+In Deploy 9.5/10.1, to improve performance on deploy operations, we introduced a cache. This change required the addition of new methods to interfaces, allowing the passing in of a cache parameter.  In order to introduce this without breaking changes, we created some new interfaces and base classes.
+
+In the example below, if instead we inherited from `ServiceConnectorBase2`, which has a type parameter of `IServiceConnector2`, we  would able to implement instead `IArtifact? IServiceConnector2.GetArtifact(Udi udi, IContextCache contextCache)`. This would allow the connector to read and write to the cache and remove the use of the obsolete methods.
+
+There's no harm in what is listed below though.  It's just that the connectors won't be able to use the cache for any look-ups that are repeated in deploy operations.  The obsolete methods won't be removed until Deploy 11.  In that version we plan to return back to the original interface and class names and introduce the new method overloads (which will be a documented breaking change).
+:::
 
 ```C#
     [UdiDefinition("mypackage-example", UdiType.GuidUdi)]

--- a/Add-ons/Umbraco-Deploy/Extending/index.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index.md
@@ -261,7 +261,7 @@ In the same way that Umbraco entities often have dependencies on one another, th
 
 If the dependent entity is also deployable, it will be included in the transfer.  Or if not, the deployment will be blocked and the reason presented to the user.
 
-In the following illustrative example, if deploying a representation of a "Person", we ensure their "Department" dependency is added, indicating that it must exist to allow the transfer.  We can also use `ArtifactDependencyMode.Exist` to ensure the dependent entity not only exists but also matches in all properties.
+In the following illustrative example, if deploying a representation of a "Person", we ensure their "Department" dependency is added, indicating that it must exist to allow the transfer.  We can also use `ArtifactDependencyMode.Match` to ensure the dependent entity not only exists but also matches in all properties.
 
 ```C#
         private PersonArtifact Map(GuidUdi udi, Person person, ICollection<ArtifactDependency> dependencies)
@@ -298,6 +298,7 @@ This is done via the following code, which can be triggered from a Umbraco compo
 
 ```C#
 UdiParser.RegisterUdiType("mypackage-example", UdiType.GuidUdi);
+```
 
 ### Disk Based Transfers
 

--- a/Add-ons/Umbraco-Deploy/Extending/index.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index.md
@@ -74,14 +74,14 @@ The class is decorated with a `UdiDefinition` via which the name of the entity t
 
 The following example shows a service connector, responsible for handling the artifact shown above and it's related entity.  There are no dependencies to consider here.  More complex examples will involve collating the dependencies and potentially handling the extraction in more than one pass to ensure updates are made in the correct order.
 
-An illustrative data service is provided via dependency injection.  This will be whatever is appropriate for your solution to use for CRUD operations around reading and writing of entities.
+An illustrative data service is provided via dependency injection. This will be whatever is appropriate for to use for create, read, update and delete (CRUD) operations around reading and writing of entities.
 
 :::note
 In Deploy 9.5/10.1, to improve performance on deploy operations, we introduced a cache. This change required the addition of new methods to interfaces, allowing the passing in of a cache parameter.  In order to introduce this without breaking changes, we created some new interfaces and base classes.
 
 In the example below, if instead we inherited from `ServiceConnectorBase2`, which has a type parameter of `IServiceConnector2`, we would be able to implement `IArtifact? IServiceConnector2.GetArtifact(Udi udi, IContextCache contextCache)`. This would allow the connector to read and write to the cache and remove the use of the obsolete methods.
 
-There's no harm in what is listed below though.  It's only that the connectors won't be able to use the cache for any look-ups that are repeated in deploy operations.  The obsolete methods won't be removed until Deploy 11.  In that version we plan to return back to the original interface and class names and introduce the new method overloads (which will be a documented breaking change).
+There's no harm in what is listed below though.  It's only that the connectors won't be able to use the cache for any look-ups that are repeated in deploy operations.  The obsolete methods won't be removed until Deploy 11.  In that version we plan to return back to the original interface and class names. We also plan to introduce the new method overloads which will be a documented breaking change.
 :::
 
 ```C#
@@ -269,7 +269,7 @@ In the same way that Umbraco entities often have dependencies on one another, th
 
 If the dependent entity is also deployable, it will be included in the transfer.  Or if not, the deployment will be blocked and the reason presented to the user.
 
-In the following illustrative example, if deploying a representation of a "Person", we ensure their "Department" dependency is added, indicating that it must exist to allow the transfer.  We can also use `ArtifactDependencyMode.Match` to ensure the dependent entity not only exists but also matches in all properties.
+In the following illustrative example, if deploying a representation of a "Person", we ensure their "Department" dependency is added. This will indicate that it must exist to allow the transfer. We can also use `ArtifactDependencyMode.Match` to ensure the dependent entity not only exists but also matches in all properties.
 
 ```C#
         private PersonArtifact Map(GuidUdi udi, Person person, ICollection<ArtifactDependency> dependencies)

--- a/Add-ons/Umbraco-Deploy/Extending/index.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index.md
@@ -74,7 +74,7 @@ The class is decorated with a `UdiDefinition` via which the name of the entity t
 
 The following example shows a service connector, responsible for handling the artifact shown above and it's related entity.  There are no dependencies to consider here.  More complex examples will involve collating the dependencies and potentially handling the extraction in more than one pass to ensure updates are made in the correct order.
 
-An illustrative data service is provided via dependency injection. This will be whatever is appropriate for to use for create, read, update and delete (CRUD) operations around reading and writing of entities.
+An illustrative data service is provided via dependency injection. This will be whatever is appropriate for to use for Create, Read, Update and Delete (CRUD) operations around reading and writing of entities.
 
 :::note
 In Deploy 9.5/10.1, to improve performance on deploy operations, we introduced a cache. This change required the addition of new methods to interfaces, allowing the passing in of a cache parameter.  In order to introduce this without breaking changes, we created some new interfaces and base classes.

--- a/Add-ons/UmbracoForms/Developer/index.md
+++ b/Add-ons/UmbracoForms/Developer/index.md
@@ -64,7 +64,3 @@ Discusses how the backoffice for Umbraco Forms is available translated into the 
 ## [Content Apps](ContentApps/index.md)
 
 Adding an Umbraco content app to the Umbraco Forms backoffice section.
-
-## [Headless/AJAX Forms](AjaxForms/index.md)
-
-Umbraco Forms provides an API for client-side rendering and submission of forms, useful when you want to handle forms in a headless style scenario.

--- a/Add-ons/UmbracoForms/Developer/index.md
+++ b/Add-ons/UmbracoForms/Developer/index.md
@@ -64,3 +64,7 @@ Discusses how the backoffice for Umbraco Forms is available translated into the 
 ## [Content Apps](ContentApps/index.md)
 
 Adding an Umbraco content app to the Umbraco Forms backoffice section.
+
+## [Headless/AJAX Forms](AjaxForms/index.md)
+
+Umbraco Forms provides an API for client-side rendering and submission of forms, useful when you want to handle forms in a headless style scenario.


### PR DESCRIPTION
This fixes a couple of layout and detail issues in this page, as well as adds a note about obsolete methods introduced in 4.7/9.5/10.1.

Can be reviewed and published at any time.