### PR TITLE
Improve readability of section trees

### DIFF
--- a/Extending/Section-Trees/Trees/index-v8.md
+++ b/Extending/Section-Trees/Trees/index-v8.md
@@ -17,20 +17,23 @@ Create a `TreeController` class in C#. A new mvc controller which inherits from 
 * GetTreeNodes (returns a `TreeNodeCollection`) - Responsible for rendering the content of the tree structure.
 * GetMenuForNode (returns a `MenuItemCollection`) - Responsible for returning the menu structure to use for a particular node within a tree.
 
-Decorate your `TreeController` with the `Tree` Attribute, which is used to define the name of the section the Tree should be loaded in, which 'Tree Group' it should belong to and also define an alias and title for your custom tree.
+The `Tree` attribute used to decorate the `TreeController` has multiple properties.
 
+- `SectionAlias` - Alias of the section in which the tree appears
+- `TreeAlias` - Alias of the tree
+- `TreeTitle` - The title of the tree
+- `TreeGroup` - The tree group, the tree belongs to
+- `SortOrder` - Sort order of the tree
 
 **For example**
 
 ```csharp
-[Tree("settings", "favouriteThingsAlias", TreeTitle = "Favourite Things Name", TreeGroup = "favouritesGroup", SortOrder = 5)]
+[Tree(SectionAlias = "settings", TreeAlias = "favouriteThingsAlias", TreeTitle = "Favourite Things Name", TreeGroup = "favouritesGroup", SortOrder = 5)]
 public class FavouriteThingsTreeController : TreeController
 { }
 ```
 
 ...would register a custom tree with a title 'Favourite Things Name' in the Settings section of Umbraco, inside a custom group called 'Favourites'
-
-The `SortOrder` controls the order of the custom tree within the Tree Group.
 
 ### Tree Groups
 Tree Groups are a new concept in V8, to enable you to group trees in a section. You provide the alias of the Tree Group name, you wish to add your tree to - see [Constants.Trees.Groups](https://our.umbraco.com/apidocs/v8/csharp/api/Umbraco.Core.Constants.Trees.Groups.html) for a list of existing group alias. An example of tree groups in the backoffice would be the *Settings* tree group and the *Templating* tree group in the *Settings* section.
@@ -46,7 +49,7 @@ If you add your own alias, you'll need to add a translation key to `config/lang/
 
 ### Customising the Root Tree Node
 
-The first node in the tree is referred to as the **Root Node**. You might want to assign a custom icon to the Root Node or specify a custom url route path in the backoffice to use with your custom tree. Perhaps if you had a single page app you customise the Root Node by overriding the abstract `CreateRootNode` method.
+The first node in the tree is referred to as the **Root Node**. You customise the Root Node by overriding the abstract `CreateRootNode` method. You can assign a custom icon to the Root Node. You can also specify a custom URL route path in the backoffice to use with your custom tree. The method can be useful if your section has a single node.
 
 
 :::note

--- a/Extending/Section-Trees/Trees/index-v8.md
+++ b/Extending/Section-Trees/Trees/index-v8.md
@@ -12,12 +12,12 @@ This section describes how to work with and create trees with the v8 APIs.
 
 To Create a Tree in a section of the Umbraco backoffice, you need to take several steps:
 
-Create a 'TreeController' class in C#. A new mvc controller which inherits from the abstract *Umbraco.Web.Trees.TreeController* class and provides an implementation for two abstract methods:
+Create a `TreeController` class in C#. A new mvc controller which inherits from the abstract `Umbraco.Web.Trees.TreeController` class and provides an implementation for two abstract methods:
 
-* GetTreeNodes (returns a *TreeNodeCollection*) - Responsible for rendering the content of the tree structure.
-* GetMenuForNode (returns a *MenuItemCollection*) - Responsible for returning the menu structure to use for a particular node within a tree.
+* GetTreeNodes (returns a `TreeNodeCollection`) - Responsible for rendering the content of the tree structure.
+* GetMenuForNode (returns a `MenuItemCollection`) - Responsible for returning the menu structure to use for a particular node within a tree.
 
-Decorate your '*TreeController*' with the *Tree* Attribute, which is used to define the name of the section the Tree should be loaded in, which 'Tree Group' it should belong to and also define an alias and title for your custom tree.
+Decorate your `TreeController` with the `Tree` Attribute, which is used to define the name of the section the Tree should be loaded in, which 'Tree Group' it should belong to and also define an alias and title for your custom tree.
 
 
 **For example**
@@ -30,7 +30,7 @@ public class FavouriteThingsTreeController : TreeController
 
 ...would register a custom tree with a title 'Favourite Things Name' in the Settings section of Umbraco, inside a custom group called 'Favourites'
 
-The SortOrder controls the order of the custom tree within the Tree Group.
+The `SortOrder` controls the order of the custom tree within the Tree Group.
 
 ### Tree Groups
 Tree Groups are a new concept in V8, to enable you to group trees in a section. You provide the alias of the Tree Group name, you wish to add your tree to - see [Constants.Trees.Groups](https://our.umbraco.com/apidocs/v8/csharp/api/Umbraco.Core.Constants.Trees.Groups.html) for a list of existing group alias. An example of tree groups in the backoffice would be the *Settings* tree group and the *Templating* tree group in the *Settings* section.
@@ -46,7 +46,7 @@ If you add your own alias, you'll need to add a translation key to `config/lang/
 
 ### Customising the Root Tree Node
 
-The first node in the tree is referred to as the **Root Node**. You might want to assign a custom icon to the Root Node or specify a custom url route path in the backoffice to use with your custom tree. Perhaps if you had a single page app you customise the Root Node by overriding the abstract *CreateRootNode* method.
+The first node in the tree is referred to as the **Root Node**. You might want to assign a custom icon to the Root Node or specify a custom url route path in the backoffice to use with your custom tree. Perhaps if you had a single page app you customise the Root Node by overriding the abstract `CreateRootNode` method.
 
 
 :::note
@@ -132,9 +132,9 @@ protected override TreeNode CreateRootNode(FormDataCollection queryStrings)
 
 The actions on items in an Umbraco Tree will trigger a request to load an AngularJS view, with a name corresponding to the name of the action, from a subfolder of the views folder matching the name of the 'customTreeAlias'.
 
-For example clicking on one of the 'Favourite Things' in the custom tree example outlined above will trigger the loading of an 'edit.html' view from the folder: */views/favouriteThingsAlias/edit.html*. The 'Delete' menu item would also load a view from: */views/favouriteThingsAlias/delete.html*
+For example clicking on one of the 'Favourite Things' in the custom tree example outlined above will trigger the loading of an 'edit.html' view from the folder: `/views/favouriteThingsAlias/edit.html`. The 'Delete' menu item would also load a view from: `/views/favouriteThingsAlias/delete.html`
 
-If you're creating a custom tree as part of an Umbraco package/plugin, it's recommended to change the location of the default folder to the `App_Plugins` folder. You achieve this by decorating you mvc *TreeController* with the *PluginController* attribute.
+If you're creating a custom tree as part of an Umbraco package/plugin, it's recommended to change the location of the default folder to the `App_Plugins` folder. You achieve this by decorating you mvc `TreeController` with the `PluginController` attribute.
 
 ```csharp
 [Tree("developer", "favouriteThingsAlias", "Favourite Things Name")]
@@ -147,7 +147,7 @@ The edit view in the example would now be loaded from the location: `/App_Plugin
 
 #### Providing functionality in your Tree Action Views
 
-You can instruct the Umbraco backoffice to load additional JavaScript resources (eg. angularJS controllers) to use in conjunction with your 'tree action views' by adding a *package.manifest* file in the same folder location as your views.
+You can instruct the Umbraco backoffice to load additional JavaScript resources (eg. angularJS controllers) to use in conjunction with your 'tree action views' by adding a `package.manifest` file in the same folder location as your views.
 
 **For example**...
 
@@ -189,7 +189,7 @@ Take a look at the [umbEditor directives in the backoffice API Documentation](ht
 It is possible to create 'trees' consisting of only a single node - perhaps to provide an area to control some settings or a placeholder for a single page backoffice app. See the LogViewer in the settings section for a good example.
 (or as in the case of the 'settings/content templates' tree, it's possible to have a custom view for the root node as an 'introduction' page to the tree).
 
-In both scenarios you need to override the *CreateRootNode* method for the custom tree.
+In both scenarios you need to override the `CreateRootNode` method for the custom tree.
 
 ```csharp
 [Tree("settings", "favouritistThingsAlias", TreeTitle = "Favourite Thing", TreeGroup = "favoritesGroup", SortOrder = 5)]
@@ -198,7 +198,7 @@ public class FavouritistThingsTreeController : TreeController
 { }
 ```
 
-Overriding the *CreateRootNode* method means it is possible to set the 'RoutePath' to where the single page application will live (or introduction page), setting HasChildren to false will result in a Single Node Tree:
+Overriding the `CreateRootNode` method means it is possible to set the 'RoutePath' to where the single page application will live (or introduction page), setting HasChildren to false will result in a Single Node Tree:
 
 ```csharp
 protected override TreeNode CreateRootNode(FormDataCollection queryStrings)

--- a/Extending/Section-Trees/Trees/index-v8.md
+++ b/Extending/Section-Trees/Trees/index-v8.md
@@ -51,7 +51,6 @@ If you add your own alias, you'll need to add a translation key to `config/lang/
 
 The first node in the tree is referred to as the **Root Node**. You customise the Root Node by overriding the abstract `CreateRootNode` method. You can assign a custom icon to the Root Node. You can also specify a custom URL route path in the backoffice to use with your custom tree. The method can be useful if your section has a single node (single page app).
 
-
 :::note
 In Umbraco 8 the `/config/trees.config` file has been removed.
 :::

--- a/Extending/Section-Trees/Trees/index-v8.md
+++ b/Extending/Section-Trees/Trees/index-v8.md
@@ -136,7 +136,7 @@ The actions on items in an Umbraco Tree will trigger a request to load an Angula
 
 Clicking on one of the 'Favourite Things' in the custom tree example will load an 'edit.html' view from the folder: `/views/favouriteThingsAlias/edit.html`. The 'Delete' menu item would also load a view from: `/views/favouriteThingsAlias/delete.html`
 
-If you're creating a custom tree as part of an Umbraco package/plugin, it's recommended to change the location of the default folder to the `App_Plugins` folder. You achieve this by decorating you mvc `TreeController` with the `PluginController` attribute.
+When creating a custom tree as part of a Umbraco package, it is recommended to change the location of the default folder. It should be changed to the `App_Plugins` folder. You achieve this by decorating your MVC `TreeController` with the `PluginController` attribute.
 
 ```csharp
 [Tree("developer", "favouriteThingsAlias", "Favourite Things Name")]

--- a/Extending/Section-Trees/Trees/index-v8.md
+++ b/Extending/Section-Trees/Trees/index-v8.md
@@ -49,7 +49,7 @@ If you add your own alias, you'll need to add a translation key to `config/lang/
 
 ### Customising the Root Tree Node
 
-The first node in the tree is referred to as the **Root Node**. You customise the Root Node by overriding the abstract `CreateRootNode` method. You can assign a custom icon to the Root Node. You can also specify a custom URL route path in the backoffice to use with your custom tree. The method can be useful if your section has a single node.
+The first node in the tree is referred to as the **Root Node**. You customise the Root Node by overriding the abstract `CreateRootNode` method. You can assign a custom icon to the Root Node. You can also specify a custom URL route path in the backoffice to use with your custom tree. The method can be useful if your section has a single node (single page app).
 
 
 :::note
@@ -200,8 +200,7 @@ In both scenarios you need to override the `CreateRootNode` method for the custo
 public class FavouritistThingsTreeController : TreeController
 { }
 ```
-
-Overriding the `CreateRootNode` method means it is possible to set the 'RoutePath' to where the single page application will live (or introduction page), setting HasChildren to false will result in a Single Node Tree:
+You can override the `CreateRootNode` method to set the 'RoutePath' to where the single page application will live (or introduction page). Setting `HasChildren` to `false` will result in a Single Node Tree.
 
 ```csharp
 protected override TreeNode CreateRootNode(FormDataCollection queryStrings)

--- a/Extending/Section-Trees/Trees/index-v8.md
+++ b/Extending/Section-Trees/Trees/index-v8.md
@@ -134,7 +134,7 @@ protected override TreeNode CreateRootNode(FormDataCollection queryStrings)
 
 The actions on items in an Umbraco Tree will trigger a request to load an AngularJS view, with a name corresponding to the name of the action, from a subfolder of the views folder matching the name of the 'customTreeAlias'.
 
-For example clicking on one of the 'Favourite Things' in the custom tree example outlined above will trigger the loading of an 'edit.html' view from the folder: `/views/favouriteThingsAlias/edit.html`. The 'Delete' menu item would also load a view from: `/views/favouriteThingsAlias/delete.html`
+Clicking on one of the 'Favourite Things' in the custom tree example will load an 'edit.html' view from the folder: `/views/favouriteThingsAlias/edit.html`. The 'Delete' menu item would also load a view from: `/views/favouriteThingsAlias/delete.html`
 
 If you're creating a custom tree as part of an Umbraco package/plugin, it's recommended to change the location of the default folder to the `App_Plugins` folder. You achieve this by decorating you mvc `TreeController` with the `PluginController` attribute.
 

--- a/Extending/Section-Trees/Trees/index-v8.md
+++ b/Extending/Section-Trees/Trees/index-v8.md
@@ -49,7 +49,7 @@ If you add your own alias, you'll need to add a translation key to `config/lang/
 
 ### Customising the Root Tree Node
 
-The first node in the tree is referred to as the **Root Node**. You customise the Root Node by overriding the abstract `CreateRootNode` method. You can assign a custom icon to the Root Node. You can also specify a custom URL route path in the backoffice to use with your custom tree. The method can be useful if your section has a single node (single page app).
+The first node in the tree is referred to as the **Root Node**. You can customise the Root Node by overriding the abstract `CreateRootNode` method. You can assign a custom icon to the Root Node. You can also specify a custom URL route path in the backoffice to use with your custom tree. The method can be useful if your section has a single node (single page app).
 
 :::note
 In Umbraco 8 the `/config/trees.config` file has been removed.

--- a/Extending/Section-Trees/Trees/index.md
+++ b/Extending/Section-Trees/Trees/index.md
@@ -209,7 +209,7 @@ You can instruct the Umbraco backoffice to load additional JavaScript resources 
 
 ...this manifest would load files for two controllers to work with the edit and delete views and a general resource file, perhaps containing code to retrieve, create, edit and delete 'favourite things' from some external non-Umbraco API.
 
-Our Tree Action View would then be wired to the loaded controller using the `ng-controller` attribute The delete view would perhaps the delete view look a little bit like this:
+Our Tree Action View would then be wired to the loaded controller using the `ng-controller` attribute. The delete view would perhaps the delete view look a little bit like this:
 
 ```csharp
 <div class="umb-dialog umb-pane" ng-controller="Our.Umbraco.FavouriteThings.DeleteController">
@@ -243,7 +243,7 @@ public class FavouritistThingsTreeController : TreeController
 { }
 ```
 
-Overriding the `CreateRootNode` method means it is possible to set the `RoutePath` to where the single page application will live (or introduction page), setting HasChildren to false will result in a Single Node Tree:
+You can override the `CreateRootNode` method to set the 'RoutePath' to where the single page application will live (or introduction page). Setting `HasChildren` to `false` will result in a Single Node Tree.
 
 ```csharp
 protected override ActionResult<TreeNode> CreateRootNode(FormCollection queryStrings)

--- a/Extending/Section-Trees/Trees/index.md
+++ b/Extending/Section-Trees/Trees/index.md
@@ -176,7 +176,7 @@ public class FavouriteThingsTreeController : TreeController
 
 The actions on items in an Umbraco Tree will trigger a request to load an AngularJS view, with a name corresponding to the name of the action, from a subfolder of the views folder matching the name of the 'customTreeAlias'.
 
-For example clicking on one of the 'Favourite Things' in the custom tree example outlined above will trigger the loading of an `edit.html` view from the folder: `/views/favouriteThingsAlias/edit.html`. The 'Delete' menu item would also load a view from: `/views/favouriteThingsAlias/delete.html`
+Clicking on one of the 'Favourite Things' in the custom tree example will load an `edit.html` view from the folder: `/views/favouriteThingsAlias/edit.html`. The 'Delete' menu item would also load a view from: `/views/favouriteThingsAlias/delete.html`
 
 When creating a custom tree as part of a Umbraco package, it is recommended to change the location of the default folder. It should be changed to the `App_Plugins` folder. You achieve this by decorating your MVC `TreeController` with the `PluginController` attribute.
 

--- a/Extending/Section-Trees/Trees/index.md
+++ b/Extending/Section-Trees/Trees/index.md
@@ -178,7 +178,7 @@ The actions on items in an Umbraco Tree will trigger a request to load an Angula
 
 For example clicking on one of the 'Favourite Things' in the custom tree example outlined above will trigger the loading of an `edit.html` view from the folder: `/views/favouriteThingsAlias/edit.html`. The 'Delete' menu item would also load a view from: `/views/favouriteThingsAlias/delete.html`
 
-If you're creating a custom tree as part of an Umbraco package/plugin, it's recommended to change the location of the default folder to the `App_Plugins` folder. You achieve this by decorating you mvc `TreeController` with the `PluginController` attribute.
+When creating a custom tree as part of a Umbraco package, it is recommended to change the location of the default folder. It should be changed to the `App_Plugins` folder. You achieve this by decorating your MVC `TreeController` with the `PluginController` attribute.
 
 ```csharp
 @using Umbraco.Cms.Web.Common.Attributes;

--- a/Extending/Section-Trees/Trees/index.md
+++ b/Extending/Section-Trees/Trees/index.md
@@ -13,14 +13,14 @@ This section describes how to work with and create trees with Umbraco APIs.
 
 To Create a Tree in a section of the Umbraco backoffice, you need to take several steps:
 
-Create a 'TreeController' class in C#. A new controller which inherits from the abstract *Umbraco.Cms.Web.BackOffice.Trees.TreeController* class and provides an implementation for two abstract methods:
+Create a `TreeController` class in C#. A new controller which inherits from the abstract `Umbraco.Cms.Web.BackOffice.Trees.TreeController`*` class and provides an implementation for two abstract methods:
 
-* GetTreeNodes (returns a *TreeNodeCollection*) - Responsible for rendering the content of the tree structure;
-* GetMenuForNode (returns a *MenuItemCollection*) - Responsible for returning the menu structure to use for a particular node within a tree.
+* GetTreeNodes (returns a `TreeNodeCollection`) - Responsible for rendering the content of the tree structure;
+* GetMenuForNode (returns a `MenuItemCollection`) - Responsible for returning the menu structure to use for a particular node within a tree.
 
-You will need to add a constructor as TreeController requires this. See full code snippet in the "Implementing the Tree" section below.
+You will need to add a constructor as `TreeController` requires this. See full code snippet in the "Implementing the Tree" section below.
 
-Decorate your '*TreeController*' with the *Tree* Attribute, which is used to define the name of the section the Tree should be loaded in, which 'Tree Group' it should belong to and also define an alias and title for your custom tree.
+Decorate your `TreeController` with the `Tree` Attribute, which is used to define the name of the section the Tree should be loaded in, which `Tree Group` it should belong to and also define an alias and title for your custom tree.
 
 For example:
 
@@ -32,7 +32,7 @@ public class FavouriteThingsTreeController : TreeController
 
 The example above would register a custom tree with a title 'Favourite Things Name' in the Settings section of Umbraco, inside a custom group called 'Favourites'.
 
-The SortOrder controls the order of the custom tree within the Tree Group.
+The `SortOrder` controls the order of the custom tree within the Tree Group.
 
 ### Tree Groups
 
@@ -52,7 +52,7 @@ The language file should contain the following XML:
 
 ### Customising the Root Tree Node
 
-The first node in the tree is referred to as the **Root Node**. You might want to assign a custom icon to the Root Node or specify a custom url route path in the backoffice to use with your custom tree. Perhaps if you had a single page app you customise the Root Node by overriding the abstract *CreateRootNode* method.
+The first node in the tree is referred to as the **Root Node**. You might want to assign a custom icon to the Root Node or specify a custom url route path in the backoffice to use with your custom tree. Perhaps if you had a single page app you customise the Root Node by overriding the abstract `CreateRootNode` method.
 
 [See Also: How to create your own custom section](../Sections/index.md)
 
@@ -91,7 +91,7 @@ public class FavouriteThingsTreeController : TreeController
     protected override ActionResult<TreeNodeCollection> GetTreeNodes(string id, FormCollection queryStrings)
     {
         var nodes = new TreeNodeCollection();
-        
+
         // check if we're rendering the root node's children
         if (id == Constants.System.Root.ToInvariantString())
         {
@@ -172,9 +172,9 @@ public class FavouriteThingsTreeController : TreeController
 
 The actions on items in an Umbraco Tree will trigger a request to load an AngularJS view, with a name corresponding to the name of the action, from a subfolder of the views folder matching the name of the 'customTreeAlias'.
 
-For example clicking on one of the 'Favourite Things' in the custom tree example outlined above will trigger the loading of an 'edit.html' view from the folder: */views/favouriteThingsAlias/edit.html*. The 'Delete' menu item would also load a view from: */views/favouriteThingsAlias/delete.html*
+For example clicking on one of the 'Favourite Things' in the custom tree example outlined above will trigger the loading of an `edit.html` view from the folder: `/views/favouriteThingsAlias/edit.html`. The 'Delete' menu item would also load a view from: `/views/favouriteThingsAlias/delete.html`
 
-If you're creating a custom tree as part of an Umbraco package/plugin, it's recommended to change the location of the default folder to the `App_Plugins` folder. You achieve this by decorating you mvc *TreeController* with the *PluginController* attribute.
+If you're creating a custom tree as part of an Umbraco package/plugin, it's recommended to change the location of the default folder to the `App_Plugins` folder. You achieve this by decorating you mvc `TreeController` with the `PluginController` attribute.
 
 ```csharp
 @using Umbraco.Cms.Web.Common.Attributes;
@@ -189,7 +189,7 @@ The edit view in the example would now be loaded from the location: `/App_Plugin
 
 #### Providing functionality in your Tree Action Views
 
-You can instruct the Umbraco backoffice to load additional JavaScript resources (eg. angularJS controllers) to use in conjunction with your 'tree action views' by adding a *package.manifest* file in the same folder location as your views.
+You can instruct the Umbraco backoffice to load additional JavaScript resources (eg. angularJS controllers) to use in conjunction with your 'tree action views' by adding a `package.manifest` file in the same folder location as your views.
 
 **For example**...
 
@@ -205,7 +205,7 @@ You can instruct the Umbraco backoffice to load additional JavaScript resources 
 
 ...this manifest would load files for two controllers to work with the edit and delete views and a general resource file, perhaps containing code to retrieve, create, edit and delete 'favourite things' from some external non-Umbraco API.
 
-Our Tree Action View would then be wired to the loaded controller using the ng-controller attribute, perhaps the delete view would look a little bit like this:
+Our Tree Action View would then be wired to the loaded controller using the `ng-controller` attribute, perhaps the delete view would look a little bit like this:
 
 ```csharp
 <div class="umb-dialog umb-pane" ng-controller="Our.Umbraco.FavouriteThings.DeleteController">
@@ -230,7 +230,7 @@ Take a look at the [umbEditor directives in the backoffice API Documentation](ht
 It is possible to create 'trees' consisting of only a single node - perhaps to provide an area to control some settings or a placeholder for a single page backoffice app. See the LogViewer in the settings section for a good example.
 (or as in the case of the 'settings/content templates' tree, it's possible to have a custom view for the root node as an 'introduction' page to the tree).
 
-In both scenarios you need to override the *CreateRootNode* method for the custom tree.
+In both scenarios you need to override the `CreateRootNode` method for the custom tree.
 
 ```csharp
 [Tree("settings", "favouritistThingsAlias", TreeTitle = "Favourite Thing", TreeGroup = "favoritesGroup", SortOrder = 5)]
@@ -239,7 +239,7 @@ public class FavouritistThingsTreeController : TreeController
 { }
 ```
 
-Overriding the *CreateRootNode* method means it is possible to set the 'RoutePath' to where the single page application will live (or introduction page), setting HasChildren to false will result in a Single Node Tree:
+Overriding the `CreateRootNode` method means it is possible to set the `RoutePath` to where the single page application will live (or introduction page), setting HasChildren to false will result in a Single Node Tree:
 
 ```csharp
 protected override ActionResult<TreeNode> CreateRootNode(FormCollection queryStrings)
@@ -378,7 +378,7 @@ public class TreeNotificationHandler : INotificationHandler<MenuRenderingNotific
     public void Handle(MenuRenderingNotification notification)
     {
         // this example will add a custom menu item for all admin users
-        
+
         // for all content tree nodes
         if (notification.TreeAlias.Equals("content") &&
             _backOfficeSecurityAccessor.BackOfficeSecurity.CurrentUser.Groups.Any(x =>
@@ -386,11 +386,11 @@ public class TreeNotificationHandler : INotificationHandler<MenuRenderingNotific
         {
             // Creates a menu action that will open /umbraco/currentSection/itemAlias.html
             var menuItem = new Umbraco.Cms.Core.Models.Trees.MenuItem("itemAlias", "Item name");
-            
+
             // optional, if you don't want to follow the naming conventions, but do want to use a angular view
             // you can also use a direct path "../App_Plugins/my/long/url/to/view.html"
             menuItem.AdditionalData.Add("actionView", "my/long/url/to/view.html");
-            
+
             // sets the icon to icon-wine-glass
             menuItem.Icon = "wine-glass";
             // insert at index 5

--- a/Extending/Section-Trees/Trees/index.md
+++ b/Extending/Section-Trees/Trees/index.md
@@ -56,7 +56,7 @@ The language file should contain the following XML:
 
 ### Customising the Root Tree Node
 
-The first node in the tree is referred to as the **Root Node**. You might want to assign a custom icon to the Root Node or specify a custom url route path in the backoffice to use with your custom tree. Perhaps if you had a single page app you customise the Root Node by overriding the abstract `CreateRootNode` method.
+The first node in the tree is referred to as the **Root Node**. You can customise the Root Node by overriding the abstract `CreateRootNode` method. You can assign a custom icon to the Root Node. You can also specify a custom URL route path in the backoffice to use with your custom tree. The method can be useful if your section has a single node (single page app).
 
 [See Also: How to create your own custom section](../Sections/index.md)
 

--- a/Extending/Section-Trees/Trees/index.md
+++ b/Extending/Section-Trees/Trees/index.md
@@ -20,7 +20,13 @@ Create a `TreeController` class in C#. A new controller which inherits from the 
 
 You will need to add a constructor as `TreeController` requires this. See full code snippet in the "Implementing the Tree" section below.
 
-Decorate your `TreeController` with the `Tree` Attribute, which is used to define the name of the section the Tree should be loaded in, which `Tree Group` it should belong to and also define an alias and title for your custom tree.
+The `Tree` attribute used to decorate the `TreeController` has multiple properties.
+
+- `SectionAlias` - Alias of the section in which the tree appears
+- `TreeAlias` - Alias of the tree
+- `TreeTitle` - The title of the tree
+- `TreeGroup` - The tree group, the tree belongs to
+- `SortOrder` - Sort order of the tree
 
 For example:
 
@@ -31,8 +37,6 @@ public class FavouriteThingsTreeController : TreeController
 ```
 
 The example above would register a custom tree with a title 'Favourite Things Name' in the Settings section of Umbraco, inside a custom group called 'Favourites'.
-
-The `SortOrder` controls the order of the custom tree within the Tree Group.
 
 ### Tree Groups
 

--- a/Extending/Section-Trees/Trees/index.md
+++ b/Extending/Section-Trees/Trees/index.md
@@ -209,7 +209,7 @@ You can instruct the Umbraco backoffice to load additional JavaScript resources 
 
 ...this manifest would load files for two controllers to work with the edit and delete views and a general resource file, perhaps containing code to retrieve, create, edit and delete 'favourite things' from some external non-Umbraco API.
 
-Our Tree Action View would then be wired to the loaded controller using the `ng-controller` attribute, perhaps the delete view would look a little bit like this:
+Our Tree Action View would then be wired to the loaded controller using the `ng-controller` attribute The delete view would perhaps the delete view look a little bit like this:
 
 ```csharp
 <div class="umb-dialog umb-pane" ng-controller="Our.Umbraco.FavouriteThings.DeleteController">


### PR DESCRIPTION
Noticed that Section Trees uses a mixture of _italics_ and `code` to mention code.  I have made it uniform