### PR TITLE
Fixed auto-generated links...

### DIFF
--- a/Add-ons/index.md
+++ b/Add-ons/index.md
@@ -3,6 +3,7 @@ meta.Title: "Add-ons for Umbraco CMS"
 meta.Description: "Learn about the Umbraco CMS add-ons; Umbraco Forms and Umbraco Courier. How to install them, what they do and how to extend functionality."
 versionFrom: 7.0.0
 versionTo: 10.0.0
+needsV8Update: "true"
 ---
 
 # Umbraco Products Documentation

--- a/Extending/Packages/Creating-a-nuget-package/index.md
+++ b/Extending/Packages/Creating-a-nuget-package/index.md
@@ -2,7 +2,7 @@
 versionFrom: 8.0.0
 meta.Title: "Creating a Nuget version of an Umbraco package"
 meta.Description: "A guide to creating a Nuget version of an Umbraco package"
-meta.RedirectLink: "/umbraco-cms/extending/packages/creating-a-package"
+meta.RedirectLink: "/umbraco-cms/extending/packages/creating-a-package#creating-a-nuget-package"
 ---
 
 # Creating a NuGet version of a package

--- a/Extending/Packages/Package-Actions/custom-package-actions.md
+++ b/Extending/Packages/Package-Actions/custom-package-actions.md
@@ -1,6 +1,7 @@
 ---
 versionFrom: 8.0.0
 versionTo: 8.0.0
+needsV8Update: "true"
 meta.Title: "Create custom package actions for your Umbraco package"
 meta.Description: "Tutorial on how to create custom package actions for your Umbraco package"
 ---

--- a/Extending/Packages/Package-Actions/index.md
+++ b/Extending/Packages/Package-Actions/index.md
@@ -1,6 +1,7 @@
 ---
 versionFrom: 8.0.0
 versionTo: 8.0.0
+needsV8Update: "true"
 meta.Title: "Package actions"
 meta.Description: "Information on how to add actions to your Umbraco package"
 ---

--- a/Extending/Packages/UmbPack/index.md
+++ b/Extending/Packages/UmbPack/index.md
@@ -1,6 +1,7 @@
 ---
 versionFrom: 7.0.0
 versionTo: 8.0.0
+needsV8Update: "true"
 meta.Title: "UmbPack"
 meta.Description: "How to use the UmbPack tool to deploy package versions to Our"
 ---

--- a/Extending/Property-Editors/tag-support.md
+++ b/Extending/Property-Editors/tag-support.md
@@ -1,5 +1,6 @@
 ---
 versionTo: 7.0.0
+needsV8Update: "true"
 ---
 
 # Tag support for property editors

--- a/Fundamentals/Backoffice/Sections/index.md
+++ b/Fundamentals/Backoffice/Sections/index.md
@@ -6,12 +6,6 @@ versionFrom: 8.0.0
 
 # Sections
 
-:::warning
-Are you using **Umbraco 10** or a later version?
-
-Find the relevant documentation in the [Sections documentation for Umbraco 10+](https://docs.umbraco.com/umbraco-cms/fundamentals/backoffice/sections).
-:::
-
 A section in Umbraco is where you perform specific tasks related to a particular area of Umbraco. For example Content, Settings and Users are all sections. You can navigate between the different sections by clicking the corresponding icon in the section menu which is positioned at the top of the Backoffice.
 
 ![Sections](images/highlight-sections.png "The Section menu is the horizontal menu located at the top of the Umbraco Backoffice.")

--- a/Fundamentals/Code/Subscribing-To-Events/index.md
+++ b/Fundamentals/Code/Subscribing-To-Events/index.md
@@ -3,7 +3,7 @@ meta.title: "Subscribing to events"
 meta.description: "Subscribing to events allows you to execute custom code on a number of events both before and after the event occurs"
 versionFrom: 8.0.0
 versionTo: 8.18.0
-needsV8Update: "true"
+meta.RedirectLink: "/umbraco-cms/fundamentals/code/subscribing-to-notifications"
 ---
 
 # Subscribing to events

--- a/Fundamentals/Code/Subscribing-To-Events/index.md
+++ b/Fundamentals/Code/Subscribing-To-Events/index.md
@@ -3,6 +3,7 @@ meta.title: "Subscribing to events"
 meta.description: "Subscribing to events allows you to execute custom code on a number of events both before and after the event occurs"
 versionFrom: 8.0.0
 versionTo: 8.18.0
+needsV8Update: "true"
 ---
 
 # Subscribing to events

--- a/Fundamentals/Code/index.md
+++ b/Fundamentals/Code/index.md
@@ -23,7 +23,3 @@ Using Tracing and MiniProfiler to debug your code.
 ## [Source/Version Control](Source-Control/)
 
 General advice on source controlling your Umbraco implementation.
-
-## [Subscribing To Notifications](Subscribing-To-Notifications/)
-
-Subscribe to notifications to execute custom code on a number of operations.

--- a/Fundamentals/Data/index.md
+++ b/Fundamentals/Data/index.md
@@ -51,7 +51,3 @@ An introduction to Relations and Relation Types, creating, and managing relation
 ## [Dictionary Items](Dictionary-Items/)
 
 Using Dictionary Items, you can store a value for each language. Dictionary Items have a unique key which is used to fetch the value of the Dictionary Item.
-
-## [Content Version Cleanup (v9.1.0+)](Content-Version-Cleanup/)
-
-How to keep the noise down whilst ensuring your important content versions stick around indefinitely.

--- a/Fundamentals/New-in-V8.md
+++ b/Fundamentals/New-in-V8.md
@@ -2,6 +2,7 @@
 meta.Title: "Learn what's new in Umbraco 8"
 meta.Description: "In this section you can read about all the new features and changes in Umbraco 8."
 versionFrom: 8.0.0
+needsV8Update: "true"
 ---
 
 # What's new in Umbraco 8?

--- a/Fundamentals/Setup/Install/index.md
+++ b/Fundamentals/Setup/Install/index.md
@@ -8,19 +8,13 @@ meta.Description: "Instructions on installing Umbraco: in VS code, via NuGet or 
 
 The easiest way to get the latest version of Umbraco up and running is with VS Code.
 
-:::note
-The information in this article covers installing Umbraco 8 or older versions of Umbraco CMS.
-
-Go to [**docs.umbraco.com**](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/install) to find documentation on installing the latest recommended version of Umbraco CMS.
-:::
-
 1. **Download and install [Visual Studio Code](https://code.visualstudio.com/)**
-1. **Download and install [IIS Express](https://www.microsoft.com/en-us/download/details.aspx?id=48264) (Optional as IIS Express for VSCode will install it)**
-1. **Download and unzip [Umbraco](https://our.umbraco.com/download)**
-1. **Install the [IIS Express Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=warren-buckley.iis-express)**
-1. **Open the unzipped root folder in VS Code**
-1. **Run the website with the IIS Express Extension (CTRL+F5)**
-1. **Follow instructions on installer**
+2. **Download and install [IIS Express](https://www.microsoft.com/en-us/download/details.aspx?id=48264) (Optional as IIS Express for VSCode will install it)**
+3. **Download and unzip [Umbraco](https://our.umbraco.com/download)**
+4. **Install the [IIS Express Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=warren-buckley.iis-express)**
+5. **Open the unzipped root folder in VS Code**
+6. **Run the website with the IIS Express Extension (CTRL+F5)**
+7. **Follow instructions on installer**
 
 If you have never used VS Code before, you can check out a more detailed guide below that shows these steps more in depth to run a local instance of Umbraco.
 Below you'll find some in-depth tutorials on the different ways to install Umbraco.

--- a/Fundamentals/Setup/Install/install-umbraco-with-nuget.md
+++ b/Fundamentals/Setup/Install/install-umbraco-with-nuget.md
@@ -1,16 +1,11 @@
 ---
 versionFrom: 8.0.0
+meta.RedirectLink: "/umbraco-cms/fundamentals/setup/install"
 ---
 
 # Install Umbraco with NuGet
 
 _Follow these steps to do a full install of Umbraco with NuGet._
-
-:::note
-The information in this article covers installing Umbraco 8 or older versions of Umbraco CMS.
-
-Go to [**docs.umbraco.com**](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/install) to find documentation on installing the latest recommended version of Umbraco CMS.
-:::
 
 ## Abbreviated version
 

--- a/Fundamentals/Setup/Requirements/index.md
+++ b/Fundamentals/Setup/Requirements/index.md
@@ -4,12 +4,6 @@ versionFrom: 8.0.0
 
 # Minimum System Requirements
 
-:::note
-This article covers requirements for Umbraco 8 and older versions of Umbraco CMS.
-
-Go to [**docs.umbraco.com**](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/requirements) to find requirements for the latest recommended version of Umbraco CMS.
-:::
-
 ## Browsers
 
 The Umbraco UI should work in all modern browsers:

--- a/Fundamentals/Setup/Server-Setup/permissions.md
+++ b/Fundamentals/Setup/Server-Setup/permissions.md
@@ -6,12 +6,6 @@ versionFrom: 8.0.0
 
 # File and folder permissions
 
-:::warning
-Are you using **Umbraco 10** or a later version?
-
-Find the relevant documentation in the [file and folder permissions documentation for Umbraco 10+](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/server-setup/permissions).
-:::
-
 :::note
 To ensure a stable and smoothly running Umbraco installation, these permissions need to be set correctly. These permissions should be setup before or during the installation of Umbraco.
 

--- a/Fundamentals/Setup/Upgrading/general.md
+++ b/Fundamentals/Setup/Upgrading/general.md
@@ -6,12 +6,6 @@ versionFrom: 8.0.0
 
 _This is the guide for upgrading in general._
 
-:::note
-The information in this article will enable you to upgrade your project to the **latest version of Umbraco 8**.
-
-Go to [**docs.umbraco.com**](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/upgrading) to find instructions on upgrading the latest recommended version of Umbraco CMS.
-:::
-
 :::warning
 **Important**: If you are upgrading to a new major version, like from Umbraco 7 to Umbraco 8, make sure to check out the **[version-specific documentation.](version-specific.md)**
 

--- a/Fundamentals/index.md
+++ b/Fundamentals/index.md
@@ -62,10 +62,6 @@ Learn more about the features in Umbraco v8.
                 <h5><a href="Setup/Upgrading/">Upgrading</a></h5>
                 <small>How to upgrade your copy of Umbraco to a newer version?</small>
             </div>
-            <div class="col-sm-6">
-                <h5><a href="Setup/Config/">Configuration</a></h5>
-                <small>Information about all of the different configuration files that control Umbraco.</small>
-            </div>
         </div>
     </div>
 </div>

--- a/Reference/Management/Services/SectionService/Index.md
+++ b/Reference/Management/Services/SectionService/Index.md
@@ -1,6 +1,6 @@
 ---
 versionFrom: 8.0.0
-needsV8Update: "true"
+versionRemoved: 8.0.0
 ---
 
 # SectionService

--- a/Reference/Management/Services/SectionService/Index.md
+++ b/Reference/Management/Services/SectionService/Index.md
@@ -1,9 +1,10 @@
 ---
 versionFrom: 8.0.0
+needsV8Update: "true"
 ---
 
 # SectionService
+
 The Umbraco backoffice consists of Sections, also referred to as Applications.
 
-In previous versions the SectionService was used to control/query the storage for section registrations in the ~/Config/applications.config file. This config file no longer exists in the current version and therefore the SectionService has become unnecessary. 
-
+In previous versions the SectionService was used to control/query the storage for section registrations in the ~/Config/applications.config file. This config file no longer exists in the current version and therefore the SectionService has become unnecessary.


### PR DESCRIPTION
- Added the `needsV8Update: "true"` tag where the "We have moved" box has to be removed since there is no higher version for that article.
- Removed links to v9+ articles since folders are not available in the current branch and throws broken link error on Our.
- Removed warning msg with links to new doc site since the "We have moved" box has the correct link.