### PR TITLE
Added rule that catches whether an acronym has been defined

### DIFF
--- a/.github/styles/UmbracoDocs/Acronyms.yml
+++ b/.github/styles/UmbracoDocs/Acronyms.yml
@@ -22,6 +22,7 @@ exceptions:
   - ASP
   - REST
   - HTTP
+  - HTTPS
   - CURL
   - BASE
   - UDA
@@ -36,3 +37,4 @@ exceptions:
   - HAL
   - LINK
   - DLL
+  - CMS

--- a/.github/styles/UmbracoDocs/Acronyms.yml
+++ b/.github/styles/UmbracoDocs/Acronyms.yml
@@ -16,6 +16,7 @@ exceptions:
   - API
   - URL
   - UDI
+  - URI
   - NET
   - MVC
   - GET
@@ -38,3 +39,7 @@ exceptions:
   - LINK
   - DLL
   - CMS
+  - ONLY
+  - IIS
+  - DNS
+  - DOM

--- a/.github/styles/UmbracoDocs/Acronyms.yml
+++ b/.github/styles/UmbracoDocs/Acronyms.yml
@@ -5,7 +5,7 @@ scope: text
 ignorecase: false
 # Ensures that the existence of 'first' implies the existence of 'second'.
 first: '\b([A-Z]{3,5})\b'
-second: '(?:\b[A-Z][a-z]+ )+\(([A-Z]{3,5})\)'
+second: '([A-Z]{3,5}): (?:\b[A-Z][a-z]+ )+|(?:\b[A-Z][a-z]+ )+\(([A-Z]{3,5})\)'
 # ... with the exception of these:
 exceptions:
   - ABC

--- a/.github/styles/UmbracoDocs/Acronyms.yml
+++ b/.github/styles/UmbracoDocs/Acronyms.yml
@@ -1,0 +1,38 @@
+extends: conditional
+message: "'%s' has no definition"
+level: error
+scope: text
+ignorecase: false
+# Ensures that the existence of 'first' implies the existence of 'second'.
+first: '\b([A-Z]{3,5})\b'
+second: '(?:\b[A-Z][a-z]+ )+\(([A-Z]{3,5})\)'
+# ... with the exception of these:
+exceptions:
+  - ABC
+  - ADD
+  - HTML
+  - JSON
+  - CSS
+  - API
+  - URL
+  - UDI
+  - NET
+  - MVC
+  - GET
+  - ASP
+  - REST
+  - HTTP
+  - CURL
+  - BASE
+  - UDA
+  - CLI
+  - KUDU
+  - XML
+  - PATH
+  - SQL
+  - POST
+  - GUID
+  - UWP
+  - HAL
+  - LINK
+  - DLL

--- a/Fundamentals/Setup/Server-Setup/Load-Balancing/flexible-advanced.md
+++ b/Fundamentals/Setup/Server-Setup/Load-Balancing/flexible-advanced.md
@@ -55,7 +55,7 @@ By setting your SchedulingPublisher server to use your custom `SchedulingPublish
 ## Subscriber servers - Read-only database access
 
 :::note
-This description pertains ONLY to Umbraco database tables
+This description pertains only to Umbraco database tables
 :::
 
 In some cases infrastructure admins will not want their front-end servers to have write access to the database.

--- a/Fundamentals/Setup/Server-Setup/permissions-v10.md
+++ b/Fundamentals/Setup/Server-Setup/permissions-v10.md
@@ -9,7 +9,7 @@ versionFrom: 10.0.0
 :::note
 To ensure a stable and smoothly running Umbraco installation, these permissions need to be set correctly. These permissions should be set up before or during the installation of Umbraco.
 
-The main account that requires 'modify' file permissions to be set on the folders below, is the account used start Umbraco. If Umbraco is hosted in IIS this will be the Application Pool Identity for the IIS website. Usually IIS APPPOOL\appPoolName or a specific local account or in some circumstances Network Service. If in doubt, ask your server admin / hosting company. Additionally, the IUSR account and IIS_IUSRS account only require 'read only' access to the site's folders.
+The main account that requires 'modify' file permissions to be set on the folders below, is the account used start Umbraco. If Umbraco is hosted in IIS this will be the Application Pool Identity for the IIS website. Usually IIS APPPOOL\appPoolName or a specific local account or in some circumstances Network Service. If in doubt, ask your server admin / hosting company. Additionally, the Internet User (IUSR) account and IIS_IUSRS account only require 'read only' access to the site's folders.
 
 Generally, when developing locally with Visual Studio or Rider, permissions do not need to be strictly applied.
 :::

--- a/Umbraco-Cloud/Troubleshooting/troubleshooting-frontend.md
+++ b/Umbraco-Cloud/Troubleshooting/troubleshooting-frontend.md
@@ -10,7 +10,7 @@ An error in the Frontend often looks like this:
 
 Errors in the frontend are presented in three ways:
 
-* YSOD: Yellow Screen Of Death (.NET error page)
+* YSOD: Yellow Screen of Death, .NET error page
 * Blank / not loading
 * 404 (Page not found)
 

--- a/Umbraco-Cloud/Troubleshooting/troubleshooting-frontend.md
+++ b/Umbraco-Cloud/Troubleshooting/troubleshooting-frontend.md
@@ -10,7 +10,7 @@ An error in the Frontend often looks like this:
 
 Errors in the frontend are presented in three ways:
 
-* YSOD (.Net error page)
+* YSOD: Yellow Screen Of Death (.NET error page)
 * Blank / not loading
 * 404 (Page not found)
 

--- a/Umbraco-Cloud/Upgrades/Migrating-from-8-to-10/index.md
+++ b/Umbraco-Cloud/Upgrades/Migrating-from-8-to-10/index.md
@@ -82,7 +82,7 @@ You need to manually upgrade the view files and custom code implementation. For 
   * Make sure to first migrate the Forms to the database, see the [Umbraco Forms in the Database](../../../Add-ons/UmbracoForms/Developer/Forms-in-the-Database/index-v8) article.
 
 * Run the Umbraco 10 project locally.
-  * It **will** give you a YSOD/error screen on the frontend as none of the Template files have been updated yet.
+  * It **will** give you a Yellow Screen of Death (YSOD)/error screen on the frontend as none of the Template files have been updated yet.
 
 * Go to the backoffice of your project.
 

--- a/Umbraco-Cloud/Upgrades/Minor-Upgrades/index.md
+++ b/Umbraco-Cloud/Upgrades/Minor-Upgrades/index.md
@@ -30,7 +30,7 @@ Symptoms, feedback given from the upgrade process: **Unable to run the Umbraco i
 The first step in the process, after having updated all the files, is to call the Umbraco install engine in order to get its  database updated to support the new version. As this step is the first time the site gets requested after the updated files are run, it may fail. The reason is often code that is incompatible with the upgraded files.
 
 It can be code that references APIs that have been deprecated, or code that has some strong references to specific versions.
-If the error is clear, then it will be shown on the screen, as it will be a typical ASP.NET error message (YSOD). You should request the site, and check the error it shows.
+If the error is clear, then it will be shown on the screen, as it will be a typical ASP.NET error message also called a Yellow Screen of Death (YSOD). You should request the site, and check the error it shows.
 If the error isn't descriptive, then it is time to clone the repository to your local machine, and fix the issue. The usual suspects would be:
 
 - The code you have running is referencing an API that has been changed, that is being modified, is obsolete, or removed.

--- a/Umbraco-Cloud/Upgrades/Minor-Upgrades/index.md
+++ b/Umbraco-Cloud/Upgrades/Minor-Upgrades/index.md
@@ -30,7 +30,7 @@ Symptoms, feedback given from the upgrade process: **Unable to run the Umbraco i
 The first step in the process, after having updated all the files, is to call the Umbraco install engine in order to get its  database updated to support the new version. As this step is the first time the site gets requested after the updated files are run, it may fail. The reason is often code that is incompatible with the upgraded files.
 
 It can be code that references APIs that have been deprecated, or code that has some strong references to specific versions.
-If the error is clear, then it will be shown on the screen, as it will be a typical ASP.NET error message also called a Yellow Screen of Death (YSOD). You should request the site, and check the error it shows.
+If the error is clear, it will be shown on the screen. It will be a typical ASP.NET error message also called a Yellow Screen of Death (YSOD). You should request the site, and check the error it shows.
 If the error isn't descriptive, then it is time to clone the repository to your local machine, and fix the issue. The usual suspects would be:
 
 - The code you have running is referencing an API that has been changed, that is being modified, is obsolete, or removed.

--- a/Umbraco-Heartcore/API-Documentation/index.md
+++ b/Umbraco-Heartcore/API-Documentation/index.md
@@ -132,7 +132,7 @@ Authorization: Bearer {token}
 
 ## Member authentication
 
-A member login can be used to access the Content Delivery API if it's protected. Members will only have access to CDN endpoint and cannot be used to access the Content Management API.
+A member login can be used to access the Content Delivery API if it's protected. Members will only have access to Content Delivery Network (CDN) endpoints and cannot be used to access the Content Management API.
 
 Content can be restricted further by using the Public Access feature in Umbraco to only allow access for specific Members or Member Groups.
 

--- a/Umbraco-Heartcore/Client-Libraries/Dot-Net-Core/MVC-Sample/index.md
+++ b/Umbraco-Heartcore/Client-Libraries/Dot-Net-Core/MVC-Sample/index.md
@@ -45,7 +45,7 @@ dotnet watch run
 
 To run the project and hot reload or recompile the project whenever changes are detected.
 
-### 2. Using an IDE
+### 2. Using an Integrated Development Environment (IDE)
 
 Run the application in Visual Studio or Visual Studio Code by hitting `F5`.
 

--- a/Umbraco-Heartcore/Getting-Started-Cloud/Webhooks/index.md
+++ b/Umbraco-Heartcore/Getting-Started-Cloud/Webhooks/index.md
@@ -44,4 +44,4 @@ When you are working with an external service that is behind a firewall and that
 20.86.53.156
 20.86.53.157
 ```
-If you need to use a CIDR (Classless Inter-Domain Routing) Range for the IPs: `20.86.53.156/31`
+If you need to use a Classless Inter-Domain Routing (CIDR) Range for the IPs: `20.86.53.156/31`

--- a/Umbraco-Heartcore/Tutorials/Creating-A-Custom-Grid-Editor/index.md
+++ b/Umbraco-Heartcore/Tutorials/Creating-A-Custom-Grid-Editor/index.md
@@ -383,7 +383,7 @@ Module aliases allows us to define a common name for a module that we can use in
 
 ![Defining custom module aliases](images/module-aliases.png)
 
-Here we have defined an alias `@headless-backoffice-bridge` pointing to a CDN URL of the [backoffice bridge library](https://github.com/umbraco/Umbraco.Headless.Backoffice.Bridge).
+Here we have defined an alias `@headless-backoffice-bridge` pointing to a Content Delivery Network (CDN) URL of the [backoffice bridge library](https://github.com/umbraco/Umbraco.Headless.Backoffice.Bridge).
 
 With this alias added we can update our import in our editor to:
 


### PR DESCRIPTION
All acronyms should be defined before continuous use in an article.
This means that when an acronym is used in an article, the first use case needs to be accompanied by a definition.

Examples have been added to the PR.

Also, a long list of excluded acronyms have been added to the rule.
This is in order to accommodate the API docs, markup languages and other commonly used acronyms like `IIS` and `CMS`.