### PR TITLE
Broken Forms links

### DIFF
--- a/umbraco-forms/README.md
+++ b/umbraco-forms/README.md
@@ -7,7 +7,7 @@ meta.Description: "Documentation on how to work with Umbraco Forms for both edit
 
 Umbraco Forms is tool that lets you build forms of all shapes and sizes, and put them on your Umbraco websites. Build forms using a long list of elements like multiple choice, dropdowns, text areas and checkboxes. Choose between a series of different workflow and control what happens once a form has been submitted.
 
-[Purchase Umbraco Forms](https://umbraco.com/apps/umbraco-forms/) or sign up for an [Umbraco Cloud](../umbraco-cloud/) project where Umbraco Forms is part of the package.
+[Purchase Umbraco Forms](https://umbraco.com/products/umbraco-forms/) or sign up for an [Umbraco Cloud](https://try.umbraco.com/) project where Umbraco Forms is part of the package.
 
 ## [Installing and Upgrading](installation/README.md)
 


### PR DESCRIPTION
The purchase and sign up link on https://docs.umbraco.com/umbraco-forms/umbraco-forms are broken. I am not sure if you want to continue to redirect the sign up to a documentation page or if it should go to the trial flow - I chose the latter :) 