### PR TITLE
Clarify max upload size settings for Cloud users

### DIFF
--- a/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
+++ b/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
@@ -29,6 +29,7 @@ To configure the default 28.6MB upload limit using IIS, we have to create a web.
 
 {% hint style="info" %}
 **Are you hosting your site on Umbraco Cloud?**
+
 Umbraco Cloud uses IIS for hosting. This means you need to add the setting in a `web.config` file for this to work on your Umbraco Cloud hosted sites.
 {% endhint %}
 

--- a/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
+++ b/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
@@ -28,7 +28,7 @@ To configure the default 28.6MB upload limit using IIS, we have to create a web.
 `maxAllowedContentLength` is specified in bytes, so this configuration would limit requests, and therefore uploaded files, to 2 megabytes
 
 {% hint style="info" %}
-If your site is hosted on Umbraco Cloud, this is the method you should use.
+If your site is hosted on Umbraco Cloud, this is the method you should use. Umbraco Cloud uses IIS for hosting, and IIS needs the setting to be in a web.config file for this to work.
 {% endhint %}
 
 # Using Kestrel

--- a/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
+++ b/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
@@ -28,7 +28,8 @@ To configure the default 28.6MB upload limit using IIS, we have to create a web.
 `maxAllowedContentLength` is specified in bytes, so this configuration would limit requests, and therefore uploaded files, to 2 megabytes
 
 {% hint style="info" %}
-If your site is hosted on Umbraco Cloud, this is the method you should use. Umbraco Cloud uses IIS for hosting, and IIS needs the setting to be in a web.config file for this to work.
+**Are you hosting your site on Umbraco Cloud?**
+Umbraco Cloud uses IIS for hosting. This means you need to add the setting in a `web.config` file for this to work on your Umbraco Cloud hosted sites.
 {% endhint %}
 
 # Using Kestrel


### PR DESCRIPTION
I was confused to why Cloud needs a web.config to set a max upload size, so I asked in Discord.

https://discordapp.com/channels/869656431308189746/882984067312787466/1064481265279049818