### PR TITLE
Azure Blob Storage: Add note about private blob containers

### DIFF
--- a/Extending/FileSystemProviders/Azure-Blob-Storage/index-v8.md
+++ b/Extending/FileSystemProviders/Azure-Blob-Storage/index-v8.md
@@ -41,7 +41,7 @@ The following six keys will have been added to the `<appSettings>` in your `web.
 </appSettings>
 ```
 
-Make sure to update this configuration to match your own setup. E.g. note that `AzureBlobFileSystem.UsePrivateContainer:media` needs to be set to `true` if your blob container is not publicly accessible.
+Make sure to update this configuration to match your own setup. For example `AzureBlobFileSystem.UsePrivateContainer:media` needs to be set to `true` if your blob container is not publicly accessible. `ImageProcessingException`s will be thrown when images are served and this is not configured properly.
 
 When you're installing the package from the **Package** section of the Umbraco Backoffice, you'll be able to fill in the configuration directly from the backoffice:
 

--- a/Extending/FileSystemProviders/Azure-Blob-Storage/index-v8.md
+++ b/Extending/FileSystemProviders/Azure-Blob-Storage/index-v8.md
@@ -144,7 +144,7 @@ Any new media files you upload to the site, will automatically be added to the B
 
 If you don't want to use a publicly accessible container for media storage, you need to follow these additional steps:
 
-1. In your `Web.config`, `AzureBlobFileSystem.UsePrivateContainer:media` needs to be set to `true`.
+1. In your `Web.config`, `AzureBlobFileSystem.UsePrivateContainer:media` needs to be set to `true`: `<add key="AzureBlobFileSystem.UsePrivateContainer:media" value="true"/>`
 2. Install `ImageProcessor.Web.Plugins.AzureBlobCache` from NuGet, which contains the `AzureImageService` that is used in the following step.
 3. In your `~/config/imageprocessor/security.config`, you need to replace the existing section similar to 
 

--- a/Extending/FileSystemProviders/Azure-Blob-Storage/index-v8.md
+++ b/Extending/FileSystemProviders/Azure-Blob-Storage/index-v8.md
@@ -173,6 +173,8 @@ with
 
 If you fail to apply set `AzureBlobFileSystem.UsePrivateContainer:media` properly, you will see a lot of `ImageProcessingException`s when images are served. If you fail to configure the `AzureImageService`, ImageProcessor will not work and your images will be served but not cropped, resized, and similar.
 
+Depending on your project configuration, the installation of `ImageProcessor.Web.Plugins.AzureBlobCache` might modify your `~/config/imageprocessor/cache.config` file. If you don't want to use the package for caching, you might want to revert the changes.
+
 ## Using Azure Blob Cache
 
 In some cases, you might also want to use the Azure Blob Cache to cache your media files. One scenario for this could be a load balancing setup where you have a lot of media files. Using the Azure Blob Cache will make sure that your media files are still cached and can be used effectively as the generated images are stored to blobs and served via a CDN instead of local disk.

--- a/Extending/FileSystemProviders/Azure-Blob-Storage/index-v8.md
+++ b/Extending/FileSystemProviders/Azure-Blob-Storage/index-v8.md
@@ -41,7 +41,7 @@ The following six keys will have been added to the `<appSettings>` in your `web.
 </appSettings>
 ```
 
-Make sure to update this configuration to match your own setup.
+Make sure to update this configuration to match your own setup. E.g. note that `AzureBlobFileSystem.UsePrivateContainer:media` needs to be set to `true` if your blob container is not publicly accessible.
 
 When you're installing the package from the **Package** section of the Umbraco Backoffice, you'll be able to fill in the configuration directly from the backoffice:
 


### PR DESCRIPTION
The need and how to configure this setting seems to be unclear to parts of the community, see <https://our.umbraco.com/forum/using-umbraco-and-getting-started/100593-log-flooding-with-imageprocessor-errors-using-blobstorage>. It took me some time to figure this out too, as basic image serving still works if this is misconfigured, but the log is full of related error messages though. Thus maybe it's worth to put a note in the corresponding docs.