### PR TITLE
Fix typo, capitalize JSON

### DIFF
--- a/Extending/Health-Check/Guides/DebugCompilationMode.md
+++ b/Extending/Health-Check/Guides/DebugCompilationMode.md
@@ -11,11 +11,11 @@ _Leaving debug compilation mode enabled can severely slow down a website and tak
 
 This health check can be fixed by providing configuration on the following path: `Umbraco:CMS:Hosting:Debug`.
 
-This configuration can be setup in a configuration source of your choice. This guide shows how to set it up in one of the json file sources.
+This configuration can be setup in a configuration source of your choice. This guide shows how to set it up in one of the JSON file sources.
 
-### Updating the json configuration
+### Updating the JSON configuration
 
-The following json needs to be merged into one of you json sources. By default the following json sources are used: `appSettings.json` and `appSettings.<environment>.json`, e.g. `appSettings.Development.json` or `appSettings.Production.json`.
+The following JSON needs to be merged into one of your JSON sources. By default the following JSON sources are used: `appSettings.json` and `appSettings.<environment>.json`, e.g. `appSettings.Development.json` or `appSettings.Production.json`.
 
 ```json
 {

--- a/Extending/Health-Check/Guides/FixedApplicationUrl.md
+++ b/Extending/Health-Check/Guides/FixedApplicationUrl.md
@@ -13,11 +13,11 @@ If this is not specified in configuration, Umbraco gets the application url from
 
 This health check can be fixed by providing configuration on the following path: `Umbraco:CMS:WebRouting:UmbracoApplicationUrl`.
 
-This configuration can be setup in a configuration source of your choice. This guide shows how to set it up in one of the json file sources.
+This configuration can be setup in a configuration source of your choice. This guide shows how to set it up in one of the JSON file sources.
 
-### Updating the json configuration
+### Updating the JSON configuration
 
-The following json needs to be merged into one of you json sources. By default the following json sources are used: `appSettings.json` and `appSettings.<environment>.json`, e.g. `appSettings.Development.json` or `appSettings.Production.json`.
+The following JSON needs to be merged into one of your JSON sources. By default the following JSON sources are used: `appSettings.json` and `appSettings.<environment>.json`, e.g. `appSettings.Development.json` or `appSettings.Production.json`.
 
 ```json
 {

--- a/Extending/Health-Check/Guides/HttpsConfiguration.md
+++ b/Extending/Health-Check/Guides/HttpsConfiguration.md
@@ -15,11 +15,11 @@ First of all, it ensures that your website is running on HTTPS using a valid cer
 
 Furthermore, it is used to specify the configuration on the following path: `Umbraco:CMS:Global:UseHttps`.
 
-This configuration can be setup in a configuration source of your choice. This guide shows how to set it up in one of the json file sources.
+This configuration can be setup in a configuration source of your choice. This guide shows how to set it up in one of the JSON file sources.
 
-### Updating the json configuration
+### Updating the JSON configuration
 
-The following json needs to be merged into one of you json sources. By default the following json sources are used: `appSettings.json` and `appSettings.<environment>.json`, e.g. `appSettings.Development.json` or `appSettings.Production.json`.
+The following JSON needs to be merged into one of your JSON sources. By default the following JSON sources are used: `appSettings.json` and `appSettings.<environment>.json`, e.g. `appSettings.Development.json` or `appSettings.Production.json`.
 
 ```json
 {

--- a/Extending/Health-Check/Guides/NotificationEmail.md
+++ b/Extending/Health-Check/Guides/NotificationEmail.md
@@ -11,11 +11,11 @@ _If notifications are used, the 'from' email address should be specified and cha
 
 This health check can be fixed by providing configuration on the following path: `Umbraco:CMS:Content:Notifications:Email`.
 
-This configuration can be setup in a configuration source of your choice. This guide shows how to set it up in one of the json file sources.
+This configuration can be setup in a configuration source of your choice. This guide shows how to set it up in one of the JSON file sources.
 
-### Updating the json configuration
+### Updating the JSON configuration
 
-The following json needs to be merged into one of you json sources. By default the following json sources are used: `appSettings.json` and `appSettings.<environment>.json`, e.g. `appSettings.Development.json` or `appSettings.Production.json`.
+The following JSON needs to be merged into one of your JSON sources. By default the following JSON sources are used: `appSettings.json` and `appSettings.<environment>.json`, e.g. `appSettings.Development.json` or `appSettings.Production.json`.
 
 ```json
 {

--- a/Extending/Health-Check/Guides/SMTP.md
+++ b/Extending/Health-Check/Guides/SMTP.md
@@ -11,11 +11,11 @@ _Checks that valid settings for sending emails are in place._
 
 This health check can be fixed by providing configuration on the following path: `Umbraco:CMS:Global:Smtp`
 
-This configuration can be setup in a configuration source of your choice, but this guide only shows how to setup in one of the json file sources.
+This configuration can be setup in a configuration source of your choice, but this guide only shows how to setup in one of the JSON file sources.
 
-### Updating the json configuration
+### Updating the JSON configuration
 
-The following json needs to be merged into one of you json sources. By default the following json sources are used: `appSettings.json` and `appSettings.<environment>.json`, e.g. `appSettings.Development.json` or `appSettings.Production.json`.
+The following JSON needs to be merged into one of your JSON sources. By default the following JSON sources are used: `appSettings.json` and `appSettings.<environment>.json`, e.g. `appSettings.Development.json` or `appSettings.Production.json`.
 
 ```json
 {

--- a/Extending/Health-Check/Guides/SMTP.md
+++ b/Extending/Health-Check/Guides/SMTP.md
@@ -11,7 +11,7 @@ _Checks that valid settings for sending emails are in place._
 
 This health check can be fixed by providing configuration on the following path: `Umbraco:CMS:Global:Smtp`
 
-This configuration can be setup in a configuration source of your choice, but this guide only shows how to setup in one of the JSON file sources.
+This configuration can be setup in a configuration source of your choice. This guide shows how to set it up in one of the JSON file sources.
 
 ### Updating the JSON configuration
 


### PR DESCRIPTION
Noticed a typo when reading the health checks. 

Included a niche readability fix for developers who happen to be called Jason 😉