### PR TITLE
Update outbound-pipeline.md

### DIFF
--- a/Reference/Routing/Request-Pipeline/outbound-pipeline.md
+++ b/Reference/Routing/Request-Pipeline/outbound-pipeline.md
@@ -318,7 +318,7 @@ using Umbraco.Cms.Core.DependencyInjection;
 
 namespace RoutingDocs.UrlProviders
 {
-    public class RegisterCustomUrlProviderComposer : IUserComposer
+    public class RegisterCustomUrlProviderComposer : IComposer
     {
         public void Compose(IUmbracoBuilder builder)
         {

--- a/Reference/Routing/Request-Pipeline/outbound-pipeline.md
+++ b/Reference/Routing/Request-Pipeline/outbound-pipeline.md
@@ -260,8 +260,9 @@ public class ProductPageUrlProvider : DefaultUrlProvider
             ILogger<DefaultUrlProvider> logger,
             ISiteDomainMapper siteDomainMapper,
             IUmbracoContextAccessor umbracoContextAccessor,
-            UriUtility uriUtility)
-            : base(requestSettings, logger, siteDomainMapper, umbracoContextAccessor, uriUtility)
+            UriUtility uriUtility,
+            ILocalizationService localizationService)
+            : base(requestSettings, logger, siteDomainMapper, umbracoContextAccessor, uriUtility, localizationService)
         {
         }
 


### PR DESCRIPTION
The example under Create Url uses an obsolete constructor and should use the constructor with full parameters, which includes `ILocalizationService`:

```
public ProductPageUrlProvider(
            IOptionsMonitor<RequestHandlerSettings> requestSettings,
            ILogger<DefaultUrlProvider> logger,
            ISiteDomainMapper siteDomainMapper,
            IUmbracoContextAccessor umbracoContextAccessor,
            UriUtility uriUtility,
            ILocalizationService localizationService)
            : base(requestSettings, logger, siteDomainMapper, umbracoContextAccessor, uriUtility, localizationService)
    {
    }
```

Registering the `ProductPageUrlProvider` in a composer also references the obsolete `IUserComposer` instead of `IComposer`.

```
public class RegisterCustomUrlProviderComposer : IComposer
{
	public void Compose(IUmbracoBuilder builder)
	{
		builder.UrlProviders().Insert<ProductPageUrlProvider>();
	}
}
```