### PR TITLE
removed the migration article from the summary

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -13,3 +13,4 @@ redirects:
     v/workflow: umbraco-workflow/README.md
     umbraco-cloud/upgrades/migrating-from-8-10: umbraco-cloud/upgrades/major-upgrades.md
     umbraco-cms/reference/templating/mvc/child-actions: umbraco-cms/reference/templating/mvc/viewcomponents
+    umbraco-cloud/upgrades/migrate-from-umbraco-10-to-11: umbraco-cloud/upgrades/major-upgrades.md

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -528,7 +528,6 @@
   * [Working with a Cloud database locally](umbraco-cloud/databases/local-database.md)
 * [Product Upgrades](umbraco-cloud/upgrades/README.md)
   * [Major Upgrades](umbraco-cloud/upgrades/major-upgrades.md)
-  * [Migrate from Umbraco 10 to 11 on Umbraco Cloud](umbraco-cloud/upgrades/migrate-from-umbraco-10-to-11.md)
   * [Minor Upgrades](umbraco-cloud/upgrades/minor-upgrades.md)
   * [Upgrade your projects manually](umbraco-cloud/upgrades/manual-upgrades/README.md)
     * [Manual upgrade of Umbraco CMS](umbraco-cloud/upgrades/manual-upgrades/manual-cms-upgrade.md)


### PR DESCRIPTION
Removed the migration to v11 article from the summary file, so it won't be displayed in the docs as the issue preventing the upgrade should be fixed now.

Gonna keep the article for a while just in case it somehow might be needed again.