### PR TITLE
Update example for `PublishedRequestHandler`

### DIFF
--- a/umbraco-cms/reference/routing/request-pipeline/published-content-request-preparation.md
+++ b/umbraco-cms/reference/routing/request-pipeline/published-content-request-preparation.md
@@ -84,18 +84,18 @@ If the template is allowed it will then use the file service to get the specifie
 The router will pick up the redirect and redirect. There is no need to write your own redirects:
 
 ```csharp
-PublishedContentRequest.Prepared += (sender, args) =>
+public class PublishedRequestHandler : INotificationHandler<RoutingRequestNotification>
 {
-public void Handle(RoutingRequestNotification notification)
-{
-    var requestBuilder = notification.RequestBuilder;
-    var content = requestBuilder.PublishedContent;
-    var redirect = content.Value<string>("myRedirect");
-    if (!string.IsNullOrWhiteSpace(redirect))
+    public void Handle(RoutingRequestNotification notification)
     {
-        requestBuilder.SetRedirect(redirect);
+        var requestBuilder = notification.RequestBuilder;
+        var content = requestBuilder.PublishedContent;
+        var redirect = content.Value<string>("myRedirect");
+        if (!string.IsNullOrWhiteSpace(redirect))
+        {
+            requestBuilder.SetRedirect(redirect);
+        }
     }
-}
 }
 ```
 


### PR DESCRIPTION
It seems this part was from the old documentation https://our.umbraco.com/Documentation/Reference/Routing/Request-Pipeline/published-content-request-preparation#findpublishedcontentandtemplate as one now subscribe to a notification.

https://docs.umbraco.com/umbraco-cms/implementation/custom-routing#routingrequestnotification
https://docs.umbraco.com/umbraco-cms/reference/routing/request-pipeline/published-content-request-preparation#redirects

Besides that I couldn't make the redirect in the example to work:
https://github.com/umbraco/Umbraco-CMS/issues/13542