### PR TITLE
Fix typo in CheatSheet

### DIFF
--- a/umbraco-11/is-helpers.md
+++ b/umbraco-11/is-helpers.md
@@ -10,7 +10,7 @@ use `@Model` in a Template
 .IsAncestorOrSelf
 .IsComposedOf
 .IsDescendant
-.IsDescendantOfSelf
+.IsDescendantOrSelf
 .IsDocumentType
 .IsEqual
 .IsInvariantOrHasCulture


### PR DESCRIPTION
Just stumbled upon this teeny-tiny typo in `.isDescendantOrSelf()` 