### PR TITLE
Add AJAX and XSLT to the acronym exception lists

### DIFF
--- a/.github/styles/UmbracoDocs/Acronyms.yml
+++ b/.github/styles/UmbracoDocs/Acronyms.yml
@@ -45,3 +45,5 @@ exceptions:
   - IIS
   - DNS
   - DOM
+  - XSLT
+  - AJAX


### PR DESCRIPTION
More people will know the acronyms that the definitions here, as both are programming languages.