### PR TITLE
Renamed meta.Description to description

### DIFF
--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Deploy settings"
-meta.Description: "Various settings for Umbraco Deploy"
+description: "Various settings for Umbraco Deploy"
 ---
 
 # Configurations for Deployments

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Deploy settings"
-meta.Description: "Various settings for Umbraco Deploy"
+description: "Various settings for Umbraco Deploy"
 ---
 
 # Configuration for Umbraco Deploy

--- a/Add-ons/Umbraco-Deploy/Deployment-Workflow/Content-Transfer/index.md
+++ b/Add-ons/Umbraco-Deploy/Deployment-Workflow/Content-Transfer/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Transferring content with Umbraco Deploy"
-meta.Description: "How to restore content in Umbraco Deploy using the deployment dashboard"
+description: "How to restore content in Umbraco Deploy using the deployment dashboard"
 ---
 
 # Transferring Content, Media and Forms

--- a/Add-ons/Umbraco-Deploy/Deployment-Workflow/Deploying-Changes/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Deployment-Workflow/Deploying-Changes/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Deploying changes from a local machine with Umbraco Deploy"
-meta.Description: "How to Deploy changes between a local machine and an environment in Umbraco Deploy using either a Git Gui or without"
+description: "How to Deploy changes between a local machine and an environment in Umbraco Deploy using either a Git Gui or without"
 ---
 
 # Deploying changes with Umbraco Deploy

--- a/Add-ons/Umbraco-Deploy/Deployment-Workflow/Deploying-Changes/index.md
+++ b/Add-ons/Umbraco-Deploy/Deployment-Workflow/Deploying-Changes/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Deploying changes from a local machine with Umbraco Deploy"
-meta.Description: "How to Deploy changes between a local machine and an environment in Umbraco Deploy using either a Git Gui or without"
+description: "How to Deploy changes between a local machine and an environment in Umbraco Deploy using either a Git Gui or without"
 ---
 
 # Deploying changes with Umbraco Deploy

--- a/Add-ons/Umbraco-Deploy/Deployment-Workflow/Deploying-Deletions/index.md
+++ b/Add-ons/Umbraco-Deploy/Deployment-Workflow/Deploying-Deletions/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Deploying deletions in Umbraco Deploy"
-meta.Description: "How deleting meta data and files work in Umbraco Deploy"
+description: "How deleting meta data and files work in Umbraco Deploy"
 ---
 
 # Deploying deletions

--- a/Add-ons/Umbraco-Deploy/Deployment-Workflow/Restoring-Content/Partial-Restore/index.md
+++ b/Add-ons/Umbraco-Deploy/Deployment-Workflow/Restoring-Content/Partial-Restore/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Partial restore of content in Umbraco Deploy"
-meta.Description: "How to partially restore content in Umbraco Deploy"
+description: "How to partially restore content in Umbraco Deploy"
 ---
 
 # Partial Restores

--- a/Add-ons/Umbraco-Deploy/Deployment-Workflow/Restoring-Content/index.md
+++ b/Add-ons/Umbraco-Deploy/Deployment-Workflow/Restoring-Content/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Restoring content in Umbraco Deploy"
-meta.Description: "How to restore content in Umbraco Deploy"
+description: "How to restore content in Umbraco Deploy"
 ---
 
 # Restoring content

--- a/Add-ons/Umbraco-Deploy/Deployment-Workflow/index.md
+++ b/Add-ons/Umbraco-Deploy/Deployment-Workflow/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Deployments in Umbraco Deploy"
-meta.Description: "A description of the proper workflow when working with Umbraco Deploy"
+description: "A description of the proper workflow when working with Umbraco Deploy"
 ---
 
 # Deployment

--- a/Add-ons/Umbraco-Deploy/Extending/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Extending Umbraco Deploy"
-meta.Description: "How to extend Umbraco Deploy to synchronize custom data"
+description: "How to extend Umbraco Deploy to synchronize custom data"
 ---
 
 # Extending Umbraco Deploy

--- a/Add-ons/Umbraco-Deploy/Extending/index.md
+++ b/Add-ons/Umbraco-Deploy/Extending/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Extending Umbraco Deploy"
-meta.Description: "How to extend Umbraco Deploy to synchronize custom data"
+description: "How to extend Umbraco Deploy to synchronize custom data"
 ---
 
 # Extending Umbraco Deploy

--- a/Add-ons/Umbraco-Deploy/Get-Started-with-Deploy/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Get-Started-with-Deploy/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Getting started with Umbraco Deploy"
-meta.Description: "What is Umbraco Deploy, how does it work and how to get started using Umbraco Deploy "
+description: "What is Umbraco Deploy, how does it work and how to get started using Umbraco Deploy "
 ---
 
 # Getting started with Umbraco Deploy

--- a/Add-ons/Umbraco-Deploy/Get-Started-with-Deploy/index.md
+++ b/Add-ons/Umbraco-Deploy/Get-Started-with-Deploy/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Getting started with Umbraco Deploy"
-meta.Description: "What is Umbraco Deploy, how does it work and how to get started using Umbraco Deploy "
+description: "What is Umbraco Deploy, how does it work and how to get started using Umbraco Deploy "
 ---
 
 # Getting started with Umbraco Deploy

--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/CICD-Pipeline/ci-cd-azure-dev-ops-v8.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/CICD-Pipeline/ci-cd-azure-dev-ops-v8.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 8.0.0
 meta.Title: "Setting up a CI/CD Build and Deployment Pipeline Using Azure DevOps"
-meta.Description: "Steps and examples on how to setup a build and deployment pipeline for Umbraco Deploy using Azure DevOps"
+description: "Steps and examples on how to setup a build and deployment pipeline for Umbraco Deploy using Azure DevOps"
 ---
 
 # Setting up CI/CD build server with Azure DevOps

--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/CICD-Pipeline/ci-cd-azure-dev-ops.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/CICD-Pipeline/ci-cd-azure-dev-ops.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Setting up a CI/CD Build and Deployment Pipeline Using Azure DevOps"
-meta.Description: "Steps and examples on how to setup a build and deployment pipeline for Umbraco Deploy using Azure DevOps"
+description: "Steps and examples on how to setup a build and deployment pipeline for Umbraco Deploy using Azure DevOps"
 ---
 
 # Setting up CI/CD build server with Azure DevOps

--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/CICD-Pipeline/ci-cd-github-actions-v8.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/CICD-Pipeline/ci-cd-github-actions-v8.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 8.0.0
 meta.Title: "Setting up a CI/CD Build and Deployment Pipeline Using GitHub Actions"
-meta.Description: "Steps and examples on how to setup a build and deployment pipeline for Umbraco Deploy using GitHub Actions"
+description: "Steps and examples on how to setup a build and deployment pipeline for Umbraco Deploy using GitHub Actions"
 ---
 
 # Setting up CI/CD build server with Github actions

--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/CICD-Pipeline/ci-cd-github-actions.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/CICD-Pipeline/ci-cd-github-actions.md
@@ -2,7 +2,7 @@
 versionFrom: 10.0.0
 versionTo: 10.0.0
 meta.Title: "Setting up a CI/CD Build and Deployment Pipeline Using GitHub Actions"
-meta.Description: "Steps and examples on how to setup a build and deployment pipeline for Umbraco Deploy using GitHub Actions"
+description: "Steps and examples on how to setup a build and deployment pipeline for Umbraco Deploy using GitHub Actions"
 ---
 
 # Setting up CI/CD build server with Github actions

--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/CICD-Pipeline/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/CICD-Pipeline/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Setting up a CI/CD Build and Deployment Pipeline"
-meta.Description: "Steps and examples on how Umbraco Deploy can be integrated into an automated build and deployment pipeline"
+description: "Steps and examples on how Umbraco Deploy can be integrated into an automated build and deployment pipeline"
 ---
 
 # Setting up a CI/CD Build and Deployment Pipeline

--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/CICD-Pipeline/index.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/CICD-Pipeline/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Setting up a CI/CD Build and Deployment Pipeline"
-meta.Description: "Steps and examples on how Umbraco Deploy can be integrated into an automated build and deployment pipeline"
+description: "Steps and examples on how Umbraco Deploy can be integrated into an automated build and deployment pipeline"
 ---
 
 # Setting up a CI/CD Build and Deployment Pipeline

--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/Existing-site/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/Existing-site/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Installing Umbraco Deploy on an existing Umbraco website"
-meta.Description: "Steps to how Umbraco Deploy can be set up on an existing Umbraco website"
+description: "Steps to how Umbraco Deploy can be set up on an existing Umbraco website"
 ---
 
 # Installing Umbraco Deploy on an existing project

--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/Existing-site/index.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/Existing-site/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Installing Umbraco Deploy on an existing Umbraco website"
-meta.Description: "Steps to how Umbraco Deploy can be set up on an existing Umbraco website"
+description: "Steps to how Umbraco Deploy can be set up on an existing Umbraco website"
 ---
 
 # Installing Umbraco Deploy on an existing project

--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/Install-Configure/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/Install-Configure/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Installing and Configuring Umbraco Deploy"
-meta.Description: "Steps to how to install and configure Umbraco Deploy"
+description: "Steps to how to install and configure Umbraco Deploy"
 ---
 
 # Installing Umbraco Deploy

--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/Install-Configure/index.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/Install-Configure/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Installing and Configuring Umbraco Deploy"
-meta.Description: "Steps to how to install and configure Umbraco Deploy"
+description: "Steps to how to install and configure Umbraco Deploy"
 ---
 
 # Installing Umbraco Deploy

--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/New-site/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/New-site/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Installing Umbraco Deploy on new Umbraco website"
-meta.Description: "Steps to how Umbraco Deploy can be set up on a new Umbraco website"
+description: "Steps to how Umbraco Deploy can be set up on a new Umbraco website"
 ---
 
 # Installing Umbraco Deploy

--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/New-site/index.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/New-site/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Installing Umbraco Deploy on new Umbraco website"
-meta.Description: "Steps to how Umbraco Deploy can be set up on a new Umbraco website"
+description: "Steps to how Umbraco Deploy can be set up on a new Umbraco website"
 ---
 
 # Installing Umbraco Deploy

--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/Streamlining-Local-Development/index.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/Streamlining-Local-Development/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Streamlining Local Development"
-meta.Description: "Additional steps you can carry out to streamline your local development workflow"
+description: "Additional steps you can carry out to streamline your local development workflow"
 ---
 
 # Streamlining Local Development

--- a/Add-ons/Umbraco-Deploy/Installing-Deploy/index.md
+++ b/Add-ons/Umbraco-Deploy/Installing-Deploy/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Installation of Umbraco Deploy"
-meta.Description: "Two guides for how to install Umbraco Deploy. One for a new website and one for existing Umbraco websites"
+description: "Two guides for how to install Umbraco Deploy. One for a new website and one for existing Umbraco websites"
 ---
 
 # Installing Umbraco Deploy

--- a/Add-ons/Umbraco-Deploy/Troubleshooting/index.md
+++ b/Add-ons/Umbraco-Deploy/Troubleshooting/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Troubleshooting Umbraco Deploy"
-meta.Description: "The troubleshooting section for Umbraco Deploy"
+description: "The troubleshooting section for Umbraco Deploy"
 ---
 # Troubleshooting
 

--- a/Add-ons/Umbraco-Deploy/Upgrades/index-v8.md
+++ b/Add-ons/Umbraco-Deploy/Upgrades/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Upgrading Umbraco Deploy"
-meta.Description: "How to upgrade Umbraco Deploy"
+description: "How to upgrade Umbraco Deploy"
 ---
 
 # Upgrading Umbraco Deploy

--- a/Add-ons/Umbraco-Deploy/Upgrades/index.md
+++ b/Add-ons/Umbraco-Deploy/Upgrades/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Upgrading Umbraco Deploy"
-meta.Description: "How to upgrade Umbraco Deploy"
+description: "How to upgrade Umbraco Deploy"
 ---
 
 # Upgrading Umbraco Deploy

--- a/Add-ons/Umbraco-Deploy/Upgrades/version-specific.md
+++ b/Add-ons/Umbraco-Deploy/Upgrades/version-specific.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Version specific upgrades"
-meta.Description: "Version specific documentation for upgrading to new major versions of Umbraco Deploy."
+description: "Version specific documentation for upgrading to new major versions of Umbraco Deploy."
 ---
 
 # Version Specific Upgrade Details

--- a/Add-ons/Umbraco-Deploy/index.md
+++ b/Add-ons/Umbraco-Deploy/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Deploy"
-meta.Description: "Documentation on how to work with Umbraco Deploy"
+description: "Documentation on how to work with Umbraco Deploy"
 ---
 
 # Umbraco Deploy

--- a/Add-ons/Umbraco-Plumber/Approval-Groups/index.md
+++ b/Add-ons/Umbraco-Plumber/Approval-Groups/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco Plumber Approval Groups"
-meta.Description: "Umbraco Plumber's Approval groups and their settings"
+description: "Umbraco Plumber's Approval groups and their settings"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Add-ons/Umbraco-Plumber/Dashboards-and-Buttons/index.md
+++ b/Add-ons/Umbraco-Plumber/Dashboards-and-Buttons/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco Plumber Dashboards and buttons"
-meta.Description: "Information about Workflow Dashboard and buttons with Umbraco Plumber"
+description: "Information about Workflow Dashboard and buttons with Umbraco Plumber"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Add-ons/Umbraco-Plumber/Email-Templates/index.md
+++ b/Add-ons/Umbraco-Plumber/Email-Templates/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco Plumber Localization"
-meta.Description: "Localization settings for Umbraco Plumber"
+description: "Localization settings for Umbraco Plumber"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Add-ons/Umbraco-Plumber/Events/index.md
+++ b/Add-ons/Umbraco-Plumber/Events/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco Plumber Events"
-meta.Description: "Information on Umbraco Plumber Events"
+description: "Information on Umbraco Plumber Events"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Add-ons/Umbraco-Plumber/Getting-Started/index.md
+++ b/Add-ons/Umbraco-Plumber/Getting-Started/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Get started working with Umbraco Plumber"
-meta.Description: "Here you can find information about getting started with Umbraco Plumber"
+description: "Here you can find information about getting started with Umbraco Plumber"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Add-ons/Umbraco-Plumber/Installing-Plumber/index.md
+++ b/Add-ons/Umbraco-Plumber/Installing-Plumber/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Installing Umbraco Plumber"
-meta.Description: "Here you can find information about how to install Umbraco Plumber"
+description: "Here you can find information about how to install Umbraco Plumber"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Add-ons/Umbraco-Plumber/Licensing/index.md
+++ b/Add-ons/Umbraco-Plumber/Licensing/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco Plumber Licensing"
-meta.Description: "Here you can find information about how to use a license with Umbraco Plumber"
+description: "Here you can find information about how to use a license with Umbraco Plumber"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Add-ons/Umbraco-Plumber/Notifications-and-Reminders/index.md
+++ b/Add-ons/Umbraco-Plumber/Notifications-and-Reminders/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco Plumber Notifications and Reminders"
-meta.Description: "Information on Umbraco Plumber Notifications and Reminders"
+description: "Information on Umbraco Plumber Notifications and Reminders"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Add-ons/Umbraco-Plumber/Upgrading-Plumber/index.md
+++ b/Add-ons/Umbraco-Plumber/Upgrading-Plumber/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco Plumber Upgrades"
-meta.Description: "Information about upgrading with Umbraco Plumber"
+description: "Information about upgrading with Umbraco Plumber"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Add-ons/Umbraco-Plumber/Workflow-Content-App/index.md
+++ b/Add-ons/Umbraco-Plumber/Workflow-Content-App/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco Plumber Content App"
-meta.Description: "Information about using the Content app with Umbraco Plumber"
+description: "Information about using the Content app with Umbraco Plumber"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Add-ons/Umbraco-Plumber/Workflow-History/index.md
+++ b/Add-ons/Umbraco-Plumber/Workflow-History/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco Plumber Workflow History"
-meta.Description: "Umbraco Plumber's Workflow History"
+description: "Umbraco Plumber's Workflow History"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Add-ons/Umbraco-Plumber/Workflow-Settings/index.md
+++ b/Add-ons/Umbraco-Plumber/Workflow-Settings/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco Plumber Settings"
-meta.Description: "Various settings for Umbraco Plumber"
+description: "Various settings for Umbraco Plumber"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Add-ons/Umbraco-Plumber/index.md
+++ b/Add-ons/Umbraco-Plumber/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco Plumber"
-meta.Description: "Documentation on how to work with Umbraco Plumber"
+description: "Documentation on how to work with Umbraco Plumber"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Add-ons/UmbracoForms/Developer/Configuration/index-v7.md
+++ b/Add-ons/UmbracoForms/Developer/Configuration/index-v7.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Umbraco Forms configuration"
-meta.Description: "In Umbraco Forms it's possible to customize the functionality with various configuration values."
+description: "In Umbraco Forms it's possible to customize the functionality with various configuration values."
 ---
 
 # Configuration

--- a/Add-ons/UmbracoForms/Developer/Configuration/index.md
+++ b/Add-ons/UmbracoForms/Developer/Configuration/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Forms configuration"
-meta.Description: "In Umbraco Forms it's possible to customize the functionality with various configuration values."
+description: "In Umbraco Forms it's possible to customize the functionality with various configuration values."
 ---
 
 # Configuration

--- a/Add-ons/UmbracoForms/Developer/Configuration/type-details.md
+++ b/Add-ons/UmbracoForms/Developer/Configuration/type-details.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 meta.Title: "Forms Provider Type Details"
-meta.Description: "Provides details of the built-in provider types available with Umbraco Forms"
+description: "Provides details of the built-in provider types available with Umbraco Forms"
 ---
 
 # Forms Provider Type Details

--- a/Add-ons/UmbracoForms/Developer/Custom-Markup/index.md
+++ b/Add-ons/UmbracoForms/Developer/Custom-Markup/index.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Forms custom markup"
-meta.Description: "With Umbraco Forms it's possible to customize the outputted markup of a Form, which means you have complete control over what Forms will output."
+description: "With Umbraco Forms it's possible to customize the outputted markup of a Form, which means you have complete control over what Forms will output."
 ---
 
 # Custom Markup

--- a/Add-ons/UmbracoForms/Developer/Email-Templates/index-v7.md
+++ b/Add-ons/UmbracoForms/Developer/Email-Templates/index-v7.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 versionTo: 8.0.0
 meta.Title: "Umbraco Forms Email Templates"
-meta.Description: "Creating an email template for Umbraco Forms."
+description: "Creating an email template for Umbraco Forms."
 ---
 
 # Email Templates

--- a/Add-ons/UmbracoForms/Developer/Email-Templates/index.md
+++ b/Add-ons/UmbracoForms/Developer/Email-Templates/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Forms Email Templates"
-meta.Description: "Creating an email template for Umbraco Forms."
+description: "Creating an email template for Umbraco Forms."
 ---
 
 # Email Templates

--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-an-Event-Handler-v8.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-an-Event-Handler-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Adding Event Handlers in Umbraco Forms"
-meta.Description: "See an example of validating a form server-side"
+description: "See an example of validating a form server-side"
 ---
 
 # Adding a server-side event handlers to Umbraco Forms

--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-an-Event-Handler.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-an-Event-Handler.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Adding Notification Handlers in Umbraco Forms"
-meta.Description: "See an example of validating a form server-side"
+description: "See an example of validating a form server-side"
 ---
 
 # Adding a server-side notification handlers to Umbraco Forms

--- a/Add-ons/UmbracoForms/Developer/Extending/Customize-default-workflows-v8.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Customize-default-workflows-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Customize default workflows"
-meta.Description: "How to amend the built-in behavior of associating workflows with new forms"
+description: "How to amend the built-in behavior of associating workflows with new forms"
 ---
 
 # Customize Default Workflows For a Form

--- a/Add-ons/UmbracoForms/Developer/Extending/Customize-default-workflows.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Customize-default-workflows.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Customize default workflows"
-meta.Description: "How to amend the built-in behavior of associating workflows with new forms"
+description: "How to amend the built-in behavior of associating workflows with new forms"
 ---
 
 # Customize Default Workflows For a Form

--- a/Add-ons/UmbracoForms/Developer/Security/index.md
+++ b/Add-ons/UmbracoForms/Developer/Security/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Forms security"
-meta.Description: "How to secure access to Umbraco Forms data and functionality."
+description: "How to secure access to Umbraco Forms data and functionality."
 ---
 
 # Security

--- a/Add-ons/UmbracoForms/Developer/Themes/index-v8.md
+++ b/Add-ons/UmbracoForms/Developer/Themes/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Theming Umbraco Forms"
-meta.Description: "Documentation on how to apply custom themes to Umbraco Forms"
+description: "Documentation on how to apply custom themes to Umbraco Forms"
 ---
 
 # Themes

--- a/Add-ons/UmbracoForms/Developer/Themes/index.md
+++ b/Add-ons/UmbracoForms/Developer/Themes/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Theming Umbraco Forms"
-meta.Description: "Documentation on how to apply custom themes to Umbraco Forms"
+description: "Documentation on how to apply custom themes to Umbraco Forms"
 ---
 
 # Themes

--- a/Add-ons/UmbracoForms/Developer/Working-With-Data/index-v8.md
+++ b/Add-ons/UmbracoForms/Developer/Working-With-Data/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Working with Umbraco Forms data"
-meta.Description: "Developer documentation on working with Forms record data."
+description: "Developer documentation on working with Forms record data."
 ---
 
 # Working with Record data

--- a/Add-ons/UmbracoForms/Developer/Working-With-Data/index.md
+++ b/Add-ons/UmbracoForms/Developer/Working-With-Data/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Working with Umbraco Forms data"
-meta.Description: "Developer documentation on working with Forms record data."
+description: "Developer documentation on working with Forms record data."
 ---
 
 # Working with Record Data

--- a/Add-ons/UmbracoForms/Developer/index.md
+++ b/Add-ons/UmbracoForms/Developer/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Forms Developer Documentation"
-meta.Description: "Developer documentation covering retrieving data, how to extend the system by hooking into the provider model, and describes the available events and workflows you can use to extend or integrate Umbraco Forms."
+description: "Developer documentation covering retrieving data, how to extend the system by hooking into the provider model, and describes the available events and workflows you can use to extend or integrate Umbraco Forms."
 ---
 
 # Developer Documentation

--- a/Add-ons/UmbracoForms/Installation/Install/index-v7.md
+++ b/Add-ons/UmbracoForms/Installation/Install/index-v7.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 
 meta.Title: "Installing Umbraco Forms"
-meta.Description: "Installing Umbraco Forms"
+description: "Installing Umbraco Forms"
 ---
 
 # Extending Umbraco with the full Forms section

--- a/Add-ons/UmbracoForms/Installation/Install/index.md
+++ b/Add-ons/UmbracoForms/Installation/Install/index.md
@@ -3,7 +3,7 @@ versionFrom: 9.0.0
 versionTo: 10.0.0
 
 meta.Title: "Installing Umbraco Forms"
-meta.Description: "Installing Umbraco Forms"
+description: "Installing Umbraco Forms"
 ---
 
 # Installing Umbraco Forms

--- a/Add-ons/UmbracoForms/Installation/ManualUpgrade-v8.md
+++ b/Add-ons/UmbracoForms/Installation/ManualUpgrade-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Manually Upgrading Umbraco Forms"
-meta.Description: "Documentation on how to upgrade Umbraco Forms"
+description: "Documentation on how to upgrade Umbraco Forms"
 ---
 
 # Manually upgrading forms

--- a/Add-ons/UmbracoForms/Installation/upgrade.md
+++ b/Add-ons/UmbracoForms/Installation/upgrade.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 versionTo: 10.0.0
 meta.Title: "Upgrading Umbraco Forms"
-meta.Description: "Documentation on how to upgrade Umbraco Forms"
+description: "Documentation on how to upgrade Umbraco Forms"
 ---
 
 # Keeping Umbraco Forms up to date

--- a/Add-ons/UmbracoForms/index.md
+++ b/Add-ons/UmbracoForms/index.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Forms"
-meta.Description: "Documentation on how to work with Umbraco Forms for both editors and developers"
+description: "Documentation on how to work with Umbraco Forms for both editors and developers"
 ---
 
 # Umbraco Forms Documentation

--- a/Add-ons/index.md
+++ b/Add-ons/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Add-ons for Umbraco CMS"
-meta.Description: "Learn about the Umbraco CMS add-ons; Umbraco Forms and Umbraco Courier. How to install them, what they do and how to extend functionality."
+description: "Learn about the Umbraco CMS add-ons; Umbraco Forms and Umbraco Courier. How to install them, what they do and how to extend functionality."
 versionFrom: 7.0.0
 versionTo: 10.0.0
 ---

--- a/Contribute/Adding-Metadata/index.md
+++ b/Contribute/Adding-Metadata/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Annotating a document with meta data"
-meta.Description: "The documentation markdown files are allowed to contain meta data.  This is done by adding YAML at the top of the document."
+description: "The documentation markdown files are allowed to contain meta data.  This is done by adding YAML at the top of the document."
 ---
 
 # Annotating a document with meta data
@@ -12,7 +12,7 @@ To add meta data, enclose the data between two lines of three dashes.  Every lin
     ---
     versionFrom: 7.3.4
     meta.Title: "Contribute to Umbraco CMS"
-    meta.Description: "Explanation of how you can contribute to Umbraco, what the process is, and what to keep in mind when contributing."
+    description: "Explanation of how you can contribute to Umbraco, what the process is, and what to keep in mind when contributing."
     ---
 
 Supported meta data properties:

--- a/Contribute/Code-samples/index.md
+++ b/Contribute/Code-samples/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Code samples - Best practices"
-meta.Description: "We highly recommend supporting your documentation articles with code samples. Make sure the samples follow our best practices outlined in this article."
+description: "We highly recommend supporting your documentation articles with code samples. Make sure the samples follow our best practices outlined in this article."
 ---
 
 # Code samples

--- a/Contribute/DocsTemplates/GenericTemplate.md
+++ b/Contribute/DocsTemplates/GenericTemplate.md
@@ -4,7 +4,7 @@ versionFrom: A property with semver notation to indicate from which version this
 versionTo: A property with semver notation to indicate till which version this article is valid
 verified-against: The version of Umbraco which has been tested against or the latest version
 meta.Title: "VERBing a(n)/the NOUN(s) [title case]"
-meta.Description: "Short description of the topic, can reuse first sentence, max 300 characters"
+description: "Short description of the topic, can reuse first sentence, max 300 characters"
 ---
 
 ## Main heading

--- a/Contribute/DocsTemplates/TutorialsTemplates.md
+++ b/Contribute/DocsTemplates/TutorialsTemplates.md
@@ -4,7 +4,7 @@ versionFrom: A property with semver notation to indicate from which version this
 versionTo: A property with semver notation to indicate till which version this article is valid
 verified-against: The version of Umbraco which has been tested against or the latest version
 meta.Title: "verbing a(n)/the noun(s) [title case]"
-meta.Description: "Short description of the topic, can reuse first sentence, max 300 characters"
+description: "Short description of the topic, can reuse first sentence, max 300 characters"
 ---
 
 ## Main heading

--- a/Contribute/DocsTemplates/index.md
+++ b/Contribute/DocsTemplates/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Documentation templates"
-meta.Description: "We highly recommend to use these templates when adding any Generic or Tutorial pages. Make sure the samples follow our best practices outlined in these guides."
+description: "We highly recommend to use these templates when adding any Generic or Tutorial pages. Make sure the samples follow our best practices outlined in these guides."
 ---
 
 # [Generic Template](DocsTemplates/GenericTemplate.md)

--- a/Contribute/File-Naming-Conventions/index.md
+++ b/Contribute/File-Naming-Conventions/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Multi version documentation conventions"
-meta.Description: "To support multi version documentation we work according to the conventions you can read about in this article."
+description: "To support multi version documentation we work according to the conventions you can read about in this article."
 ---
 
 # Multi version documentation conventions

--- a/Contribute/How-to-add-a-new-version/index.md
+++ b/Contribute/How-to-add-a-new-version/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "A tutorial on how to add a new version of an existing article."
-meta.Description: "Through a very detailed tutorial learn all the steps involved with creating a new version of an article in the Umbraco Docs and how to target it for a specific version of Umbraco."
+description: "Through a very detailed tutorial learn all the steps involved with creating a new version of an article in the Umbraco Docs and how to target it for a specific version of Umbraco."
 ---
 
 # How to add a new version of an article
@@ -102,7 +102,7 @@ Example:
 ---
 versionFrom: 9.0.0
 meta.Title: "Installing Umbraco"
-meta.Description: "Instructions on installing Umbraco: in VS code, via NuGet or on a Mac"
+description: "Instructions on installing Umbraco: in VS code, via NuGet or on a Mac"
 ---
 ```
 

--- a/Contribute/Issues/index.md
+++ b/Contribute/Issues/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "How to raise a question, start a discussion or report an issue on the Umbraco Documentation Issue Tracker."
-meta.Description: "Explanation on how to raise a question, start a discussion or report an issue on the Umbraco Documentation Issue Tracker."
+description: "Explanation on how to raise a question, start a discussion or report an issue on the Umbraco Documentation Issue Tracker."
 ---
 # What is an Issue?
 

--- a/Contribute/Markdown-Conventions/index.md
+++ b/Contribute/Markdown-Conventions/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Markdown conventions"
-meta.Description: "Explanation of how to use markdown and how we structure the files."
+description: "Explanation of how to use markdown and how we structure the files."
 ---
 
 # Markdown conventions

--- a/Contribute/Pull-Requests/index.md
+++ b/Contribute/Pull-Requests/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "How to request a change to an article by submitting a Pull Request"
-meta.Description: "Explanation on how to request a change to an article by submitting a Pull Request"
+description: "Explanation on how to request a change to an article by submitting a Pull Request"
 ---
 
 # What is a pull request

--- a/Contribute/Style-Guide/index.md
+++ b/Contribute/Style-Guide/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Style Guide"
-meta.Description: "A style guide for Umbraco documentation repo."
+description: "A style guide for Umbraco documentation repo."
 ---
 
 # Style Guide

--- a/Contribute/index.md
+++ b/Contribute/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Contribute to Umbraco CMS"
-meta.Description: "An explanation of how you can contribute to the Umbraco Documentation, what the process is and what things to keep in mind when contributing."
+description: "An explanation of how you can contribute to the Umbraco Documentation, what the process is and what things to keep in mind when contributing."
 ---
 # Contribute to the Umbraco Documentation
 

--- a/Development-Guidelines/Coding-Standards/index.md
+++ b/Development-Guidelines/Coding-Standards/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Coding Standards"
-meta.Description: "A guide to coding standards and naming conventions in Umbraco core."
+description: "A guide to coding standards and naming conventions in Umbraco core."
 ---
 
 # Coding standards and naming conventions

--- a/Development-Guidelines/Coding-Standards/jquery-guidelines.md
+++ b/Development-Guidelines/Coding-Standards/jquery-guidelines.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "jQuery coding guidelines"
-meta.Description: "A guide to coding in jQuery in Umbraco."
+description: "A guide to coding in jQuery in Umbraco."
 ---
 
 # jQuery coding guidelines

--- a/Development-Guidelines/Coding-Standards/js-guidelines.md
+++ b/Development-Guidelines/Coding-Standards/js-guidelines.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Coding Standards"
-meta.Description: "A guide to Javascript coding standards in Umbraco."
+description: "A guide to Javascript coding standards in Umbraco."
 ---
 
 # JavaScript coding standards and guidelines

--- a/Development-Guidelines/Coding-Standards/naming-conventions.md
+++ b/Development-Guidelines/Coding-Standards/naming-conventions.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Naming Conventions in Umbraco CMS codebase"
-meta.Description: "A guide to coding naming conventions in Umbraco."
+description: "A guide to coding naming conventions in Umbraco."
 ---
 
 # Naming conventions

--- a/Development-Guidelines/building-angular-project.md
+++ b/Development-Guidelines/building-angular-project.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Working with the backoffice UI AngularJS project"
-meta.Description: "Guidelines for working with backoffice UI AngularJS project"
+description: "Guidelines for working with backoffice UI AngularJS project"
 ---
 
 # Working with the backoffice UI AngularJS project

--- a/Development-Guidelines/index.md
+++ b/Development-Guidelines/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Development Guidelines"
-meta.Description: "A guide to developing in the Umbraco core codebase"
+description: "A guide to developing in the Umbraco core codebase"
 ---
 
 # Development Guidelines

--- a/Development-Guidelines/project-structure.md
+++ b/Development-Guidelines/project-structure.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Umbraco solution and project structure"
-meta.Description: "How the Visual Studio solution is structured and what is the functionality of each project."
+description: "How the Visual Studio solution is structured and what is the functionality of each project."
 ---
 
 # Solution and project structure

--- a/Development-Guidelines/working-with-code.md
+++ b/Development-Guidelines/working-with-code.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Working with with Umbraco codebase"
-meta.Description: "Guidelines for creating and updating code in the Umbraco core"
+description: "Guidelines for creating and updating code in the Umbraco core"
 ---
 
 # Working with the code

--- a/Extending/Backoffice-Search/index-v8.6.md
+++ b/Extending/Backoffice-Search/index-v8.6.md
@@ -2,7 +2,7 @@
 keywords: Backoffice Search
 versionFrom: 8.6.0
 meta.Title: "Backoffice Search"
-meta.Description: "A guide to customization of Backoffice Search"
+description: "A guide to customization of Backoffice Search"
 ---
 
 # Backoffice Search

--- a/Extending/Backoffice-Search/index.md
+++ b/Extending/Backoffice-Search/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Backoffice Search"
-meta.Description: "A guide to customization of Backoffice Search"
+description: "A guide to customization of Backoffice Search"
 ---
 
 # Backoffice Search

--- a/Extending/Backoffice-Tours/index-v8.6.md
+++ b/Extending/Backoffice-Tours/index-v8.6.md
@@ -2,7 +2,7 @@
 keywords: Backoffice tours
 versionFrom: 8.6.0
 meta.Title: "Backoffice Tours"
-meta.Description: "A guide configuring backoffice tours in Umbraco"
+description: "A guide configuring backoffice tours in Umbraco"
 ---
 
 # Backoffice tours

--- a/Extending/Backoffice-Tours/index-vpre7.11.md
+++ b/Extending/Backoffice-Tours/index-vpre7.11.md
@@ -3,7 +3,7 @@ keywords: Backoffice tours
 versionFrom: 7.8.0
 versionTo: 7.10.0
 meta.Title: "Backoffice Tours"
-meta.Description: "A guide configuring backoffice tours in Umbraco"
+description: "A guide configuring backoffice tours in Umbraco"
 ---
 
 # Backoffice tours

--- a/Extending/Backoffice-Tours/index-vpre8.6.md
+++ b/Extending/Backoffice-Tours/index-vpre8.6.md
@@ -3,7 +3,7 @@ keywords: Backoffice tours
 versionFrom: 7.11.0
 versionTo: 8.5.0
 meta.Title: "Backoffice Tours"
-meta.Description: "A guide configuring backoffice tours in Umbraco"
+description: "A guide configuring backoffice tours in Umbraco"
 ---
 
 # Backoffice tours

--- a/Extending/Backoffice-Tours/index.md
+++ b/Extending/Backoffice-Tours/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Backoffice Tours"
-meta.Description: "A guide configuring backoffice tours in Umbraco"
+description: "A guide configuring backoffice tours in Umbraco"
 ---
 
 # Backoffice Tours

--- a/Extending/Content-Apps/index-v8.7.md
+++ b/Extending/Content-Apps/index-v8.7.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.7.0
 meta.Title: "Content apps"
-meta.Description: "A guide to extending and creating content apps in Umbraco"
+description: "A guide to extending and creating content apps in Umbraco"
 ---
 
 # Content Apps

--- a/Extending/Content-Apps/index-vpre8.6.md
+++ b/Extending/Content-Apps/index-vpre8.6.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 8.5.3
 meta.Title: "Content Apps"
-meta.Description: "A guide to Umbraco Content Apps in the backoffice"
+description: "A guide to Umbraco Content Apps in the backoffice"
 ---
 
 # Content Apps

--- a/Extending/Content-Apps/index-vpre8.7.md
+++ b/Extending/Content-Apps/index-vpre8.7.md
@@ -2,7 +2,7 @@
 versionFrom: 8.6.0
 versionTo: 8.6.4
 meta.Title: "Content Apps"
-meta.Description: "A guide to Umbraco Content Apps in the backoffice"
+description: "A guide to Umbraco Content Apps in the backoffice"
 ---
 
 # Content Apps

--- a/Extending/Content-Apps/index-vpre9.2.md
+++ b/Extending/Content-Apps/index-vpre9.2.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Content Apps"
-meta.Description: "A guide configuring content apps in Umbraco"
+description: "A guide configuring content apps in Umbraco"
 ---
 
 # Content Apps

--- a/Extending/Content-Apps/index.md
+++ b/Extending/Content-Apps/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.2.0
 versionTo: 10.0.0
 meta.Title: "Content Apps"
-meta.Description: "A guide configuring content apps in Umbraco"
+description: "A guide configuring content apps in Umbraco"
 ---
 
 # Content Apps

--- a/Extending/Dashboards/index-v8.5.md
+++ b/Extending/Dashboards/index-v8.5.md
@@ -2,7 +2,7 @@
 keywords: dashboards dashboard extending v8 version8
 versionFrom: 8.5.0
 meta.Title: "Umbraco Custom Dashboards"
-meta.Description: "A guide to creating custom dashboards in Umbraco"
+description: "A guide to creating custom dashboards in Umbraco"
 ---
 
 # Dashboards

--- a/Extending/Dashboards/index-vpre8.5.md
+++ b/Extending/Dashboards/index-vpre8.5.md
@@ -2,7 +2,7 @@
 keywords: dashboards dashboard extending v8 version8
 versionFrom: 8.0.0
 meta.Title: "Umbraco Custom Dashboards"
-meta.Description: "A guide to creating custom dashboards in Umbraco"
+description: "A guide to creating custom dashboards in Umbraco"
 ---
 
 # Dashboards

--- a/Extending/Dashboards/index.md
+++ b/Extending/Dashboards/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Custom Dashboards"
-meta.Description: "A guide to creating custom dashboards in Umbraco"
+description: "A guide to creating custom dashboards in Umbraco"
 ---
 
 # Dashboards

--- a/Extending/Database/index-v11.md
+++ b/Extending/Database/index-v11.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 11.0.0
 meta.Title: "Umbraco Database"
-meta.Description: "A guide to creating a custom Database table in Umbraco"
+description: "A guide to creating a custom Database table in Umbraco"
 ---
 
 # Creating a Custom Database Table

--- a/Extending/Database/index-v8.md
+++ b/Extending/Database/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Database"
-meta.Description: "A guide to creating a custom Database table in Umbraco"
+description: "A guide to creating a custom Database table in Umbraco"
 ---
 
 # Creating a Custom Database Table

--- a/Extending/Database/index-v9.md
+++ b/Extending/Database/index-v9.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 9.0.0
 meta.Title: "Umbraco Database"
-meta.Description: "A guide to creating a custom Database table in Umbraco"
+description: "A guide to creating a custom Database table in Umbraco"
 ---
 
 # Creating a custom Database table

--- a/Extending/Database/index.md
+++ b/Extending/Database/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 meta.Title: "Umbraco Database"
-meta.Description: "A guide to creating a custom Database table in Umbraco"
+description: "A guide to creating a custom Database table in Umbraco"
 ---
 
 # Creating a Custom Database Table

--- a/Extending/Embedded-Media-Provider/index-v8.md
+++ b/Extending/Embedded-Media-Provider/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Embed Providers"
-meta.Description: "A guide to creating a custom embed providers in Umbraco"
+description: "A guide to creating a custom embed providers in Umbraco"
 ---
 
 # Embed Providers

--- a/Extending/Embedded-Media-Provider/index.md
+++ b/Extending/Embedded-Media-Provider/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Embed Providers"
-meta.Description: "A guide to creating a custom embed providers in Umbraco"
+description: "A guide to creating a custom embed providers in Umbraco"
 
 ---
 

--- a/Extending/FileSystemProviders/Azure-Blob-Storage/index-v9.md
+++ b/Extending/FileSystemProviders/Azure-Blob-Storage/index-v9.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 9.0.0
 meta.Title: "Using Azure Blob Storage for Media and ImageSharp Cache"
-meta.Description: "Setup your site to use Azure Blob storage for media and ImageSharp cache"
+description: "Setup your site to use Azure Blob storage for media and ImageSharp cache"
 ---
 
 # Setup Your Site to use Azure Blob Storage for Media and ImageSharp Cache

--- a/Extending/FileSystemProviders/Azure-Blob-Storage/index.md
+++ b/Extending/FileSystemProviders/Azure-Blob-Storage/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 meta.Title: "Using Azure Blob Storage for Media and ImageSharp Cache"
-meta.Description: "Setup your site to use Azure Blob storage for media and ImageSharp cache"
+description: "Setup your site to use Azure Blob storage for media and ImageSharp cache"
 ---
 
 # Setup Your Site to use Azure Blob Storage for Media and ImageSharp Cache

--- a/Extending/FileSystemProviders/index-v8.md
+++ b/Extending/FileSystemProviders/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco File System Providers"
-meta.Description: "A guide to creating custom file systems in Umbraco"
+description: "A guide to creating custom file systems in Umbraco"
 ---
 
 # Custom file systems (IFileSystem)

--- a/Extending/FileSystemProviders/index-v9.md
+++ b/Extending/FileSystemProviders/index-v9.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Umbraco File System Providers"
-meta.Description: "A guide to creating custom file systems in Umbraco"
+description: "A guide to creating custom file systems in Umbraco"
 ---
 
 # Custom file systems (IFileSystem)

--- a/Extending/FileSystemProviders/index.md
+++ b/Extending/FileSystemProviders/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 meta.Title: "Umbraco File System Providers"
-meta.Description: "A guide to creating custom file systems in Umbraco"
+description: "A guide to creating custom file systems in Umbraco"
 ---
 
 # Custom file systems (IFileSystem)

--- a/Extending/Health-Check/index-v8.md
+++ b/Extending/Health-Check/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Healthcheck"
-meta.Description: "The Settings section of the Umbraco backoffice holds a dashboard named 'Health Check'. It is a handy list of checks to see if your Umbraco installation is configured according to best practices."
+description: "The Settings section of the Umbraco backoffice holds a dashboard named 'Health Check'. It is a handy list of checks to see if your Umbraco installation is configured according to best practices."
 ---
 
 # Health Check

--- a/Extending/Health-Check/index.md
+++ b/Extending/Health-Check/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Healthcheck"
-meta.Description: "The Settings section of the Umbraco backoffice holds a dashboard named 'Health Check'. It is a handy list of checks to see if your Umbraco installation is configured according to best practices."
+description: "The Settings section of the Umbraco backoffice holds a dashboard named 'Health Check'. It is a handy list of checks to see if your Umbraco installation is configured according to best practices."
 ---
 
 # Health Check

--- a/Extending/Key-Vault/index-v9.md
+++ b/Extending/Key-Vault/index-v9.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Azure Key Vault"
-meta.Description: "A guide configuring an Azure Key Vault"
+description: "A guide configuring an Azure Key Vault"
 ---
 
 # Configuring an Azure Key Vault

--- a/Extending/Key-Vault/index.md
+++ b/Extending/Key-Vault/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 meta.Title: "Azure Key Vault"
-meta.Description: "A guide for configuring Azure Key Vault"
+description: "A guide for configuring Azure Key Vault"
 ---
 
 # Configuring Azure Key Vault

--- a/Extending/Language-Files/index-v8.md
+++ b/Extending/Language-Files/index-v8.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 needsV8Update: "true"
 meta.Title: "Language Files & Localization"
-meta.Description: "Language files are used to translate the Umbraco backoffice user interface so that end users can use Umbraco in their native language."
+description: "Language files are used to translate the Umbraco backoffice user interface so that end users can use Umbraco in their native language."
 ---
 
 # Language Files & Localization

--- a/Extending/Language-Files/index.md
+++ b/Extending/Language-Files/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Language Files & Localization"
-meta.Description: "Language files are used to translate the Umbraco backoffice user interface so that end users can use Umbraco in their native language."
+description: "Language files are used to translate the Umbraco backoffice user interface so that end users can use Umbraco in their native language."
 ---
 
 # Language Files & Localization

--- a/Extending/Macro-Parameter-Editors/index-v8.md
+++ b/Extending/Macro-Parameter-Editors/index-v8.md
@@ -3,7 +3,7 @@ versionFrom: 7.0.0
 versionTo: 8.15.0
 product: "CMS"
 meta.Title: "Macro Parameter Editors"
-meta.Description: "A guide to creating macro property editors in Umbraco"
+description: "A guide to creating macro property editors in Umbraco"
 ---
 
 # Macro Parameter Editors

--- a/Extending/Macro-Parameter-Editors/index.md
+++ b/Extending/Macro-Parameter-Editors/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Macro Parameter Editors"
-meta.Description: "A guide to creating macro property editors in Umbraco"
+description: "A guide to creating macro property editors in Umbraco"
 ---
 
 # Macro Parameter Editors

--- a/Extending/Packages/Creating-a-Package/index-v11.md
+++ b/Extending/Packages/Creating-a-Package/index-v11.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 11.0.0
 meta.Title: "Creating a package"
-meta.Description: "Tutorial to create a package in Umbraco"
+description: "Tutorial to create a package in Umbraco"
 ---
 
 # Creating a Package

--- a/Extending/Packages/Creating-a-Package/index-v8.md
+++ b/Extending/Packages/Creating-a-Package/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Creating a package"
-meta.Description: "Tutorial to create a package in Umbraco"
+description: "Tutorial to create a package in Umbraco"
 ---
 
 # Creating a Package

--- a/Extending/Packages/Creating-a-Package/index.md
+++ b/Extending/Packages/Creating-a-Package/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Creating a package"
-meta.Description: "Tutorial to create a package in Umbraco"
+description: "Tutorial to create a package in Umbraco"
 ---
 
 # Creating a Package

--- a/Extending/Packages/Creating-a-nuget-package/index.md
+++ b/Extending/Packages/Creating-a-nuget-package/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Creating a Nuget version of an Umbraco package"
-meta.Description: "A guide to creating a Nuget version of an Umbraco package"
+description: "A guide to creating a Nuget version of an Umbraco package"
 ---
 
 # Creating a NuGet version of a package

--- a/Extending/Packages/Installing-And-Uninstalling-Packages/index.md
+++ b/Extending/Packages/Installing-And-Uninstalling-Packages/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Installing and uninstalling Umbraco packages"
-meta.Description: "How to install a package, and remove a package from a solution"
+description: "How to install a package, and remove a package from a solution"
 ---
 
 # Installing packages

--- a/Extending/Packages/Language-Files-For-Packages/index-v8.md
+++ b/Extending/Packages/Language-Files-For-Packages/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.3.0
 meta.Title: "Language file for packages"
-meta.Description: "Information on how to use language files to make your Umbraco package UI support multiple languages"
+description: "Information on how to use language files to make your Umbraco package UI support multiple languages"
 ---
 
 # Language file for packages

--- a/Extending/Packages/Language-Files-For-Packages/index.md
+++ b/Extending/Packages/Language-Files-For-Packages/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Language file for packages"
-meta.Description: "Information on how to use language files to make your Umbraco package UI support multiple languages"
+description: "Information on how to use language files to make your Umbraco package UI support multiple languages"
 ---
 
 # Language file for packages

--- a/Extending/Packages/Maintaining-Packages/index-v8.md
+++ b/Extending/Packages/Maintaining-Packages/index-v8.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 keywords: packages 
 meta.Title: "Maintaining Umbraco Packages"
-meta.Description: "Once you've created and published your package, here is what's involved in it's ongoing maintenance"
+description: "Once you've created and published your package, here is what's involved in it's ongoing maintenance"
 ---
 
 # Maintaining packages

--- a/Extending/Packages/Maintaining-Packages/index.md
+++ b/Extending/Packages/Maintaining-Packages/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Maintaining Umbraco Packages"
-meta.Description: "Once you've created and published your package, here is what's involved in it's ongoing maintenance"
+description: "Once you've created and published your package, here is what's involved in it's ongoing maintenance"
 ---
 
 # Maintaining packages

--- a/Extending/Packages/Package-Actions/custom-package-actions.md
+++ b/Extending/Packages/Package-Actions/custom-package-actions.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 8.0.0
 meta.Title: "Create custom package actions for your Umbraco package"
-meta.Description: "Tutorial on how to create custom package actions for your Umbraco package"
+description: "Tutorial on how to create custom package actions for your Umbraco package"
 versionRemoved: 9.0.0
 ---
 

--- a/Extending/Packages/Package-Actions/index.md
+++ b/Extending/Packages/Package-Actions/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 8.0.0
 meta.Title: "Package actions"
-meta.Description: "Information on how to add actions to your Umbraco package"
+description: "Information on how to add actions to your Umbraco package"
 versionRemoved: 9.0.0
 ---
 

--- a/Extending/Packages/Packages-on-Umbraco-Cloud/index.md
+++ b/Extending/Packages/Packages-on-Umbraco-Cloud/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Packages on Umbraco Cloud"
-meta.Description: "Things to consider for package development and usage in Umbraco Cloud"
+description: "Things to consider for package development and usage in Umbraco Cloud"
 v9-equivalent: "https://github.com/umbraco/UmbracoCMSDocs/blob/main/Articles/Packages/packages-on-Umbraco-Cloud.md"
 needsv9Update: "true"
 ---

--- a/Extending/Packages/Types-of-Packages/index-v8.md
+++ b/Extending/Packages/Types-of-Packages/index-v8.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 versionTo: 8.0.0
 meta.Title: "Umbraco Package Types"
-meta.Description: "Types of packages in Umbraco"
+description: "Types of packages in Umbraco"
 ---
 
 # Package Types

--- a/Extending/Packages/UmbPack/index.md
+++ b/Extending/Packages/UmbPack/index.md
@@ -3,7 +3,7 @@ versionFrom: 7.0.0
 versionTo: 8.0.0
 versionRemoved: 9.0.0
 meta.Title: "UmbPack"
-meta.Description: "How to use the UmbPack tool to deploy package versions to Our"
+description: "How to use the UmbPack tool to deploy package versions to Our"
 ---
 
 # UmbPack

--- a/Extending/Packages/Uploading-to-Our/index-v8.md
+++ b/Extending/Packages/Uploading-to-Our/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Uploading an Umbraco package to Our"
-meta.Description: "Information on how to upload your Umbraco package on Our"
+description: "Information on how to upload your Umbraco package on Our"
 ---
 
 # Uploading to Our

--- a/Extending/Packages/Uploading-to-Our/index.md
+++ b/Extending/Packages/Uploading-to-Our/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Uploading an Umbraco package to Our"
-meta.Description: "Information on how to upload your Umbraco package on Our"
+description: "Information on how to upload your Umbraco package on Our"
 ---
 
 # Uploading to Our

--- a/Extending/Packages/index-v8.md
+++ b/Extending/Packages/index-v8.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 keywords: packages 
 meta.Title: "Umbraco Packages"
-meta.Description: "A package extends the functionality of Umbraco to provide additional functionality to editors, developers, site visitors, and all other types of users of Umbraco."
+description: "A package extends the functionality of Umbraco to provide additional functionality to editors, developers, site visitors, and all other types of users of Umbraco."
 ---
 
 # Packages

--- a/Extending/Packages/index.md
+++ b/Extending/Packages/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Umbraco Packages"
-meta.Description: "A package extends the functionality of Umbraco to provide additional functionality to editors, developers, site visitors, and all other types of users of Umbraco."
+description: "A package extends the functionality of Umbraco to provide additional functionality to editors, developers, site visitors, and all other types of users of Umbraco."
 ---
 
 # Packages

--- a/Extending/Property-Editors/Property-Actions/index-v8.md
+++ b/Extending/Property-Editors/Property-Actions/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.4.0
 meta.Title: "Umbraco Property Editors - Property Actions"
-meta.Description: "Guide on how to implement Property Actions for Property Editors in Umbraco"
+description: "Guide on how to implement Property Actions for Property Editors in Umbraco"
 ---
 
 # Property Actions

--- a/Extending/Property-Editors/Property-Actions/index.md
+++ b/Extending/Property-Editors/Property-Actions/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Property Editors - Property Actions"
-meta.Description: "Guide on how to implement Property Actions for Property Editors in Umbraco"
+description: "Guide on how to implement Property Actions for Property Editors in Umbraco"
 ---
 
 # Property Actions

--- a/Extending/Property-Editors/Property-Value-Converters/index-v8.md
+++ b/Extending/Property-Editors/Property-Value-Converters/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Property Value Converters"
-meta.Description: "A guide to creating a custom property value converter in Umbraco"
+description: "A guide to creating a custom property value converter in Umbraco"
 ---
 
 # Property Value Converters

--- a/Extending/Property-Editors/Property-Value-Converters/index.md
+++ b/Extending/Property-Editors/Property-Value-Converters/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Property Value Converters"
-meta.Description: "A guide to creating a custom property value converter in Umbraco"
+description: "A guide to creating a custom property value converter in Umbraco"
 ---
 
 

--- a/Extending/Property-Editors/Tracking/index-v8.md
+++ b/Extending/Property-Editors/Tracking/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.6.0
 meta.Title: "Umbraco Property Editors - Tracking References"
-meta.Description: "Guide on how to implement tracking entity references for Property Editors in Umbraco"
+description: "Guide on how to implement tracking entity references for Property Editors in Umbraco"
 ---
 
 # Tracking References

--- a/Extending/Property-Editors/Tracking/index.md
+++ b/Extending/Property-Editors/Tracking/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Property Editors - Tracking References"
-meta.Description: "Guide on how to implement tracking entity references for Property Editors in Umbraco"
+description: "Guide on how to implement tracking entity references for Property Editors in Umbraco"
 ---
 
 # Tracking References

--- a/Extending/Property-Editors/index-v7-8.md
+++ b/Extending/Property-Editors/index-v7-8.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 needsV8Update: "true"
 meta.Title: "Umbraco Property Editors"
-meta.Description: "Guide on how to work with and create Property Editors in Umbraco"
+description: "Guide on how to work with and create Property Editors in Umbraco"
 needsv9Update: "true"
 ---
 

--- a/Extending/Property-Editors/index.md
+++ b/Extending/Property-Editors/index.md
@@ -4,7 +4,7 @@ updated-links: false
 verified-against: alpha-3
 versionFrom: 9.0.0
 meta.Title: "Umbraco Property Editors"
-meta.Description: "Guide on how to work with and create Property Editors in Umbraco"
+description: "Guide on how to work with and create Property Editors in Umbraco"
 ---
 
 # Property Editors

--- a/Extending/Section-Trees/Sections/index-v8.md
+++ b/Extending/Section-Trees/Sections/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Sections & Trees"
-meta.Description: "An explanation on sections and trees in Umbraco"
+description: "An explanation on sections and trees in Umbraco"
 ---
 
 # Sections

--- a/Extending/Section-Trees/Sections/index-vpre9.2.md
+++ b/Extending/Section-Trees/Sections/index-vpre9.2.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Umbraco Sections & Trees"
-meta.Description: "An explanation on sections and trees in Umbraco"
+description: "An explanation on sections and trees in Umbraco"
 ---
 
 # Sections

--- a/Extending/Section-Trees/Sections/index.md
+++ b/Extending/Section-Trees/Sections/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.2.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Sections & Trees"
-meta.Description: "An explanation on sections and trees in Umbraco"
+description: "An explanation on sections and trees in Umbraco"
 ---
 
 # Sections

--- a/Extending/Section-Trees/Trees/index-v8.md
+++ b/Extending/Section-Trees/Trees/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Tree"
-meta.Description: "A guide to creating a custom tree in Umbraco"
+description: "A guide to creating a custom tree in Umbraco"
 ---
 
 # Trees

--- a/Extending/Section-Trees/Trees/index.md
+++ b/Extending/Section-Trees/Trees/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Tree"
-meta.Description: "A guide to creating a custom tree in Umbraco"
+description: "A guide to creating a custom tree in Umbraco"
 ---
 
 # Trees

--- a/Extending/Section-Trees/Trees/tree-actions-v7.md
+++ b/Extending/Section-Trees/Trees/tree-actions-v7.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Umbraco Tree Actions"
-meta.Description: "A guide to creating a custom tree action in Umbraco"
+description: "A guide to creating a custom tree action in Umbraco"
 v9-equivalent: "https://github.com/umbraco/UmbracoCMSDocs/blob/main/Articles/Section-Trees/tree-actions.md"
 ---
 

--- a/Extending/Section-Trees/Trees/tree-actions-v8.md
+++ b/Extending/Section-Trees/Trees/tree-actions-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Tree Actions"
-meta.Description: "A guide to creating a custom tree action in Umbraco"
+description: "A guide to creating a custom tree action in Umbraco"
 ---
 
 # Tree Actions

--- a/Extending/Section-Trees/Trees/tree-actions.md
+++ b/Extending/Section-Trees/Trees/tree-actions.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Tree Actions"
-meta.Description: "A guide to creating a custom tree action in Umbraco"
+description: "A guide to creating a custom tree action in Umbraco"
 ---
 
 # Tree Actions

--- a/Extending/Section-Trees/index-v8.md
+++ b/Extending/Section-Trees/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Sections & Trees"
-meta.Description: "An explanation on sections and trees in Umbraco"
+description: "An explanation on sections and trees in Umbraco"
 ---
 
 # Sections & Trees

--- a/Extending/Section-Trees/index.md
+++ b/Extending/Section-Trees/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Umbraco Sections & Trees"
-meta.Description: "An explanation on sections and trees in Umbraco"
+description: "An explanation on sections and trees in Umbraco"
 ---
 
 # Sections & Trees

--- a/Extending/UI-Library/index.md
+++ b/Extending/UI-Library/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "UI Library"
-meta.Description: "A guide for getting started working with the Umbraco UI Library"
+description: "A guide for getting started working with the Umbraco UI Library"
 ---
 
 # UI Library

--- a/Extending/index-v8.md
+++ b/Extending/index-v8.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 product: "CMS"
 meta.Title: "Learn about extending the functionality of Umbraco"
-meta.Description: "This section shows the different ways you can extend Umbraco. From Content Apps to Backoffice tours, and many more."
+description: "This section shows the different ways you can extend Umbraco. From Content Apps to Backoffice tours, and many more."
 ---
 
 # Extending Umbraco

--- a/Extending/index.md
+++ b/Extending/index.md
@@ -3,7 +3,7 @@ versionFrom: 9.0.0
 versionTo: 10.0.0
 product: "CMS"
 meta.Title: "Learn about extending the functionality of Umbraco"
-meta.Description: "This section shows the different ways you can extend Umbraco. From Content Apps to Backoffice tours, and many more."
+description: "This section shows the different ways you can extend Umbraco. From Content Apps to Backoffice tours, and many more."
 ---
 
 # Extending Umbraco

--- a/Fundamentals/Backoffice/Content-Templates/index-v7.md
+++ b/Fundamentals/Backoffice/Content-Templates/index-v7.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.7.0
 meta.Title: "Content Templates in Umbraco"
-meta.Description: "In this article you can learn about how to create and use Content Templates in Umbraco."
+description: "In this article you can learn about how to create and use Content Templates in Umbraco."
 ---
 
 # Content Templates

--- a/Fundamentals/Backoffice/Content-Templates/index.md
+++ b/Fundamentals/Backoffice/Content-Templates/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Content Templates in Umbraco"
-meta.Description: "In this article you can learn about how to create and use Content Templates in Umbraco."
+description: "In this article you can learn about how to create and use Content Templates in Umbraco."
 ---
 
 # Content Templates

--- a/Fundamentals/Backoffice/Infinite-editing/index.md
+++ b/Fundamentals/Backoffice/Infinite-editing/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Infinite Editing in Umbraco"
-meta.Description: "This section explains how the concept of infinite editing in the Umbraco backoffice works."
+description: "This section explains how the concept of infinite editing in the Umbraco backoffice works."
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Backoffice/LogViewer/index-v8.md
+++ b/Fundamentals/Backoffice/LogViewer/index-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Log Viewer"
-meta.Description: "Information on using the Umbraco log viewer in version 8"
+description: "Information on using the Umbraco log viewer in version 8"
 keywords: logging logviewer logs serilog messagetemplates logs v8 version8
 versionFrom: 8.0.0
 

--- a/Fundamentals/Backoffice/LogViewer/index.md
+++ b/Fundamentals/Backoffice/LogViewer/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Log Viewer"
-meta.Description: "Information on using the Umbraco log viewer in version 8"
+description: "Information on using the Umbraco log viewer in version 8"
 keywords: logging logviewer logs serilog messagetemplates logs v8 version8
 versionFrom: 9.0.0
 versionTo: 10.0.0

--- a/Fundamentals/Backoffice/Login/index-v7.md
+++ b/Fundamentals/Backoffice/Login/index-v7.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Configure and customize the Login screen"
-meta.Description: "In this article you can learn the various ways of customizing the Umbraco backoffice login screen and form."
+description: "In this article you can learn the various ways of customizing the Umbraco backoffice login screen and form."
 versionFrom: 7.0.0
 ---
 

--- a/Fundamentals/Backoffice/Login/index-v8.md
+++ b/Fundamentals/Backoffice/Login/index-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Configure and customize the Login screen"
-meta.Description: "In this article you can learn the various ways of customizing the Umbraco backoffice login screen and form."
+description: "In this article you can learn the various ways of customizing the Umbraco backoffice login screen and form."
 versionFrom: 8.0.0
 ---
 

--- a/Fundamentals/Backoffice/Login/index.md
+++ b/Fundamentals/Backoffice/Login/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Configure and customize the Login screen"
-meta.Description: "In this article you can learn the various ways of customizing the Umbraco backoffice login screen and form."
+description: "In this article you can learn the various ways of customizing the Umbraco backoffice login screen and form."
 versionFrom: 9.0.0
 ---
 

--- a/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Email-Address/index.md
+++ b/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Email-Address/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Display an email address"
-meta.Description: "In this article you can learn how to use the build in email property editor"
+description: "In this article you can learn how to use the build in email property editor"
 versionFrom: 9.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Backoffice/Property-Editors/index-v7.md
+++ b/Fundamentals/Backoffice/Property-Editors/index-v7.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Property editors"
-meta.Description: "A Property editor is the editor that a Data Type references, and it's defined in a JSON manifest file and an associated JavaScript file."
+description: "A Property editor is the editor that a Data Type references, and it's defined in a JSON manifest file and an associated JavaScript file."
 versionFrom: 7.0.0
 ---
 

--- a/Fundamentals/Backoffice/Property-Editors/index-v8.md
+++ b/Fundamentals/Backoffice/Property-Editors/index-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Property editors"
-meta.Description: "A Property editor is the editor that a Data Type references, and it's defined in a JSON manifest file and an associated JavaScript file."
+description: "A Property editor is the editor that a Data Type references, and it's defined in a JSON manifest file and an associated JavaScript file."
 versionFrom: 8.0.0
 ---
 

--- a/Fundamentals/Backoffice/Property-Editors/index.md
+++ b/Fundamentals/Backoffice/Property-Editors/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Property editors"
-meta.Description: "A Property editor is the editor that a Data Type references, and it's defined in a JSON manifest file and an associated JavaScript file."
+description: "A Property editor is the editor that a Data Type references, and it's defined in a JSON manifest file and an associated JavaScript file."
 versionFrom: 9.0.0
 ---
 

--- a/Fundamentals/Backoffice/Sections/index-v7.md
+++ b/Fundamentals/Backoffice/Sections/index-v7.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Sections in the Umbraco Backoffice"
-meta.Description: "In this article you can learn more about the various sections you can find within the Umbraco Backoffice."
+description: "In this article you can learn more about the various sections you can find within the Umbraco Backoffice."
 versionFrom: 7.0.0
 ---
 

--- a/Fundamentals/Backoffice/Sections/index.md
+++ b/Fundamentals/Backoffice/Sections/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Sections in the Umbraco Backoffice"
-meta.Description: "In this article you can learn more about the various sections you can find within the Umbraco Backoffice."
+description: "In this article you can learn more about the various sections you can find within the Umbraco Backoffice."
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Backoffice/Variants/index.md
+++ b/Fundamentals/Backoffice/Variants/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Language Variants in Umbraco"
-meta.Description: "Language Variants allow you to vary content by culture, so you can allow a content node to exist in several languages."
+description: "Language Variants allow you to vary content by culture, so you can allow a content node to exist in several languages."
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Backoffice/index-v7.md
+++ b/Fundamentals/Backoffice/index-v7.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "The Umbraco Backoffice"
-meta.Description: "In this article you can learn more about the common terms and concepts that are used throughout the Umbraco Backoffice."
+description: "In this article you can learn more about the common terms and concepts that are used throughout the Umbraco Backoffice."
 versionFrom: 7.0.0
 ---
 

--- a/Fundamentals/Backoffice/index.md
+++ b/Fundamentals/Backoffice/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "The Umbraco Backoffice"
-meta.Description: "In this article you can learn more about the common terms and concepts that are used throughout the Umbraco Backoffice."
+description: "In this article you can learn more about the common terms and concepts that are used throughout the Umbraco Backoffice."
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Code/Creating-Forms/index-v8.md
+++ b/Fundamentals/Code/Creating-Forms/index-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Creating Forms"
-meta.Description: "Information on creating forms in Umbraco"
+description: "Information on creating forms in Umbraco"
 versionFrom: 8.0.0
 ---
 

--- a/Fundamentals/Code/Creating-Forms/index.md
+++ b/Fundamentals/Code/Creating-Forms/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Creating Forms"
-meta.Description: "Information on creating forms in Umbraco"
+description: "Information on creating forms in Umbraco"
 versionFrom: 9.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Code/Debugging/index-v8.md
+++ b/Fundamentals/Code/Debugging/index-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Debugging"
-meta.Description: "Debugging in Umbraco"
+description: "Debugging in Umbraco"
 versionFrom: 8.0.0
 ---
 

--- a/Fundamentals/Code/Debugging/index.md
+++ b/Fundamentals/Code/Debugging/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Debugging"
-meta.Description: "Debugging in Umbraco"
+description: "Debugging in Umbraco"
 versionFrom: 9.0.0
 ---
 

--- a/Fundamentals/Code/Source-Control/index-v8.md
+++ b/Fundamentals/Code/Source-Control/index-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Source Control with Umbraco"
-meta.Description: "In this article you can learn more about how to effectively source control your Umbraco site."
+description: "In this article you can learn more about how to effectively source control your Umbraco site."
 versionFrom: 8.0.0
 ---
 

--- a/Fundamentals/Code/Source-Control/index-v9.md
+++ b/Fundamentals/Code/Source-Control/index-v9.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Source Control with Umbraco"
-meta.Description: "In this article you can learn more about how to effectively source control your Umbraco site."
+description: "In this article you can learn more about how to effectively source control your Umbraco site."
 ---
 
 # Source Control

--- a/Fundamentals/Code/Source-Control/index.md
+++ b/Fundamentals/Code/Source-Control/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 meta.Title: "Source Control with Umbraco"
-meta.Description: "In this article you can learn more about how to effectively source control your Umbraco site."
+description: "In this article you can learn more about how to effectively source control your Umbraco site."
 ---
 
 # Source Control

--- a/Fundamentals/Code/Subscribing-To-Events/index.md
+++ b/Fundamentals/Code/Subscribing-To-Events/index.md
@@ -1,6 +1,6 @@
 ---
 meta.title: "Subscribing to events"
-meta.description: "Subscribing to events allows you to execute custom code on a number of events both before and after the event occurs"
+description: "Subscribing to events allows you to execute custom code on a number of events both before and after the event occurs"
 versionFrom: 8.0.0
 versionTo: 8.18.0
 versionRemoved: 9.0.0

--- a/Fundamentals/Code/Subscribing-To-Notifications/index.md
+++ b/Fundamentals/Code/Subscribing-To-Notifications/index.md
@@ -1,6 +1,6 @@
 ---
 meta.title: "Subscribing to notifications"
-meta.description: "Subscribing to notifications allows you to execute custom code on a number of operations both before and after the operation occurs"
+description: "Subscribing to notifications allows you to execute custom code on a number of operations both before and after the operation occurs"
 versionFrom: 9.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Code/Umbraco-Services/index-v8.md
+++ b/Fundamentals/Code/Umbraco-Services/index-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.title: "Using Umbraco's service APIs"
-meta.description: "Using the Umbraco service APIs you can create, update and delete any of the core Umbraco entities directly from your custom code"
+description: "Using the Umbraco service APIs you can create, update and delete any of the core Umbraco entities directly from your custom code"
 versionFrom: 8.0.0
 ---
 

--- a/Fundamentals/Data/Creating-Media/index-v7.md
+++ b/Fundamentals/Data/Creating-Media/index-v7.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Creating media in Umbraco"
-meta.Description: "Media in Umbraco is handled in much the same way as content. From the backoffice you can upload and create media items, such as images and files."
+description: "Media in Umbraco is handled in much the same way as content. From the backoffice you can upload and create media items, such as images and files."
 versionFrom: 7.0.0
 ---
 

--- a/Fundamentals/Data/Creating-Media/index-vpre8.13.md
+++ b/Fundamentals/Data/Creating-Media/index-vpre8.13.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Creating media in Umbraco"
-meta.Description: "Media in Umbraco is handled in much the same way as content. From the backoffice you can upload and create media items, such as images and files."
+description: "Media in Umbraco is handled in much the same way as content. From the backoffice you can upload and create media items, such as images and files."
 versionFrom: 8.0.0
 versionTo: 8.13.0
 ---

--- a/Fundamentals/Data/Creating-Media/index.md
+++ b/Fundamentals/Data/Creating-Media/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Creating media in Umbraco"
-meta.Description: "Media in Umbraco is handled in much the same way as content. From the backoffice you can upload and create media items, such as images and files."
+description: "Media in Umbraco is handled in much the same way as content. From the backoffice you can upload and create media items, such as images and files."
 versionFrom: 8.14.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Data/Data-Types/default-data-types-v8.md
+++ b/Fundamentals/Data/Data-Types/default-data-types-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Default data types in Umbraco"
-meta.Description: "Learn about the default data types in Umbraco."
+description: "Learn about the default data types in Umbraco."
 ---
 
 # Default Data Types

--- a/Fundamentals/Data/Data-Types/default-data-types.md
+++ b/Fundamentals/Data/Data-Types/default-data-types.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Default data types in Umbraco"
-meta.Description: "Learn about the default data types in Umbraco."
+description: "Learn about the default data types in Umbraco."
 ---
 
 # Default Data Types

--- a/Fundamentals/Data/Data-Types/index.md
+++ b/Fundamentals/Data/Data-Types/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Data types in Umbraco"
-meta.Description: "Learn about the data types in Umbraco."
+description: "Learn about the data types in Umbraco."
 ---
 
 # Data Types

--- a/Fundamentals/Data/Defining-content/index-v8.md
+++ b/Fundamentals/Data/Defining-content/index-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Defining content"
-meta.Description: "Here you'll find an explanation of how content is defined in Umbraco 8"
+description: "Here you'll find an explanation of how content is defined in Umbraco 8"
 versionFrom: 8.0.0
 versionTo: 9.2.0
 ---

--- a/Fundamentals/Data/Defining-content/index.md
+++ b/Fundamentals/Data/Defining-content/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Defining content"
-meta.Description: "Here you'll find an explanation of how content is defined in Umbraco 8"
+description: "Here you'll find an explanation of how content is defined in Umbraco 8"
 versionFrom: 9.2.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Data/Dictionary-Items/index-v8.md
+++ b/Fundamentals/Data/Dictionary-Items/index-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Creating Dictionary Items in Umbraco"
-meta.Description: "Creating Dictionary Items in Umbraco"
+description: "Creating Dictionary Items in Umbraco"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Data/Dictionary-Items/index.md
+++ b/Fundamentals/Data/Dictionary-Items/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Creating Dictionary Items in Umbraco"
-meta.Description: "Creating Dictionary Items in Umbraco"
+description: "Creating Dictionary Items in Umbraco"
 versionFrom: 10.1.0
 ---
 

--- a/Fundamentals/Data/Members/index-v7.md
+++ b/Fundamentals/Data/Members/index-v7.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Creating Members in Umbraco"
-meta.Description: "Members are used for registering and authentication external / frontend users of an Umbraco installation. This could be Forum members and Intranet members."
+description: "Members are used for registering and authentication external / frontend users of an Umbraco installation. This could be Forum members and Intranet members."
 versionFrom: 7.0.0
 ---
 

--- a/Fundamentals/Data/Members/index-v8.md
+++ b/Fundamentals/Data/Members/index-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Creating Members in Umbraco"
-meta.Description: "Members are used for registering and authentication external / frontend users of an Umbraco installation. This could be Forum members and Intranet members."
+description: "Members are used for registering and authentication external / frontend users of an Umbraco installation. This could be Forum members and Intranet members."
 versionFrom: 8.0.0
 needsV9Update: "true"
 ---

--- a/Fundamentals/Data/Members/index.md
+++ b/Fundamentals/Data/Members/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Creating Members in Umbraco"
-meta.Description: "Members are used for registering and authentication external / frontend users of an Umbraco installation. This could be Forum members and Intranet members."
+description: "Members are used for registering and authentication external / frontend users of an Umbraco installation. This could be Forum members and Intranet members."
 versionFrom: 9.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Data/Relations/index.md
+++ b/Fundamentals/Data/Relations/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Working with Relations in Umbraco"
-meta.Description: "What are relations, how to create and manage them"
+description: "What are relations, how to create and manage them"
 versionFrom: 7.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Data/Scheduled-Publishing/index.md
+++ b/Fundamentals/Data/Scheduled-Publishing/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Scheduled Publishing"
-meta.Description: "Each document in Umbraco can be scheduled for publishing and unpublishing on a pre-defined date and time."
+description: "Each document in Umbraco can be scheduled for publishing and unpublishing on a pre-defined date and time."
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Data/Users/index.md
+++ b/Fundamentals/Data/Users/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Users in Umbraco"
-meta.Description: "This guide will explain how to define, create, and manage users in the backoffice"
+description: "This guide will explain how to define, create, and manage users in the backoffice"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 

--- a/Fundamentals/Data/index.md
+++ b/Fundamentals/Data/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco Data"
-meta.Description: "This section focuses on how to create data using the Umbraco backoffice"
+description: "This section focuses on how to create data using the Umbraco backoffice"
 versionFrom: 7.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Design/Partial-View-Macro-Files/index.md
+++ b/Fundamentals/Design/Partial-View-Macro-Files/index.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 versionTo: 10.0.0
 meta.Title: "Partial View Macro Files"
-meta.Description: "Information on working with partial view macro files in Umbraco"
+description: "Information on working with partial view macro files in Umbraco"
 ---
 
 # Partial View Macro Files

--- a/Fundamentals/Design/Partial-Views/index.md
+++ b/Fundamentals/Design/Partial-Views/index.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 versionTo: 10.0.0
 meta.Title: "Partial Views"
-meta.Description: "Information on working with partial views in Umbraco"
+description: "Information on working with partial views in Umbraco"
 ---
 
 # Partial Views

--- a/Fundamentals/Design/Rendering-Media/index-v8.md
+++ b/Fundamentals/Design/Rendering-Media/index-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Rendering Media in Umbraco"
-meta.Description: "Info on rendering media items and imaging cropping"
+description: "Info on rendering media items and imaging cropping"
 keywords: v8 version8 rendering media imagecropper
 versionFrom: 8.0.0
 ---

--- a/Fundamentals/Design/Rendering-Media/index.md
+++ b/Fundamentals/Design/Rendering-Media/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Rendering Media in Umbraco"
-meta.Description: "Info on rendering media items and imaging cropping"
+description: "Info on rendering media items and imaging cropping"
 keywords: rendering media imagecropper
 versionFrom: 9.0.0
 versionTo: 10.0.0

--- a/Fundamentals/Design/Stylesheets-Javascript/index-v7.md
+++ b/Fundamentals/Design/Stylesheets-Javascript/index-v7.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Working with stylesheets and JavaScript in Umbraco"
-meta.Description: "Information on working with stylesheets and JavaScript in Umbraco, including bundling & minification"
+description: "Information on working with stylesheets and JavaScript in Umbraco, including bundling & minification"
 versionFrom: 7.0.0
 ---
 

--- a/Fundamentals/Design/Stylesheets-Javascript/index.md
+++ b/Fundamentals/Design/Stylesheets-Javascript/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Working with stylesheets and JavaScript in Umbraco"
-meta.Description: "Information on working with stylesheets and JavaScript in Umbraco, including bundling & minification"
+description: "Information on working with stylesheets and JavaScript in Umbraco, including bundling & minification"
 ---
 
 # Working with stylesheets and JavaScript

--- a/Fundamentals/Design/Templates/basic-razor-syntax-v8.md
+++ b/Fundamentals/Design/Templates/basic-razor-syntax-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Razor Syntax with Umbraco"
-meta.Description: "How to perform common logical tasks in Razor like if/else, foreach loops, switch statements and using the @ character to separate code and markup"
+description: "How to perform common logical tasks in Razor like if/else, foreach loops, switch statements and using the @ character to separate code and markup"
 versionFrom: 8.0.0
 versionTo: 8.0.0
 ---

--- a/Fundamentals/Design/Templates/basic-razor-syntax.md
+++ b/Fundamentals/Design/Templates/basic-razor-syntax.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Razor Syntax with Umbraco"
-meta.Description: "How to perform common logical tasks in Razor like if/else, foreach loops, switch statements and using the @ character to separate code and markup"
+description: "How to perform common logical tasks in Razor like if/else, foreach loops, switch statements and using the @ character to separate code and markup"
 versionFrom: 9.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Design/Templates/index.md
+++ b/Fundamentals/Design/Templates/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Templates in Umbraco"
-meta.Description: "Templating in Umbraco including inheriting from master template"
+description: "Templating in Umbraco including inheriting from master template"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Design/Templates/named-sections.md
+++ b/Fundamentals/Design/Templates/named-sections.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Named Sections in Umbraco"
-meta.Description: "Using named sections in Umbraco"
+description: "Using named sections in Umbraco"
 versionFrom: 7.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/New-in-V8.md
+++ b/Fundamentals/New-in-V8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Learn what's new in Umbraco 8"
-meta.Description: "In this section you can read about all the new features and changes in Umbraco 8."
+description: "In this section you can read about all the new features and changes in Umbraco 8."
 versionFrom: 8.0.0
 ---
 

--- a/Fundamentals/Setup/Install/Unattended-Install-v8.md
+++ b/Fundamentals/Setup/Install/Unattended-Install-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Unattended installation of Umbraco CMS"
-meta.Description: "A guide on how to install Umbraco unattended including details about the feature."
+description: "A guide on how to install Umbraco unattended including details about the feature."
 versionFrom: 8.11.0
 ---
 

--- a/Fundamentals/Setup/Install/iis.md
+++ b/Fundamentals/Setup/Install/iis.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Local IIS with Umbraco 9"
-meta.Description: "This article describes how to run an Umbraco 9 site on a local IIS server."
+description: "This article describes how to run an Umbraco 9 site on a local IIS server."
 versionFrom: 9.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Setup/Install/index-v7.md
+++ b/Fundamentals/Setup/Install/index-v7.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Installing Umbraco"
-meta.Description: "Instructions on installing Umbraco: in VS code, via NuGet or on a Mac"
+description: "Instructions on installing Umbraco: in VS code, via NuGet or on a Mac"
 ---
 
 # Installation

--- a/Fundamentals/Setup/Install/index.md
+++ b/Fundamentals/Setup/Install/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Installing Umbraco"
-meta.Description: "Instructions on installing Umbraco on various platforms using various tools."
+description: "Instructions on installing Umbraco on various platforms using various tools."
 ---
 
 # Installation

--- a/Fundamentals/Setup/Install/installing-nightly-builds.md
+++ b/Fundamentals/Setup/Install/installing-nightly-builds.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Installing Umbraco Nightly Builds"
-meta.Description: "Instructions on installing nightly builds of Umbraco."
+description: "Instructions on installing nightly builds of Umbraco."
 ---
 
 # Installing nightly builds

--- a/Fundamentals/Setup/Server-Setup/Load-Balancing/index-v8.md
+++ b/Fundamentals/Setup/Server-Setup/Load-Balancing/index-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco in Load Balanced Environments"
-meta.Description: "Information on how to deploy Umbraco in a Load Balanced scenario and other details to consider when setting up Umbraco for load balancing"
+description: "Information on how to deploy Umbraco in a Load Balanced scenario and other details to consider when setting up Umbraco for load balancing"
 versionFrom: 8.0.0
 ---
 

--- a/Fundamentals/Setup/Server-Setup/Load-Balancing/index.md
+++ b/Fundamentals/Setup/Server-Setup/Load-Balancing/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco in Load Balanced Environments"
-meta.Description: "Information on how to deploy Umbraco in a Load Balanced scenario and other details to consider when setting up Umbraco for load balancing"
+description: "Information on how to deploy Umbraco in a Load Balanced scenario and other details to consider when setting up Umbraco for load balancing"
 versionFrom: 9.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Setup/Server-Setup/iis/index.md
+++ b/Fundamentals/Setup/Server-Setup/iis/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Hosting v9+ in IIS"
-meta.Description: "Information on hosting Umbraco v9+ on IIS"
+description: "Information on hosting Umbraco v9+ on IIS"
 versionFrom: 9.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Setup/Server-Setup/index-v7.md
+++ b/Fundamentals/Setup/Server-Setup/index-v7.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Information on server setup for Umbraco hosting"
-meta.Description: "This section describes different ways of setting up servers for use with Umbraco"
+description: "This section describes different ways of setting up servers for use with Umbraco"
 versionFrom: 7.0.0
 ---
 

--- a/Fundamentals/Setup/Server-Setup/index.md
+++ b/Fundamentals/Setup/Server-Setup/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Information on server setup for Umbraco hosting"
-meta.Description: "This section describes different ways of setting up servers for use with Umbraco"
+description: "This section describes different ways of setting up servers for use with Umbraco"
 versionFrom: 9.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Setup/Server-Setup/permissions-v10.md
+++ b/Fundamentals/Setup/Server-Setup/permissions-v10.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco file and folder permissions"
-meta.Description: "Information on file and folder permissions required for Umbraco sites"
+description: "Information on file and folder permissions required for Umbraco sites"
 versionFrom: 10.0.0
 ---
 

--- a/Fundamentals/Setup/Server-Setup/permissions-v8.md
+++ b/Fundamentals/Setup/Server-Setup/permissions-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco file and folder permissions"
-meta.Description: "Information on file and folder permissions required for Umbraco sites"
+description: "Information on file and folder permissions required for Umbraco sites"
 versionFrom: 8.0.0
 ---
 

--- a/Fundamentals/Setup/Server-Setup/permissions.md
+++ b/Fundamentals/Setup/Server-Setup/permissions.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco file and folder permissions"
-meta.Description: "Information on file and folder permissions required for Umbraco sites"
+description: "Information on file and folder permissions required for Umbraco sites"
 versionFrom: 9.0.0
 ---
 

--- a/Fundamentals/Setup/Upgrading/index-v7.md
+++ b/Fundamentals/Setup/Upgrading/index-v7.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Upgrading existing installs"
-meta.Description: "Info on the steps to upgrade your copy of Umbraco to a newer version"
+description: "Info on the steps to upgrade your copy of Umbraco to a newer version"
 versionFrom: 7.0.0
 ---
 

--- a/Fundamentals/Setup/Upgrading/index.md
+++ b/Fundamentals/Setup/Upgrading/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Upgrading existing installs"
-meta.Description: "Info on the steps to upgrade your copy of Umbraco to a newer version"
+description: "Info on the steps to upgrade your copy of Umbraco to a newer version"
 versionFrom: 9.0.0
 versionTo: 10.0.0
 ---

--- a/Fundamentals/Setup/Upgrading/umbraco10-breaking-changes.md
+++ b/Fundamentals/Setup/Upgrading/umbraco10-breaking-changes.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 meta.Title: "Breaking changes going from Umbraco 9 to 10"
-meta.Description: "In this article we list the breaking changes between Umbraco 9 and 10"
+description: "In this article we list the breaking changes between Umbraco 9 and 10"
 ---
 
 # Breaking changes

--- a/Fundamentals/Setup/Upgrading/umbraco11-breaking-changes.md
+++ b/Fundamentals/Setup/Upgrading/umbraco11-breaking-changes.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 11.0.0
 meta.Title: "Breaking changes going from Umbraco 10 to 11"
-meta.Description: "In this article we list the breaking changes between Umbraco 10 and 11"
+description: "In this article we list the breaking changes between Umbraco 10 and 11"
 ---
 
 # Breaking changes

--- a/Fundamentals/Setup/index-v7.md
+++ b/Fundamentals/Setup/index-v7.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "How to install and configure your Umbraco installation"
-meta.Description: "Information on the requirements to setup, install & upgrade Umbraco"
+description: "Information on the requirements to setup, install & upgrade Umbraco"
 versionFrom: 7.0.0
 versionTo: 8.0.0
 ---

--- a/Fundamentals/Setup/index.md
+++ b/Fundamentals/Setup/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "How to install and configure your Umbraco installation"
-meta.Description: "Information on the requirements to setup, install & upgrade Umbraco"
+description: "Information on the requirements to setup, install & upgrade Umbraco"
 ---
 
 # Setup

--- a/Fundamentals/index-v8.md
+++ b/Fundamentals/index-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco Fundamentals"
-meta.Description: "This section shows you some beginner tools and information to get your started with Umbraco 8. From making a local installation to extending the backoffice."
+description: "This section shows you some beginner tools and information to get your started with Umbraco 8. From making a local installation to extending the backoffice."
 versionFrom: 7.0.0
 versionTo: 8.0.0
 ---

--- a/Fundamentals/index.md
+++ b/Fundamentals/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco Fundamentals"
-meta.Description: "This section shows you some beginner tools and information to get your started with Umbraco 8. From making a local installation to extending the backoffice."
+description: "This section shows you some beginner tools and information to get your started with Umbraco 8. From making a local installation to extending the backoffice."
 versionFrom: 9.0.0
 versionTo: 10.0.0
 ---

--- a/Getting-Started/Creating-websites-with-Umbraco/index.md
+++ b/Getting-Started/Creating-websites-with-Umbraco/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Creating websites with Umbraco" 
-meta.description: "This section shows you some beginner tools and information to get you started with Umbraco. From making a local installation to extending the backoffice."
+description: "This section shows you some beginner tools and information to get you started with Umbraco. From making a local installation to extending the backoffice."
 versionFrom: 8.0.0
 ---
 

--- a/Getting-Started/Developing-websites-with-Umbraco/Customizing-Umbraco-sites/index.md
+++ b/Getting-Started/Developing-websites-with-Umbraco/Customizing-Umbraco-sites/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Customizing Umbraco websites"
-meta.Description: "This section shows you some beginner tools and information to get your started with Umbraco. From making a local installation to extending the backoffice."
+description: "This section shows you some beginner tools and information to get your started with Umbraco. From making a local installation to extending the backoffice."
 versionFrom: 8.0.0
 ---
 # Customizing Umbraco website

--- a/Getting-Started/Developing-websites-with-Umbraco/Extending-the-Umbraco-Backoffice/index.md
+++ b/Getting-Started/Developing-websites-with-Umbraco/Extending-the-Umbraco-Backoffice/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Extending the Umbraco Backoffice" 
-meta.description: "The Umbraco backoffice itself can be customised and extended, this section is dedicated to getting started with these extension points."
+description: "The Umbraco backoffice itself can be customised and extended, this section is dedicated to getting started with these extension points."
 versionFrom: 8.0.0
 ---
 # Extending the Umbraco Backoffice

--- a/Getting-Started/Developing-websites-with-Umbraco/index.md
+++ b/Getting-Started/Developing-websites-with-Umbraco/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Developing websites with Umbraco"
-meta.Description: "This section shows you some beginner tools and information to get your started with Umbraco 8. From making a local installation to extending the backoffice."
+description: "This section shows you some beginner tools and information to get your started with Umbraco 8. From making a local installation to extending the backoffice."
 versionFrom: 8.0.0
 ---
 # Developing websites with Umbraco

--- a/Getting-Started/Editing-websites-with-Umbraco/index.md
+++ b/Getting-Started/Editing-websites-with-Umbraco/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Editing websites with Umbraco"
-meta.Description: "This section shows you some beginner tools and information to get you started with editor content in Umbraco."
+description: "This section shows you some beginner tools and information to get you started with editor content in Umbraco."
 versionFrom: 8.0.0
 ---
 

--- a/Getting-Started/Hosting-an-Umbraco-infrastructure/index.md
+++ b/Getting-Started/Hosting-an-Umbraco-infrastructure/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Hosting an Umbraco infrastructure" 
-meta.description: "Here you will find details on Azure, Umbraco Cloud, upgrading Umbraco, server configuration and system requirements."
+description: "Here you will find details on Azure, Umbraco Cloud, upgrading Umbraco, server configuration and system requirements."
 versionFrom: 8.0.0
 ---
 

--- a/Getting-Started/Managing-an-Umbraco-project/index.md
+++ b/Getting-Started/Managing-an-Umbraco-project/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Managing an Umbraco project" 
-meta.Description: "This section allows you to investigate the deployment process, the commercial options and how to best plan out an Umbraco project."
+description: "This section allows you to investigate the deployment process, the commercial options and how to best plan out an Umbraco project."
 versionFrom: 8.0.0
 ---
 

--- a/Getting-Started/Where-can-I-get-help/index.md
+++ b/Getting-Started/Where-can-I-get-help/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Where can I get help" 
-meta.description: "This section will guide you on where to find the answers for any questions you may have."
+description: "This section will guide you on where to find the answers for any questions you may have."
 versionFrom: 8.0.0
 ---
 # Where can I get help?

--- a/Getting-Started/index.md
+++ b/Getting-Started/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Getting Started" 
-meta.description: ""
+description: ""
 versionFrom: 8.0.0
 ---
 

--- a/Implementation/Composing/index-v8.md
+++ b/Implementation/Composing/index-v8.md
@@ -2,7 +2,7 @@
 keywords: composing composers components runtime boot booting v8 version8 events registering
 versionFrom: 8.0.0
 meta.Title: "Composers in Umbraco"
-meta.Description: "Customising the behaviour of an Umbraco Application at start up"
+description: "Customising the behaviour of an Umbraco Application at start up"
 ---
 
 # Composing

--- a/Implementation/Composing/index.md
+++ b/Implementation/Composing/index.md
@@ -3,7 +3,7 @@ keywords: composing composers components runtime boot booting v9 version9 events
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Composers in Umbraco"
-meta.Description: "Customising the behaviour of an Umbraco Application at start up"
+description: "Customising the behaviour of an Umbraco Application at start up"
 ---
 
 # Composing

--- a/Implementation/Controllers/index-v7.md
+++ b/Implementation/Controllers/index-v7.md
@@ -4,7 +4,7 @@ product: "UmbracoCms"
 complexity: "Intermediate"
 audience: "Developers"
 meta.Title: "Controllers in Umbraco"
-meta.Description: "An Umbraco API Controller is an ASP.NET WebApi controller that is used for creating REST services."
+description: "An Umbraco API Controller is an ASP.NET WebApi controller that is used for creating REST services."
 ---
 
 # Controllers in Umbraco

--- a/Implementation/Controllers/index.md
+++ b/Implementation/Controllers/index.md
@@ -5,7 +5,7 @@ product: "UmbracoCms"
 complexity: "Intermediate"
 audience: "Developers"
 meta.Title: "Controllers in Umbraco"
-meta.Description: "An Umbraco API Controller is an ASP.NET WebApi controller that is used for creating REST services."
+description: "An Umbraco API Controller is an ASP.NET WebApi controller that is used for creating REST services."
 ---
 
 # Controllers in Umbraco

--- a/Implementation/Custom-Routing/index-v8.md
+++ b/Implementation/Custom-Routing/index-v8.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 product: "CMS"
 meta.Title: "Custom routing in Umbraco"
-meta.Description: "There are a couple of ways of controlling the routing behavior in Umbraco: customizing how the inbound request pipeline finds content & creating custom MVC routes that integrate within the Umbraco pipeline"
+description: "There are a couple of ways of controlling the routing behavior in Umbraco: customizing how the inbound request pipeline finds content & creating custom MVC routes that integrate within the Umbraco pipeline"
 
 ---
 

--- a/Implementation/Custom-Routing/index.md
+++ b/Implementation/Custom-Routing/index.md
@@ -3,7 +3,7 @@ versionFrom: 9.0.0
 versionTo: 10.0.0
 product: "CMS"
 meta.Title: "Custom routing in Umbraco"
-meta.Description: "There are a couple of ways of controlling the routing behavior in Umbraco: customizing how the inbound request pipeline finds content & creating custom MVC routes that integrate within the Umbraco pipeline"
+description: "There are a couple of ways of controlling the routing behavior in Umbraco: customizing how the inbound request pipeline finds content & creating custom MVC routes that integrate within the Umbraco pipeline"
 
 ---
 

--- a/Implementation/Custom-Routing/signalR.md
+++ b/Implementation/Custom-Routing/signalR.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 product: "CMS"
 meta.Title: "Adding a signlR hub"
-meta.Description: "Umbraco ships with signalR installed, find out how to add your own hub(s) to the existing setup"
+description: "Umbraco ships with signalR installed, find out how to add your own hub(s) to the existing setup"
 
 ---
 

--- a/Implementation/Integration-Testing/index.md
+++ b/Implementation/Integration-Testing/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.1.0
 versionTo: 10.0.0
 meta.Title: "Integration Testing Umbraco"
-meta.Description: "A guide to getting started with integration testing in Umbraco"
+description: "A guide to getting started with integration testing in Umbraco"
 ---
 
 # Integration Testing Umbraco

--- a/Implementation/Nullable-Reference-Types/index.md
+++ b/Implementation/Nullable-Reference-Types/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 Meta.Title: Nullable Reference Types
-Meta.Description: In this article we describe what Nullable reference types is.
+description: In this article we describe what Nullable reference types is.
 ---
 
 # Nullable Reference Types

--- a/Implementation/Services/index-v8.md
+++ b/Implementation/Services/index-v8.md
@@ -2,7 +2,7 @@
 keywords: implementing services injecting di custom services service pattern UmbracoHelper reusing dry
 versionFrom: 8.0.0
 meta.Title: "Umbraco Services and Helpers"
-meta.Description: "Umbraco has a range of 'Core' Services and Helpers that act as a 'gateway' to Umbraco data and functionality to use when extending or implementing an Umbraco site"
+description: "Umbraco has a range of 'Core' Services and Helpers that act as a 'gateway' to Umbraco data and functionality to use when extending or implementing an Umbraco site"
 ---
 
 # Services and Helpers

--- a/Implementation/Services/index.md
+++ b/Implementation/Services/index.md
@@ -2,7 +2,7 @@
 keywords: implementing services injecting di custom services service pattern UmbracoHelper reusing dry
 versionFrom: 9.0.0
 meta.Title: "Umbraco Services and Helpers"
-meta.Description: "Umbraco has a range of 'Core' Services and Helpers that act as a 'gateway' to Umbraco data and functionality to use when extending or implementing an Umbraco site"
+description: "Umbraco has a range of 'Core' Services and Helpers that act as a 'gateway' to Umbraco data and functionality to use when extending or implementing an Umbraco site"
 ---
 
 # Services and Helpers

--- a/Implementation/Unit-Testing/index-v8.md
+++ b/Implementation/Unit-Testing/index-v8.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 needsV9Update: false
 meta.Title: "Unit Testing Umbraco"
-meta.Description: "A guide to getting started with unit testing in Umbraco"
+description: "A guide to getting started with unit testing in Umbraco"
 ---
 
 # Unit Testing Umbraco

--- a/Implementation/Unit-Testing/index.md
+++ b/Implementation/Unit-Testing/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.1.0
 meta.Title: "Unit Testing Umbraco"
-meta.Description: "A guide to getting started with unit testing in Umbraco"
+description: "A guide to getting started with unit testing in Umbraco"
 ---
 
 # Unit Testing Umbraco

--- a/Implementation/index-v8.md
+++ b/Implementation/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Learn how to implement an Umbraco site"
-meta.Description: "Get to know the Umbraco codebase. Developing an application requires knowledge about the tool you're working with. This section will give you an introduction to the structure of Umbraco."
+description: "Get to know the Umbraco codebase. Developing an application requires knowledge about the tool you're working with. This section will give you an introduction to the structure of Umbraco."
 ---
 # Implementation
 

--- a/Implementation/index.md
+++ b/Implementation/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Learn how to implement an Umbraco site"
-meta.Description: "Get to know the Umbraco codebase. Developing an application requires knowledge about the tool you're working with. This section will give you an introduction to the structure of Umbraco."
+description: "Get to know the Umbraco codebase. Developing an application requires knowledge about the tool you're working with. This section will give you an introduction to the structure of Umbraco."
 Links-updated: partial
 ---
 # Implementation

--- a/Reference/API-Documentation/index-v8.md
+++ b/Reference/API-Documentation/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco API Documentation"
-meta.Description: "Information on Umbraco API Documentation"
+description: "Information on Umbraco API Documentation"
 ---
 
 # API Documentation

--- a/Reference/API-Documentation/index-v9.md
+++ b/Reference/API-Documentation/index-v9.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Umbraco API Documentation"
-meta.Description: "Information on Umbraco API Documentation"
+description: "Information on Umbraco API Documentation"
 ---
 
 # API Documentation

--- a/Reference/API-Documentation/index.md
+++ b/Reference/API-Documentation/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 meta.Title: "Umbraco API Documentation"
-meta.Description: "Information on Umbraco API Documentation"
+description: "Information on Umbraco API Documentation"
 ---
 
 # API Documentation

--- a/Reference/Cache/Examples/tags-v8.md
+++ b/Reference/Cache/Examples/tags-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Working with the runtime cache in Umbraco"
-meta.Description: "Information on how to insert and delete from the runtime cache"
+description: "Information on how to insert and delete from the runtime cache"
 ---
 
 # Working with caching

--- a/Reference/Cache/Examples/tags.md
+++ b/Reference/Cache/Examples/tags.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Working with the runtime cache in Umbraco"
-meta.Description: "Information on how to insert and delete from the runtime cache"
+description: "Information on how to insert and delete from the runtime cache"
 ---
 
 # Working with caching

--- a/Reference/Common-Pitfalls/index-v11.md
+++ b/Reference/Common-Pitfalls/index-v11.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 11.0.0
 meta.Title: "Common Pitfalls and Anti-Patterns in Umbraco"
-meta.Description: "Information on common Pitfalls and Anti-Patterns in Umbraco"
+description: "Information on common Pitfalls and Anti-Patterns in Umbraco"
 ---
 
 # Common Pitfalls & Anti-Patterns

--- a/Reference/Common-Pitfalls/index-v7.md
+++ b/Reference/Common-Pitfalls/index-v7.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 needsV8Update: "true"
 meta.Title: "Common Pitfalls and Anti-Patterns in Umbraco"
-meta.Description: "Information on common Pitfalls and Anti-Patterns in Umbraco"
+description: "Information on common Pitfalls and Anti-Patterns in Umbraco"
 ---
 
 # Common Pitfalls & Anti-Patterns

--- a/Reference/Common-Pitfalls/index.md
+++ b/Reference/Common-Pitfalls/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Common Pitfalls and Anti-Patterns in Umbraco"
-meta.Description: "Information on common Pitfalls and Anti-Patterns in Umbraco"
+description: "Information on common Pitfalls and Anti-Patterns in Umbraco"
 ---
 
 # Common Pitfalls & Anti-Patterns

--- a/Reference/Configuration-for-Umbraco-7-and-8/Serilog/index.md
+++ b/Reference/Configuration-for-Umbraco-7-and-8/Serilog/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 8.0.0
 meta.Title: "Umbraco Serilog config"
-meta.Description: "Reference for the Serilog config file in Umbraco"
+description: "Reference for the Serilog config file in Umbraco"
 ---
 
 # Serilog Config

--- a/Reference/Configuration-for-Umbraco-7-and-8/fileSystemProviders/index.md
+++ b/Reference/Configuration-for-Umbraco-7-and-8/fileSystemProviders/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "FileSystemProviders in Umbraco"
-meta.Description: "Information on FileSystemProviders and how to configure them in Umbraco"
+description: "Information on FileSystemProviders and how to configure them in Umbraco"
 ---
 
 # FileSystemProviders Configuration

--- a/Reference/Configuration-for-Umbraco-7-and-8/index.md
+++ b/Reference/Configuration-for-Umbraco-7-and-8/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco configuration files"
-meta.Description: "Information on the various configuration files in Umbraco"
+description: "Information on the various configuration files in Umbraco"
 versionRemoved: 9.0.0
 ---
 

--- a/Reference/Configuration-for-Umbraco-7-and-8/nucache-settings.md
+++ b/Reference/Configuration-for-Umbraco-7-and-8/nucache-settings.md
@@ -2,7 +2,7 @@
 versionFrom: 8.6.0
 versionTo: 9.0.0
 meta.Title: "Umbraco NuCache Settings"
-meta.Description: "Information on the NuCache settings section"
+description: "Information on the NuCache settings section"
 ---
 
 # NuCache Settings

--- a/Reference/Configuration-for-Umbraco-7-and-8/tinyMceConfig/index.md
+++ b/Reference/Configuration-for-Umbraco-7-and-8/tinyMceConfig/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "tinyMce Configuration in Umbraco"
-meta.Description: "Reference on tinyMce Configuration in Umbraco"
+description: "Reference on tinyMce Configuration in Umbraco"
 ---
 
 :::note

--- a/Reference/Configuration-for-Umbraco-7-and-8/umbracoSettings/index-v7.md
+++ b/Reference/Configuration-for-Umbraco-7-and-8/umbracoSettings/index-v7.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 versionTo: 7.15.0
 meta.Title: "umbracoSettings.config options in Umbraco"
-meta.Description: "Reference on umbracoSettings.config options in Umbraco"
+description: "Reference on umbracoSettings.config options in Umbraco"
 ---
 
 # umbracoSettings

--- a/Reference/Configuration-for-Umbraco-7-and-8/umbracoSettings/index.md
+++ b/Reference/Configuration-for-Umbraco-7-and-8/umbracoSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 8.18.0
 meta.Title: "umbracoSettings.config options in Umbraco"
-meta.Description: "Reference on umbracoSettings.config options in Umbraco"
+description: "Reference on umbracoSettings.config options in Umbraco"
 ---
 
 # umbracoSettings

--- a/Reference/Configuration-for-Umbraco-7-and-8/webconfig/index.md
+++ b/Reference/Configuration-for-Umbraco-7-and-8/webconfig/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "web.config settings in Umbraco"
-meta.Description: "Reference on web.config settings in Umbraco"
+description: "Reference on web.config settings in Umbraco"
 ---
 
 # Web.config

--- a/Reference/Configuration/BasicAuthSettings/index.md
+++ b/Reference/Configuration/BasicAuthSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Basic Authentication Settings"
-meta.Description: "Information on the basic authentication section"
+description: "Information on the basic authentication section"
 ---
 
 # Basic Authentication Settings

--- a/Reference/Configuration/ConnectionStringsSettings/index-v9.md
+++ b/Reference/Configuration/ConnectionStringsSettings/index-v9.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Umbraco Connection Strings Settings"
-meta.Description: "Information on the connection strings settings section"
+description: "Information on the connection strings settings section"
 ---
 
 # Connection strings settings

--- a/Reference/Configuration/ConnectionStringsSettings/index.md
+++ b/Reference/Configuration/ConnectionStringsSettings/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 meta.Title: "Umbraco Connection Strings Settings"
-meta.Description: "Information on the connection strings settings section"
+description: "Information on the connection strings settings section"
 ---
 
 # Connection strings settings

--- a/Reference/Configuration/ContentDashboard/index.md
+++ b/Reference/Configuration/ContentDashboard/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Content Dashboard Settings"
-meta.Description: "Information on the content dashboard settings section"
+description: "Information on the content dashboard settings section"
 ---
 
 # Content Dashboard Settings

--- a/Reference/Configuration/ContentSettings/index-10.0.0.md
+++ b/Reference/Configuration/ContentSettings/index-10.0.0.md
@@ -2,7 +2,7 @@
 versionFrom: 9.4.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Content Settings"
-meta.Description: "Information on the content settings section"
+description: "Information on the content settings section"
 ---
 
 # Content Settings

--- a/Reference/Configuration/ContentSettings/index-v9.0.0.md
+++ b/Reference/Configuration/ContentSettings/index-v9.0.0.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Umbraco Content Settings"
-meta.Description: "Information on the content settings section"
+description: "Information on the content settings section"
 ---
 
 # Content Settings

--- a/Reference/Configuration/ContentSettings/index-v9.1.0.md
+++ b/Reference/Configuration/ContentSettings/index-v9.1.0.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.1.0
 meta.Title: "Umbraco Content Settings"
-meta.Description: "Information on the content settings section"
+description: "Information on the content settings section"
 ---
 
 # Content Settings

--- a/Reference/Configuration/ContentSettings/index.md
+++ b/Reference/Configuration/ContentSettings/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 11.0.0
 meta.Title: "Umbraco Content Settings"
-meta.Description: "Information on the content settings section"
+description: "Information on the content settings section"
 ---
 
 # Content Settings

--- a/Reference/Configuration/DataTypes/index.md
+++ b/Reference/Configuration/DataTypes/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 meta.Title: "Umbraco Data Types Settings"
-meta.Description: "Information on the data types settings section"
+description: "Information on the data types settings section"
 ---
 
 # Data Types Settings

--- a/Reference/Configuration/DebugSettings/index.md
+++ b/Reference/Configuration/DebugSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Debug Settings"
-meta.Description: "Information on debug settings section"
+description: "Information on debug settings section"
 ---
 
 # Debug settings

--- a/Reference/Configuration/ExamineSettings/index.md
+++ b/Reference/Configuration/ExamineSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Examine Settings"
-meta.Description: "Information on the Examine settings section"
+description: "Information on the Examine settings section"
 ---
 
 # Examine settings

--- a/Reference/Configuration/ExceptionFilterSettings/index.md
+++ b/Reference/Configuration/ExceptionFilterSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Exception Filter Settings"
-meta.Description: "Information on the exception filter settings section"
+description: "Information on the exception filter settings section"
 ---
 
 # Exception filter settings

--- a/Reference/Configuration/GlobalSettings/index-v9.md
+++ b/Reference/Configuration/GlobalSettings/index-v9.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Umbraco Global Settings"
-meta.Description: "Information on the global settings section"
+description: "Information on the global settings section"
 ---
 
 # Global Settings

--- a/Reference/Configuration/GlobalSettings/index.md
+++ b/Reference/Configuration/GlobalSettings/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 meta.Title: "Umbraco Global Settings"
-meta.Description: "Information on the global settings section"
+description: "Information on the global settings section"
 ---
 
 # Global Settings

--- a/Reference/Configuration/HealthChecks/index.md
+++ b/Reference/Configuration/HealthChecks/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Health Check Settings"
-meta.Description: "Information on the health check settings section"
+description: "Information on the health check settings section"
 ---
 
 # Health checks

--- a/Reference/Configuration/HostingSettings/index.md
+++ b/Reference/Configuration/HostingSettings/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Umbraco Hosting Settings"
-meta.Description: "Information on the hosting settings section"
+description: "Information on the hosting settings section"
 ---
 
 # Hosting settings

--- a/Reference/Configuration/ImagingSettings/index-v9.md
+++ b/Reference/Configuration/ImagingSettings/index-v9.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Umbraco Imaging Settings"
-meta.Description: "Information on the imaging settings section"
+description: "Information on the imaging settings section"
 ---
 
 

--- a/Reference/Configuration/ImagingSettings/index.md
+++ b/Reference/Configuration/ImagingSettings/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 meta.Title: "Umbraco Imaging Settings"
-meta.Description: "Information on the imaging settings section"
+description: "Information on the imaging settings section"
 ---
 
 

--- a/Reference/Configuration/InstallDefaultDataSettings/index.md
+++ b/Reference/Configuration/InstallDefaultDataSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Install Default Data Settings"
-meta.Description: "Information on configuration allowing for the modification of default data installed in new projects"
+description: "Information on configuration allowing for the modification of default data installed in new projects"
 ---
 
 # Install Default Data Settings

--- a/Reference/Configuration/KeepAliveSettings/index.md
+++ b/Reference/Configuration/KeepAliveSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Keep Alive Settings"
-meta.Description: "Information on the keep alive settings section"
+description: "Information on the keep alive settings section"
 ---
 
 # Keep alive settings

--- a/Reference/Configuration/LoggingSettings/index.md
+++ b/Reference/Configuration/LoggingSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Logging Settings"
-meta.Description: "Information on the logging settings section"
+description: "Information on the logging settings section"
 ---
 
 # Logging settings

--- a/Reference/Configuration/MaximumUploadSizeSettings/index.md
+++ b/Reference/Configuration/MaximumUploadSizeSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Maximum upload size settings"
-meta.Description: "Information on how to change the default cap of upload size"
+description: "Information on how to change the default cap of upload size"
 ---
 
 Umbraco does not touch the default maximum allowed content size of the different services, but you can configure this yourself.

--- a/Reference/Configuration/ModelsBuilderSettings/index.md
+++ b/Reference/Configuration/ModelsBuilderSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Models Builder Settings"
-meta.Description: "Information on the models builder settings section"
+description: "Information on the models builder settings section"
 ---
 
 # Models builder settings

--- a/Reference/Configuration/NuCacheSettings/index.md
+++ b/Reference/Configuration/NuCacheSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco NuCache Settings"
-meta.Description: "Information on the NuCache settings section"
+description: "Information on the NuCache settings section"
 ---
 
 # NuCache Settings

--- a/Reference/Configuration/PackageMigrationSettings/index.md
+++ b/Reference/Configuration/PackageMigrationSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.1
 versionTo: 10.0.0
 meta.Title: "Umbraco Package Migration Settings"
-meta.Description: "Information on the package migration settings section"
+description: "Information on the package migration settings section"
 ---
 
 # Package Migration

--- a/Reference/Configuration/PluginsSettings/index.md
+++ b/Reference/Configuration/PluginsSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Plugins Settings"
-meta.Description: "Information on the plugins settings section"
+description: "Information on the plugins settings section"
 ---
 
 # Plugins settings

--- a/Reference/Configuration/RequestHandlerSettings/index.md
+++ b/Reference/Configuration/RequestHandlerSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Request Handler Settings"
-meta.Description: "Information on the request handler settings section"
+description: "Information on the request handler settings section"
 ---
 
 # Request handler settings

--- a/Reference/Configuration/RichTextEditorSettings/index.md
+++ b/Reference/Configuration/RichTextEditorSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Rich Text Editor Settings"
-meta.Description: "Information on the Rich text editor settings section"
+description: "Information on the Rich text editor settings section"
 ---
 
 # Rich text editor settings

--- a/Reference/Configuration/RuntimeMinificationSettings/index.md
+++ b/Reference/Configuration/RuntimeMinificationSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Runtime Minification Settings"
-meta.Description: "Information on the runtime minification settings section"
+description: "Information on the runtime minification settings section"
 ---
 
 # Runtime minification settings

--- a/Reference/Configuration/RuntimeSettings/index.md
+++ b/Reference/Configuration/RuntimeSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Runtime Settings"
-meta.Description: "Information on the runtime settings section"
+description: "Information on the runtime settings section"
 ---
 
 # Runtime settings

--- a/Reference/Configuration/SecuritySettings/index.md
+++ b/Reference/Configuration/SecuritySettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Security Settings"
-meta.Description: "Information on the security settings section"
+description: "Information on the security settings section"
 ---
 
 # Security Settings

--- a/Reference/Configuration/Serilog/index.md
+++ b/Reference/Configuration/Serilog/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Umbraco Serilog Settings"
-meta.Description: "Information on the serilog settings section"
+description: "Information on the serilog settings section"
 ---
 
 # Serilog settings

--- a/Reference/Configuration/ToursSettings/index.md
+++ b/Reference/Configuration/ToursSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Tours Settings"
-meta.Description: "Information on the tours settings section"
+description: "Information on the tours settings section"
 ---
 
 # Tours settings

--- a/Reference/Configuration/TypeFinderSettings/index.md
+++ b/Reference/Configuration/TypeFinderSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Type Finder Settings"
-meta.Description: "Information on the type finder settings section"
+description: "Information on the type finder settings section"
 ---
 
 # Type finder settings

--- a/Reference/Configuration/UnattendedSettings/index.md
+++ b/Reference/Configuration/UnattendedSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Unattended Settings"
-meta.Description: "Information on the unattended settings section"
+description: "Information on the unattended settings section"
 ---
 
 # Unattended

--- a/Reference/Configuration/WebRoutingSettings/index.md
+++ b/Reference/Configuration/WebRoutingSettings/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Web Routing Settings"
-meta.Description: "Information on the web routing settings section"
+description: "Information on the web routing settings section"
 ---
 
 # Web routing

--- a/Reference/Configuration/filesystemProviders.md
+++ b/Reference/Configuration/filesystemProviders.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "FileSystemProviders in Umbraco"
-meta.Description: "Information on FileSystemProviders and how to configure them in Umbraco"
+description: "Information on FileSystemProviders and how to configure them in Umbraco"
 ---
 
 # FileSystemProviders Configuration

--- a/Reference/Configuration/index.md
+++ b/Reference/Configuration/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco configuration"
-meta.Description: "Information on configuring Umbraco"
+description: "Information on configuring Umbraco"
 ---
 
 :::note

--- a/Reference/Debugging/index-v8.md
+++ b/Reference/Debugging/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.1.0
 meta.Title: "Debugging with SourceLink"
-meta.Description: "Information on SourceLink and how to use it to debug the Umbraco CMS source code"
+description: "Information on SourceLink and how to use it to debug the Umbraco CMS source code"
 ---
 
 # Debugging with SourceLink

--- a/Reference/Debugging/index.md
+++ b/Reference/Debugging/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Debugging with SourceLink"
-meta.Description: "Information on SourceLink and how to use it to debug the Umbraco CMS source code"
+description: "Information on SourceLink and how to use it to debug the Umbraco CMS source code"
 ---
 
 # Debugging with SourceLink

--- a/Reference/Events/Application-Startup.md
+++ b/Reference/Events/Application-Startup.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Handling application startup events in Umbraco"
-meta.Description: "How to handle application startup events in Umbraco"
+description: "How to handle application startup events in Umbraco"
 ---
 
 # Application startup

--- a/Reference/Events/CacheRefresher-Events.md
+++ b/Reference/Events/CacheRefresher-Events.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionRemoved: 9.0.0
 meta.Title: "Umbraco CacheRefresher Events"
-meta.Description: "Information on the various CacheRefresher events available"
+description: "Information on the various CacheRefresher events available"
 ---
 
 # CacheRefresher Events

--- a/Reference/Events/ContentService-Events/index.md
+++ b/Reference/Events/ContentService-Events/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionRemoved: 9.0.0
 meta.Title: "Umbraco ContentService Events"
-meta.Description: "Information on the various events available in the ContentService"
+description: "Information on the various events available in the ContentService"
 ---
 
 # ContentService Events

--- a/Reference/Events/DataTypeService-Events/index.md
+++ b/Reference/Events/DataTypeService-Events/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco DataTypeService Events"
-meta.Description: "Information on the various events available in the DataTypeService"
+description: "Information on the various events available in the DataTypeService"
 ---
 
 # DataTypeService Events

--- a/Reference/Events/EditorModel-Events/index.md
+++ b/Reference/Events/EditorModel-Events/index.md
@@ -3,7 +3,7 @@ keywords: EditorModelEventManager setting default values defaultvalue
 versionFrom: 8.0.0
 versionRemoved: 9.0.0
 meta.Title: "EditorModel Events - or how to set a default value"
-meta.Description: "Explanation of how handle the EditorModelEventManager SendingContent event to set an initial default value for a propery when the editor creates a new content item in the backoffice"
+description: "Explanation of how handle the EditorModelEventManager SendingContent event to set an initial default value for a propery when the editor creates a new content item in the backoffice"
 ---
 
 # EditorModel Events

--- a/Reference/Events/MediaService-Events/index.md
+++ b/Reference/Events/MediaService-Events/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionRemoved: 9.0.0
 meta.Title: "Umbraco MediaService Events"
-meta.Description: "Information on the various events available in the MediaService"
+description: "Information on the various events available in the MediaService"
 ---
 
 # MediaService Events

--- a/Reference/Events/MemberService-Events/index.md
+++ b/Reference/Events/MemberService-Events/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionRemoved: 9.0.0
 meta.Title: "Umbraco MemberService Events"
-meta.Description: "Information on the various events available in the MemberService"
+description: "Information on the various events available in the MemberService"
 ---
 
 # MemberService Events

--- a/Reference/Events/determining-new-entity.md
+++ b/Reference/Events/determining-new-entity.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionRemoved: 9.0.0
 meta.Title: "Determining whether an entity is new in Umbraco"
-meta.Description: "How to determine whether an entity is new in Umbraco"
+description: "How to determine whether an entity is new in Umbraco"
 ---
 
 # Determining if an entity is new

--- a/Reference/Events/index.md
+++ b/Reference/Events/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco events"
-meta.Description: "Information on various backoffice events in Umbraco"
+description: "Information on various backoffice events in Umbraco"
 versionRemoved: 9.0.0
 ---
 

--- a/Reference/Management/Models/Content.md
+++ b/Reference/Management/Models/Content.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Content Model"
-meta.Description: "The Content class represents a single item in the content tree, its values are fetched directly from the database, not from the cache." 
+description: "The Content class represents a single item in the content tree, its values are fetched directly from the database, not from the cache." 
 ---
 
 # Content

--- a/Reference/Management/Models/ContentType.md
+++ b/Reference/Management/Models/ContentType.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "ContentType Model"
-meta.Description: "A ContentType corresponds to the Document Type found in the backoffice."
+description: "A ContentType corresponds to the Document Type found in the backoffice."
 ---
 
 # ContentType

--- a/Reference/Management/Models/DataType.md
+++ b/Reference/Management/Models/DataType.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "DataType Model"
-meta.Description: "A DataType is what you see in the backoffice in the Settings / DataTypes tree. The listed nodes are definitions of the DataTypes that are available to use on your PropertyTypes."
+description: "A DataType is what you see in the backoffice in the Settings / DataTypes tree. The listed nodes are definitions of the DataTypes that are available to use on your PropertyTypes."
 ---
 
 # DataType

--- a/Reference/Management/Models/DictionaryItem.md
+++ b/Reference/Management/Models/DictionaryItem.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "DictionaryItem Model"
-meta.Description: "Represents a Dictionary Item. A Dictionary Item is what you see in the Translation / Dictionary tree."
+description: "Represents a Dictionary Item. A Dictionary Item is what you see in the Translation / Dictionary tree."
 ---
 
 # DictionaryItem

--- a/Reference/Management/Models/Language.md
+++ b/Reference/Management/Models/Language.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Language Model"
-meta.Description: "Represents a Language. Installed languages can be found in the settings section."
+description: "Represents a Language. Installed languages can be found in the settings section."
 ---
 
 # Language

--- a/Reference/Management/Models/Media.md
+++ b/Reference/Management/Models/Media.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Media Model"
-meta.Description: "The Media class represents a single item in the media tree."
+description: "The Media class represents a single item in the media tree."
 ---
 
 # Media

--- a/Reference/Management/Models/MediaType.md
+++ b/Reference/Management/Models/MediaType.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "MediaType Model"
-meta.Description: "A MediaType is almost the same as a ContentType. I.e. a model / data definition for your media nodes."
+description: "A MediaType is almost the same as a ContentType. I.e. a model / data definition for your media nodes."
 ---
 
 # MediaType

--- a/Reference/Management/Models/Relation.md
+++ b/Reference/Management/Models/Relation.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Relation Model"
-meta.Description: "Represents a Relation between two items."
+description: "Represents a Relation between two items."
 ---
 
 # Relation

--- a/Reference/Management/Models/RelationType.md
+++ b/Reference/Management/Models/RelationType.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "RelationType Model"
-meta.Description: "The `RelationType` class represents a relation definition between two node types (content or media)."
+description: "The `RelationType` class represents a relation definition between two node types (content or media)."
 ---
 # RelationType
 

--- a/Reference/Management/Models/ServerRegistration.md
+++ b/Reference/Management/Models/ServerRegistration.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "ServerRegistration"
-meta.Description: "Represents a registered server in a multiple-servers environment."
+description: "Represents a registered server in a multiple-servers environment."
 ---
 
 # ServerRegistration

--- a/Reference/Management/Models/Template.md
+++ b/Reference/Management/Models/Template.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Template Model"
-meta.Description: "Represents a Template file."
+description: "Represents a Template file."
 ---
 
 # Template

--- a/Reference/Management/Services/UserService/Create-a-new-user-vpre7.7.md
+++ b/Reference/Management/Services/UserService/Create-a-new-user-vpre7.7.md
@@ -1,7 +1,7 @@
 ---
 versionTo: 7.7.0
 meta.Title: "Creating a new user with the UserService"
-meta.Description: "This will show you how to create a new user using the UserService in Umbraco."
+description: "This will show you how to create a new user using the UserService in Umbraco."
 ---
 # Create a new user
 

--- a/Reference/Management/Services/UserService/Create-a-new-user.md
+++ b/Reference/Management/Services/UserService/Create-a-new-user.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.7.0
 meta.Title: "Creating a new user with the UserService"
-meta.Description: "This will show you how to create a new user using the UserService in Umbraco."
+description: "This will show you how to create a new user using the UserService in Umbraco."
 needsV8Update: "true"
 ---
 # Creating a user

--- a/Reference/Notifications/Creating-And-Publishing-Notifications/index-v11.md
+++ b/Reference/Notifications/Creating-And-Publishing-Notifications/index-v11.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 11.0.0
 meta-title: Creating and Publishing Custom Notifications
-meta.Description: How to create and publish your own custom notifications
+description: How to create and publish your own custom notifications
 ---
 
 # Creating And Publishing Custom Notifications

--- a/Reference/Notifications/Creating-And-Publishing-Notifications/index-v9.md
+++ b/Reference/Notifications/Creating-And-Publishing-Notifications/index-v9.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 9.0.0
 meta-title: Creating and Publishing Custom Notifications
-meta.Description: How to create and publish your own custom notifications
+description: How to create and publish your own custom notifications
 ---
 
 # Creating And Publishing Custom Notifications

--- a/Reference/Notifications/Creating-And-Publishing-Notifications/index.md
+++ b/Reference/Notifications/Creating-And-Publishing-Notifications/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 meta-title: Creating and Publishing Custom Notifications
-meta.Description: How to create and publish your own custom notifications
+description: How to create and publish your own custom notifications
 ---
 
 # Creating And Publishing Custom Notifications

--- a/Reference/Notifications/UmbracoApplicationLifetime-Notifications/index.md
+++ b/Reference/Notifications/UmbracoApplicationLifetime-Notifications/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.3.0
 versionTo: 10.0.0
 meta-title: Umbraco Application Lifetime Notifications
-meta.Description: Represents an Umbraco application lifetime (starting, started, stopping, stopped) notification
+description: Represents an Umbraco application lifetime (starting, started, stopping, stopped) notification
 ---
 
 # Umbraco Application Lifetime Notifications

--- a/Reference/Querying/IMemberManager/index.md
+++ b/Reference/Querying/IMemberManager/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco IMemberManager"
-meta.Description: "Using the IMemberManager1"
+description: "Using the IMemberManager1"
 ---
 
 # IMemberManager

--- a/Reference/Querying/IPublishedContentQuery/index.md
+++ b/Reference/Querying/IPublishedContentQuery/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco IPublishedContentQuery"
-meta.Description: "Querying in views with IPublishedContentQuery in Umbraco"
+description: "Querying in views with IPublishedContentQuery in Umbraco"
 ---
 
 # IPublishedContentQuery

--- a/Reference/Querying/ITagQuery/index.md
+++ b/Reference/Querying/ITagQuery/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Tag Query"
-meta.Description: "Working with tags in Umbraco"
+description: "Working with tags in Umbraco"
 ---
 
 # ITagQuery

--- a/Reference/Querying/UmbracoContext/index.md
+++ b/Reference/Querying/UmbracoContext/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Umbraco Request Context"
-meta.Description: "The UmbracoContext is a helpful service provided on each request to the website"
+description: "The UmbracoContext is a helpful service provided on each request to the website"
 ---
 
 # UmbracoContext helper

--- a/Reference/Querying/UmbracoHelper/index.md
+++ b/Reference/Querying/UmbracoHelper/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Helper"
-meta.Description: "Using the Umbraco Helper"
+description: "Using the Umbraco Helper"
 ---
 
 # UmbracoHelper

--- a/Reference/Routing/Authorized/index.md
+++ b/Reference/Routing/Authorized/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Routing Requirements for Backoffice authentication"
-meta.Description: "Requirements for authenticating requests for the backoffice"
+description: "Requirements for authenticating requests for the backoffice"
 ---
 
 # Routing requirements for backoffice authentication

--- a/Reference/Routing/Custom-Controllers/index.md
+++ b/Reference/Routing/Custom-Controllers/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta-title: "Umbraco Route Hijacking"
-meta.Description: "Use a custom controller to handle and control incoming requests for content pages based on a specific Document Type"
+description: "Use a custom controller to handle and control incoming requests for content pages based on a specific Document Type"
 ---
 
 # Custom MVC controllers (Umbraco Route Hijacking)

--- a/Reference/Routing/Custom-Routes/index.md
+++ b/Reference/Routing/Custom-Routes/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Custom Umbraco Routes"
-meta.Description: "Setting up your own controllers and routes that exist alongside the Umbraco pipeline"
+description: "Setting up your own controllers and routes that exist alongside the Umbraco pipeline"
 ---
 
 # Custom MVC Routes

--- a/Reference/Routing/Request-Pipeline/IContentFinder.md
+++ b/Reference/Routing/Request-Pipeline/IContentFinder.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Creating content finders"
-meta.Description: "Information about creating your own content finders"
+description: "Information about creating your own content finders"
 ---
 
 # IContentFinder

--- a/Reference/Routing/Request-Pipeline/inbound-pipeline.md
+++ b/Reference/Routing/Request-Pipeline/inbound-pipeline.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Inbound request pipeline"
-meta.Description: "How the Umbraco inbound request pipeline works"
+description: "How the Umbraco inbound request pipeline works"
 ---
 
 # Inbound request pipeline

--- a/Reference/Routing/Request-Pipeline/index.md
+++ b/Reference/Routing/Request-Pipeline/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Routing in Umbraco"
-meta.Description: "What the Umbraco Request Pipeline is"
+description: "What the Umbraco Request Pipeline is"
 ---
 
 # Routing in Umbraco

--- a/Reference/Routing/Request-Pipeline/outbound-pipeline.md
+++ b/Reference/Routing/Request-Pipeline/outbound-pipeline.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Outbound request pipeline"
-meta.Description: "How the Umbraco outbound request pipeline works"
+description: "How the Umbraco outbound request pipeline works"
 ---
 # Outbound request pipeline
 

--- a/Reference/Routing/Request-Pipeline/published-content-request-preparation.md
+++ b/Reference/Routing/Request-Pipeline/published-content-request-preparation.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Published Content Request Preparation"
-meta.Description: "How Umbraco prepares content requests"
+description: "How Umbraco prepares content requests"
 ---
 
 # Published Content Request Preparation

--- a/Reference/Routing/Routing-Properties/index.md
+++ b/Reference/Routing/Routing-Properties/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Special Property Type Aliases for Routing"
-meta.Description: "Describes special property type aliases which can be used to customise routing"
+description: "Describes special property type aliases which can be used to customise routing"
 ---
 
 # Special Property Type aliases for routing

--- a/Reference/Routing/Surface-Controllers/index-v8.md
+++ b/Reference/Routing/Surface-Controllers/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Surface Controllers"
-meta.Description: "Information about Surface Controllers in Umbraco"
+description: "Information about Surface Controllers in Umbraco"
 ---
 
 # Surface controllers

--- a/Reference/Routing/Surface-Controllers/index.md
+++ b/Reference/Routing/Surface-Controllers/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Surface Controllers"
-meta.Description: "Information about Surface Controllers in Umbraco"
+description: "Information about Surface Controllers in Umbraco"
 ---
 
 # Surface controllers

--- a/Reference/Routing/Surface-Controllers/surface-controllers-actions-v8.md
+++ b/Reference/Routing/Surface-Controllers/surface-controllers-actions-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Surface Controller Actions"
-meta.Description: "Information about Surface Controller Actions Result Helpers in Umbraco"
+description: "Information about Surface Controller Actions Result Helpers in Umbraco"
 ---
 
 # Surface controller actions

--- a/Reference/Routing/Surface-Controllers/surface-controllers-actions.md
+++ b/Reference/Routing/Surface-Controllers/surface-controllers-actions.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Surface Controller Actions"
-meta.Description: "Information about Surface Controller Actions Result Helpers in Umbraco"
+description: "Information about Surface Controller Actions Result Helpers in Umbraco"
 ---
 
 # Surface controller actions

--- a/Reference/Routing/URL-Tracking/index.md
+++ b/Reference/Routing/URL-Tracking/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "URL Redirect Management"
-meta.Description: "URL redirect management in Umbraco"
+description: "URL redirect management in Umbraco"
 ---
 
 # URL Redirect Management

--- a/Reference/Routing/Umbraco-API-Controllers/authorization.md
+++ b/Reference/Routing/Umbraco-API-Controllers/authorization.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco WebApi Authorization"
-meta.Description: "How to secure your Umbraco Api controllers"
+description: "How to secure your Umbraco Api controllers"
 ---
 
 

--- a/Reference/Routing/Umbraco-API-Controllers/index-v8.md
+++ b/Reference/Routing/Umbraco-API-Controllers/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco WebApi Routing"
-meta.Description: "A guide to implenting WebApi in Umbraco projects"
+description: "A guide to implenting WebApi in Umbraco projects"
 ---
 
 # Umbraco Api

--- a/Reference/Routing/Umbraco-API-Controllers/index.md
+++ b/Reference/Routing/Umbraco-API-Controllers/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco WebApi"
-meta.Description: "A guide to implenting WebApi in Umbraco projects"
+description: "A guide to implenting WebApi in Umbraco projects"
 ---
 
 # Umbraco API Controllers

--- a/Reference/Routing/Umbraco-API-Controllers/routing.md
+++ b/Reference/Routing/Umbraco-API-Controllers/routing.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco WebApi Routing & Urls"
-meta.Description: "How api controllers are routed and how to retrieve their URLs"
+description: "How api controllers are routed and how to retrieve their URLs"
 ---
 
 # Umbraco Api - Routing & Urls

--- a/Reference/Routing/index.md
+++ b/Reference/Routing/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 9.0.0
 meta.Title: "Routing & Controllers Reference"
-meta.Description: "All about Umbraco's routing pipeline & the types of Controllers used in Umbraco"
+description: "All about Umbraco's routing pipeline & the types of Controllers used in Umbraco"
 ---
 
 # Routing & Controllers

--- a/Reference/Scheduling/index-v11.md
+++ b/Reference/Scheduling/index-v11.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 11.0.0
 meta.title: "Scheduling with hosted services in Umbraco"
-meta.Description: "Use hosted services to run a background task"
+description: "Use hosted services to run a background task"
 ---
 
 # Scheduling with RecurringHostedServiceBase

--- a/Reference/Scheduling/index.md
+++ b/Reference/Scheduling/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.title: "Scheduling with hosted services in Umbraco"
-meta.Description: "Use hosted services to run a background task"
+description: "Use hosted services to run a background task"
 ---
 
 # Scheduling with RecurringHostedServiceBase

--- a/Reference/Security/BackOfficeUserManager-and-Notifications/index-v7.3.0.md
+++ b/Reference/Security/BackOfficeUserManager-and-Notifications/index-v7.3.0.md
@@ -2,7 +2,7 @@
 versionFrom: 7.3.0
 versionTo: 8.9.0
 meta.Title: "BackOfficeUserManager and Events"
-meta.Description: "The BackOfficeUserManager is the ASP.NET Identity UserManager implementation in Umbraco. It exposes APIs for working with Umbraco User's via the ASP.NET Identity including password handling."
+description: "The BackOfficeUserManager is the ASP.NET Identity UserManager implementation in Umbraco. It exposes APIs for working with Umbraco User's via the ASP.NET Identity including password handling."
 ---
 
 # BackOfficeUserManager and Events

--- a/Reference/Security/BackOfficeUserManager-and-Notifications/index-v8.9.md
+++ b/Reference/Security/BackOfficeUserManager-and-Notifications/index-v8.9.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.9.0
 meta.Title: "BackOfficeUserManager and Events"
-meta.Description: "The BackOfficeUserManager is the ASP.NET Identity UserManager implementation in Umbraco. It exposes APIs for working with Umbraco User's via the ASP.NET Identity including password handling."
+description: "The BackOfficeUserManager is the ASP.NET Identity UserManager implementation in Umbraco. It exposes APIs for working with Umbraco User's via the ASP.NET Identity including password handling."
 ---
 
 # BackOfficeUserManager and Events

--- a/Reference/Security/BackOfficeUserManager-and-Notifications/index.md
+++ b/Reference/Security/BackOfficeUserManager-and-Notifications/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "BackOfficeUserManager and Notifications"
-meta.Description: "The BackOfficeUserManager is the ASP.NET Core Identity UserManager implementation in Umbraco. It exposes APIs for working with Umbraco User's via the ASP.NET Core Identity including password handling."
+description: "The BackOfficeUserManager is the ASP.NET Core Identity UserManager implementation in Umbraco. It exposes APIs for working with Umbraco User's via the ASP.NET Core Identity including password handling."
 ---
 
 # BackOfficeUserManager and Events

--- a/Reference/Security/External-login-providers/index-v7.md
+++ b/Reference/Security/External-login-providers/index-v7.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.3.0
 meta.Title: "External login providers"
-meta.Description: "The Umbraco backoffice supports external login providers (OAuth) for performing authentication of your users. This could be any OpenIDConnect provider such as Azure Active Directory, Identity Server, Google or Facebook."
+description: "The Umbraco backoffice supports external login providers (OAuth) for performing authentication of your users. This could be any OpenIDConnect provider such as Azure Active Directory, Identity Server, Google or Facebook."
 ---
 
 # External login providers

--- a/Reference/Security/External-login-providers/index-vpre-9.3.0.md
+++ b/Reference/Security/External-login-providers/index-vpre-9.3.0.md
@@ -3,7 +3,7 @@ versionFrom: 9.0.0
 versionTo: 9.2.0
 keywords: oauth, security
 meta.Title: "External login providers"
-meta.Description: "The Umbraco backoffice supports external login providers (OAuth) for performing authentication of your users. This could be any OpenIDConnect provider such as Azure Active Directory, Identity Server, Google or Facebook."
+description: "The Umbraco backoffice supports external login providers (OAuth) for performing authentication of your users. This could be any OpenIDConnect provider such as Azure Active Directory, Identity Server, Google or Facebook."
 ---
 
 # External login providers

--- a/Reference/Security/External-login-providers/index.md
+++ b/Reference/Security/External-login-providers/index.md
@@ -3,7 +3,7 @@ versionFrom: 9.3.0
 versionTo: 10.0.0
 keywords: oauth, security
 meta.Title: "External login providers"
-meta.Description: "Umbraco supports supports external login providers (OAuth) for performing authentication of your users and members. This could be any OpenIDConnect provider such as Azure Active Directory, Identity Server, Google or Facebook."
+description: "Umbraco supports supports external login providers (OAuth) for performing authentication of your users and members. This could be any OpenIDConnect provider such as Azure Active Directory, Identity Server, Google or Facebook."
 ---
 
 # External login providers

--- a/Reference/Security/SSL-HTTPS/index-v8.md
+++ b/Reference/Security/SSL-HTTPS/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Learn how to enforce the use of HTTPS UseHttps on your Umbraco websites."
-meta.Description: "In production environments it is highly recommend that you enforce the use of HTTPS (UseHttps). It grealy increases the general trust of your site and guards you against various attacks, like 'Man in the middle' and phising attacks."
+description: "In production environments it is highly recommend that you enforce the use of HTTPS (UseHttps). It grealy increases the general trust of your site and guards you against various attacks, like 'Man in the middle' and phising attacks."
 ---
 
 # HTTPS

--- a/Reference/Security/SSL-HTTPS/index.md
+++ b/Reference/Security/SSL-HTTPS/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Learn how to enforce the use of HTTPS (UseHttps) on your Umbraco websites."
-meta.Description: "In production environments it is highly recommend that you enforce the use of HTTPS (UseHttps). It grealy increases the general trust of your site and guards you against various attacks, like 'Man in the middle' and phising attacks."
+description: "In production environments it is highly recommend that you enforce the use of HTTPS (UseHttps). It grealy increases the general trust of your site and guards you against various attacks, like 'Man in the middle' and phising attacks."
 ---
 
 # HTTPS

--- a/Reference/Security/Serverside-sanitizing/index-v8.md
+++ b/Reference/Security/Serverside-sanitizing/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.18.0
 meta.Title: "Serverside Sanitizing"
-meta.Description: "This section describes how to sanitize the Rich Text Editor serverside"
+description: "This section describes how to sanitize the Rich Text Editor serverside"
 ---
 
 # Sanitizing the Rich Text Editor

--- a/Reference/Security/Serverside-sanitizing/index.md
+++ b/Reference/Security/Serverside-sanitizing/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.3.0
 versionTo: 10.0.0
 meta.Title: "Serverside Sanitizing"
-meta.Description: "This section describes how to sanitize the Rich Text Editor serverside"
+description: "This section describes how to sanitize the Rich Text Editor serverside"
 ---
 
 # Sanitizing the Rich Text Editor

--- a/Reference/Security/Two-factor-authentication/index-v9.3.0.md
+++ b/Reference/Security/Two-factor-authentication/index-v9.3.0.md
@@ -2,7 +2,7 @@
 versionFrom: 9.3.0
 keywords: 2fa, security, members
 meta.Title: "Two-factor authentication"
-meta.Description: "Umbraco users and members support a two-factor authentication (2FA) abstraction for implementing a 2FA provider of your choice"
+description: "Umbraco users and members support a two-factor authentication (2FA) abstraction for implementing a 2FA provider of your choice"
 ---
 
 # Two-factor authentication for Members

--- a/Reference/Security/Two-factor-authentication/index.md
+++ b/Reference/Security/Two-factor-authentication/index.md
@@ -3,7 +3,7 @@ versionFrom: 9.5.0
 versionTo: 10.0.0
 keywords: 2fa, security, members, users
 meta.Title: "Two-factor authentication"
-meta.Description: "Umbraco users and members support a two-factor authentication (2FA) abstraction for implementing a 2FA provider of your choice"
+description: "Umbraco users and members support a two-factor authentication (2FA) abstraction for implementing a 2FA provider of your choice"
 ---
 
 # Two-factor Authentication

--- a/Reference/Security/index-v7.md
+++ b/Reference/Security/index-v7.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Security in Umbraco"
-meta.Description: "This section includes information on Umbraco security, its various security options and configuring how authentication & authorization works in Umbraco"
+description: "This section includes information on Umbraco security, its various security options and configuring how authentication & authorization works in Umbraco"
 ---
 
 # Security

--- a/Reference/Security/index-v8.md
+++ b/Reference/Security/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Security in Umbraco"
-meta.Description: "This section includes information on Umbraco security, its various security options and configuring how authentication & authorization works in Umbraco"
+description: "This section includes information on Umbraco security, its various security options and configuring how authentication & authorization works in Umbraco"
 ---
 
 # Security

--- a/Reference/Security/index.md
+++ b/Reference/Security/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Security in Umbraco"
-meta.Description: "This section includes information on Umbraco security, its various security options and configuring how authentication & authorization works in Umbraco"
+description: "This section includes information on Umbraco security, its various security options and configuring how authentication & authorization works in Umbraco"
 ---
 
 # Security

--- a/Reference/Templating/Modelsbuilder/Builder-Modes.md
+++ b/Reference/Templating/Modelsbuilder/Builder-Modes.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Modelsbuilder Modes"
-meta.Description: "Modelsbuilder modes"
+description: "Modelsbuilder modes"
 ---
 
 # Builder Modes

--- a/Reference/Templating/Modelsbuilder/CoolThingsWithModels.md
+++ b/Reference/Templating/Modelsbuilder/CoolThingsWithModels.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Cool Things to do With Models"
-meta.Description: "Cool things you can do with models"
+description: "Cool things you can do with models"
 ---
 # Cool things you can do with strongly-typed models
 

--- a/Reference/Templating/Modelsbuilder/Introduction.md
+++ b/Reference/Templating/Modelsbuilder/Introduction.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Modelsbuilder Introduction"
-meta.Description: "Modelsbuilder introduction"
+description: "Modelsbuilder introduction"
 ---
 
 # Umbraco Models Builder Introduction

--- a/Reference/Templating/Modelsbuilder/Understand-And-Extend.md
+++ b/Reference/Templating/Modelsbuilder/Understand-And-Extend.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Understand and Extend Modelsbuilder"
-meta.Description: "Understand and extend modelsbuilder"
+description: "Understand and extend modelsbuilder"
 ---
 
 

--- a/Reference/Templating/Modelsbuilder/Using-Interfaces.md
+++ b/Reference/Templating/Modelsbuilder/Using-Interfaces.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Using Modelsbuilder interfaces"
-meta.Description: "Using interfaces with modelsbuilder"
+description: "Using interfaces with modelsbuilder"
 ---
 
 # Using Interfaces

--- a/Reference/Templating/Modelsbuilder/configuration.md
+++ b/Reference/Templating/Modelsbuilder/configuration.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "ModelsBuilder Configuration"
-meta.Description: "Explanation of how to configure models builder"
+description: "Explanation of how to configure models builder"
 ---
 
 # Configuration

--- a/Reference/Templating/Modelsbuilder/index.md
+++ b/Reference/Templating/Modelsbuilder/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Modelsbuilder Reference"
-meta.Description: "Modelsbuilder reference"
+description: "Modelsbuilder reference"
 ---
 
 

--- a/Reference/Using-Ioc/index.md
+++ b/Reference/Using-Ioc/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Umbraco Dependency Injection"
-meta.Description: "Inversion of Control/Dependency Injection in Umbraco"
+description: "Inversion of Control/Dependency Injection in Umbraco"
 ---
 
 # Inversion of Control / Dependency injection

--- a/Reference/index-v7.md
+++ b/Reference/index-v7.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Reference section for the Umbraco APIs"
-meta.Description: "Developers' Reference primarily consists of API references of the different core Umbraco APIs. In many cases, the references come with code snippets with simple examples. For a more in-depth study of the different APIs, consult the using-umbraco and extending-umbraco sections of the documentation."
+description: "Developers' Reference primarily consists of API references of the different core Umbraco APIs. In many cases, the references come with code snippets with simple examples. For a more in-depth study of the different APIs, consult the using-umbraco and extending-umbraco sections of the documentation."
 ---
 
 # Developers' Reference

--- a/Reference/index-v8.md
+++ b/Reference/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Reference section for the Umbraco APIs"
-meta.Description: "Developers' Reference primarily consists of API references of the different core Umbraco APIs. In many cases, the references come with code snippets with simple examples. For a more in-depth study of the different APIs, consult the using-umbraco and extending-umbraco sections of the documentation."
+description: "Developers' Reference primarily consists of API references of the different core Umbraco APIs. In many cases, the references come with code snippets with simple examples. For a more in-depth study of the different APIs, consult the using-umbraco and extending-umbraco sections of the documentation."
 ---
 
 # Developers' Reference

--- a/Reference/index.md
+++ b/Reference/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Reference section for the Umbraco APIs"
-meta.Description: "Developers' Reference primarily consists of API references of the different core Umbraco APIs. In many cases, the references come with code snippets with simple examples. For a more in-depth study of the different APIs, consult the using-umbraco and extending-umbraco sections of the documentation."
+description: "Developers' Reference primarily consists of API references of the different core Umbraco APIs. In many cases, the references come with code snippets with simple examples. For a more in-depth study of the different APIs, consult the using-umbraco and extending-umbraco sections of the documentation."
 ---
 
 # Developers' Reference

--- a/Tutorials/Add-Google-Authentication/index-v7.md
+++ b/Tutorials/Add-Google-Authentication/index-v7.md
@@ -3,7 +3,7 @@ versionFrom: 7.0.0
 versionTo: 8.0.0
 needsV8Update: "false"
 meta.Title: "Add Google Authentication"
-meta.Description: "A guide to setup a Google login for the Umbraco backoffice."
+description: "A guide to setup a Google login for the Umbraco backoffice."
 needsV9Update: "true"
 ---
 

--- a/Tutorials/Add-Google-Authentication/index.md
+++ b/Tutorials/Add-Google-Authentication/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Add Google Authentication"
-meta.Description: "A guide to set up a Google login for the Umbraco Backoffice."
+description: "A guide to set up a Google login for the Umbraco Backoffice."
 ---
 
 

--- a/Tutorials/Creating-Basic-Site/index.md
+++ b/Tutorials/Creating-Basic-Site/index.md
@@ -3,7 +3,7 @@ versionFrom: 8.0.0
 versionTo: 10.0.0
 product: "CMS"
 meta.Title: "Creating a Basic Website using Umbraco"
-meta.Description: "A guide to creating a Basic Website using Umbraco"
+description: "A guide to creating a Basic Website using Umbraco"
 ---
 # Creating a Basic Website using Umbraco
 

--- a/Tutorials/Creating-a-Custom-Dashboard/index.md
+++ b/Tutorials/Creating-a-Custom-Dashboard/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Creating a Custom Dashboard"
-meta.Description: "A guide to creating a custom dashboard in Umbraco"
+description: "A guide to creating a custom dashboard in Umbraco"
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Tutorials/Creating-a-Property-Editor/index-v7.md
+++ b/Tutorials/Creating-a-Property-Editor/index-v7.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Creating a property editor"
-meta.Description: "A guide to creating a property editor in Umbraco"
+description: "A guide to creating a property editor in Umbraco"
 ---
 
 

--- a/Tutorials/Creating-a-Property-Editor/index-v8.md
+++ b/Tutorials/Creating-a-Property-Editor/index-v8.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Creating a property editor"
-meta.Description: "A guide to creating a property editor in Umbraco"
+description: "A guide to creating a property editor in Umbraco"
 ---
 
 # Creating a property editor

--- a/Tutorials/Creating-a-Property-Editor/index.md
+++ b/Tutorials/Creating-a-Property-Editor/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Creating a property editor"
-meta.Description: "A guide to creating a property editor in Umbraco"
+description: "A guide to creating a property editor in Umbraco"
 ---
 
 # Creating a Property Editor

--- a/Tutorials/Creating-an-XML-Site-Map/index-v8.md
+++ b/Tutorials/Creating-an-XML-Site-Map/index-v8.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 product: "CMS"
 meta.Title: "Creating an XML sitemap"
-meta.Description: "A guide to creating an XML sitemap in Umbraco"
+description: "A guide to creating an XML sitemap in Umbraco"
 needsV9Update: "true"
 ---
 

--- a/Tutorials/Creating-an-XML-Site-Map/index.md
+++ b/Tutorials/Creating-an-XML-Site-Map/index.md
@@ -3,7 +3,7 @@ versionFrom: 9.0.0
 versionTo: 10.0.0
 product: "CMS"
 meta.Title: "Creating an XML sitemap"
-meta.Description: "A guide to creating an XML sitemap in Umbraco"
+description: "A guide to creating an XML sitemap in Umbraco"
 ---
 
 # Creating a Search Engine XML Site Map

--- a/Tutorials/Editors-Manual/index-v7.md
+++ b/Tutorials/Editors-Manual/index-v7.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Editors Manual for Umbraco 7"
-meta.Description: "How-tos and best practices for working with the Umbraco backoffice as a content editor."
+description: "How-tos and best practices for working with the Umbraco backoffice as a content editor."
 versionFrom: 7.0.0
 ---
 

--- a/Tutorials/Editors-Manual/index.md
+++ b/Tutorials/Editors-Manual/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Editors Manual for Umbraco 8"
-meta.Description: "How-tos and best practices for working with the Umbraco backoffice as a content editor."
+description: "How-tos and best practices for working with the Umbraco backoffice as a content editor."
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Tutorials/Members-Registration-And-Logins/index-v9.md
+++ b/Tutorials/Members-Registration-And-Logins/index-v9.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Members Registration and Logins"
-meta.Description: "In this article you can learn about how to create Member registration and login functionality for the frontend of your application."
+description: "In this article you can learn about how to create Member registration and login functionality for the frontend of your application."
 needsV9Update: "true"
 ---
 

--- a/Tutorials/Members-Registration-And-Logins/index.md
+++ b/Tutorials/Members-Registration-And-Logins/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 meta.Title: "Members Registration and Logins"
-meta.Description: "In this article you can learn about how to create Member registration and login functionality for the frontend of your application."
+description: "In this article you can learn about how to create Member registration and login functionality for the frontend of your application."
 ---
 
 # Member registration and login 

--- a/Tutorials/Multilanguage-Setup/index.md
+++ b/Tutorials/Multilanguage-Setup/index.md
@@ -3,7 +3,7 @@ versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Multilanguage setup in Umbraco"
 product: "CMS"
-meta.Description: "A guide to multilanguage setup in Umbraco"
+description: "A guide to multilanguage setup in Umbraco"
 ---
 
 # Creating a Multilingual Site

--- a/Tutorials/Multisite-Setup/index.md
+++ b/Tutorials/Multisite-Setup/index.md
@@ -3,7 +3,7 @@ versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Multisite setup in Umbraco"
 product: "CMS"
-meta.Description: "A guide to multisite setup in Umbraco"
+description: "A guide to multisite setup in Umbraco"
 ---
 
 # Multisite setup

--- a/Tutorials/Porting-Packages-V8/index.md
+++ b/Tutorials/Porting-Packages-V8/index.md
@@ -4,7 +4,7 @@ product: "CMS"
 complexity: "Intermediate"
 audience: "Package developers"
 meta.Title: "How to port packages from Umbraco v7 to Umbraco v8"
-meta.Description: "This guide will tell you how you can turn your Umbraco v7 package into an Umbraco v8 package"
+description: "This guide will tell you how you can turn your Umbraco v7 package into an Umbraco v8 package"
 needsV9Update: "true"
 ---
 # Porting packages to V8

--- a/Tutorials/Starter-kit/Index.md
+++ b/Tutorials/Starter-kit/Index.md
@@ -3,7 +3,7 @@ versionFrom: 7.0.0
 versionTo: 10.0.0
 product: "CMS"
 meta.Title: "Getting started with Umbraco using the Starter Kit"
-meta.Description: "A tutorial on getting started with Umbraco using the starter kit"
+description: "A tutorial on getting started with Umbraco using the starter kit"
 ---
 
 # The Starter Kit

--- a/Tutorials/index.md
+++ b/Tutorials/index.md
@@ -3,7 +3,7 @@ versionFrom: 7.0.0
 versionTo: 10.0.0
 product: "CMS"
 meta.Title: "Tutorials for beginners and master alike"
-meta.Description: "Here you can find tutorials covering things like creating a site from scratch, setting up multilingual sites and many more"
+description: "Here you can find tutorials covering things like creating a site from scratch, setting up multilingual sites and many more"
 ---
 
 # Tutorials

--- a/Umbraco-Cloud/Databases/Local-Database/index-v7.md
+++ b/Umbraco-Cloud/Databases/Local-Database/index-v7.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 versionTo: 9.0.0
 meta.Title: "Working with a Cloud database locally"
-meta.Description: "Explanation on how to work with an Umbraco Cloud database locally, connecting to your local database using Visual Studio and working with custom tables in the Cloud database"
+description: "Explanation on how to work with an Umbraco Cloud database locally, connecting to your local database using Visual Studio and working with custom tables in the Cloud database"
 ---
 
 # Working with a Cloud database locally

--- a/Umbraco-Cloud/Databases/Local-Database/index.md
+++ b/Umbraco-Cloud/Databases/Local-Database/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 10.0.0
 meta.Title: "Working with a Cloud database locally"
-meta.Description: "Explanation on how to work with an Umbraco Cloud database locally, connecting to your local database using Visual Studio and working with custom tables in the Cloud database"
+description: "Explanation on how to work with an Umbraco Cloud database locally, connecting to your local database using Visual Studio and working with custom tables in the Cloud database"
 ---
 
 # Working with a Cloud database locally

--- a/Umbraco-Cloud/Deployment/Content-Transfer/index.md
+++ b/Umbraco-Cloud/Deployment/Content-Transfer/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Transfering content with Umbraco Deploy"
-meta.Description: "How to restore content in Umbraco Deploy using the deployment dashboard"
+description: "How to restore content in Umbraco Deploy using the deployment dashboard"
 ---
 
 # Transferring Content, Media, and Forms

--- a/Umbraco-Cloud/Deployment/Local-to-Cloud/index-v7.md
+++ b/Umbraco-Cloud/Deployment/Local-to-Cloud/index-v7.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 versionTo: 8.0.0
 meta.Title: "Deploying changes from a local machine to Umbraco Cloud"
-meta.Description: "How to Deploy changes between a local machine and an environment with Umbraco Deploy using either a Git GUI or CLI"
+description: "How to Deploy changes between a local machine and an environment with Umbraco Deploy using either a Git GUI or CLI"
 ---
 
 # Deploying changes with Umbraco Deploy

--- a/Umbraco-Cloud/Deployment/Local-to-Cloud/index.md
+++ b/Umbraco-Cloud/Deployment/Local-to-Cloud/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Deploying changes from a local machine to Umbraco Cloud"
-meta.Description: "How to Deploy changes between a local machine and an environment with Umbraco Deploy using either a Git GUI or CLI"
+description: "How to Deploy changes between a local machine and an environment with Umbraco Deploy using either a Git GUI or CLI"
 ---
 
 # Deploying changes with Umbraco Deploy

--- a/Umbraco-Cloud/Deployment/index-v8.md
+++ b/Umbraco-Cloud/Deployment/index-v8.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "A deployment model that relies on Git, Kudu, and Umbraco Deploy core technology to move your changes from one environment to another"
-meta.Description: "Umbraco Cloud uses a deployment model that relies on Git, Kudu, and Umbraco Deploy core technology to move your changes from one environment to another. Umbraco Cloud uses a classic 'left to right' deployment model, meaning that changes are first made in the Development or local environment and then deployed to the Live environment"
+description: "Umbraco Cloud uses a deployment model that relies on Git, Kudu, and Umbraco Deploy core technology to move your changes from one environment to another. Umbraco Cloud uses a classic 'left to right' deployment model, meaning that changes are first made in the Development or local environment and then deployed to the Live environment"
 versionFrom: 7.0.0
 versionTo: 8.0.0
 ---

--- a/Umbraco-Cloud/Deployment/index.md
+++ b/Umbraco-Cloud/Deployment/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "A deployment model that relies on Git, Kudu, and Umbraco Deploy core technology to move your changes from one environment to another"
-meta.Description: "Umbraco Cloud uses a deployment model that relies on Git, Kudu, and Umbraco Deploy core technology to move your changes from one environment to another. Umbraco Cloud uses a classic 'left to right' deployment model, meaning that changes are first made in the Development or local environment and then deployed to the Live environment"
+description: "Umbraco Cloud uses a deployment model that relies on Git, Kudu, and Umbraco Deploy core technology to move your changes from one environment to another. Umbraco Cloud uses a classic 'left to right' deployment model, meaning that changes are first made in the Development or local environment and then deployed to the Live environment"
 versionFrom: 9.0.0
 versionTo: 10.0.0
 ---

--- a/Umbraco-Cloud/Getting-Started/Migrate-Existing-Site/Migrating-Users-To-Umbraco-Cloud/index.md
+++ b/Umbraco-Cloud/Getting-Started/Migrate-Existing-Site/Migrating-Users-To-Umbraco-Cloud/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Migrating Users to Umbraco Cloud"
-meta.Description: "In this guide we show you how you can migrate users from your existing on-premise site to Umbraco Cloud and Umbraco ID."
+description: "In this guide we show you how you can migrate users from your existing on-premise site to Umbraco Cloud and Umbraco ID."
 versionFrom: 8.0.0
 versionTo: 10.0.0
 ---

--- a/Umbraco-Cloud/Getting-Started/index.md
+++ b/Umbraco-Cloud/Getting-Started/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Get started working with Umbraco Cloud"
-meta.Description: "Here you can find information about getting started working with Umbraco Cloud"
+description: "Here you can find information about getting started working with Umbraco Cloud"
 versionFrom: 9.0.0
 versionTo: 10.0.0
 ---

--- a/Umbraco-Cloud/Set-Up/2-factor-authentication-on-cloud/index.md
+++ b/Umbraco-Cloud/Set-Up/2-factor-authentication-on-cloud/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "2-factor authentication on Umbraco Cloud"
-meta.Description: "This article shows you how you can enable 2-factor authentication for when you log in to the Umbraco Cloud Portal."
+description: "This article shows you how you can enable 2-factor authentication for when you log in to the Umbraco Cloud Portal."
 ---
 
 # 2-factor authentication on Umbraco Cloud

--- a/Umbraco-Cloud/Set-Up/Manage-Hostnames/Move-away-from-Latch/index.md
+++ b/Umbraco-Cloud/Set-Up/Manage-Hostnames/Move-away-from-Latch/index.md
@@ -2,7 +2,7 @@
 versionFrom: 7.0.0
 versionTo: 9.0.0
 meta.Title: "How to move away from using Umbraco Latch"
-meta.Description: "The Umbraco Latch service has been deprecated and it is instead being replaced by a new Umbraco Cloud service which uses Cloudflare as a provider for issuing TLS (HTTPS) certificates to hostnames added to Cloud environments. In this article, you can learn how to move to use the new service."
+description: "The Umbraco Latch service has been deprecated and it is instead being replaced by a new Umbraco Cloud service which uses Cloudflare as a provider for issuing TLS (HTTPS) certificates to hostnames added to Cloud environments. In this article, you can learn how to move to use the new service."
 ---
 
 # How to move away from using Umbraco Latch

--- a/Umbraco-Cloud/Set-Up/Media/Connect-to-Azure-Storage-Explorer/index-v7.md
+++ b/Umbraco-Cloud/Set-Up/Media/Connect-to-Azure-Storage-Explorer/index-v7.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Using Azure Storage Explorer with Umbraco Cloud"
-meta.Description: "All Media files for Umbraco Cloud projects are stored in Azure Blob Storage contaiers. Each environment has a separate container linked to it."
+description: "All Media files for Umbraco Cloud projects are stored in Azure Blob Storage contaiers. Each environment has a separate container linked to it."
 ---
 
 # Connect to Azure Storage Explorer to upload files manually

--- a/Umbraco-Cloud/Set-Up/Media/Connect-to-Azure-Storage-Explorer/index.md
+++ b/Umbraco-Cloud/Set-Up/Media/Connect-to-Azure-Storage-Explorer/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Using Azure Storage Explorer with Umbraco Cloud"
-meta.Description: "All Media files for Umbraco Cloud projects are stored in Azure Blob Storage containers. Each environment has a separate container linked to it."
+description: "All Media files for Umbraco Cloud projects are stored in Azure Blob Storage containers. Each environment has a separate container linked to it."
 ---
 
 # Connect to Azure Storage Explorer to upload files manually

--- a/Umbraco-Cloud/Set-Up/Media/index-v7.md
+++ b/Umbraco-Cloud/Set-Up/Media/index-v7.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 7.0.0
 meta.Title: "Azure Blob Storage on Umbraco Cloud"
-meta.Description: "All Media files for Umbraco Cloud projects are stored in Azure Blob Storage contaiers. Each environment has a separate container linked to it."
+description: "All Media files for Umbraco Cloud projects are stored in Azure Blob Storage contaiers. Each environment has a separate container linked to it."
 ---
 
 # Media on Umbraco Cloud

--- a/Umbraco-Cloud/Set-Up/Media/index.md
+++ b/Umbraco-Cloud/Set-Up/Media/index.md
@@ -2,7 +2,7 @@
 versionFrom: 9.0.0
 versionTo: 10.0.0
 meta.Title: "Azure Blob Storage on Umbraco Cloud"
-meta.Description: "All Media files for Umbraco Cloud projects are stored in Azure Blob Storage containers. Each environment has a separate container linked to it."
+description: "All Media files for Umbraco Cloud projects are stored in Azure Blob Storage containers. Each environment has a separate container linked to it."
 ---
 
 # Media on Umbraco Cloud

--- a/Umbraco-Cloud/Set-Up/Users-On-Cloud/index.md
+++ b/Umbraco-Cloud/Set-Up/Users-On-Cloud/index.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Users on Umbraco Cloud"
-meta.Description: "An article explaining how Umbraco Users are working on Umbraco Cloud."
+description: "An article explaining how Umbraco Users are working on Umbraco Cloud."
 versionFrom: 7.0.0
 versionTo: 10.0.0
 ---

--- a/Umbraco-Cloud/index.md
+++ b/Umbraco-Cloud/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 versionTo: 10.0.0
 meta.Title: "Cloud-based CMS that lets you focus on the fun stuff"
-meta.Description: "Welcome to the Umbraco Cloud documentation. Here you can read all about how to set up and work with Umbraco Cloud. You can find articles about the deployment workflow, how to work locally, and all the features that comes with your Umbraco Cloud project. You can also find articles about troubleshooting various issues."
+description: "Welcome to the Umbraco Cloud documentation. Here you can read all about how to set up and work with Umbraco Cloud. You can find articles about the deployment workflow, how to work locally, and all the features that comes with your Umbraco Cloud project. You can also find articles about troubleshooting various issues."
 ---
 
 # Umbraco Cloud documentation

--- a/Umbraco-Heartcore/API-Documentation/Content-Delivery/index.md
+++ b/Umbraco-Heartcore/API-Documentation/Content-Delivery/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Heartcore Content Delivery"
-meta.Description: "Documentation for Heartcore Content Delivery APIs"
+description: "Documentation for Heartcore Content Delivery APIs"
 ---
 
 # Content Delivery API

--- a/Umbraco-Heartcore/API-Documentation/Content-Management/index.md
+++ b/Umbraco-Heartcore/API-Documentation/Content-Management/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Heartcore Content Management"
-meta.Description: "Documentation for Heartcore Content Management APIs"
+description: "Documentation for Heartcore Content Management APIs"
 ---
 
 # Content Management API

--- a/Umbraco-Heartcore/API-Documentation/GraphQL/Filtering-and-Ordering/index.md
+++ b/Umbraco-Heartcore/API-Documentation/GraphQL/Filtering-and-Ordering/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Filtering content in Umbraco Heartcore with GraphQL"
-meta.Description: "Documentation for GraphQL filtering in Umbraco Heartcore."
+description: "Documentation for GraphQL filtering in Umbraco Heartcore."
 ---
 
 # Introduction

--- a/Umbraco-Heartcore/API-Documentation/GraphQL/Property-Editors/index.md
+++ b/Umbraco-Heartcore/API-Documentation/GraphQL/Property-Editors/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Heartcore GraphQL Property Editors"
-meta.Description: "Documentation for Umbraco Heartcore GraphQL property editors and their types"
+description: "Documentation for Umbraco Heartcore GraphQL property editors and their types"
 ---
 
 # Property Editors

--- a/Umbraco-Heartcore/API-Documentation/GraphQL/Schema-Generation/index.md
+++ b/Umbraco-Heartcore/API-Documentation/GraphQL/Schema-Generation/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Heartcore GraphQL Schema Generation"
-meta.Description: "Documentation for Umbraco Heartcore GraphQL schema generation"
+description: "Documentation for Umbraco Heartcore GraphQL schema generation"
 ---
 
 # Schema Generation

--- a/Umbraco-Heartcore/API-Documentation/GraphQL/index.md
+++ b/Umbraco-Heartcore/API-Documentation/GraphQL/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Heartcore GraphQL API"
-meta.Description: "Documentation for Umbraco Heartcore GraphQL API"
+description: "Documentation for Umbraco Heartcore GraphQL API"
 ---
 
 # GraphQL API

--- a/Umbraco-Heartcore/API-Documentation/Redirect/index.md
+++ b/Umbraco-Heartcore/API-Documentation/Redirect/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Heartcore Redirect"
-meta.Description: "Documentation for Heartcore Redirect APIs"
+description: "Documentation for Heartcore Redirect APIs"
 ---
 
 # Redirect API

--- a/Umbraco-Heartcore/API-Documentation/index.md
+++ b/Umbraco-Heartcore/API-Documentation/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Heartcore API Documentation"
-meta.Description: "Documentation for Umbraco Heartcore REST APIs"
+description: "Documentation for Umbraco Heartcore REST APIs"
 ---
 
 # API Documentation

--- a/Umbraco-Heartcore/Backoffice/Grid-Editors/index.md
+++ b/Umbraco-Heartcore/Backoffice/Grid-Editors/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Custom Grid Editors in Umbraco Heartcore"
-meta.Description: "Documentation for Custom Grid Editors in Umbraco Heartcore"
+description: "Documentation for Custom Grid Editors in Umbraco Heartcore"
 ---
 
 # Custom Grid Editors

--- a/Umbraco-Heartcore/Backoffice/index.md
+++ b/Umbraco-Heartcore/Backoffice/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Heartcore backoffice"
-meta.Description: "Documentation for working in the backoffice in Umbraco Heartcore"
+description: "Documentation for working in the backoffice in Umbraco Heartcore"
 ---
 
 # Working in the backoffice

--- a/Umbraco-Heartcore/Getting-Started-Cloud/Backoffice-Users-and-API-Keys/index.md
+++ b/Umbraco-Heartcore/Getting-Started-Cloud/Backoffice-Users-and-API-Keys/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Backoffice users and API keys"
-meta.Description: "Managing Umbraco Heartcore Users and API keys"
+description: "Managing Umbraco Heartcore Users and API keys"
 ---
 
 # Backoffice Users and API Keys

--- a/Umbraco-Heartcore/Getting-Started-Cloud/Creating-a-Heartcore-project/index.md
+++ b/Umbraco-Heartcore/Getting-Started-Cloud/Creating-a-Heartcore-project/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Creating a Heartcore Project"
-meta.Description: "A guide to building an Umbraco Heartcore project"
+description: "A guide to building an Umbraco Heartcore project"
 ---
 
 # Building an Umbraco Heartcore project from scratch

--- a/Umbraco-Heartcore/Getting-Started-Cloud/GraphQL-Playground/index.md
+++ b/Umbraco-Heartcore/Getting-Started-Cloud/GraphQL-Playground/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Heartcore GraphQL Playground"
-meta.Description: "Documentation for Umbraco Heartcore GraphQL Playground"
+description: "Documentation for Umbraco Heartcore GraphQL Playground"
 ---
 
 # GraphQL Playground

--- a/Umbraco-Heartcore/Getting-Started-Cloud/The-Umbraco-Backoffice/index.md
+++ b/Umbraco-Heartcore/Getting-Started-Cloud/The-Umbraco-Backoffice/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Heartcore Backoffice"
-meta.Description: "Tour of Umbraco Heartcore backoffice"
+description: "Tour of Umbraco Heartcore backoffice"
 ---
 
 # Tour of the Umbraco Backoffice

--- a/Umbraco-Heartcore/Tutorials/Creating-A-Custom-Grid-Editor/index.md
+++ b/Umbraco-Heartcore/Tutorials/Creating-A-Custom-Grid-Editor/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Creating a Custom Grid Editor"
-meta.Description: "Learn how to create a Custom Grid Editor in Umbraco Heartcore."
+description: "Learn how to create a Custom Grid Editor in Umbraco Heartcore."
 ---
 
 # Custom Grid Editors in Umbraco Heartcore

--- a/Umbraco-Heartcore/Tutorials/Querying-With-GraphQL/index.md
+++ b/Umbraco-Heartcore/Tutorials/Querying-With-GraphQL/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Querying Umbraco Heartcore with GraphQL"
-meta.Description: "Learn how to query Umbraco Heartcore with GraphQL."
+description: "Learn how to query Umbraco Heartcore with GraphQL."
 ---
 
 # Querying Umbraco Heartcore with GraphQL

--- a/Umbraco-Heartcore/Tutorials/index.md
+++ b/Umbraco-Heartcore/Tutorials/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Heartcore Tutorials"
-meta.Description: "Here you can find tutorials for Umbraco Heartcore"
+description: "Here you can find tutorials for Umbraco Heartcore"
 ---
 
 # Umbraco Heartcore Tutorials

--- a/Umbraco-Heartcore/index.md
+++ b/Umbraco-Heartcore/index.md
@@ -1,7 +1,7 @@
 ---
 versionFrom: 8.0.0
 meta.Title: "Umbraco Heartcore"
-meta.Description: "An introduction to Umbraco Heartcore"
+description: "An introduction to Umbraco Heartcore"
 ---
 
 # Umbraco Heartcore

--- a/Umbraco-Heartcore/sso-guide.md
+++ b/Umbraco-Heartcore/sso-guide.md
@@ -1,6 +1,6 @@
 ---
 Meta.Title: Single-Sign-On for Umbraco Heartcore
-Meta.Description: Short guide on how to log in the first time after a Heartcore project has been migrated to UmbracoID
+description: Short guide on how to log in the first time after a Heartcore project has been migrated to UmbracoID
 ---
 
 # Single-Sign-On for Umbraco Heartcore

--- a/Umbraco8FAQ.md
+++ b/Umbraco8FAQ.md
@@ -1,6 +1,6 @@
 ---
 meta.Title: "Umbraco 8 FAQ"
-meta.Description: "Frequently asked questions on Umbraco 8"
+description: "Frequently asked questions on Umbraco 8"
 ---
 
 # Umbraco 8 - Frequently Asked Questions


### PR DESCRIPTION
GitBook uses the description as the meta description.
This PR will make the old descriptions visible below the title and also fill out the meta tag in GitBook.