### PR TITLE
Instructions for restoring a bacpac file

### DIFF
--- a/Umbraco-Cloud/Databases/Backups/index.md
+++ b/Umbraco-Cloud/Databases/Backups/index.md
@@ -34,6 +34,7 @@ Use the following steps:
 
 :::note
 When you restore a bacpac to your SQL server if it fails, check that you have the configuration flag for 'Contained Database Authentication' set to true. If this is not set the import will fail.
+:::
 
 To Enable Contained Database Authentication, run the following SQL against your sql server on the Master database
 
@@ -43,7 +44,7 @@ To Enable Contained Database Authentication, run the following SQL against your 
     GO  
     
 For refrence please see [this article](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/contained-database-authentication-server-configuration-option?view=sql-server-ver16).
-:::
+
 
 
 

--- a/Umbraco-Cloud/Databases/Backups/index.md
+++ b/Umbraco-Cloud/Databases/Backups/index.md
@@ -43,7 +43,7 @@ To Enable Contained Database Authentication, run the following SQL against your 
     RECONFIGURE;  
     GO  
     
-For refrence please see [this article](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/contained-database-authentication-server-configuration-option?view=sql-server-ver16).
+For reference please see the [contained database authentication Server Configuration Option documentation](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/contained-database-authentication-server-configuration-option?view=sql-server-ver16).
 
 
 

--- a/Umbraco-Cloud/Databases/Backups/index.md
+++ b/Umbraco-Cloud/Databases/Backups/index.md
@@ -24,7 +24,7 @@ Follow these steps:
 - Proceed through the dialog, setting the options appropriate to your situation, to save the "bacpac" file. This is your database backup.
 
 
-## Restoring a cloud backup to a SQL Server Database
+## Restoring a Cloud backup to a SQL Server Database
 
 Use the following steps:
 - Connect to your SQL Server using Sql Server Management Studio (SSMS).

--- a/Umbraco-Cloud/Databases/Backups/index.md
+++ b/Umbraco-Cloud/Databases/Backups/index.md
@@ -33,7 +33,7 @@ Use the following steps:
 - Complete the import dialog and the database will be restored.
 
 :::note
-When restoring a bacpac to your SQL server if it fails, check that you have the configuration flag for 'Contained Database Authentication' set to true. 
+When restoring a `bacpac` to your SQL server if it fails, check that you have the configuration flag for 'Contained Database Authentication' set to true. 
 
 If it is not set the import will fail.
 :::

--- a/Umbraco-Cloud/Databases/Backups/index.md
+++ b/Umbraco-Cloud/Databases/Backups/index.md
@@ -29,7 +29,7 @@ Follow these steps:
 Use the following steps:
 - Connect to your SQL Server using Sql Server Management Studio (SSMS).
 - Expand "Databases", right-click "Databases", select "Tasks", then select "Import Data-tier Application...".
-- Proceed through the dialog, by browsing to the saved location of your bacpac file, and then setting the options appropriate to your coniguration
+- Proceed through the dialog, by browsing to the saved location of your `bacpac` file, and then setting the options appropriate to your configuration
 - Complete the import dialog and the database will be restored.
 
 :::note

--- a/Umbraco-Cloud/Databases/Backups/index.md
+++ b/Umbraco-Cloud/Databases/Backups/index.md
@@ -26,7 +26,14 @@ Follow these steps:
 
 ## Restoring a cloud backup to a SQL Server Database
 
-In order to restore a .bacpac file to a SQL Server database, you will need to first ensure that the SQL Server has has 'Contained Database Authentication' enabled. This is a security feature that is disabled by default, and without enabling it you will not be able to restore the database. For refrence please see [this article](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/contained-database-authentication-server-configuration-option?view=sql-server-ver16).
+Use the following steps:
+- Connect to your SQL Server using Sql Server Management Studio (SSMS).
+- Expand "Databases", right-click "Databases", select "Tasks", then select "Import Data-tier Application...".
+- Proceed through the dialog, by browsing to the saved location of your bacpac file, and then setting the options appropriate to your coniguration
+- Complete the import dialog and the database will be restored.
+
+:::note
+When you restore a bacpac to your SQL server if it fails, check that you have the configuration flag for 'Contained Database Authentication' set to true. If this is not set the import will fail.
 
 To Enable Contained Database Authentication, run the following SQL against your sql server on the Master database
 
@@ -34,10 +41,9 @@ To Enable Contained Database Authentication, run the following SQL against your 
     GO  
     RECONFIGURE;  
     GO  
+    
+For refrence please see [this article](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/contained-database-authentication-server-configuration-option?view=sql-server-ver16).
+:::
 
-Once this is done you will be able to restore the database using the following steps:
-- Connect to your SQL Server using Sql Server Management Studio (SSMS).
-- Expand "Databases", right-click "Databases", select "Tasks", then select "Import Data-tier Application...".
-- Proceed through the dialog, by browsing to the saved location of your bacpac file, and then setting the options appropriate to your coniguration
-- Complete the import dialog and the database will be restored.
+
 

--- a/Umbraco-Cloud/Databases/Backups/index.md
+++ b/Umbraco-Cloud/Databases/Backups/index.md
@@ -22,3 +22,21 @@ Follow these steps:
 - It is very important that you enter the database name. If you do not, the connection will fail.
 - Expand "Databases", right-click your database (it should be the only one listed), select "Tasks", then select "Export Data-tier Application...".
 - Proceed through the dialog, setting the options appropriate to your situation, to save the "bacpac" file. This is your database backup.
+
+
+## Restoring a cloud backup to a SQL Server Database
+
+In order to restore a .bacpac file to a SQL Server database, you will need to first ensure that the SQL Server has has 'Contained Database Authentication' enabled. This is a security feature that is disabled by default, and without enabling it you will not be able to restore the database. For refrence please see [this article](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/contained-database-authentication-server-configuration-option?view=sql-server-ver16).
+
+To Enable Contained Database Authentication, run the following SQL against your sql server on the Master database
+
+    sp_configure 'contained database authentication', 1;  
+    GO  
+    RECONFIGURE;  
+    GO  
+
+Once this is done you will be able to restore the database using the following steps:
+- Connect to your SQL Server using Sql Server Management Studio (SSMS).
+- Expand "Databases", right-click "Databases", select "Tasks", then select "Import Data-tier Application...".
+- Proceed through the dialog, setting the options appropriate to your situation, to restore the "bacpac" file. This is your database backup.
+

--- a/Umbraco-Cloud/Databases/Backups/index.md
+++ b/Umbraco-Cloud/Databases/Backups/index.md
@@ -45,7 +45,7 @@ To Enable Contained Database Authentication, run the following SQL against your 
     RECONFIGURE;  
     GO  
     
-For reference please see the [contained database authentication Server Configuration Option documentation](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/contained-database-authentication-server-configuration-option?view=sql-server-ver16).
+For reference please see the [Microsoft documentation on the topic](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/contained-database-authentication-server-configuration-option?view=sql-server-ver16).
 
 
 

--- a/Umbraco-Cloud/Databases/Backups/index.md
+++ b/Umbraco-Cloud/Databases/Backups/index.md
@@ -33,7 +33,9 @@ Use the following steps:
 - Complete the import dialog and the database will be restored.
 
 :::note
-When you restore a bacpac to your SQL server if it fails, check that you have the configuration flag for 'Contained Database Authentication' set to true. If this is not set the import will fail.
+When restoring a bacpac to your SQL server if it fails, check that you have the configuration flag for 'Contained Database Authentication' set to true. 
+
+If it is not set the import will fail.
 :::
 
 To Enable Contained Database Authentication, run the following SQL against your SQL server on the Master database.

--- a/Umbraco-Cloud/Databases/Backups/index.md
+++ b/Umbraco-Cloud/Databases/Backups/index.md
@@ -38,5 +38,6 @@ To Enable Contained Database Authentication, run the following SQL against your 
 Once this is done you will be able to restore the database using the following steps:
 - Connect to your SQL Server using Sql Server Management Studio (SSMS).
 - Expand "Databases", right-click "Databases", select "Tasks", then select "Import Data-tier Application...".
-- Proceed through the dialog, setting the options appropriate to your situation, to restore the "bacpac" file. This is your database backup.
+- Proceed through the dialog, by browsing to the saved location of your bacpac file, and then setting the options appropriate to your coniguration
+- Complete the import dialog and the database will be restored.
 

--- a/Umbraco-Cloud/Databases/Backups/index.md
+++ b/Umbraco-Cloud/Databases/Backups/index.md
@@ -36,7 +36,7 @@ Use the following steps:
 When you restore a bacpac to your SQL server if it fails, check that you have the configuration flag for 'Contained Database Authentication' set to true. If this is not set the import will fail.
 :::
 
-To Enable Contained Database Authentication, run the following SQL against your sql server on the Master database
+To Enable Contained Database Authentication, run the following SQL against your SQL server on the Master database.
 
     sp_configure 'contained database authentication', 1;  
     GO  


### PR DESCRIPTION
This is an amend to the documentation, with thanks to Seb for his help. It outlines the steps required to restore a bacpac file from an Umbraco Cloud backup to a local SQL Server instance