### PR TITLE
Add section on runtime minification

### DIFF
--- a/Extending/Macro-Parameter-Editors/index.md
+++ b/Extending/Macro-Parameter-Editors/index.md
@@ -215,7 +215,7 @@ If your custom property editor doesn't load when your project is deployed, you m
   "Umbraco": {
     "CMS": {
       "RuntimeMinification": {
-        "cacheBuster": "AppDomain"
+        "CacheBuster": "AppDomain"
       }
     }
   }

--- a/Extending/Macro-Parameter-Editors/index.md
+++ b/Extending/Macro-Parameter-Editors/index.md
@@ -201,8 +201,23 @@ In the `ImagePosition.controller.js` we can now read the 'options' values from t
 @using Umbraco.Extensions
 @inherits Umbraco.Cms.Web.Common.Macros.PartialViewMacroPage
 @{
-var imagePosition = Model.MacroParameters["imagePosition"];
-//or if for convenience if you are using Umbraco.Extensions namespace there is a GetParameterValue extension method, which allows a default value to be specified if the parameter is not provided:
-imagePosition = Model.GetParameterValue<string>("imagePosition","full-width");
+    var imagePosition = Model.MacroParameters["imagePosition"];
+    //or if for convenience if you are using Umbraco.Extensions namespace there is a GetParameterValue extension method, which allows a default value to be specified if the parameter is not provided:
+    imagePosition = Model.GetParameterValue<string>("imagePosition","full-width");
 }
 ```
+
+### Runtime minification cache busting in Production
+
+If your custom property editor doesn't load when your project is deployed, you may need to modify your [Runtime Minification Settings](/Reference/Configuration/RuntimeMinificationSettings/index.md) in `appsettings.json` to 'bust' the minification bundle cache. For example, to bust the cache whenever the app is restarted, you can use this configuration:
+
+```json
+  "Umbraco": {
+    "CMS": {
+      "RuntimeMinification": {
+        "cacheBuster": "AppDomain"
+      }
+    }
+  }
+  ```
+

--- a/Extending/Macro-Parameter-Editors/index.md
+++ b/Extending/Macro-Parameter-Editors/index.md
@@ -209,7 +209,7 @@ In the `ImagePosition.controller.js` we can now read the 'options' values from t
 
 ### Runtime minification cache busting in Production
 
-If your custom property editor doesn't load when your project is deployed, you may need to modify your [Runtime Minification Settings](/Reference/Configuration/RuntimeMinificationSettings/index.md) in `appsettings.json` to 'bust' the minification bundle cache. For example, to bust the cache whenever the app is restarted, you can use this configuration:
+If your custom property editor doesn't load when your project is deployed, you may need to modify your [Runtime Minification Settings](/Reference/Configuration/RuntimeMinificationSettings/index.md). The minified bundle cache may need to be "busted" to get your new code to load. For example, to bust the cache whenever the app is restarted, you can use this configuration:
 
 ```json
   "Umbraco": {


### PR DESCRIPTION
We had deployed an update to our site that included custom macro parameter editors, but the editor wasn't loading the AngularJS controller at runtime. After much head scratching, we found this post: https://our.umbraco.com/forum/umbraco-9/107740-umbraco-9-cant-register-controller-for-a-custom-dashboard-that-works-locally-but-fails-when-deploy which described the issue and the solution. I figured it would be valuable to include a note about this on this documentation page for others.