### PR TITLE
Macro Parameter Editors has a broken link

### DIFF
--- a/Extending/Macro-Parameter-Editors/index-v8.md
+++ b/Extending/Macro-Parameter-Editors/index-v8.md
@@ -25,7 +25,7 @@ It is possible to create custom macro parameter types.
 
 ### isParameterEditor
 
-To create a custom Macro Parameter Type, first create a custom 'Property Editor' (or copy one from the core). See [Property Editors documentation](../../Extending/Property-Editors/) and in the corresponding [Package Manifest file](../../Extending/Property-Editors/Package-Manifest/index.md) for the editor, set the `isParameterEditor` property to be true.
+To create a custom Macro Parameter Type, first create a custom 'Property Editor' (or copy one from the core). See [Property Editors documentation](../../Extending/Property-Editors/index-v7-8) and in the corresponding [Package Manifest file](../../Extending/Property-Editors/Package-Manifest/index.md) for the editor, set the `isParameterEditor` property to be true.
 
 ```json
 propertyEditors: [

--- a/Extending/Macro-Parameter-Editors/index-v8.md
+++ b/Extending/Macro-Parameter-Editors/index-v8.md
@@ -25,7 +25,7 @@ It is possible to create custom macro parameter types.
 
 ### isParameterEditor
 
-To create a custom Macro Parameter Type, first create a custom 'Property Editor' (or copy one from the core). See [Property Editors documentation](../../Extending/Property-Editors/index-v8.md) and in the corresponding [Package Manifest file](../../Extending/Property-Editors/Package-Manifest/index.md) for the editor, set the `isParameterEditor` property to be true.
+To create a custom Macro Parameter Type, first create a custom 'Property Editor' (or copy one from the core). See [Property Editors documentation](../../Extending/Property-Editors/) and in the corresponding [Package Manifest file](../../Extending/Property-Editors/Package-Manifest/index.md) for the editor, set the `isParameterEditor` property to be true.
 
 ```json
 propertyEditors: [


### PR DESCRIPTION
Just a small edit to fix a broken link that I found when reading the documentation for Macros. 

The link was pointing to a now removed page for V8, I've change the link to point to the main Property Editors page.