### PR TITLE
Fix the KeyVault code sample

### DIFF
--- a/Extending/Key-Vault/index.md
+++ b/Extending/Key-Vault/index.md
@@ -25,7 +25,7 @@ dotnet add package Azure.Identity
 ```
 
 ## Configuration
-The next step is to add the Azure Key Vault endpoint to the `appsettings.json` file. 
+The next step is to add the Azure Key Vault endpoint to the `appsettings.json` file (or create as an Environment Variable). 
 
 ```json
 {
@@ -38,17 +38,21 @@ After adding the Key Vault endpoint you have to update the `CreateHostBuilder` m
 ```csharp
 public static IHostBuilder CreateHostBuilder(string[] args) =>
     Host.CreateDefaultBuilder(args)
-        .ConfigureLogging(x => x.ClearProviders())
+        .ConfigureUmbracoDefaults()
         .ConfigureAppConfiguration((context, config) =>
         {
             var settings = config.Build();
-            var keyVaultEndpoint = settings[Constants.Azure.AzureKeyVaultEndpoint];
+            var keyVaultEndpoint = settings["AzureKeyVaultEndpoint"];
             if (!string.IsNullOrEmpty(keyVaultEndpoint) && Uri.TryCreate(keyVaultEndpoint, UriKind.Absolute, out var validUri))
             {
                 config.AddAzureKeyVault(validUri, new DefaultAzureCredential());
             }
         })
-        .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>());
+        .ConfigureWebHostDefaults(webBuilder =>
+        {
+            webBuilder.UseStaticWebAssets();
+            webBuilder.UseStartup<Startup>();
+        });
 ```
 
 ## Authentication 
@@ -63,7 +67,7 @@ There are different ways to access the Azure Key Vault. It is important that the
 1. Click review + assign
 
 
-### Local Developement 
+### Local Development 
 
 1. [Sign in to Visual Studio using the credentials that can access the Key Vault.](https://docs.microsoft.com/en-us/visualstudio/ide/signing-in-to-visual-studio) 
 1. [Use Azure CLI to store your preferred account into the credential cache.](https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli)


### PR DESCRIPTION
CreateHostBuilder updated to v10 (it's currently the v9 version) and the Constants.Azure.AzureKeyVaultEndpoint doesn't exist so it should be a string in the sample.