### PR TITLE
Updates to the Umbraco Forms developer documentation

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Workflowtype.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Workflowtype.md
@@ -50,6 +50,20 @@ namespace MyFormsExtensions
 
                 // or get it as a string
                 rf.ValuesAsString();
+
+                // set or replace values against a field in the current form submission
+                if(rf.Alias.Equals("myField", StringComparison.InvariantCulture))
+                {
+                    rf.Values.Clear();
+                    rf.Values.Add("My new value");
+                }
+
+                // Update the form submission via the UpdateRecord method, but only when the Workflow is in an Approval chain. If not in an Approval chain, the values are still saved against the RecordField.
+                if (context.State.Equals(FormState.Approved))
+                {
+                    _recordStorage.UpdateRecord(context.Record, context.Form);
+                }
+
             }
 
             //Change the state

--- a/Add-ons/UmbracoForms/Developer/Rendering-Scripts/index.md
+++ b/Add-ons/UmbracoForms/Developer/Rendering-Scripts/index.md
@@ -5,25 +5,58 @@ versionTo: 10.0.0
 
 # Rendering Forms Scripts
 
-Forms output some JavaScript which is by default rendered right below the markup.
-
-In many cases, you might prefer rendering your scripts at the bottom of the page, e.g. before the closing `</body>` tag, as this generally improves site performance.
-
-In order to render your scripts where you want, you need to add the following snippet to your template. Make sure you add it below your scripts, right before the closing `</body>` tag:
+Script delivery is done automatically using [Themes](/documentation/Add-ons/UmbracoForms/Developer/Themes/) without the need to include any additional code into your own views. The 'default' theme (bundled with Umbraco Forms) comes with the file `Scripts.cshtml` containing all the relevant logic & data required by the Umbraco Forms JavaScript. For reference, the file looks like this *(as per Umbraco Forms 10.2)*:
 
 ```csharp
-@using Umbraco.Forms.Web.Extensions;
+@model Umbraco.Forms.Web.Models.FormViewModel
 
-@if (TempData["UmbracoForms"] != null)
-{
-    foreach (var form in TempData.Get<List<Guid>>("UmbracoForms"))
-    {
-        @await Component.InvokeAsync("RenderFormScripts", new {formId = form, theme = "bootstrap3-horizontal"})
-    }
+@using Newtonsoft.Json
+@using Umbraco.Forms.Core
+@using Umbraco.Forms.Web
+
+@{
+    Html.AddFormThemeScriptFile("~/App_Plugins/UmbracoForms/Assets/themes/default/umbracoforms.js");
 }
+
+<div class="umbraco-forms-form-config"
+     style="display: none"
+     data-id="@Model.FormClientId"
+     data-serialized-page-button-conditions="@JsonConvert.SerializeObject(Model.PageButtonConditions, FormsJsonSerializerSettings.Default)"
+     data-serialized-fieldset-conditions="@JsonConvert.SerializeObject(Model.FieldsetConditions, FormsJsonSerializerSettings.Default)"
+     data-serialized-field-conditions="@JsonConvert.SerializeObject(Model.FieldConditions, FormsJsonSerializerSettings.Default)"
+     data-serialized-fields-not-displayed="@JsonConvert.SerializeObject(Model.GetFieldsNotDisplayed(), FormsJsonSerializerSettings.Default)"
+     data-trigger-conditions-check-on="@Model.TriggerConditionsCheckOn"
+     data-form-element-html-id-prefix="@Model.FormElementHtmlIdPrefix"></div>
+
+@* Only render out scripts on the page if the form has not been submitted yet *@
+@if (Model.SubmitHandled == false)
+{
+    @*
+        If the current page of the form has any Partial view files attached to render
+        Likely used by events and third parties adding tracking or other 3rd party functionality to a form
+    *@
+    if (Model.CurrentPage.PartialViewFiles.Any())
+    {
+        foreach (var partial in Model.CurrentPage.PartialViewFiles)
+        {
+            @await Html.PartialAsync(partial.Value)
+        }
+    }
+
+    @* Render references to javascript files needed by fields on the current page*@
+    @Html.RenderFormsScripts(Url, Model, Model.JavaScriptTagAttributes)
+    @Html.RenderFormsStylesheets(Url, Model)
+}
+
 ```
 
+:::note
+If you are upgrading from an older version of Umbraco Forms and using a variant of `Scripts.cshtml` within your own project you may be missing some required and fundamental parts of this file. As an example, the `<div class="umbraco-forms-form-config" />` element introduced the `data-form-element-html-id-prefix` attribute in Umbraco Forms 10.2. Failing to update this within your own version of this file may lead to a loss of functionality and/or JavaScript errors.
+:::
+
 ## Enabling `ExcludeScripts`
+
+Forms output some JavaScript which is by default rendered right below the markup.
 
 If you do not want to render the associated scripts with a Form, you need to explicitly say so. You need to make sure `ExcludeScripts` is checked/enabled, whether you are inserting your Form using a macro or adding it directly in your template.
 
@@ -42,6 +75,11 @@ To enable `ExcludeScripts`:
 :::note
 `ExcludeScripts = "1"` prevents the associated scripts from being rendered. Any other value, an empty value, or if the parameter is excluded, will render the scripts on the Form.
 :::
+
+The `Scripts.cshtml` file (from the current or default theme) will not be initiated and won't be included as part of the current form. You may however use parts (or all) of the code from the snippet of `Scripts.cshtml` within your own template or partial views.
+
+
+In many cases, you might prefer rendering your scripts at the bottom of the page, e.g. before the closing `</body>` tag, as this generally improves site performance.
 
 ---
 

--- a/Add-ons/UmbracoForms/Developer/Themes/index.md
+++ b/Add-ons/UmbracoForms/Developer/Themes/index.md
@@ -15,7 +15,7 @@ To create a theme, you need to create a folder at `/Views/Partials/Forms/Themes/
 
 Copy the explicit files you wish to override in your theme, it may be a single file or all files from the default theme folder. Make the necessary changes you desire to CSS class names, markup etc.
 
-For Umbraco 9 and previous, it's straightforward to simply copy the files you need from the default theme folder.  Umbraco 10 distributes these files as part of a Razor class library, so you won't find them on disk. The easiest way to obtain copies of the files included in the default theme is to [download this zip file](https://our.umbraco.com/FileDownload?id=23911) and extract the ones you need.
+For Umbraco 9 and previous, it's straightforward to simply copy the files you need from the default theme folder.  Umbraco 10 distributes these files as part of a Razor class library, so you won't find them on disk. The easiest way to obtain copies of the files included in the default theme is to [download this zip file](https://our.umbraco.com/FileDownload?id=24022) and extract the ones you need.
 
 :::note
 Umbraco Forms conditional JavaScript logic depends on some CSS classes currently and it is advised that you add any additional classes you require but **do not remove those already being set**.


### PR DESCRIPTION
- Updated - Umbraco Forms > Developer > Themes doc - Updated URL to the downloadable 'default' theme for Umbraco Forms 10.2.
- Updated - Umbraco Forms > Developer > Rendering Scripts doc - Somewhat overhauled the page with the intention for it to be more informative by mentioning the Scripts.cshtml file, what it contains and what it does.
- Updated - Umbraco Forms > Developer > Extending > Adding a Workflow Type doc - Added some additional code to the example snippet to demo how to alter the form submission data.