### PR TITLE
Update docs on usage of language-files

### DIFF
--- a/umbraco-cms/extending/language-files.md
+++ b/umbraco-cms/extending/language-files.md
@@ -10,9 +10,8 @@ description: >-
 # Language Files & Localization
 
 Language files are used for translating:
-- The Umbraco backoffice user interface so that end users can use Umbraco in their native language.
-  This is particularly important for content editors who do not speak English.
-- The member identity errors in a Umbraco website so that end users can use Umbraco in the website language.
+- The Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
+- The member identity errors in an Umbraco website enabling end users to use Umbraco in the website language.
 
 If you are a package developer, [see here for docs on how to include translations for your own package](packages/language-files-for-packages.md).
 

--- a/umbraco-cms/extending/language-files.md
+++ b/umbraco-cms/extending/language-files.md
@@ -9,7 +9,10 @@ description: >-
 
 # Language Files & Localization
 
-Language files are used to translate the Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
+Language files are used for translating:
+- the Umbraco backoffice user interface so that end users can use Umbraco in their native language.
+  This is particularly important for content editors who do not speak English.
+- the member identity errors in a Umbraco website so that end users can use Umbraco in the website language.
 
 If you are a package developer, [see here for docs on how to include translations for your own package](packages/language-files-for-packages.md).
 

--- a/umbraco-cms/extending/language-files.md
+++ b/umbraco-cms/extending/language-files.md
@@ -10,9 +10,9 @@ description: >-
 # Language Files & Localization
 
 Language files are used for translating:
-- the Umbraco backoffice user interface so that end users can use Umbraco in their native language.
+- The Umbraco backoffice user interface so that end users can use Umbraco in their native language.
   This is particularly important for content editors who do not speak English.
-- the member identity errors in a Umbraco website so that end users can use Umbraco in the website language.
+- The member identity errors in a Umbraco website so that end users can use Umbraco in the website language.
 
 If you are a package developer, [see here for docs on how to include translations for your own package](packages/language-files-for-packages.md).
 


### PR DESCRIPTION
Language files are not only used in backoffice, but also for member identity errors in a website. This is missing in the docs.