### PR TITLE
Fixing a typo in the code example

### DIFF
--- a/umbraco-cms/reference/searching/examine/quick-start.md
+++ b/umbraco-cms/reference/searching/examine/quick-start.md
@@ -135,7 +135,7 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace MyStarterKitSite.Services;
 
-public class SearchServices : ISearchService
+public class SearchService : ISearchService
 {
     private readonly IExamineManager _examineManager;
     public SearchServices(IExamineManager examineManager)


### PR DESCRIPTION
Removed an S from the Service(s) class name as it should have been Service.