### PR TITLE
Casing fixes + add regex for name rules

### DIFF
--- a/.github/styles/UmbracoDocs/Names.yml
+++ b/.github/styles/UmbracoDocs/Names.yml
@@ -6,8 +6,7 @@ swap:
   css: "'CSS'"
   html: "'HTML'"
   url: "'URL'"
-  js: "'JavaScript'"
-  javascript: "'JavaScript'"
+  '(?:(?<!\.)js|[jJ]ava[sS]cript)' : JavaScript
   .net: "'.NET'"
   dot net: "'.NET'"
   cms: "'CMS'"

--- a/.github/styles/UmbracoDocs/Names.yml
+++ b/.github/styles/UmbracoDocs/Names.yml
@@ -10,5 +10,4 @@ swap:
   .net: "'.NET'"
   dot net: "'.NET'"
   cms: "'CMS'"
-  AngularJs: "'AngularJS'"
-  angularjs: "'AngularJS'"  
+  '[aA]ngular[jJ][sS]' : AngularJS

--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/CICD-Pipeline/ci-cd-azure-dev-ops-v8.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/CICD-Pipeline/ci-cd-azure-dev-ops-v8.md
@@ -60,13 +60,13 @@ variables:
   # The Visual Studio .csproj Web App name
   vsProjectName: DeployOnPremSite
 
-  # The umbraco deploy trigger reason
+  # The Umbraco deploy trigger reason
   umbracoDeployReason: AzureDeployment
 
-  # The umbraco deploy data folder path
+  # The Umbraco deploy data folder path
   umbracoDeployData: $(Build.SourcesDirectory)\$(vsSolutionName)\data
 
-  # The umbraco deploy license folder path
+  # The Umbraco deploy license folder path
   deployLicense: $(Build.SourcesDirectory)\$(vsSolutionName)\bin
 
   # The TriggerDeploy.ps1 file path

--- a/Extending/Health-Check/index-v8.md
+++ b/Extending/Health-Check/index-v8.md
@@ -341,7 +341,7 @@ namespace Umbraco.Web.HealthCheck.NotificationMethods
                 results.ResultsAsHtml(Verbosity)
             });
 
-            // Include the umbraco Application URL host in the message subject so that
+            // Include the Umbraco Application URL host in the message subject so that
             // you can identify the site that these results are for.
             var host = _runtimeState.ApplicationUrl;
 

--- a/Extending/Health-Check/index.md
+++ b/Extending/Health-Check/index.md
@@ -358,7 +358,7 @@ namespace Umbraco.Cms.Core.HealthChecks.NotificationMethods
                 _markdownToHtmlConverter?.ToHtml(results, Verbosity)
             });
 
-            // Include the umbraco Application URL host in the message subject so that
+            // Include the Umbraco Application URL host in the message subject so that
             // you can identify the site that these results are for.
             var host = _hostingEnvironment?.ApplicationMainUrl?.ToString();
 

--- a/Fundamentals/Code/Debugging/Logging/index.md
+++ b/Fundamentals/Code/Debugging/Logging/index.md
@@ -115,7 +115,7 @@ Serilog uses levels as the primary means for assigning importance to log events.
 
 ## Configuration
 
-Serilog can be configured and extended by using the .NETCore configuration such as the AppSetting.json files or environment variables.
+Serilog can be configured and extended by using the .NET Core configuration such as the AppSetting.json files or environment variables.
 Info on the Serilog config [here](../../../../Reference/V9-Config/Serilog/index.md).
 
 ## The logviewer dashboard

--- a/Fundamentals/Code/Source-Control/index-v9.md
+++ b/Fundamentals/Code/Source-Control/index-v9.md
@@ -90,7 +90,7 @@ But these are not the only files in the Umbraco folder that you should not commi
 
 We've now covered most of the folders within the `/umbraco` folder, however, there are two left, the `/umbraco/models` folder, and the `/umbraco/PartialViewMacros`. The model's folder has its own section right below, but for the `PartialViewMacros` folder, the answer to "should I commit this to git" is that it depends. If you want to change the templates within the folder or add your own, then you should commit it to git, if you don't need to do that, you should not, the build will automatically create it and its content.
 
-##### The umbraco wwwroot folder
+##### The Umbraco wwwroot folder
 
 The `/wwwroot/umbraco` folder contains static assets for the backoffice, these files will be automatically created when you do a build, and should not be included in source control.
 

--- a/Fundamentals/Setup/Upgrading/version-specific.md
+++ b/Fundamentals/Setup/Upgrading/version-specific.md
@@ -12,7 +12,7 @@ Follow the steps in the [general upgrade guide](general.md), then these addition
 ## Version 9 to version 10
 
 :::warning
-**Important**: .NET version 6.0.5 is the minimum required version for Umbraco 10 to be able to run. You can check with `dotnet --list-sdks` what your latest installed SDK version is.
+**Important**: .NET version 6.0.5 is the minimum required version for Umbraco 10 to be able to run. You can check with `dotnet --list-sdks` what your latest installed Software Development Kit (SDK) version is.
 SDK version 6.0.300 is the one that includes .NET 6.0.5.
 At the time of writing, .NET 6.0.6 is out with an SDK version of 6.0.301.
 :::

--- a/Fundamentals/Setup/Upgrading/version-specific.md
+++ b/Fundamentals/Setup/Upgrading/version-specific.md
@@ -12,9 +12,9 @@ Follow the steps in the [general upgrade guide](general.md), then these addition
 ## Version 9 to version 10
 
 :::warning
-**Important**: .net version 6.0.5 is the minimum required version for Umbraco 10 to be able to run. You can check with `dotnet --list-sdks` what your latest installed SDK version is.
-SDK version 6.0.300 is the one that includes .net 6.0.5.
-At the time of writing, .net 6.0.6 is out with an SDK version of 6.0.301.
+**Important**: .NET version 6.0.5 is the minimum required version for Umbraco 10 to be able to run. You can check with `dotnet --list-sdks` what your latest installed SDK version is.
+SDK version 6.0.300 is the one that includes .NET 6.0.5.
+At the time of writing, .NET 6.0.6 is out with an SDK version of 6.0.301.
 :::
 
 ## Video Tutorial

--- a/Implementation/Custom-Routing/signalR.md
+++ b/Implementation/Custom-Routing/signalR.md
@@ -158,7 +158,7 @@ You need to provide the default reserved paths, else you'll run into an issue as
 And lastly we can test the setup with some JavaScript in our view:
 
 ```html
-<!-- We reference the signalR js file that comes with umbraco -->
+<!-- We reference the signalR js file that comes with Umbraco -->
 <script type="text/javascript" src="/umbraco/lib/signalr/signalr.min.js"></script>
 <script>
     var connection = new signalR.HubConnectionBuilder()

--- a/Reference/Configuration-for-Umbraco-7-and-8/dashboard/index-v7.md
+++ b/Reference/Configuration-for-Umbraco-7-and-8/dashboard/index-v7.md
@@ -94,7 +94,7 @@ Example on permissions:
 In order to customize the dashboard in Umbraco, one needs to do a couple of things.
 
 :::note
-Older version can use a .net `UserControl`. See [creating dashboards with usercontrols](index-v6.md)
+Older version can use a .NET `UserControl`. See [creating dashboards with usercontrols](index-v6.md)
 :::
 
 ## Create an AngularJS View

--- a/Reference/Configuration/ConnectionStringsSettings/index-v9.md
+++ b/Reference/Configuration/ConnectionStringsSettings/index-v9.md
@@ -6,7 +6,7 @@ meta.Description: "Information on the connection strings settings section"
 
 # Connection strings settings
 
-The connection strings settings section contains the connection string to the database Umbraco will connect to. This section is very similar to what is used by default in .Netcore. The important thing is that the key for the connection string Umbraco will use is `"umbracoDbDSN"`. It is also important to note that this section is outside the `Umbraco.CMS` section, and is therefore in the root of the config.
+The connection strings settings section contains the connection string to the database Umbraco will connect to. This section is very similar to what is used by default in .NET Core. The important thing is that the key for the connection string Umbraco will use is `"umbracoDbDSN"`. It is also important to note that this section is outside the `Umbraco.CMS` section, and is therefore in the root of the config.
 
 A connection strings config can look like this: 
 

--- a/Reference/Configuration/ConnectionStringsSettings/index.md
+++ b/Reference/Configuration/ConnectionStringsSettings/index.md
@@ -6,7 +6,7 @@ meta.Description: "Information on the connection strings settings section"
 
 # Connection strings settings
 
-The connection strings settings section contains the connection string to the database Umbraco will connect to. This section is very similar to what's used by default in .NET Core, the important thing though is that the key for the connection string Umbraco will use is `"umbracoDbDSN"`. It is also important to note that this section is outside the `Umbraco.CMS` section, and is therefore in the root of the config.
+The connection strings settings section contains the connection string to the database Umbraco will connect to. This section is similar to what is used by default in .NET Core. The important thing is that the key for the connection string Umbraco will use is `"umbracoDbDSN"`. It is also important to know that this section is outside the `Umbraco.CMS` section, and is therefore in the root of the config.
 
 An connection strings config can look like this:
 

--- a/Reference/Configuration/ConnectionStringsSettings/index.md
+++ b/Reference/Configuration/ConnectionStringsSettings/index.md
@@ -6,7 +6,7 @@ meta.Description: "Information on the connection strings settings section"
 
 # Connection strings settings
 
-The connection strings settings section contains the connection string to the database Umbraco will connect to. This section is very similar to what's used by default in .Netcore, the important thing though is that the key for the connection string umbraco will use is `"umbracoDbDSN"`. It is also important to note that this section is outside the `Umbraco.CMS` section, and is therefore in the root of the config.
+The connection strings settings section contains the connection string to the database Umbraco will connect to. This section is very similar to what's used by default in .Netcore, the important thing though is that the key for the connection string Umbraco will use is `"umbracoDbDSN"`. It is also important to note that this section is outside the `Umbraco.CMS` section, and is therefore in the root of the config.
 
 An connection strings config can look like this:
 

--- a/Reference/Configuration/ConnectionStringsSettings/index.md
+++ b/Reference/Configuration/ConnectionStringsSettings/index.md
@@ -6,7 +6,7 @@ meta.Description: "Information on the connection strings settings section"
 
 # Connection strings settings
 
-The connection strings settings section contains the connection string to the database Umbraco will connect to. This section is very similar to what's used by default in .Netcore, the important thing though is that the key for the connection string Umbraco will use is `"umbracoDbDSN"`. It is also important to note that this section is outside the `Umbraco.CMS` section, and is therefore in the root of the config.
+The connection strings settings section contains the connection string to the database Umbraco will connect to. This section is very similar to what's used by default in .NET Core, the important thing though is that the key for the connection string Umbraco will use is `"umbracoDbDSN"`. It is also important to note that this section is outside the `Umbraco.CMS` section, and is therefore in the root of the config.
 
 An connection strings config can look like this:
 

--- a/Reference/Configuration/ContentSettings/index-v9.0.0.md
+++ b/Reference/Configuration/ContentSettings/index-v9.0.0.md
@@ -147,7 +147,7 @@ Umbraco can send out email notifications, set the sender email address for the n
 
 ## Imaging
 
-This section is used for managing how umbraco handles images, allowed attributes and, which properties of an image that should be automatically updated on upload.
+This section is used for managing how Umbraco handles images, allowed attributes and, which properties of an image that should be automatically updated on upload.
 
 ```json
 "Imaging": {

--- a/Reference/Configuration/ContentSettings/index-v9.1.0.md
+++ b/Reference/Configuration/ContentSettings/index-v9.1.0.md
@@ -147,7 +147,7 @@ Umbraco can send out email notifications, set the sender email address for the n
 
 ## Imaging
 
-This section is used for managing how umbraco handles images, allowed attributes and, which properties of an image that should be automatically updated on upload.
+This section is used for managing how Umbraco handles images, allowed attributes and, which properties of an image that should be automatically updated on upload.
 
 ```json
 "Imaging": {

--- a/Reference/Configuration/UnattendedSettings/index.md
+++ b/Reference/Configuration/UnattendedSettings/index.md
@@ -45,7 +45,7 @@ Umbraco will only automatically install if this is set to true, and if there is 
 
 ## Upgrade unattended
 
-If this is set to true, umbraco will automatically run the upgrade migrations once the site has been upgraded.
+If this is set to true, Umbraco will automatically run the upgrade migrations once the site has been upgraded.
 
 ## Unattended user name
 

--- a/Reference/Management/Models/index.md
+++ b/Reference/Management/Models/index.md
@@ -11,7 +11,7 @@ Since the release of Umbraco 10, we will no longer be updating the articles in t
 You can find up-to-date code references for all Models in our [API Documentation](https://apidocs.umbraco.com/v10/csharp/api/Umbraco.Cms.Core.Models.html).
 :::
 
-The intended audience for these reference pages are .net developers, it is assumed the reader already has a knowledge of the basics of Umbraco and knows .net & c#.
+The intended audience for these reference pages are .NET developers, it is assumed the reader already has a knowledge of the basics of Umbraco and knows .NET & C#.
 
 The links listed below are api references for Umbraco's public model.
 

--- a/Reference/Management/Models/index.md
+++ b/Reference/Management/Models/index.md
@@ -11,7 +11,7 @@ Since the release of Umbraco 10, we will no longer be updating the articles in t
 You can find up-to-date code references for all Models in our [API Documentation](https://apidocs.umbraco.com/v10/csharp/api/Umbraco.Cms.Core.Models.html).
 :::
 
-The intended audience for these reference pages are .NET developers, it is assumed the reader already has a knowledge of the basics of Umbraco and knows .NET & C#.
+The intended audience for these reference pages are .NET developers. It is assumed the reader already has knowledge of the basics of Umbraco and knows .NET & C#.
 
 The links listed below are api references for Umbraco's public model.
 

--- a/Reference/Management/Services/index.md
+++ b/Reference/Management/Services/index.md
@@ -13,7 +13,7 @@ Since the release of Umbraco 10, we will no longer be updating the articles in t
 You can find up-to-date code references for all Models in our [API Documentation](https://apidocs.umbraco.com/v10/csharp/api/Umbraco.Cms.Core.Services.html).
 :::
 
-The intended audience for these reference pages are .NET developers, it is assumed the reader already has a knowledge of the basics of Umbraco and knows .NET & C#.
+The intended audience for these reference pages are .NET developers. It is assumed the reader already has knowledge of the basics of Umbraco and knows .NET & C#.
 
 ## [AuditService](AuditService)
 

--- a/Reference/Management/Services/index.md
+++ b/Reference/Management/Services/index.md
@@ -13,7 +13,7 @@ Since the release of Umbraco 10, we will no longer be updating the articles in t
 You can find up-to-date code references for all Models in our [API Documentation](https://apidocs.umbraco.com/v10/csharp/api/Umbraco.Cms.Core.Services.html).
 :::
 
-The intended audience for these reference pages are .net developers, it is assumed the reader already has a knowledge of the basics of Umbraco and knows .net & c#.
+The intended audience for these reference pages are .NET developers, it is assumed the reader already has a knowledge of the basics of Umbraco and knows .NET & C#.
 
 ## [AuditService](AuditService)
 

--- a/Reference/Management/index.md
+++ b/Reference/Management/index.md
@@ -7,7 +7,7 @@ versionTo: 9.0.0
 
 _Details of CRUD operations within Umbraco and how to interact with the data persisted in the database_
 
-The intended audience for these reference pages are .net developers, it is assumed the reader already has a knowledge of the basics of Umbraco and knows .NET & C#.
+The intended audience for these reference pages are .NET developers, it is assumed the reader already has a knowledge of the basics of Umbraco and knows .NET & C#.
 
 ## [Models](Models/index.md)
 Here you will find references for the models in the public api including the Content, ContentType, DataTypeDefinition, DictionaryItem, Language, Media, MediaType, Relation, RelationType, Task, TaskType and Template classes.

--- a/Reference/Management/index.md
+++ b/Reference/Management/index.md
@@ -7,7 +7,7 @@ versionTo: 9.0.0
 
 _Details of CRUD operations within Umbraco and how to interact with the data persisted in the database_
 
-The intended audience for these reference pages are .NET developers, it is assumed the reader already has a knowledge of the basics of Umbraco and knows .NET & C#.
+The intended audience for these reference pages are .NET developers. It is assumed the reader already has knowledge of the basics of Umbraco and knows .NET & C#.
 
 ## [Models](Models/index.md)
 Here you will find references for the models in the public api including the Content, ContentType, DataTypeDefinition, DictionaryItem, Language, Media, MediaType, Relation, RelationType, Task, TaskType and Template classes.

--- a/Reference/Routing/Request-Pipeline/published-content-request-preparation.md
+++ b/Reference/Routing/Request-Pipeline/published-content-request-preparation.md
@@ -21,7 +21,7 @@ What it does:
 - Routes the request with the request builder using the `PublishedRouter.RouteRequestAsync(…)`.
   - This will handle redirects, find domain, template, published content and so on.
   - Build the final `IPublishedRequest`.
-- Sets the routed request in the umbraco context, so it will be available to the controller.
+- Sets the routed request in the Umbraco context, so it will be available to the controller.
 - Create the route values with the `UmbracoRouteValuesFactory`.
   - This is what actually routes your request to the correct controller and action, and allows you to hijack routes.
 - Set the route values to the http context.

--- a/Reference/Routing/Umbraco-API-Controllers/index.md
+++ b/Reference/Routing/Umbraco-API-Controllers/index.md
@@ -24,7 +24,7 @@ A great resource for getting started with creating web API's using .Net Core is 
 
 ## Web Api in Umbraco
 
-We've created a base api controller for developers to inherit from which will ensure that the api controller gets routed. Unlike V8, this does not expose any specific umbraco related services or objects, but does inherit from the .Net Core controller base, meaning you will have access to the same things you would from a regular .Net Core controller. Dependency injection is also available to controllers, so any Umbraco specific services or objects you might need can be injected in the constructor.
+We've created a base api controller for developers to inherit from which will ensure that the api controller gets routed. Unlike V8, this does not expose any specific Umbraco related services or objects, but does inherit from the .Net Core controller base, meaning you will have access to the same things you would from a regular .Net Core controller. Dependency injection is also available to controllers, so any Umbraco specific services or objects you might need can be injected in the constructor.
 
 The class to inherit from is: `Umbraco.Cms.Web.Common.Controllers.UmbracoApiController`
 

--- a/Reference/Routing/Umbraco-API-Controllers/index.md
+++ b/Reference/Routing/Umbraco-API-Controllers/index.md
@@ -24,7 +24,7 @@ A great resource for getting started with creating web API's using .Net Core is 
 
 ## Web Api in Umbraco
 
-We've created a base api controller for developers to inherit from which will ensure that the api controller gets routed. Unlike V8, this does not expose any specific Umbraco related services or objects, but does inherit from the .Net Core controller base, meaning you will have access to the same things you would from a regular .Net Core controller. Dependency injection is also available to controllers, so any Umbraco specific services or objects you might need can be injected in the constructor.
+We have created a base API controller for developers to inherit from. This will ensure that the API controller gets routed. Unlike Umbraco 8, this does not expose any specific Umbraco-related services or objects but does inherit from the .Net Core controller base. This means that you will have access to the same things you would from a regular .Net Core controller. Dependency injection is also available to controllers. Any Umbraco-specific services or objects you might need can be injected into the constructor.
 
 The class to inherit from is: `Umbraco.Cms.Web.Common.Controllers.UmbracoApiController`
 

--- a/Reference/Security/Auto-linking/index.md
+++ b/Reference/Security/Auto-linking/index.md
@@ -270,7 +270,7 @@ public static IUmbracoBuilder AddMemberGoogleAuthentication(this IUmbracoBuilder
             memberAuthenticationBuilder =>
             {
                 memberAuthenticationBuilder.AddGoogle(
-                    // The scheme must be set with this method to work for the umbraco members
+                    // The scheme must be set with this method to work for the Umbraco members
                     memberAuthenticationBuilder.SchemeForMembers(GoogleMemberExternalLoginProviderOptions.SchemeName),
                     options =>
                     {

--- a/Reference/Security/Security-hardening/index-v9.md
+++ b/Reference/Security/Security-hardening/index-v9.md
@@ -64,7 +64,7 @@ This can be done by following these steps:
 1. Clean solution - This will delete the `wwwroot/umbraco` folder
 2. Add the following line into a property group element of your `csproj`-file
    - `<UmbracoWwwrootName>my-secret-loginpanel</UmbracoWwwrootName>`
-3. Build sulution - This will copy umbraco content into `wwwroot/my-secret-loginpanel`
+3. Build sulution - This will copy Umbraco content into `wwwroot/my-secret-loginpanel`
 4. Change the three keys in your configuration `Umbraco:CMS:Global:ReservedPaths`,`Umbraco:CMS:Global:UmbracoPath`, and `Umbraco:CMS:Global:IconsPath` to your new path:
 
 ```json

--- a/Reference/Security/index-v7.md
+++ b/Reference/Security/index-v7.md
@@ -64,7 +64,7 @@ Some security settings that can be used in Umbraco.
 
 ### Introduction of Custom OAuth providers (Available from Umbraco version 7.3.1)
 
-Starting with Umbraco 7.3.1 Umbraco uses [ASP.Net Identity](https://www.asp.net/identity) for authentication of backoffice users. Asp.net identity is a flexible and extensible framework for authentication.
+Starting with Umbraco 7.3.1 Umbraco uses [ASP.Net Identity](https://www.asp.net/identity) for authentication of backoffice users. Asp.NET identity is a flexible and extensible framework for authentication.
 
 Out of the box Umbraco ships with a ASP.Net Identity implementation which uses Umbraco's database data. Normally this is fine for most Umbraco developers
 but in some cases the authentication process needs to be customized.

--- a/Reference/Using-Ioc/index.md
+++ b/Reference/Using-Ioc/index.md
@@ -266,7 +266,7 @@ namespace IOCDocs.Services
         
         public IEnumerable<IPublishedContent> GetContentAtRoot()
         {
-            // Try and get the umbraco helper
+            // Try and get the Umbraco helper
             var success = _umbracoHelperAccessor.TryGetUmbracoHelper(out var umbracoHelper);
             if (success is false)
             {
@@ -274,7 +274,7 @@ namespace IOCDocs.Services
                 return null;
             }
             
-            // We got umbraco helper, now we can do something with it.
+            // We got Umbraco helper, now we can do something with it.
             return umbracoHelper.ContentAtRoot();
         }
     }
@@ -327,7 +327,7 @@ namespace IOCDocs.Services
             // Do stuff with the index
             if (_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext) is false)
             {
-                throw new InvalidOperationException("Could not get umbraco context");
+                throw new InvalidOperationException("Could not get Umbraco context");
             }
 
             return umbracoIndex.Searcher.Search(searchTerm).ToPublishedSearchResults(umbracoContext.PublishedSnapshot.Content);

--- a/Umbraco-Heartcore/API-Documentation/Redirect/index.md
+++ b/Umbraco-Heartcore/API-Documentation/Redirect/index.md
@@ -6,10 +6,10 @@ meta.Description: "Documentation for Heartcore Redirect APIs"
 
 # Redirect API
 
-This is the read-only API for delivering redirects, caused by moving or renaming content in the umbraco backoffice, to any app, website, device, or platform.
+This is the read-only API for delivering redirects, caused by moving or renaming content in the Umbraco backoffice, to any app, website, device, or platform.
 
 :::note
-The redirect API is only available if your project is using the **Content Delivery Platform**. You can verify this in the umbraco backoffice, settings section in the headless overview panel.
+The redirect API is only available if your project is using the **Content Delivery Platform**. You can verify this in the Umbraco backoffice, settings section in the headless overview panel.
 :::
 
 ## Cultures


### PR DESCRIPTION
- Fixed some casing warnings for `Umbraco` and `.NET`
- Added a regex rule for `js` and `[jJ]ava[sS]cript`
  - This fixes the warnings showing where lower case `js` is used correctly with a `.` before it, for example `Node.js`
- Added a regex rule for `[aA]ngular[jJ][sS]` to fix casing warnings

@sofietoft Let me know what you think about the regex/if it's not helpful!
 