### PR TITLE
Added git hook documentation for Umbraco Deploy

### DIFF
--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/Streamlining-Local-Development/index.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/Streamlining-Local-Development/index.md
@@ -1,0 +1,39 @@
+---
+versionFrom: 9.0.0
+versionTo: 10.0.0
+meta.Title: "Streamlining Local Development"
+meta.Description: "Additional steps you can carry out to streamline your local development workflow"
+---
+
+# Streamlining Local Development
+
+In this section we discuss some additional steps you can carry out to streamline your local development workflow.
+
+## Creating Git Hooks
+
+When working in a project team, it's common for a developer pulling the code from source control to want to update their local environment with the latest Umbraco schema.
+
+They can do this by starting up the website, navigating to the _Settings > Deploy_ dashboard and triggering a data extraction.
+
+We can automate this step using a [git hook](https://www.atlassian.com/git/tutorials/git-hooks).
+
+When working with Umbraco Cloud, this step is configured automatically for you when you clone and run your project the first time. If working with Umbraco Deploy On-Premise, you can set it up yourself.
+
+The process works by making use of the marker file Umbraco Deploy uses to trigger an update of the Umbraco schema from the `.uda` files retrieved from source control.  If a file by the name of `deploy-on-start` is found in the `/umbraco/Deploy` folder, an update will be run automatically when the site starts up. As such, if we ensure that file is created everytime the source code is pulled from the remote repository, we can automate the update.
+
+To do this, carry out the following steps:
+
+- Find the `.git` folder within your solution root.
+    - It might be a hidden folder, so if you don't see it, make sure your file browser is configured to show hidden files and folders.
+- Within that you'll find a `hooks` folder, and inside that, a file called `post-merge.sample`.
+- Rename the file to remove the `.sample` extension and open it in a text editor.
+- Apply the following text and save the file (amending the path to the web project as appropriate for your solution structure):
+
+```sh
+#!/bin/sh
+echo > src/UmbracoProject/umbraco/Deploy/deploy-on-start
+```
+
+- Run a `git pull origin <branchname>`.
+- Start up the website and you should find the Umbraco schema update has been triggered.
+


### PR DESCRIPTION
I've added this detail as it looked a useful setup step for Deploy customers.  We make this available automatically for Umbraco Cloud projects, but not for on-premise (mainly as we can't know the solution structure in advance).  However, customers could still make the update manually, as described in this new docs page.

It can be reviewed and be published at any time.

Relates to [this issue](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/142).