### PR TITLE
Adding crops directly into templates

### DIFF
--- a/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Image-Cropper/index-v8.md
+++ b/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Image-Cropper/index-v8.md
@@ -98,6 +98,13 @@ Or, alternatively:
     <img src="@Model.Image.GetCropUrl(height: 300, width: 400, imageUrlGenerator: Current.ImageUrlGenerator)" />
 }
 ```
+:::note
+Creating multiple crop URLs directly in your template will result in a different image, which will fill up the Azure Blob storage cache folder adding to the overall media storage on the project plan. 
+
+An option to be considered will be using cache trimming trimCache=true so cached processed images can be automatically deleted after being created a certain amount of days ago (maxDays): https://imageprocessor.org/imageprocessor-web/configuration/. 
+
+Note that Umbraco 7/8 previously shipped with config to turn this off, since it had some performance issues in earlier ImageProcessor versions.
+:::
 
 ### CSS background example to output a "banner" crop from a cropper property with alias "image"
 

--- a/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Image-Cropper/index-v8.md
+++ b/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Image-Cropper/index-v8.md
@@ -99,6 +99,8 @@ Or, alternatively:
 }
 ```
 :::note
+**Is your site hosted on Umbraco Cloud?**
+
 Creating multiple crop URLs directly in your template will result in generating a new image. This will fill up the Azure Blob storage cache folder adding to the overall media storage on the project plan. 
 
 A solution to this is to use cache trimming by adding `trimCache=true`. With this enabled cached processed images can be automatically deleted after being created a certain amount of days ago. Learn more about this in the [ImageProcessor documentation](https://imageprocessor.org/imageprocessor-web/configuration/). 

--- a/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Image-Cropper/index-v8.md
+++ b/Fundamentals/Backoffice/Property-Editors/Built-in-Property-Editors/Image-Cropper/index-v8.md
@@ -99,11 +99,11 @@ Or, alternatively:
 }
 ```
 :::note
-Creating multiple crop URLs directly in your template will result in a different image, which will fill up the Azure Blob storage cache folder adding to the overall media storage on the project plan. 
+Creating multiple crop URLs directly in your template will result in generating a new image. This will fill up the Azure Blob storage cache folder adding to the overall media storage on the project plan. 
 
-An option to be considered will be using cache trimming trimCache=true so cached processed images can be automatically deleted after being created a certain amount of days ago (maxDays): https://imageprocessor.org/imageprocessor-web/configuration/. 
+A solution to this is to use cache trimming by adding `trimCache=true`. With this enabled cached processed images can be automatically deleted after being created a certain amount of days ago. Learn more about this in the [ImageProcessor documentation](https://imageprocessor.org/imageprocessor-web/configuration/). 
 
-Note that Umbraco 7/8 previously shipped with config to turn this off, since it had some performance issues in earlier ImageProcessor versions.
+Older versions of Umbraco 7/8 shipped with the config set to `false`. This was due to performance issues in earlier ImageProcessor versions.
 :::
 
 ### CSS background example to output a "banner" crop from a cropper property with alias "image"


### PR DESCRIPTION
Adding crops directly into templates can cause media usage to increase.

Each of those crop URLs will result in a different image, but those will only be generated/processed once when the URL is requested and any consecutive requests will then get it from the cache... Deleting files from the cache will reduce the overall size, but if those crop URLs are requested again (meaning they are actively used in the website), they will need to be processed and cached again, requiring additional CPU power to do so without actually resulting in a reduced cache size.

Basically, the cache size can't be smaller than all actively used crops. So if you have an image of 1MB that's rendered in 7 crop sizes (widths 800 to 2200 from the example), you might end up using around 7MB of cache storage. Smaller crops will most likely result in cached images that are less than 1MB, but the 2200 ones might actually be bigger if the original image is upscaled.