### PR TITLE
Follow-Through from Rest API to Heartcore

### DIFF
--- a/Implementation/Rest-Api/index.md
+++ b/Implementation/Rest-Api/index.md
@@ -3,4 +3,11 @@ versionFrom: 7.0.0
 versionRemoved: 8.0.0
 ---
 
-# The Umbraco REST API project has been discontinued [in favor of Umbraco Heartcore](https://umbraco.com/products/umbraco-headless/)
+# Rest Api
+
+ The Umbraco REST API project has been discontinued [in favor of Umbraco Heartcore](https://umbraco.com/products/umbraco-headless/). 
+ 
+ # Umbraco Heartcore
+
+ If you were looking for documentation on Umbraco Heartcore instead, you can follow the following link for the [Umbraco Heartcore API Documentation](/documentation/Umbraco-Heartcore/API-Documentation/).
+ 

--- a/Implementation/Rest-Api/index.md
+++ b/Implementation/Rest-Api/index.md
@@ -5,7 +5,7 @@ versionRemoved: 8.0.0
 
 # Rest Api
 
- The Umbraco REST API project has been discontinued [in favor of Umbraco Heartcore](https://umbraco.com/products/umbraco-headless/). 
+ The Umbraco REST API project has been discontinued [in favor of Umbraco Heartcore](https://umbraco.com/products/umbraco-heartcore/). 
  
  # Umbraco Heartcore
 


### PR DESCRIPTION
The current Rest Api page only redirects to the official Umbraco Heartcore product page. I thought it would be a useful addition to add a follow-through to the Heartcore Api Documentation too, as some may end up on this page, looking for information on Heartcore instead! 🙂