### PR TITLE
Forms 10.2 post RC docs updates

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Magic-Strings/index.md
+++ b/Add-ons/UmbracoForms/Developer/Magic-Strings/index.md
@@ -32,6 +32,10 @@ The variables are not case-sensitive.
 
 For multi-lingual websites, rather than hard-coding labels like form field captions, a dictionary key can be entered as, for example, `#MyKey`.  When the form is rendered, the placeholder will be replaced by the value of the dictionary item identified by the key, according to the current language.
 
+In most cases, the field must contain only the magic string for the replacement to be carried out. This makes sense for translated values, as you will want the whole phrase replaced when, for example, using one for a field's placeholder.
+
+We also though translate dictionary keys found within the rich text field, which will be contained within HTML tags. Here we look for dictionary keys making up the full inner text of a tag.  So for example, `<p>#myKey</p>` would be translated, but `<p>Lorem ipsum #myKey dolor sit amet.</p>` would not.
+
 ### Session & Cookies
 
 `[%SomeSessionOrCookieItem]` this allows you to display an item from the current `HttpContext.Session` with the key of 'SomeSessionOrCookieItem'. The session key can only contain alphanumeric chars and you cannot use dots for example. `[%Member.Firstname]` cannot be used, but `[%MemberFirstname]` can be used. You would have to fill these session keys yourself.

--- a/Add-ons/UmbracoForms/Developer/Magic-Strings/index.md
+++ b/Add-ons/UmbracoForms/Developer/Magic-Strings/index.md
@@ -34,7 +34,7 @@ For multi-lingual websites, rather than hard-coding labels like form field capti
 
 In most cases, the field must contain only the magic string for the replacement to be carried out. This makes sense for translated values, as you will want the whole phrase replaced when, for example, using one for a field's placeholder.
 
-We also though translate dictionary keys found within the rich text field, which will be contained within HTML tags. Here we look for dictionary keys making up the full inner text of a tag.  So for example, `<p>#myKey</p>` would be translated, but `<p>Lorem ipsum #myKey dolor sit amet.</p>` would not.
+We also translate dictionary keys found within the rich text field, which will be contained within HTML tags. Here we look for dictionary keys making up the full inner text of a tag.  So for example, `<p>#myKey</p>` would be translated, but `<p>Lorem ipsum #myKey dolor sit amet.</p>` would not.
 
 ### Session & Cookies
 


### PR DESCRIPTION
This PR contains updates made for Forms 10.2 following the RC release.  Ideally it would be reviewed and released early on November 8th.

Includes:

- Added details of magic strings in HTML tags.