### PR TITLE
Prevents error "cannot convert from 'void' to 'object?'"

### DIFF
--- a/umbraco-cms/tutorials/creating-an-xml-site-map.md
+++ b/umbraco-cms/tutorials/creating-an-xml-site-map.md
@@ -151,7 +151,11 @@ So for the homepage we'll now have:
     IPublishedContent siteHomePage = Model.Root(); 
 }
     
-    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemalocation="http://www.google.com/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">@RenderSiteMapUrlEntry(siteHomePage)</urlset>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemalocation="http://www.google.com/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+@{
+    RenderSiteMapUrlEntry(siteHomePage)
+}
+</urlset>
 ```
 
 visit the url of your sitemap page (http://yoursite.com/sitemap) and this will render a single sitemap entry for the homepage, which ermmmm, isn't very comprehensive!


### PR DESCRIPTION
This might just be in Rider, but I suspect not.  If the RenderSiteMapUrlEntry(siteHomePage) is inline then there is an error. If not, it runs ok.