### PR TITLE
V11: Remove reference to UmbracoApplicationMainDomAcquiredNotification in common pitfalls

### DIFF
--- a/Reference/Common-Pitfalls/index-v11.md
+++ b/Reference/Common-Pitfalls/index-v11.md
@@ -1,6 +1,5 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+versionFrom: 11.0.0
 meta.Title: "Common Pitfalls and Anti-Patterns in Umbraco"
 meta.Description: "Information on common Pitfalls and Anti-Patterns in Umbraco"
 ---
@@ -220,7 +219,7 @@ In some cases, this might be ok but many times we've seen bulk imports occur on 
 
 ## Processing during startup
 
-Umbraco allows you to run some initialization code during startup by using `UmbracoApplicationStartingNotification` or `UmbracoApplicationMainDomAcquiredNotification`, however, great
+Umbraco allows you to run some initialization code during startup by using `UmbracoApplicationStartingNotification`, however, great
 care should be used to ensure that you are not slowing down application startup. You should be especially careful
 as a Package developer that you are not slowing down application startup since your package may end up being used for
 thousands of websites.

--- a/Reference/Common-Pitfalls/index-v9.md
+++ b/Reference/Common-Pitfalls/index-v9.md
@@ -1,5 +1,6 @@
 ---
-versionFrom: 11.0.0
+versionFrom: 9.0.0
+versionTo: 10.0.0
 meta.Title: "Common Pitfalls and Anti-Patterns in Umbraco"
 meta.Description: "Information on common Pitfalls and Anti-Patterns in Umbraco"
 ---
@@ -219,7 +220,7 @@ In some cases, this might be ok but many times we've seen bulk imports occur on 
 
 ## Processing during startup
 
-Umbraco allows you to run some initialization code during startup by using `UmbracoApplicationStartingNotification`, however, great
+Umbraco allows you to run some initialization code during startup by using `UmbracoApplicationStartingNotification` or `UmbracoApplicationMainDomAcquiredNotification`, however, great
 care should be used to ensure that you are not slowing down application startup. You should be especially careful
 as a Package developer that you are not slowing down application startup since your package may end up being used for
 thousands of websites.

--- a/Reference/Common-Pitfalls/index.md
+++ b/Reference/Common-Pitfalls/index.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 11.0.0
+versionFrom: 9.0.0
 meta.Title: "Common Pitfalls and Anti-Patterns in Umbraco"
 meta.Description: "Information on common Pitfalls and Anti-Patterns in Umbraco"
 ---
@@ -219,7 +219,7 @@ In some cases, this might be ok but many times we've seen bulk imports occur on 
 
 ## Processing during startup
 
-Umbraco allows you to run some initialization code during startup by using `UmbracoApplicationStartingNotification`, however, great
+Umbraco allows you to run some initialization code during startup by using `UmbracoApplicationStartingNotification` or `UmbracoApplicationMainDomAcquiredNotification`, however, great
 care should be used to ensure that you are not slowing down application startup. You should be especially careful
 as a Package developer that you are not slowing down application startup since your package may end up being used for
 thousands of websites.


### PR DESCRIPTION
Removes the reference to the `UmbracoApplicationMainDomAcquiredNotification` in the common pitfalls document, since this notification no longer exists in V11 😄 


I'm still a bit shaky about the whole multiple versions thing, but I've copied the old one and named it `index-v9.md` even though it covers both v9 and v10 and then made index.md be the v11 one. Feel free to change this if I've done it wrong 😄 