### PR TITLE
Add sending allowed children notification article

### DIFF
--- a/Add-ons/UmbracoForms/Editor/Attaching-Workflows/index.md
+++ b/Add-ons/UmbracoForms/Editor/Attaching-Workflows/index.md
@@ -9,10 +9,6 @@ In this article, you can learn how to add extra functionality to your Form by at
 
 Workflows are a way of defining actions after your Form is submitted like sending an email or creating a content node.
 
-## Video Tutorial
-
-<iframe width="800" height="450" title="Attaching Workflows to Umbraco Forms" src="https://www.youtube.com/embed/qJrf1drw1Bg?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
 ## Default Workflow
 
 By default, when a Form is submitted the record data is stored in the database. This can be configured in the [Store records](../Creating-a-Form/Form-Settings/index.md#settings-options) of the Forms settings.

--- a/Reference/Notifications/SendingAllowedChildrenNotification/index.md
+++ b/Reference/Notifications/SendingAllowedChildrenNotification/index.md
@@ -69,3 +69,25 @@ namespace Umbraco.Docs.Samples.Web.Notifications
     }
 }
 ```
+
+You also need to register this notification handler. You can achieve this by updating the `Startup` class like:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+#pragma warning disable IDE0022 // Use expression body for methods
+    services.AddUmbraco(_env, _config)
+        .AddBackOffice()             
+        .AddWebsite()
+        .AddComposers()
+        .AddNotificationHandler<SendingAllowedChildrenNotification, SendingAllowedChildrenNotificationHandler>()
+        .Build();
+#pragma warning restore IDE0022 // Use expression body for methods
+}
+```
+
+For more information av
+
+:::note
+The license for Umbraco Deploy comes with a recurring yearly fee. Learn more about this and pricing on [Umbraco.com](https://umbraco.com/products/umbraco-deploy/).
+:::

--- a/Reference/Notifications/SendingAllowedChildrenNotification/index.md
+++ b/Reference/Notifications/SendingAllowedChildrenNotification/index.md
@@ -5,11 +5,11 @@ versionTo: 10.0.0
 
 # Sending Allowed Children Notification
 
-The `SendingAllowedChildrenNotification` enables you to manipulate the document types that will be shown in the create menu when adding new content in the backoffice.
+The `SendingAllowedChildrenNotification` enables you to manipulate the Document Types that will be shown in the create menu when adding new content in the backoffice.
 
 ## Usage
 
-With the example below we can ensure that a document type cannot be selected if the type already exists in the Content tree.
+With the example below we can ensure that a Document Type cannot be selected if the type already exists in the Content tree.
 
 ```csharp
 using System.Web;

--- a/Reference/Notifications/SendingAllowedChildrenNotification/index.md
+++ b/Reference/Notifications/SendingAllowedChildrenNotification/index.md
@@ -5,18 +5,16 @@ versionTo: 10.0.0
 
 # Sending Allowed Children Notification
 
-The `SendingAllowedChildrenNotification` enables you to manipulate the content types that will be shown in the create menu when adding new content in the backoffice.
+The `SendingAllowedChildrenNotification` enables you to manipulate the document types that will be shown in the create menu when adding new content in the backoffice.
 
 ## Usage
 
-With the example below we can ensure that a content type cannot be selected if the type already exists in the Content tree.
+With the example below we can ensure that a document type cannot be selected if the type already exists in the Content tree.
 
 ```csharp
-using System.Linq;
 using System.Web;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
-using Umbraco.Extensions;
 
 namespace Umbraco.Docs.Samples.Web.Notifications
 {
@@ -24,10 +22,10 @@ namespace Umbraco.Docs.Samples.Web.Notifications
     {
         public void Handle(SendingAllowedChildrenNotification notification)
         {
-            //try get the id from the content item in the back office 
+            const string contentIdKey = "contentId";
+
+            // Try get the id from the content item in the backoffice 
             var queryStringCollection = HttpUtility.ParseQueryString(notification.UmbracoContext.OriginalRequestUrl.Query);
-            
-            var contentIdKey = "contentId";
 
             if (!queryStringCollection.ContainsKey(contentIdKey))
             {
@@ -43,27 +41,27 @@ namespace Umbraco.Docs.Samples.Web.Notifications
 
             var content = notification.UmbracoContext.Content?.GetById(true, contentId);
 
-            if (content == null)
+            if (content is null)
             {
                 return;
             }
 
-            // allowed children as configured in the backoffice
+            // Allowed children as configured in the backoffice
             var allowedChildren = notification.Children.ToList();
 
-            if (content.ChildrenForAllCultures != null)
+            if (content.ChildrenForAllCultures is not null)
             {
-                // get all children of current page.
+                // Get all children of current page
                 var childNodes = content.ChildrenForAllCultures.ToList();
 
-                // if there is a settings page already created, then don't allow it anymore
-                if (childNodes.Any(x => x.ContentType.Alias == Settings.ModelTypeAlias))
+                // If there is a Settings page already created, then don't allow it anymore
+                if (childNodes.Any(x => x.ContentType.Alias == "settings"))
                 {
-                    allowedChildren.RemoveAll(x => x.Alias == Settings.ModelTypeAlias);
+                    allowedChildren.RemoveAll(x => x.Alias == "settings");
                 }
             }
 
-            // update the allowed children.
+            // Update the allowed children
             notification.Children = allowedChildren;
         }
     }

--- a/Reference/Notifications/SendingAllowedChildrenNotification/index.md
+++ b/Reference/Notifications/SendingAllowedChildrenNotification/index.md
@@ -86,8 +86,6 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-For more information av
-
 :::note
-The license for Umbraco Deploy comes with a recurring yearly fee. Learn more about this and pricing on [Umbraco.com](https://umbraco.com/products/umbraco-deploy/).
+For more information about registering notifications read the [Registering notification handlers](../index.md/#registering-notification-handlers) article.
 :::

--- a/Reference/Notifications/SendingAllowedChildrenNotification/index.md
+++ b/Reference/Notifications/SendingAllowedChildrenNotification/index.md
@@ -55,6 +55,8 @@ namespace Umbraco.Docs.Samples.Web.Notifications
                 var childNodes = content.ChildrenForAllCultures.ToList();
 
                 // If there is a Settings page already created, then don't allow it anymore
+                // You can also use the ModelTypeAlias property from your PublishedModel for comparison,
+                // like Settings.ModelTypeAlias if you have set models builder to generate SourceCode models
                 if (childNodes.Any(x => x.ContentType.Alias == "settings"))
                 {
                     allowedChildren.RemoveAll(x => x.Alias == "settings");

--- a/Reference/Notifications/SendingAllowedChildrenNotification/index.md
+++ b/Reference/Notifications/SendingAllowedChildrenNotification/index.md
@@ -6,3 +6,62 @@ versionTo: 10.0.0
 # Sending Allowed Children Notification
 The `SendingAllowedChildrenNotification` enable you to manipulate the content types that will be shown in the create menu.
 
+## Usage
+Example usage of the `SendingAllowedChildrenNotification` - for example show only the settings content type if none have been added yet.
+
+```csharp
+using System.Linq;
+using System.Web;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Extensions;
+
+namespace Umbraco.Docs.Samples.Web.Notifications
+{
+    public class SendingAllowedChildrenNotificationHandler : INotificationHandler<SendingAllowedChildrenNotification>
+    {
+        public void Handle(SendingAllowedChildrenNotification notification)
+        {
+            //try get the id from the content item in the back office 
+            var queryStringCollection = HttpUtility.ParseQueryString(notification.UmbracoContext.OriginalRequestUrl.Query);
+            
+            if (!queryStringCollection.ContainsKey("contentId"))
+            {
+                return;
+            }
+
+            var contentId = queryStringCollection["contentId"].TryConvertTo<int>().ResultOr(-1);
+
+            if (contentId == -1)
+            {
+                return;
+            }
+
+            var content = notification.UmbracoContext.Content?.GetById(true, contentId);
+
+            if (content == null)
+            {
+                return;
+            }
+
+            // allowed children as configured in the backoffice
+            var allowedChildren = notification.Children.ToList();
+
+            if (content.ChildrenForAllCultures != null)
+            {
+                // get all children of current page.
+                var childNodes = content.ChildrenForAllCultures.ToList();
+
+                // if there is a settings page already created, then don't allow it anymore
+                if (childNodes.Any(x => x.ContentType.Alias == Settings.ModelTypeAlias))
+                {
+                    allowedChildren.RemoveAll(x => x.Alias == Settings.ModelTypeAlias);
+                }
+            }
+
+            // update the allowed children.
+            notification.Children = allowedChildren;
+        }
+    }
+}
+```

--- a/Reference/Notifications/SendingAllowedChildrenNotification/index.md
+++ b/Reference/Notifications/SendingAllowedChildrenNotification/index.md
@@ -1,0 +1,4 @@
+---
+versionFrom: 9.0.0
+versionTo: 10.0.0
+---

--- a/Reference/Notifications/SendingAllowedChildrenNotification/index.md
+++ b/Reference/Notifications/SendingAllowedChildrenNotification/index.md
@@ -25,12 +25,14 @@ namespace Umbraco.Docs.Samples.Web.Notifications
             //try get the id from the content item in the back office 
             var queryStringCollection = HttpUtility.ParseQueryString(notification.UmbracoContext.OriginalRequestUrl.Query);
             
-            if (!queryStringCollection.ContainsKey("contentId"))
+            var contentIdKey = "contentId";
+
+            if (!queryStringCollection.ContainsKey(contentIdKey))
             {
                 return;
             }
 
-            var contentId = queryStringCollection["contentId"].TryConvertTo<int>().ResultOr(-1);
+            var contentId = queryStringCollection[contentIdKey].TryConvertTo<int>().ResultOr(-1);
 
             if (contentId == -1)
             {

--- a/Reference/Notifications/SendingAllowedChildrenNotification/index.md
+++ b/Reference/Notifications/SendingAllowedChildrenNotification/index.md
@@ -75,14 +75,12 @@ You also need to register this notification handler. You can achieve this by upd
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-#pragma warning disable IDE0022 // Use expression body for methods
     services.AddUmbraco(_env, _config)
         .AddBackOffice()             
         .AddWebsite()
         .AddComposers()
         .AddNotificationHandler<SendingAllowedChildrenNotification, SendingAllowedChildrenNotificationHandler>()
         .Build();
-#pragma warning restore IDE0022 // Use expression body for methods
 }
 ```
 

--- a/Reference/Notifications/SendingAllowedChildrenNotification/index.md
+++ b/Reference/Notifications/SendingAllowedChildrenNotification/index.md
@@ -1,4 +1,8 @@
 ---
-versionFrom: 9.0.0
+versionFrom: 9.5.0
 versionTo: 10.0.0
 ---
+
+# Sending Allowed Children Notification
+The `SendingAllowedChildrenNotification` enable you to manipulate the content types that will be shown in the create menu.
+


### PR DESCRIPTION
During [DF22](https://df22.nl/) @dawoe did a talk of the unknown features of Umbraco. One of the subjecs was `SendingAllowedChildrenNotification`

I think it would be nice if we can add an example to the docs