### PR TITLE
Update and rename/move static asset cache tutorial to "Reference/Response Caching"

### DIFF
--- a/Reference/Response-Caching/index.md
+++ b/Reference/Response-Caching/index.md
@@ -1,8 +1,11 @@
 ---
 versionFrom: 9.3.0
 ---
+# Response Caching
 
-# Modify the `Cache-Control` header for Static Files
+Response caching reduces the number of requests a client or proxy makes to a web server. See the Microsoft documentation for details of [Response caching in ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/performance/caching/response?view=aspnetcore-6.0) and how to implement the [Response Caching Middleware](https://learn.microsoft.com/en-us/aspnet/core/performance/caching/middleware?view=aspnetcore-6.0).
+
+## Modify the `Cache-Control` header for Static Files
 
 Example class to allow the modification of the `Cache-Control` header for static assets by file extension, but excluding Umbraco BackOffice assets.
 
@@ -84,3 +87,22 @@ public void ConfigureServices(IServiceCollection services)
 For setting `Cache-Control` max-age header for images processed by the ImageSharp middleware, you can set the `Umbraco:CMS:Imaging:Cache:BrowserMaxAge` setting.
 
 See the [Images Settings](https://our.umbraco.com/Documentation/Reference/Configuration/ImagingSettings/) article for more information.
+
+## Add the `Cache-Control` header for rendering using the [ResponseCache attribute](https://learn.microsoft.com/en-us/aspnet/core/performance/caching/response?view=aspnetcore-6.0#responsecache-attribute)
+
+For example using a custom [Default Controller](https://our.umbraco.com/Documentation/Implementation/Default-Routing/Controller-Selection/#change-the-default-controllers) you can add the ResponseCache attribute to the `Index` method
+
+```csharp
+public class DefaultController : RenderController
+{
+    public DefaultController(ILogger<RenderController> logger, ICompositeViewEngine compositeViewEngine, IUmbracoContextAccessor umbracoContextAccessor) : base(logger, compositeViewEngine, umbracoContextAccessor)
+    {
+    }
+
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
+    public override IActionResult Index()
+    {
+        return CurrentTemplate(new ContentModel(CurrentPage));
+    }
+}
+```

--- a/Reference/index.md
+++ b/Reference/index.md
@@ -78,6 +78,10 @@ Run recurring code using the RecurringHostedServiceBase.
 
 Information about setting up Inversion of Control / Dependency Injection to work with Umbraco.
 
+## [Response Caching](Response-Caching/)
+
+Information about how to modify or add the `Cache-Control` header.
+
 ## API Documentation V9
 
 ### [Umbraco.Core](https://apidocs.umbraco.com/v9/csharp/api/Umbraco.Cms.Core.html)

--- a/Tutorials/Cache-Static-Assets/index.md
+++ b/Tutorials/Cache-Static-Assets/index.md
@@ -2,34 +2,29 @@
 versionFrom: 9.3.0
 ---
 
-# Cache static assets
+# Modify the `Cache-Control` header for Static Files
 
-Example to cache static assets by file extension, but excluding Umbraco BackOffice assets.
+Example class to allow the modification of the `Cache-Control` header for static assets by file extension, but excluding Umbraco BackOffice assets.
+
+
 
 ```csharp
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Headers;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
-using Microsoft.Net.Http.Headers;
+using System.IO;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using Umbraco.Cms.Core.Composing;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Http.Headers;
+using Microsoft.Net.Http.Headers;
+
 using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Extensions;
 using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
 
-namespace My.Site.Composers;
-
-public class StaticFilesComposer : IComposer
+namespace Umbraco.Docs.Samples.Web.Tutorials
 {
-    public void Compose(IUmbracoBuilder builder)
-        => builder.Services.AddTransient<IConfigureOptions<StaticFileOptions>, ConfigureStaticFileOptions>();
-
-    private class ConfigureStaticFileOptions : IConfigureOptions<StaticFileOptions>
+    public class ConfigureStaticFileOptions : IConfigureOptions<StaticFileOptions>
     {
         // These are the extensions of the file types we want to cache (add and remove as you see fit)
         private static readonly HashSet<string> _cachedFileExtensions = new(StringComparer.OrdinalIgnoreCase)
@@ -38,7 +33,8 @@ public class StaticFilesComposer : IComposer
             ".css",
             ".js",
             ".svg",
-            ".woff2"
+            ".woff2",
+            ".jpg"
         };
 
         private readonly string _backOfficePath;
@@ -72,7 +68,18 @@ public class StaticFilesComposer : IComposer
 }
 ```
 
-## Cache images in ImageSharp
+Register the service in `Startup.cs`
+
+```csharp
+
+public void ConfigureServices(IServiceCollection services)
+{
+	services.AddTransient<IConfigureOptions<StaticFileOptions>, ConfigureStaticFileOptions>();
+
+```
+
+
+## Modify the `Cache-Control` header for ImageSharp.Web
 
 For setting `Cache-Control` max-age header for images processed by the ImageSharp middleware, you can set the `Umbraco:CMS:Imaging:Cache:BrowserMaxAge` setting.
 

--- a/Tutorials/index.md
+++ b/Tutorials/index.md
@@ -68,10 +68,6 @@ Learn how to implement a basic register/login functionality on your website, hid
 
 This tutorial explains how to host multiple sites from one project/installation of Umbraco.
 
-## [Modify the `Cache-Control` header for Static Files](Cache-Static-Assets/)
-
-This tutorial shows how to modify the `Cache-Control` header for Static Files.
-
 ## [Porting Packages from Version 7 to Version 8](Porting-Packages-V8/index.md)
 
 A working document, that gives tips & pointers on how to port an Umbraco V7 package to work with the up coming Umbraco V8 release.

--- a/Tutorials/index.md
+++ b/Tutorials/index.md
@@ -68,9 +68,9 @@ Learn how to implement a basic register/login functionality on your website, hid
 
 This tutorial explains how to host multiple sites from one project/installation of Umbraco.
 
-## [Cache Static Assets](Cache-Static-Assets/)
+## [Modify the `Cache-Control` header for Static Files](Cache-Static-Assets/)
 
-This sample shows how to cache static assets in Umbraco.
+This tutorial shows how to modify the `Cache-Control` header for Static Files.
 
 ## [Porting Packages from Version 7 to Version 8](Porting-Packages-V8/index.md)
 


### PR DESCRIPTION
The current tutorial name of "Cache static assets" is not accurate. This tutorial does not cache anything it allows the setting of a response header that is used to determine how long a file should be cached for by the browser or a proxy server.

This PR updates the title for static assets cache control tutorial, updates code samples from Samples project, and swaps from IComposer to Startup.cs registration