### PR TITLE
Added basic auth back to project settings

### DIFF
--- a/Umbraco-Cloud/Set-Up/Project-settings/index.md
+++ b/Umbraco-Cloud/Set-Up/Project-settings/index.md
@@ -46,7 +46,7 @@ It requires you to enter your Cloud credentials in order to view the frontend.
 
 You can disable/enable it with one click on the Public access page.
 
-Access to disabling/enabling basic authentication requires your project to be on the Standard plan or higher.
+Access to manage the basic authentication requires your project to be on the Standard plan or higher.
 
 
 ## [Webhooks](../../Deployment/Deployment-webhook)

--- a/Umbraco-Cloud/Set-Up/Project-settings/index.md
+++ b/Umbraco-Cloud/Set-Up/Project-settings/index.md
@@ -42,7 +42,7 @@ Used to upload and bind your custom security certificate to your hostnames inste
 ## Public access
 
 Staging and Development environments on Umbraco Cloud projects can be protected by basic authentication.
-It require you to enter your Cloud credentials in order to view the frontend. 
+It requires you to enter your Cloud credentials in order to view the frontend. 
 
 You can disable/enable it with one click on the Public access page.
 

--- a/Umbraco-Cloud/Set-Up/Project-settings/index.md
+++ b/Umbraco-Cloud/Set-Up/Project-settings/index.md
@@ -39,6 +39,16 @@ Manage CDN Cache settings for your project. You can modify default settings, whi
 
 Used to upload and bind your custom security certificate to your hostnames instead of using the TLS (HTTPS) certificates provided by the Umbraco Cloud service.
 
+## Public access
+
+Staging and Development environments on Umbraco Cloud projects can be protected by basic authentication.
+It require you to enter your Cloud credentials in order to view the frontend. 
+
+You can disable/enable it with one click on the Public access page.
+
+Access to disabling/enabling basic authentication requires your project to be on the Standard plan or higher.
+
+
 ## [Webhooks](../../Deployment/Deployment-webhook)
 
 It is possible to configure a deployment webhook on your environments on Umbraco Cloud projects. This will be triggered upon successful deployments, you can configure where you would like information about the deployment to be posted.


### PR DESCRIPTION
As it is now possible to add basic auth on environments on cloud again, i have added it to our docs again.

There will still be made some changes to it as described in the following PR: 
- https://github.com/umbraco/UmbracoDocs/pull/4176#issuecomment-1278878795