### PR TITLE
Fix link to Image Cropper v7 page

### DIFF
--- a/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/index-v7.md
+++ b/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/index-v7.md
@@ -85,7 +85,7 @@ Used mainly with container Media Types, the Folder Browser displays a list of th
 
 New to Umbraco 7.2, gives editors a grid layout editor which allows them to insert different types of content in a predefined layout.
 
-## [Image Cropper](Image-Cropper.md)
+## [Image Cropper](Image-Cropper/index-v7.md)
 `Alias: Umbraco.ImageCropper`
 
 Used to crop and resize images to predefined sizes. Available from Umbraco 7.1


### PR DESCRIPTION
I was on the "Built-in Property Editors" page for v7 and clicked the Image Cropper link, and noticed I ended up on the "v10 (current)" version, so did some digging to see if there was a version for v7. Lo and behold, I found it, so decided to fix the link 😀 
