### PR TITLE
Update config sample

### DIFF
--- a/Reference/Configuration/Serilog/index.md
+++ b/Reference/Configuration/Serilog/index.md
@@ -19,7 +19,8 @@ When you create a new Umbraco project the following Serilog section will be incl
   "MinimumLevel": {
     "Default": "Information",
     "Override": {
-      "Microsoft.AspNetCore": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
       "System": "Warning"
     }
   }


### PR DESCRIPTION
The provided config sample was out-of-date. It doesn't match what you get in Umbraco 10.3 and it doesn't match the description in the second paragraph after the "Specifying minimum log level" heading.