### PR TITLE
Add instructions on migrating members from Umbraco 8 to 10

### DIFF
--- a/Umbraco-Cloud/Upgrades/Migrating-from-8-to-10/index.md
+++ b/Umbraco-Cloud/Upgrades/Migrating-from-8-to-10/index.md
@@ -144,36 +144,47 @@ If you have Members in your Umbraco database these were not transferred when you
    SELECT MAX(id) FROM umbracoContentVersion
    SELECT MAX(id) FROM umbracoPropertyData
    ```
-* Use the SQL Server Import and Export Wizard to query data from your Umbraco 8 database and insert it into your Umbraco 10 database. You can start the wizard by right-clicking any database and selecting Tasks > Import Data... Use the 'Microsoft OLE DB Driver for SQL Server' to connect first to your Umbraco 8 database as the data source, then your Umbraco 10 database.
+* Use the SQL Server Import and Export Wizard to query data from your Umbraco 8 database and insert it into your Umbraco 10 database. You can start the wizard by right-clicking any database and selecting Tasks > Import Data... 
+ 
+    Use the 'Microsoft OLE DB Driver for SQL Server' to connect first to your Umbraco 8 database as the data source, then your Umbraco 10 database as the destination. Next, select 'Write a query to specify the data to transfer', and use the following queries. You will need to run this wizard again from the start for each query. 
 
-You will need to run this wizard once for each of the following queries. 
-
-Replace `{umbracoNode}` and `{umbracoContentVersion}` with the results from your previous query.
+    In this query replace `{umbracoNode}` and `{umbracoContentVersion}` with the results from your previous query. After you enter your query in the wizard you'll see the 'Select Source Tables and Views' page of the wizard. Change the destination from `[dbo].[Query]` to `[dbo].[umbracoNode]`. Click 'Edit Mappings...` and tick 'Enable identity insert'. You're now ready to complete the wizard.
 
    ```
-   -- Insert the results of this query on your Umbraco 8 database into the umbracoNode table on your Umbraco 10 database. This requires you to enable Identity Insert in the wizard options.
    SELECT id + {umbracoNode} AS id, uniqueid, parentid, level, path, sortOrder, trashed, -1 AS nodeUser, text, nodeObjectType, createDate 
    FROM umbracoNode 
    WHERE nodeObjectType IN ('39EB0F98-B348-42A1-8662-E7EB18487560', '366E63B9-880F-4E13-A61C-98069B029728')
+   ```	
+   
+* Run the wizard again and select your Umbraco 8 database as the data source, then your Umbraco 10 database as the destination. Enter the query below. Replace `{umbracoNode}` with the result from your earlier query. Change the destination to `[dbo].[umbracoContent]`, and this time you don't need to select 'Enable identity insert'.
+ 
+    ```
+    SELECT nodeId + {umbracoNode} AS nodeId, contentTypeId 
+    FROM umbracoContent 
+    WHERE nodeId IN (SELECT nodeId FROM cmsMember)
+	```
+    
+* Run the wizard again and select your Umbraco 8 database as the data source, then your Umbraco 10 database as the destination. Enter the query below. Replace `{umbracoNode}` with the result from your earlier query. Change the destination to `[dbo].[cmsMember]`, and this time you don't need to select 'Enable identity insert'.
+
+    ```
+    SELECT nodeId + {umbracoNode} AS nodeId, Email, LoginName, Password 
+    FROM cmsMember
+    ```
 	
-   -- Run the wizard again and insert the results of this query on your Umbraco 8 database into the umbracoContent table on your Umbraco 10 database.
-   SELECT nodeId + {umbracoNode} AS nodeId, contentTypeId 
-   FROM umbracoContent 
-   WHERE nodeId IN (SELECT nodeId FROM cmsMember)
+* Run the wizard again and select your Umbraco 8 database as the data source, then your Umbraco 10 database as the destination. Enter the query below. Replace `{umbracoContentVersion}` and `{umbracoNode}` with the results from your earlier queries. Change the destination to `[dbo].[umbracoContentVersion]`. This time you **do** need to select 'Enable identity insert'.
+
+    ```
+    SELECT id + {umbracoContentVersion} AS id, nodeId + {umbracoNode} AS nodeId, versionDate, userId, [current], [text] 
+    FROM umbracoContentVersion 
+    WHERE nodeId IN (SELECT nodeId FROM cmsMember) 
+    ```
 	
-   -- Run the wizard again and insert the results of this query on your Umbraco 8 database into the cmsMember table on your Umbraco 10 database.
-   SELECT nodeId + {umbracoNode} AS nodeId, Email, LoginName, Password 
-   FROM cmsMember
-	
-   -- Run the wizard again and insert the results of this query on your Umbraco 8 database into the umbracoContentVersion table on your Umbraco 10 database. This requires you to enable Identity Insert in the wizard options.
-   SELECT id + {umbracoContentVersion} AS id, nodeId + {umbracoNode} AS nodeId, versionDate, userId, [current], [text] 
-   FROM umbracoContentVersion 
-   WHERE nodeId IN (SELECT nodeId FROM cmsMember) 
-	
-   -- Run the wizard again and insert the results of this query on your Umbraco 8 database into the cmsMember2MemberGroup table on your Umbraco 10 database.
-   SELECT Member + {umbracoNode} As Member, MemberGroup + {umbracoNode} AS MemberGroup 
-   FROM cmsMember2MemberGroup
-   ```
+* Run the wizard again and select your Umbraco 8 database as the data source, then your Umbraco 10 database as the destination. Enter the query below. Replace `{umbracoNode}` with the result from your earlier query. Change the destination to `[dbo].[cmsMember2MemberGroup]`. This time you don't need to select 'Enable identity insert'.
+
+    ```
+    SELECT Member + {umbracoNode} As Member, MemberGroup + {umbracoNode} AS MemberGroup 
+    FROM cmsMember2MemberGroup
+    ```
    
 * Now you need to transfer the properties that belong to the Members. Run the following query on both your Umbraco 8 database and your Umbraco 10 database and note the results, which will probably be different between the two:
 
@@ -185,7 +196,7 @@ Replace `{umbracoNode}` and `{umbracoContentVersion}` with the results from your
     ORDER BY Alias
     ```
     
-    Using those results, run the wizard again and insert the results of this query on your Umbraco 8 database into the umbracoPropertyData table on your Umbraco 10 database. Replace `{umbracoPropertyData}` and `{umbracoContentVersion}` with the results from your first query above, and replace all the id values with the results from your two queries just now. You must enable Identity Insert in the wizard options as well.
+    Using those results, run the wizard again and select your Umbraco 8 database as the data source, then your Umbraco 10 database as the destination. Enter the query below. Replace `{umbracoPropertyData}` and `{umbracoContentVersion}` with the results from your first queries above, and replace all the `{umbraco x id for alias xxx}` values with the results from your two queries just now. Change the destination to `[dbo].[umbracoPropertyData]`. This time you **do** need to select 'Enable identity insert'.
     
     ```
     SELECT id + {umbracoPropertyData} AS id, versionid + {umbracoContentVersion} AS versionid,  
@@ -203,15 +214,17 @@ Replace `{umbracoNode}` and `{umbracoContentVersion}` with the results from your
       languageId, segment, intValue, decimalValue, dateValue, varcharValue, textValue
       FROM umbracoPropertyData
       WHERE versionid IN (SELECT id FROM umbracoContentVersion WHERE nodeId IN (SELECT nodeId FROM cmsMember))
-      ```
+    ```
 
 * On your Umbraco 10 database reset the identity seeds where you used Identity Insert:
 
     ```
-	DBCC CHECKIDENT(umbracoNode)
-	DBCC CHECKIDENT(umbracoContentVersion)
-	DBCC CHECKIDENT(umbracoPropertyData)
+    DBCC CHECKIDENT(umbracoNode)
+    DBCC CHECKIDENT(umbracoContentVersion)
+    DBCC CHECKIDENT(umbracoPropertyData)
     ```
+    
+You should now be able to see your members and member groups in the Umbraco back office, and login using existing member accounts on your front-end website.
 
 ## Step 5: Deploy and Test on Umbraco Cloud
 

--- a/Umbraco-Cloud/Upgrades/Migrating-from-8-to-10/index.md
+++ b/Umbraco-Cloud/Upgrades/Migrating-from-8-to-10/index.md
@@ -197,20 +197,21 @@ If you have Members in your Umbraco database these were not transferred when you
     ORDER BY cmsContentType.alias, cmsPropertyType.Alias
     ```
     
-    Using those results, run the wizard again and select your Umbraco 8 database as the data source, then your Umbraco 10 database as the destination. Follow the template below to build up a query that gets all the custom property data for your Member Types, and updates the `propertyTypeId` to that used by your Umbraco 10 database. You need to:
+    Using those results, run the wizard again and select your Umbraco 8 database as the data source, then your Umbraco 10 database as the destination. Follow the template below to build up a query that gets all the custom property data for your Member Types. Change the destination to `[dbo].[umbracoPropertyData]`. This time you **do** need to select 'Enable identity insert'. 
+
+    Your query needs to update the `propertyTypeId` from the one used by your Umbraco 8 database to that used by your Umbraco 10 database. You need to:
     - Replace `{umbracoPropertyData}` and `{umbracoContentVersion}` with the results from your first queries above
-    - For each row returned by your most recent query on your Umbraco 8 database, make a copy of the line that starts with `WHEN`. Find the row with matching `MemberTypeAlias` and `CustomPropertyAlias` in your Umbraco 10 query results. Replace `{umbraco x id for CustomPropertyAlias result}` values with the values from the id columns in the Umbraco 8 result and the Umbraco 10 result.
+    - For each row returned by your most recent query on your Umbraco 8 database, make a copy of the line that starts with `WHEN`. Find the row with matching `MemberTypeAlias` and `CustomPropertyAlias` values in your Umbraco 10 query results. Replace `{umbraco x id}` with the values from the `id` columns in the Umbraco 8 result and the Umbraco 10 result.
      
-    ```
-    SELECT id + {umbracoPropertyData} AS id, versionid + {umbracoContentVersion} AS versionid,  
+        ```
+        SELECT id + {umbracoPropertyData} AS id, versionid + {umbracoContentVersion} AS versionid,  
     	CASE 
-        WHEN propertyTypeId = {umbraco 8 id for CustomPropertyAlias result} THEN {umbraco 10 id for CustomPropertyAlias result} 
+        WHEN propertyTypeId = {umbraco 8 id} THEN {umbraco 10 id} 
         ELSE propertyTypeId END AS propertyTypeId, 
-      languageId, segment, intValue, decimalValue, dateValue, varcharValue, textValue
-      FROM umbracoPropertyData
-      WHERE versionid IN (SELECT id FROM umbracoContentVersion WHERE nodeId IN (SELECT nodeId FROM cmsMember))
-    ```
-    Change the destination to `[dbo].[umbracoPropertyData]`. This time you **do** need to select 'Enable identity insert'. Finish the wizard.
+        languageId, segment, intValue, decimalValue, dateValue, varcharValue, textValue
+        FROM umbracoPropertyData
+        WHERE versionid IN (SELECT id FROM umbracoContentVersion WHERE nodeId IN (SELECT nodeId FROM cmsMember))
+        ```
 
 * On your Umbraco 10 database reset the identity seeds where you used Identity Insert:
 

--- a/Umbraco-Cloud/Upgrades/Migrating-from-8-to-10/index.md
+++ b/Umbraco-Cloud/Upgrades/Migrating-from-8-to-10/index.md
@@ -201,7 +201,7 @@ If you have Members in your Umbraco database these were not transferred when you
 
     Your query needs to update the `propertyTypeId` from the one used by your Umbraco 8 database to that used by your Umbraco 10 database. You need to:
     - Replace `{umbracoPropertyData}` and `{umbracoContentVersion}` with the results from your first queries above
-    - For each row returned by your most recent query on your Umbraco 8 database, make a copy of the line that starts with `WHEN`. Find the row with matching `MemberTypeAlias` and `CustomPropertyAlias` values in your Umbraco 10 query results. Replace `{umbraco x id}` with the values from the `id` columns in the Umbraco 8 result and the Umbraco 10 result.
+    - For each row returned by your most recent query on your Umbraco 8 database, make a copy of the line that starts with `WHEN`. Find the row with matching `MemberTypeAlias` and `CustomPropertyAlias` values in your Umbraco 10 query results. Replace `{umbraco 8 id}` and `{umbraco 10 id}` with the values from the `id` columns in the Umbraco 8 result and the Umbraco 10 result.
      
         ```
         SELECT id + {umbracoPropertyData} AS id, versionid + {umbracoContentVersion} AS versionid,  

--- a/Umbraco-Cloud/Upgrades/Migrating-from-8-to-10/index.md
+++ b/Umbraco-Cloud/Upgrades/Migrating-from-8-to-10/index.md
@@ -146,7 +146,7 @@ If you have Members in your Umbraco database these were not transferred when you
    ```
 * Use the SQL Server Import and Export Wizard to query data from your Umbraco 8 database and insert it into your Umbraco 10 database. You can start the wizard by right-clicking any database and selecting Tasks > Import Data... 
  
-    Use the 'Microsoft OLE DB Driver for SQL Server' to connect first to your Umbraco 8 database as the data source, then your Umbraco 10 database as the destination. Next, select 'Write a query to specify the data to transfer', and use the following queries. You will need to run this wizard again from the start for each query. 
+    Use the `Microsoft OLE DB Driver for SQL Server` to connect first to your Umbraco 8 database as the data source, then your Umbraco 10 database as the destination. Next, select 'Write a query to specify the data to transfer', and use the following queries. You will need to run this wizard again from the start for each query. 
 
     In this query replace `{umbracoNode}` and `{umbracoContentVersion}` with the results from your previous query. After you enter your query in the wizard you'll see the 'Select Source Tables and Views' page of the wizard. Change the destination from `[dbo].[Query]` to `[dbo].[umbracoNode]`. Click 'Edit Mappings...` and tick 'Enable identity insert'. You're now ready to complete the wizard.
 

--- a/Umbraco-Cloud/Upgrades/Migrating-from-8-to-10/index.md
+++ b/Umbraco-Cloud/Upgrades/Migrating-from-8-to-10/index.md
@@ -196,7 +196,7 @@ If you have Members in your Umbraco database these were not transferred when you
     ORDER BY Alias
     ```
     
-    Using those results, run the wizard again and select your Umbraco 8 database as the data source, then your Umbraco 10 database as the destination. Enter the query below. Replace `{umbracoPropertyData}` and `{umbracoContentVersion}` with the results from your first queries above, and replace all the `{umbraco x id for alias xxx}` values with the results from your two queries just now. Change the destination to `[dbo].[umbracoPropertyData]`. This time you **do** need to select 'Enable identity insert'.
+    Using those results, run the wizard again and select your Umbraco 8 database as the data source, then your Umbraco 10 database as the destination. Enter the query below. Replace `{umbracoPropertyData}` and `{umbracoContentVersion}` with the results from your first queries above, and replace all the `{umbraco x id for alias xxx}` values with the results from your two most recent queries. Change the destination to `[dbo].[umbracoPropertyData]`. This time you **do** need to select 'Enable identity insert'.
     
     ```
     SELECT id + {umbracoPropertyData} AS id, versionid + {umbracoContentVersion} AS versionid,  
@@ -224,7 +224,7 @@ If you have Members in your Umbraco database these were not transferred when you
     DBCC CHECKIDENT(umbracoPropertyData)
     ```
     
-You should now be able to see your members and member groups in the Umbraco back office, and login using existing member accounts on your front-end website.
+You should now see your Members and Member Groups in the Umbraco backoffice, and login using existing Member accounts on your front-end website.
 
 ## Step 5: Deploy and Test on Umbraco Cloud
 


### PR DESCRIPTION
When I migrated my site from Umbraco 8 to 9 I followed this guide, but I found that migration of members was not covered. I asked Cloud support and they were only able to tell me there was no tool to support it, and I would have to do it on my own with database queries. It seemed as if I was the first one to ask, yet this must be a common requirement. This documents the process I ended up using, which worked for my site.