### PR TITLE
Upgrade notes for Forms/Deploy 11

### DIFF
--- a/Add-ons/Umbraco-Deploy/Extending/index.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index.md
@@ -472,7 +472,9 @@ If access to any services is required when parsing the entity Id, where the `Htt
 var localizationService = httpContext.RequestServices.GetRequiredService<ILocalizationService>();
 ```
 
-Note that the `HttpContext` parameter for the `matchesRoutePath` and `matchesNodeId` functions was added in Deploy 11. Before that version it is necessary to use the `StaticServiceProvider.Instance` to access registered services or the `HttpContext`.
+:::note
+The `HttpContext` parameter for the `matchesRoutePath` and `matchesNodeId` functions was added in Deploy 11. Before that version, it is necessary to use the `StaticServiceProvider.Instance` to access registered services or the `HttpContext`.
+:::
 
 Finally, the `remoteTree` optional parameter adds support for plugins to implement Deploy's "partial restore" feature.  This gives the editor the option to select an item to restore, from a tree picker displaying details from a remote environment.  The parameter is of type `DeployRegisteredEntityTypeDetail.RemoteTreeDetail` that defines three pieces of information:
 

--- a/Add-ons/Umbraco-Deploy/Extending/index.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index.md
@@ -466,7 +466,7 @@ _transferEntityService.RegisterTransferEntityType(
     (string nodeId, HttpContext httpContext, out Guid entityId) => Guid.TryParse(nodeId.Substring("rider-".Length), out entityId);
 ```
 
-If access to any services is required when parsing the entity Id, where the `HttpContext` is provided as a parameter to the function, a service can be retrieved. For example:
+If access to services is required when parsing the entity ID, where the `HttpContext` is provided as a parameter, a service can be retrieved. For example:
 
 ```c#
 var localizationService = httpContext.RequestServices.GetRequiredService<ILocalizationService>();

--- a/Add-ons/Umbraco-Deploy/Extending/index.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index.md
@@ -466,7 +466,7 @@ _transferEntityService.RegisterTransferEntityType(
     (string nodeId, HttpContext httpContext, out Guid entityId) => Guid.TryParse(nodeId.Substring("rider-".Length), out entityId);
 ```
 
-If access to any services is required when parsing the entity Id, where the `HttpContext` is provided as a parameter to the function, a service can be retrieved, for example.:
+If access to any services is required when parsing the entity Id, where the `HttpContext` is provided as a parameter to the function, a service can be retrieved. For example:
 
 ```c#
 var localizationService = httpContext.RequestServices.GetRequiredService<ILocalizationService>();

--- a/Add-ons/Umbraco-Deploy/Extending/index.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index.md
@@ -466,13 +466,13 @@ _transferEntityService.RegisterTransferEntityType(
     (string nodeId, HttpContext httpContext, out Guid entityId) => Guid.TryParse(nodeId.Substring("rider-".Length), out entityId);
 ```
 
-If access to any services is required when parsing the entity Id, where the `HttpContext` is provided as a parameter to the function. A service can be accessed from this, e.g.:
+If access to any services is required when parsing the entity Id, where the `HttpContext` is provided as a parameter to the function, a service can be retrieved, for example.:
 
 ```c#
 var localizationService = httpContext.RequestServices.GetRequiredService<ILocalizationService>();
 ```
 
-Note that the `HttpContext` parameter for the `matchesRoutePath` and `matchesNodeId` functions was added in Deploy 11. Before that version it's necessary to use the `StaticServiceProvider.Instance` to access registered services or the `HttpContext`.
+Note that the `HttpContext` parameter for the `matchesRoutePath` and `matchesNodeId` functions was added in Deploy 11. Before that version it is necessary to use the `StaticServiceProvider.Instance` to access registered services or the `HttpContext`.
 
 Finally, the `remoteTree` optional parameter adds support for plugins to implement Deploy's "partial restore" feature.  This gives the editor the option to select an item to restore, from a tree picker displaying details from a remote environment.  The parameter is of type `DeployRegisteredEntityTypeDetail.RemoteTreeDetail` that defines three pieces of information:
 

--- a/Add-ons/Umbraco-Deploy/Extending/index.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index.md
@@ -416,8 +416,8 @@ public class ExampleDataDeployComponent : IComponent
             },
             false,
             "exampleTreeAlias",
-            (string routePath) => true,
-            (string nodeId) => true,
+            (string routePath, HttpContext httpContext) => true,
+            (string nodeId, HttpContext httpContext) => true,
             (string nodeId, HttpContext httpContext, out Guid entityId) => Guid.TryParse(nodeId, out entityId),
             new DeployRegisteredEntityTypeDetail.RemoteTreeDetail(FormsTreeHelper.GetExampleTree, "example", "externalExampleTree"));
     }
@@ -450,8 +450,8 @@ For example, as shown in the linked sample and video, we have entities for "Team
 _transferEntityService.RegisterTransferEntityType(
     ...
     "teams",
-    (string routePath) => routePath.Contains($"/teamEdit/") || routePath.Contains($"/teamsOverview"),
-    (string nodeId) => nodeId == "-1" || nodeId.StartsWith("team-"),
+    (string routePath, HttpContext httpContext) => routePath.Contains($"/teamEdit/") || routePath.Contains($"/teamsOverview"),
+    (string nodeId, HttpContext httpContext) => nodeId == "-1" || nodeId.StartsWith("team-"),
     (string nodeId, HttpContext httpContext, out Guid entityId) => Guid.TryParse(nodeId.Substring("team-".Length), out entityId);
 ```
 
@@ -466,11 +466,13 @@ _transferEntityService.RegisterTransferEntityType(
     (string nodeId, HttpContext httpContext, out Guid entityId) => Guid.TryParse(nodeId.Substring("rider-".Length), out entityId);
 ```
 
-If access to any services is required when parsing the entity Id, the `HttpContext` is provided as a parameter to the function. A service can be accessed from this, e.g.:
+If access to any services is required when parsing the entity Id, where the `HttpContext` is provided as a parameter to the function. A service can be accessed from this, e.g.:
 
 ```c#
 var localizationService = httpContext.RequestServices.GetRequiredService<ILocalizationService>();
 ```
+
+Note that the `HttpContext` parameter for the `matchesRoutePath` and `matchesNodeId` functions was added in Deploy 11. Before that version it's necessary to use the `StaticServiceProvider.Instance` to access registered services or the `HttpContext`.
 
 Finally, the `remoteTree` optional parameter adds support for plugins to implement Deploy's "partial restore" feature.  This gives the editor the option to select an item to restore, from a tree picker displaying details from a remote environment.  The parameter is of type `DeployRegisteredEntityTypeDetail.RemoteTreeDetail` that defines three pieces of information:
 

--- a/Add-ons/Umbraco-Deploy/Upgrades/version-specific.md
+++ b/Add-ons/Umbraco-Deploy/Upgrades/version-specific.md
@@ -9,6 +9,34 @@ meta.Description: "Version specific documentation for upgrading to new major ver
 
 This page covers specific upgrade documentation for when migrating to a new major of Umbraco Deploy.
 
+## Version 11
+
+Version 11 of Umbraco Deploy has a minimum dependency on Umbraco CMS core of `11.0.0`. It runs on .NET 7.
+
+The forms deployment component has a minimum dependency on Umbraco Forms of `11.0.0`.
+
+### Breaking changes
+
+Version 11 contains a number of breaking changes but we won't expect many projects to be affected by them as they are in areas that are not typical extension points.  For reference though, the full details are listed here.
+
+#### Code
+
+- The property `PreValues` on `FormArtifact` was changed from an `IEnumerable<string>`  to an `IEnumerable<FieldPrevalue>`, where `FieldPrevalue` contains a `Value` and `Caption`.
+- Nullable checks were enabled in the `Umbraco.Deploy.Forms` project and issues resolved by applying appropriate nullable settings to various properties.
+- The `TreeNodeGetter` function set as a property on `DeployTransferRegisteredEntityTypeDetail.RemoteTreeDetail` now takes a non-nullable `HttpContext`
+parameter.
+- The `matchesRoutePath` and `matchesNodeId` parameters provided to `ITransferEntityService.RegisterTransferEntityType`, and which populate the `MatchesRoutePath` and `MatchesNodeId` properties on `DeployTransferRegisteredEntityTypeDetail`, now take an HttpContext argument.
+- The `MultiNodeTreePickerPreValueConnector` was removed (as the format for Umbraco 8+ is as UDIs, and hence there is no processing to do).
+- Obsolete constructors, properties and methods on `Manifest` were removed.
+- Namespace of the `Package` class was adjusted and the obsolete property `Artifacts` was removed.  `ArtifactsWithOptions` was renamed to `Artifacts`.
+- The signature of `EnvironmentController.BeginCreateManifestForUdis` was changed.
+- The temporary interface `IUmbracoEnvironmentWithOptionsAwareManifest` was removed and elements added to `IUmbracoEnvironment`.
+- The signature of `IWorkItemFactory.CreateSourceDeplo`y was changed to accommodate culture and scheduled publishing options.
+- The obsolete constructor on `SourceDeployWorkItem` was removed.
+- The class `UmbracoFormsCompatibilit`y that is no longer required has been removed.
+- Obsolete constructors were removed on `NoNodesController`, `UiController` and `UiControllerBase`.
+- Temporary interfaces for connectors, introduced to avoid breaking changes with the introduction of the `IContextCache` in 10.2, were removed and the method overloads added to the original interfaces.
+
 ## Version 10
 
 Version 10 of Umbraco Deploy has a minimum dependency on Umbraco CMS core of `10.0.0`. It runs on .NET 6.

--- a/Add-ons/Umbraco-Deploy/Upgrades/version-specific.md
+++ b/Add-ons/Umbraco-Deploy/Upgrades/version-specific.md
@@ -17,7 +17,7 @@ The forms deployment component has a minimum dependency on Umbraco Forms of `11.
 
 ### Breaking changes
 
-Version 11 contains a number of breaking changes but we won't expect many projects to be affected by them as they are in areas that are not typical extension points.  For reference though, the full details are listed here.
+Version 11 contains a number of breaking changes. We don't expect many projects to be affected by them as they are in areas that are not typical extension points.  For reference though, the full details are listed here:
 
 #### Code
 
@@ -27,14 +27,14 @@ Version 11 contains a number of breaking changes but we won't expect many projec
 parameter.
 - The `matchesRoutePath` and `matchesNodeId` parameters provided to `ITransferEntityService.RegisterTransferEntityType`, and which populate the `MatchesRoutePath` and `MatchesNodeId` properties on `DeployTransferRegisteredEntityTypeDetail`, now take an HttpContext argument.
 - The `MultiNodeTreePickerPreValueConnector` was removed (as the format for Umbraco 8+ is as UDIs, and hence there is no processing to do).
-- Obsolete constructors, properties and methods on `Manifest` were removed.
+- Obsolete constructors, properties, and methods on `Manifest` were removed.
 - Namespace of the `Package` class was adjusted and the obsolete property `Artifacts` was removed.  `ArtifactsWithOptions` was renamed to `Artifacts`.
 - The signature of `EnvironmentController.BeginCreateManifestForUdis` was changed.
 - The temporary interface `IUmbracoEnvironmentWithOptionsAwareManifest` was removed and elements added to `IUmbracoEnvironment`.
 - The signature of `IWorkItemFactory.CreateSourceDeplo`y was changed to accommodate culture and scheduled publishing options.
 - The obsolete constructor on `SourceDeployWorkItem` was removed.
-- The class `UmbracoFormsCompatibilit`y that is no longer required has been removed.
-- Obsolete constructors were removed on `NoNodesController`, `UiController` and `UiControllerBase`.
+- The class `UmbracoFormsCompatibility` that is no longer required has been removed.
+- Obsolete constructors were removed on `NoNodesController`, `UiController`, and `UiControllerBase`.
 - Temporary interfaces for connectors, introduced to avoid breaking changes with the introduction of the `IContextCache` in 10.2, were removed and the method overloads added to the original interfaces.
 
 ## Version 10

--- a/Add-ons/UmbracoForms/Installation/Version-Specific.md
+++ b/Add-ons/UmbracoForms/Installation/Version-Specific.md
@@ -7,6 +7,45 @@ versionTo: 10.0.0
 
 This page covers specific upgrade documentation for specific versions.
 
+## Version 11
+
+### 11.0
+
+Version 10 of Umbraco Forms has a minimum dependency on Umbraco CMS core of `11.0.0`. It runs on .NET 7.
+
+#### Breaking changes
+
+Version 11 contains a number of breaking changes but we won't expect many projects to be affected by them as they are in areas that are not typical extension points. For reference though, the full details are listed here.
+
+##### Presentation
+
+- A CSS class for each field is rendered out matching the caption of the form field.  This has been changed to use the alias of the form field, as this is considered less likely to change and potentially break custom styles.
+
+##### Code
+
+- The int `DeleteFormRecords(Form form, FormState formState, DateTime deleteRecordsCreatedEarlierThan)` method was added to `IRecordStorage`.
+- Name of` FormsUmbracoBuiderExtensions` was corrected to `FormsUmbracoBuilderExtensions`.
+- The method `RegenerateFormStructureIds` on Form was amended to return a response.
+- The method void `ExecuteWorkflows(List<IWorkflow> workflows, Record record, Form form, FormState state)` was added to `IWorkflowExecutionService`.
+- Obsolete constructor on `PlaceholderParsingService` removed.
+- Obsolete constructor on `ServerVariablesParsingHandler` removed.
+- `IsMandatory` and `Condition` properties were added to the `IWorkflow` and `IWorkflowEntity` interface.
+- `DaysToRetainSubmittedRecordsFor` and `DaysToRetainApprovedRecordsForproperties` were added to the `IFormEntity` interface.
+- Obsolete constructor on the export type `ExportToExcel` removed.
+- Obsolete constructor on the workflow type `SendRazorEmail` removed.
+- Obsolete constructor on the controllers `UmbracoFormsController`, `ExportController`, `FieldController`, `FormController`, `RecordController` and  `EmailTemplateTreeController` removed.
+- Duplicate method `GetAllDocumentTypesWithAlias` in `PickerController` was removed.
+- Obsolete overloads to the `Build` method on `FormViewModel` were removed.
+- Obsolete constructor on `FormRenderingService` was removed.
+- Legacy storage of prevalues with captions using a single string with a separator was updated to store them as an object with a value and caption.
+    - A `JsonConverter` was added to `FormsJsonSerializerSettings` that will convert forms saved in older versions with the string storage into the new structure.
+    - The public field `Field.PrevalueCaptionSeparator` was removed.
+    - `Field.Prevalues` now returns `IEnumerable<FieldPrevalue>` instead of `IEnumerable<string>`, and the property `Field.ParsedPreValues` was removed.
+- The obsolete overload of the methods `Test` and `TestRule` in `FieldConditionEvaluation` was removed and the existing method made private.
+- The obsolete overload of the method `IsVisible` in `FieldConditionEvaluation` was removed.
+- The property `ConditionCheckFunctions` was added to the `IFieldType` interface.
+- The property `Alias` was added to the interfaces for all provider types inheriting from `ProviderBase`.
+
 ## Version 10
 
 ### 10.1

--- a/Add-ons/UmbracoForms/Installation/Version-Specific.md
+++ b/Add-ons/UmbracoForms/Installation/Version-Specific.md
@@ -11,11 +11,11 @@ This page covers specific upgrade documentation for specific versions.
 
 ### 11.0
 
-Version 10 of Umbraco Forms has a minimum dependency on Umbraco CMS core of `11.0.0`. It runs on .NET 7.
+Version 11 of Umbraco Forms has a minimum dependency on Umbraco CMS core of `11.0.0`. It runs on .NET 7.
 
 #### Breaking changes
 
-Version 11 contains a number of breaking changes but we won't expect many projects to be affected by them as they are in areas that are not typical extension points. For reference though, the full details are listed here.
+Version 11 contains a number of breaking changes. We don't expect many projects to be affected by them as they are in areas that are not typical extension points. For reference though, the full details are listed here:
 
 ##### Presentation
 
@@ -24,7 +24,7 @@ Version 11 contains a number of breaking changes but we won't expect many projec
 ##### Code
 
 - The int `DeleteFormRecords(Form form, FormState formState, DateTime deleteRecordsCreatedEarlierThan)` method was added to `IRecordStorage`.
-- Name of` FormsUmbracoBuiderExtensions` was corrected to `FormsUmbracoBuilderExtensions`.
+- Name of `FormsUmbracoBuiderExtensions` was corrected to `FormsUmbracoBuilderExtensions`.
 - The method `RegenerateFormStructureIds` on Form was amended to return a response.
 - The method void `ExecuteWorkflows(List<IWorkflow> workflows, Record record, Form form, FormState state)` was added to `IWorkflowExecutionService`.
 - Obsolete constructor on `PlaceholderParsingService` removed.
@@ -33,7 +33,7 @@ Version 11 contains a number of breaking changes but we won't expect many projec
 - `DaysToRetainSubmittedRecordsFor` and `DaysToRetainApprovedRecordsForproperties` were added to the `IFormEntity` interface.
 - Obsolete constructor on the export type `ExportToExcel` removed.
 - Obsolete constructor on the workflow type `SendRazorEmail` removed.
-- Obsolete constructor on the controllers `UmbracoFormsController`, `ExportController`, `FieldController`, `FormController`, `RecordController` and  `EmailTemplateTreeController` removed.
+- Obsolete constructor on the controllers `UmbracoFormsController`, `ExportController`, `FieldController`, `FormController`, `RecordController`, and  `EmailTemplateTreeController` removed.
 - Duplicate method `GetAllDocumentTypesWithAlias` in `PickerController` was removed.
 - Obsolete overloads to the `Build` method on `FormViewModel` were removed.
 - Obsolete constructor on `FormRenderingService` was removed.


### PR DESCRIPTION
This adds the documentation about Forms and Deploy 11, mostly just adding the breaking changes for reference.

Now the first release candidates are out, these can be reviewed and published at any time.