### PR TITLE
Add V8 version of Nucache settings

### DIFF
--- a/Reference/Configuration-for-Umbraco-7-and-8/nucache-settings.md
+++ b/Reference/Configuration-for-Umbraco-7-and-8/nucache-settings.md
@@ -7,25 +7,23 @@ meta.Description: "Information on the NuCache settings section"
 
 # NuCache Settings
 
-NuCache uses the BPlusTree library for storing the cache of published content, which has a default 'block' size for where data is stored in memory, it's possible in some niche situations for an Umbraco content item to have such a large footprint that it will cause an error when being stored in the BPlusTree block, in these circumstances it is possible to configure BPlusTree to use larger size blocks.
+NuCache uses the BPlusTree library for storing the cache of published content. It has a default 'block' size for where data is stored in memory. It is possible for a Umbraco content item to have a footprint that is too large. In these cases, it will cause an error when being stored in the BPlusTree block. In these circumstances it is possible to configure BPlusTree to use larger size blocks.
 
-Add the following AppSetting to your Web.Config file:
+Add the following AppSetting to your `web.config` file:
 
 ```xml
 <appSettings>
-		<add key="Umbraco.Web.PublishedCache.NuCache.BTree.BlockSize" value="4096" />
+	<add key="Umbraco.Web.PublishedCache.NuCache.BTree.BlockSize" value="4096" />
 </appSettings>
-
 ```
 
 This is how NuCache is configured by default. It is important to mention that the block size must be a power of two, at least 512, and at most 65536 (64K).
-
 
 ## Additional Settings
 
 It is possible to configure NuCache to work in memory only without reading/writing the NuCache database files.
 
-For larger sites this is likely to increase startup duration for a "warm boot" however for a smaller site there should be little to no impact.
+For larger sites this is likely to increase startup duration for a "warm boot". However, for a smaller site there should be little to no impact.
 
 This is configurable by adding the following composer:
 
@@ -42,3 +40,9 @@ public class DisableNuCacheDatabaseComposer : IComposer
         }
     }
 ```
+
+:::note
+The example above applies to Umbraco 8.6+.
+
+Are you using Umbraco 9+ or later versions, please refer to the article on [NuCache Settings for Umbraco 9+](../Configuration/NuCacheSettings/).
+:::

--- a/Reference/Configuration/NuCacheSettings/index-v8.6.md
+++ b/Reference/Configuration/NuCacheSettings/index-v8.6.md
@@ -1,0 +1,44 @@
+---
+versionFrom: 8.6.0
+versionTo: 9.0.0
+meta.Title: "Umbraco NuCache Settings"
+meta.Description: "Information on the NuCache settings section"
+---
+
+# NuCache Settings
+
+NuCache uses the BPlusTree library for storing the cache of published content, which has a default 'block' size for where data is stored in memory, it's possible in some niche situations for an Umbraco content item to have such a large footprint that it will cause an error when being stored in the BPlusTree block, in these circumstances it is possible to configure BPlusTree to use larger size blocks.
+
+Add the following AppSetting to your Web.Config file:
+
+```xml
+<appSettings>
+		<add key="Umbraco.Web.PublishedCache.NuCache.BTree.BlockSize" value="4096" />
+</appSettings>
+
+```
+
+This is how NuCache is configured by default. It is important to mention that the block size must be a power of two, at least 512, and at most 65536 (64K).
+
+
+## Additional Settings
+
+It is possible to configure NuCache to work in memory only without reading/writing the NuCache database files.
+
+For larger sites this is likely to increase startup duration for a "warm boot" however for a smaller site there should be little to no impact.
+
+This is configurable by adding the following composer:
+
+```csharp
+public class DisableNuCacheDatabaseComposer : IComposer
+    {
+        public void Compose(Composition composition)
+        {
+            var settings = new Umbraco.Web.PublishedCache.NuCache.PublishedSnapshotServiceOptions
+            {
+                IgnoreLocalDb = true
+            };
+            composition.Register(factory => settings, Lifetime.Singleton);
+        }
+    }
+```

--- a/Reference/Configuration/NuCacheSettings/index.md
+++ b/Reference/Configuration/NuCacheSettings/index.md
@@ -21,7 +21,6 @@ This settings section allows you to specify the block size of the BTree used by 
 
 This is how NuCache is configured by default. It is important to mention that the block size must be a power of two, at least 512, and at most 65536 (64K).
 
-
 ## Additional Settings
 
 It is possible to configure NuCache to work in memory only without reading/writing the NuCache database files.
@@ -43,3 +42,9 @@ public class DisableNuCacheDatabaseComposer : IComposer
     }
 }
 ```
+
+:::note
+The example above applies only to Umbraco 9+ sites.
+
+Are you using Umbraco 8, please refer to the article on [NuCache Settings for Umbraco 8](../../Configuration-for-Umbraco-7-and-8/nucache-settings.md).
+:::


### PR DESCRIPTION
We mention how to set ignorelocaldb for V8 in load balancing docs but now we have a specific NuCache settings page for V9+ makes sense to do a V8 version here?

Fixes #4456 