### PR TITLE
Update rewrite rules docs

### DIFF
--- a/10/umbraco-cms/reference/routing/iisrewriterules.md
+++ b/10/umbraco-cms/reference/routing/iisrewriterules.md
@@ -110,3 +110,9 @@ Another example would be to redirect from non-www to www (except for the Umbraco
   <action type="Redirect" url="https://www.{HTTP_HOST}/{R:0}" />
 </rule>
 ```
+
+{% hint style="warning" %}
+Adding the www redirect rule requires a `<add input="{HTTP_HOST}" pattern=".*azurewebsites.net*" negate="true" ignoreCase="true" />` condition to be added in order for Umbraco Cloud to function correctly.
+
+This step is required for the deployment service and the content transfer between environments to continue to function.
+{% endhint %}

--- a/11/umbraco-cms/reference/routing/iisrewriterules.md
+++ b/11/umbraco-cms/reference/routing/iisrewriterules.md
@@ -108,5 +108,5 @@ Another example would be to redirect from non-www to www (except for the Umbraco
 
 {% hint style="warning" %}
 Adding wwww redirect rule requires <add input="{HTTP_HOST}" pattern=".*azurewebsites.net*" negate="true" ignoreCase="true" /> condition to be added as well in order for Umbraco to function correctly.
-Failing to do so will cause the deployment service to fail and content transfer between environments will fail.
+This step is required for the deployment service and the content transfer between environments to function properly.
 {% endhint %}

--- a/11/umbraco-cms/reference/routing/iisrewriterules.md
+++ b/11/umbraco-cms/reference/routing/iisrewriterules.md
@@ -99,9 +99,15 @@ Another example would be to redirect from non-www to www (except for the Umbraco
   <match url=".*" />
   <conditions>
     <add input="{HTTP_HOST}" pattern="^www\." negate="true" />
+    <add input="{HTTP_HOST}" pattern=".*azurewebsites.net*" negate="true" ignoreCase="true" />
     <add input="{HTTP_HOST}" pattern="^localhost(:[0-9]+)?$" negate="true" />
     <add input="{HTTP_HOST}" pattern="\.umbraco\.io$" negate="true" />
   </conditions>
   <action type="Redirect" url="https://www.{HTTP_HOST}/{R:0}" />
 </rule>
 ```
+
+{% hint style="warning" %}
+Adding wwww redirect rule requires the ".*azurewebsites.net*" pattern to be added as well in order for Umbraco to function correctly.
+Failing to do so will cause the deployment service to fail and you will be unable to deploy changes from one environment to the next.
+{% endhint %}

--- a/11/umbraco-cms/reference/routing/iisrewriterules.md
+++ b/11/umbraco-cms/reference/routing/iisrewriterules.md
@@ -107,6 +107,7 @@ Another example would be to redirect from non-www to www (except for the Umbraco
 ```
 
 {% hint style="warning" %}
-Adding wwww redirect rule requires <add input="{HTTP_HOST}" pattern=".*azurewebsites.net*" negate="true" ignoreCase="true" /> condition to be added as well in order for Umbraco to function correctly.
-This step is required for the deployment service and the content transfer between environments to function properly.
+Adding the www redirect rule requires a `<add input="{HTTP_HOST}" pattern=".*azurewebsites.net*" negate="true" ignoreCase="true" />` condition to be added in order for Umbraco Cloud to function correctly.
+
+This step is required for the deployment service and the content transfer between environments to continue to function.
 {% endhint %}

--- a/11/umbraco-cms/reference/routing/iisrewriterules.md
+++ b/11/umbraco-cms/reference/routing/iisrewriterules.md
@@ -99,7 +99,6 @@ Another example would be to redirect from non-www to www (except for the Umbraco
   <match url=".*" />
   <conditions>
     <add input="{HTTP_HOST}" pattern="^www\." negate="true" />
-    <add input="{HTTP_HOST}" pattern=".*azurewebsites.net*" negate="true" ignoreCase="true" />
     <add input="{HTTP_HOST}" pattern="^localhost(:[0-9]+)?$" negate="true" />
     <add input="{HTTP_HOST}" pattern="\.umbraco\.io$" negate="true" />
   </conditions>
@@ -108,6 +107,6 @@ Another example would be to redirect from non-www to www (except for the Umbraco
 ```
 
 {% hint style="warning" %}
-Adding wwww redirect rule requires the ".*azurewebsites.net*" pattern to be added as well in order for Umbraco to function correctly.
-Failing to do so will cause the deployment service to fail and you will be unable to deploy changes from one environment to the next.
+Adding wwww redirect rule requires <add input="{HTTP_HOST}" pattern=".*azurewebsites.net*" negate="true" ignoreCase="true" /> condition to be added as well in order for Umbraco to function correctly.
+Failing to do so will cause the deployment service to fail and content transfer between environments will fail.
 {% endhint %}


### PR DESCRIPTION
We need to enrich the www redirect rule to contain ".*azurewebsites.net*" pattern, otherwise we will have issues deploying as the rule will redirect to www.{stie}.azurewebsites.net which will break the deployment process.

Fixing this in the site extension is a no-go, as we don't want to hijack the customer's rewrite rules.

DISCUSSION:
Do we want to include a warning hint mentioning this? 🤔  
I've added it, but can be removed or updated if it does not make sense.