### PR TITLE
Update Parsing Umbraco Form field

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Magic-Strings/index.md
+++ b/Add-ons/UmbracoForms/Developer/Magic-Strings/index.md
@@ -50,7 +50,7 @@ Some extra variables are:
 
 ## Parsing Umbraco Form field
 
-`{myAliasForFormField}` this allows you to display the entered value for that specific field from the form submission. Used in workflows to send an automated email back to the customer based on the email address submitted in the form. The value here needs to be the alias of the field, and not the name of the field.
+`{myAliasForFormField}` this allows you to display the entered value for that specific field from the form submission. Used in workflows to send an automated email back to the customer based on the email address submitted in the form. The value here needs to be the alias of the field, and not the name of the field. When entering the value into the Umbraco workflow form field the value must be in double curly braces. For example the alias for an email address form field in Umbraco Forms is emailAddress so the value entered into the 'Email' workflow options should be {{emailAddress}}.
 
 Some extra variables are:
 - `{record.id}`: The ID of the current record - this is only accessible on workflows triggered "on approve" rather than "on submit"


### PR DESCRIPTION
When entering the alias {emailAddress} into the Umbraco Forms workflow 'Email' form field this does not pick up the value, however, {{emailAddress}} with double curly braces does.