### PR TITLE
Remove duplicate meta description

### DIFF
--- a/umbraco-deploy/deploy-settings.md
+++ b/umbraco-deploy/deploy-settings.md
@@ -1,6 +1,5 @@
 ---
 meta.Title: Umbraco Deploy settings
-meta.Description: Various settings for Umbraco Deploy
 description: >-
   Learn about the different settings and configurations available in Umbraco
   Deploy.


### PR DESCRIPTION
I suspect that the duplicate description meta-tag is causing the article to not being searchable.