### PR TITLE
Readability on Where can I get help.

### DIFF
--- a/Getting-Started/Where-can-I-get-help/index.md
+++ b/Getting-Started/Where-can-I-get-help/index.md
@@ -33,7 +33,7 @@ You can talk to developers across the globe via the Umbraco Forum, report an iss
 
 [Found an issue in Umbraco? Report it on our CMS Issue Tracker](https://github.com/umbraco/Umbraco-CMS/issues)
 
-[Found an issue with the Umbraco Documentation? Report it on our Documentation Issue Tracker](https://github.com/umbraco/UmbracoDocs)
+[Found an issue with the Umbraco Documentation? Report it on our Documentation Issue Tracker](https://github.com/umbraco/UmbracoDocs/issues)
 
 [Find out how to suggest an improvement to the Umbraco Documentation](../../Contribute/)
 

--- a/Getting-Started/Where-can-I-get-help/index.md
+++ b/Getting-Started/Where-can-I-get-help/index.md
@@ -31,9 +31,9 @@ You can talk to developers across the globe via the Umbraco Forum, report an iss
 
 ## Other resources
 
-[Found an issue in Umbraco? Report it on our Issue Tracker](https://github.com/umbraco/Umbraco-CMS/issues)
+[Found an issue in Umbraco? Report it on our CMS Issue Tracker](https://github.com/umbraco/Umbraco-CMS/issues)
 
-[Found an issue with the Umbraco Documentation? Report it to the Documentation team](https://github.com/umbraco/UmbracoDocs)
+[Found an issue with the Umbraco Documentation? Report it on our Documentation Issue Tracker](https://github.com/umbraco/UmbracoDocs)
 
 [Find out how to suggest an improvement to the Umbraco Documentation](../../Contribute/)
 


### PR DESCRIPTION
The previous version implied contacting directly to the Team but the link was for the Docs issue tracker.  I thought it would be better when consistent with the CMS issue tracker.