### PR TITLE
Fix custom error page config formatting

### DIFF
--- a/Tutorials/Custom-Error-Pages/index.md
+++ b/Tutorials/Custom-Error-Pages/index.md
@@ -104,14 +104,16 @@ In order to customize this error page it is recommend that you create a **new HT
 :::note
 The `BootFailed.html` page will only be shown if debugging is disabled in `appsettings.json` i.e.
 
-```json  
-"Umbraco": {
-    "CMS": {
-      "Hosting": {
-        "Debug": false
-      }
+```json
+{
+    "Umbraco": {
+        "CMS": {
+            "Hosting": {
+                "Debug": false
+            }
+        }
     }
-  }
+}
 ```
 
 The full error can always be found in the log file.


### PR DESCRIPTION
The format of the configuration examples on the "Custom Error Page" docs is a bit out of whack... I've fixed it!

<img width="818" alt="Screenshot 2022-10-19 at 15 28 32" src="https://user-images.githubusercontent.com/16511093/196719890-975fe177-c4a2-4e4e-a2eb-c97dd50b9f2c.png">