### PR TITLE
Update ImagingSettings

### DIFF
--- a/Reference/Configuration/ImagingSettings/index.md
+++ b/Reference/Configuration/ImagingSettings/index.md
@@ -34,7 +34,7 @@ All these settings contain default values, so nothing needs to be explicitly con
 ## Cache
 
 Contains configuration for browser and server caching. 
-When changing these cache headers, its recommended to clear your media cache, as this meta data is stored in the cache and not updated when the configuration is changed.
+When changing these cache headers, its recommended to clear your media cache. As meta data is stored in the cache and not updated when the configuration is changed.
 
 ### Browser max age
 

--- a/Reference/Configuration/ImagingSettings/index.md
+++ b/Reference/Configuration/ImagingSettings/index.md
@@ -33,7 +33,8 @@ All these settings contain default values, so nothing needs to be explicitly con
 
 ## Cache
 
-Contains configuration for browser and server caching.
+Contains configuration for browser and server caching. 
+When changing these cache headers, its recommended to clear your media cache, as this meta data is stored in the cache and not updated when the configuration is changed.
 
 ### Browser max age
 

--- a/Reference/Configuration/ImagingSettings/index.md
+++ b/Reference/Configuration/ImagingSettings/index.md
@@ -34,7 +34,7 @@ All these settings contain default values, so nothing needs to be explicitly con
 ## Cache
 
 Contains configuration for browser and server caching. 
-When changing these cache headers, its recommended to clear your media cache. As meta data is stored in the cache and not updated when the configuration is changed.
+When changing these cache headers, it is recommended to clear your media cache. This is due to the data being stored in the cache and not updated when the configuration is changed.
 
 ### Browser max age
 


### PR DESCRIPTION
During the hackathon, we looked at the max-age issue, and found this data is cached, resulting in needed the cache for the new settings to be applied.