### PR TITLE
Improve readability - Fundamentals Design Rendering-Content

### DIFF
--- a/Fundamentals/Design/Rendering-Content/index.md
+++ b/Fundamentals/Design/Rendering-Content/index.md
@@ -7,11 +7,11 @@ versionTo: 10.0.0
 
 # Rendering Content
 
-_The primary task of any template in Umbraco is to render the values of the current page or the result of a query against the content cache._
+_The primary task of any template is to render the values of the current page or the result of a query against the content cache._
 
 ## Display a value in your template view
 
-Each property in your [document type](../../Data/Defining-Content/index.md#what-is-a-document-type) has an alias, this is used to specify where in the template view to display the value.
+Each property in your [Document Type](../../Data/Defining-Content/index.md#what-is-a-document-type) has an alias, this is used to specify where in the template view to display the value.
 
 ```html
 <h1>@Model.Value("pageTitle")</h1>
@@ -45,7 +45,7 @@ To render the content from the Grid, see the [Render Grid in Template](../../Bac
 
 ### Using fall-back methods
 
-The `.Value()` method has a number of optional parameters that support scenarios where we want to "fall-back" to some other content when the property value does not exist on the current content item.
+The `.Value()` method has a number of optional parameters that support scenarios where we want to "fall-back" to some other content. 
 
 To use the `fallback` type, add the `@using Umbraco.Cms.Core.Models.PublishedContent;` directive.
 


### PR DESCRIPTION
Belongs to: https://github.com/umbraco/UmbracoDocs/issues/4416

- [x] use 'Document Type' instead of 'document type'
- [x] write shorter sentences