### PR TITLE
Added link to Umbraco OpenID Connect example package.

### DIFF
--- a/Reference/Security/External-login-providers/index.md
+++ b/Reference/Security/External-login-providers/index.md
@@ -21,6 +21,8 @@ Install an appropriate nuget package for the provider you wish to use. Some popu
  * [Open ID Connect](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.OpenIdConnect)
  * [Others](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/social/other-logins?view=aspnetcore-5.0)
 
+There is also a complete Umbraco solution with a SQLite database that demonstrates how OpenID Connect with Umbraco works: [https://github.com/jbreuer/Umbraco-OpenIdConnect-Example](https://github.com/jbreuer/Umbraco-OpenIdConnect-Example).
+
 To configure the provider create a new static extension class for your provider and configure a custom named options like `GoogleBackOfficeExternalLoginProviderOptions` described in details in the [auto linking](../auto-linking/index.md) section.
 The code example below shows how the configuration for Google Authentication can be done. You can find an example for how this can be done with Microsoft in the [Authenticating on the Umbraco backoffice with Active Directory credentials](../Authenticate-with-Active-Directory/index.md) article.
 

--- a/Reference/Security/External-login-providers/index.md
+++ b/Reference/Security/External-login-providers/index.md
@@ -21,7 +21,13 @@ Install an appropriate nuget package for the provider you wish to use. Some popu
  * [Open ID Connect](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.OpenIdConnect)
  * [Others](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/social/other-logins?view=aspnetcore-5.0)
 
-There is also a complete Umbraco solution with a SQLite database that demonstrates how OpenID Connect with Umbraco works: [https://github.com/jbreuer/Umbraco-OpenIdConnect-Example](https://github.com/jbreuer/Umbraco-OpenIdConnect-Example).
+:::tip
+**Try it out**
+
+This community-created package with a complete Umbraco solution incl. an SQLite database demonstrates how OpenID Connect can be used: [Umbraco OpenIdConnect Example](https://github.com/jbreuer/Umbraco-OpenIdConnect-Example).
+
+It is great for testing and for trying out the implementation before building it into your own project.
+:::
 
 To configure the provider create a new static extension class for your provider and configure a custom named options like `GoogleBackOfficeExternalLoginProviderOptions` described in details in the [auto linking](../auto-linking/index.md) section.
 The code example below shows how the configuration for Google Authentication can be done. You can find an example for how this can be done with Microsoft in the [Authenticating on the Umbraco backoffice with Active Directory credentials](../Authenticate-with-Active-Directory/index.md) article.


### PR DESCRIPTION
When people are reading the documentation about external login providers it can help them to show a working example which they can download and run without any configuration.