### PR TITLE
Example of how to create async RenderController

### DIFF
--- a/Reference/Routing/Custom-Controllers/index.md
+++ b/Reference/Routing/Custom-Controllers/index.md
@@ -66,7 +66,7 @@ namespace My.Website
 
 ALL requests to ANY 'product' pages in the site will be'hijacked' and routed through the custom ProductPageController.
 
-If you perfer to use a async controller your need to overide both the sync and the async Index()-methods to disable the default behavior from the base controller.
+If you prefer to use an async controller your need to override both the sync and the async Index()-methods. This is done to disable the default behavior from the base controller.
 
 ```csharp
 public class ProductPageController : RenderController

--- a/Reference/Routing/Custom-Controllers/index.md
+++ b/Reference/Routing/Custom-Controllers/index.md
@@ -66,6 +66,24 @@ namespace My.Website
 
 ALL requests to ANY 'product' pages in the site will be'hijacked' and routed through the custom ProductPageController.
 
+If you perfer to use a async controller your need to overide both the sync and the async Index()-methods to disable the default behavior from the base controller.
+
+```csharp
+public class ProductPageController : RenderController
+{
+       
+    [NonAction]
+    public sealed override IActionResult Index() => throw new NotImplementedException();
+
+    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    {
+        await SomethingAsync(cancellationToken);
+
+        return CurrentTemplate(CurrentPage);
+    }
+}
+```
+
 This example shows the default behaviour that Umbraco's core RenderController provides. The 'Index' action of the controller is executed, and the CurrentTemplate helper sends the model containing the details of the published content item related to the request to the relevant template/view.
 
 ## Routing via template


### PR DESCRIPTION
It was hard to find any documented way to use an async Index()-method but this approach works. I think that official docs should have an example for people looking to use a async implementation in the controller. 

Without the sync Index() with the [NoAction]-attribute the call would be ambiguous between the async version on the ProductPageController and the sync Index()-method on RenderController.

As far as I can tell this is the best approach at the moment.