### PR TITLE
Readability improvements - Fundamentals design rendering-content

### DIFF
--- a/umbraco-cms/fundamentals/design/rendering-content.md
+++ b/umbraco-cms/fundamentals/design/rendering-content.md
@@ -9,7 +9,7 @@ _The primary task of any template is to render the values of the current page or
 
 ## Display a value in your template view
 
-Each property in your [document type](../data/defining-content.md#what-is-a-document-type) has an alias, this is used to specify where in the template view to display the value.
+Each property in your [Document Type](../data/defining-content.md#what-is-a-document-type) has an alias, this is used to specify where in the template view to display the value.
 
 ```html
 <h1>@Model.Value("pageTitle")</h1>


### PR DESCRIPTION
Belongs to: https://github.com/umbraco/UmbracoDocs/issues/4416

- [x] use 'Document Type' instead of document type