### PR TITLE
Updated Fundamentals Setup Install readme to use new install command

### DIFF
--- a/umbraco-cms/fundamentals/setup/install/README.md
+++ b/umbraco-cms/fundamentals/setup/install/README.md
@@ -8,7 +8,7 @@ meta.Description: "Instructions on installing Umbraco on various platforms using
 The easiest way to get the latest version of Umbraco up and running is using the command line (CLI).
 
 1. Open your command line
-2. Install the Umbraco templates with `dotnet new -i Umbraco.Templates`
+2. Install the Umbraco templates with `dotnet new install Umbraco.Templates`
 3. Run `dotnet new umbraco --name MyProject` to create a new project
 4. Enter the project folder. It will be the folder containing the `.csproj` file
 5. Run and build your project using `dotnet run`


### PR DESCRIPTION
Updated fundamentals/setup/install/README.md to use new install command. It looks like since .NET 7, the install flag has changed:

![Screenshot 2022-12-01 at 08 23 09](https://user-images.githubusercontent.com/596453/205002390-b49aa403-645d-461a-9dd6-eb40e36ced1a.png)
