### PR TITLE
Fixed auto-gen links

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Healthchecks/scripts/Apply-keys.md
+++ b/Add-ons/UmbracoForms/Developer/Healthchecks/scripts/Apply-keys.md
@@ -1,5 +1,6 @@
 ---
 meta.Title: "Apply keys and indexes"
+meta.RedirectLink: "/umbraco-forms/developer/healthchecks/apply-keys"
 ---
 
 # Apply keys and indexes

--- a/Add-ons/UmbracoForms/Developer/Healthchecks/scripts/Forms-in-the-database-apply-keys.md
+++ b/Add-ons/UmbracoForms/Developer/Healthchecks/scripts/Forms-in-the-database-apply-keys.md
@@ -1,5 +1,6 @@
 ---
 meta.Title: "Apply keys and indexes for forms in the database"
+meta.RedirectLink: "/umbraco-forms/developer/healthchecks/forms-in-the-database-apply-keys"
 ---
 
 # Apply keys and indexes for forms in the database

--- a/Fundamentals/Code/Source-Control/index-v7.md
+++ b/Fundamentals/Code/Source-Control/index-v7.md
@@ -1,6 +1,5 @@
 ---
 versionFrom: 7.0.0
-needsV8Update: "true"
 ---
 
 # Source Control

--- a/Fundamentals/Setup/Server-Setup/Load-Balancing/files-replicated.md
+++ b/Fundamentals/Setup/Server-Setup/Load-Balancing/files-replicated.md
@@ -1,5 +1,6 @@
 ---
 versionFrom: 8.0.0
+meta.RedirectLink: "/umbraco-cms/fundamentals/setup/server-setup/load-balancing/file-system-replication"
 ---
 
 [Replaced by file system replication in v8+](file-system-replication.md)

--- a/Fundamentals/Setup/Server-Setup/Load-Balancing/files-shared.md
+++ b/Fundamentals/Setup/Server-Setup/Load-Balancing/files-shared.md
@@ -1,6 +1,6 @@
 ---
 versionFrom: 8.0.0
-meta.RedirectLink: "/umbraco-cms/fundamentals/setup/server-setup/load-balancing/file-system-replication"
+versionRemoved: 8.0.0
 ---
 
 [Replaced by file system replication in v8+](file-system-replication.md)

--- a/Fundamentals/Setup/Server-Setup/Load-Balancing/files-shared.md
+++ b/Fundamentals/Setup/Server-Setup/Load-Balancing/files-shared.md
@@ -1,5 +1,6 @@
 ---
 versionFrom: 8.0.0
+meta.RedirectLink: "/umbraco-cms/fundamentals/setup/server-setup/load-balancing/file-system-replication"
 ---
 
 [Replaced by file system replication in v8+](file-system-replication.md)

--- a/Fundamentals/Setup/Server-Setup/Load-Balancing/flexible.md
+++ b/Fundamentals/Setup/Server-Setup/Load-Balancing/flexible.md
@@ -1,6 +1,6 @@
 ---
 versionFrom: 8.0.0
-meta.RedirectLink: "/umbraco-cms/fundamentals/setup/server-setup/load-balancing/file-system-replication"
+versionRemoved: 8.0.0
 ---
 
 [Replaced by file system replication in v8+](file-system-replication.md)

--- a/Fundamentals/Setup/Server-Setup/Load-Balancing/flexible.md
+++ b/Fundamentals/Setup/Server-Setup/Load-Balancing/flexible.md
@@ -1,5 +1,6 @@
 ---
 versionFrom: 8.0.0
+meta.RedirectLink: "/umbraco-cms/fundamentals/setup/server-setup/load-balancing/file-system-replication"
 ---
 
 [Replaced by file system replication in v8+](file-system-replication.md)


### PR DESCRIPTION
For the https://our.umbraco.com/Documentation/Fundamentals/Code/Source-Control/index-v7, I've removed the `needsV8Update: "true"` tag since we have a v8 article for it.