### PR TITLE
Update language-files to document usage by member identity errors in website

### DIFF
--- a/10/umbraco-cms/extending/language-files.md
+++ b/10/umbraco-cms/extending/language-files.md
@@ -9,7 +9,9 @@ description: >-
 
 # Language Files & Localization
 
-Language files are used to translate the Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
+Language files are used to translate:
+- The Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
+- The member identity errors in an Umbraco website enabling end users to use Umbraco in the website language.
 
 If you are a package developer, [see here for docs on how to include translations for your own package](packages/language-files-for-packages.md).
 

--- a/11/umbraco-cms/extending/language-files.md
+++ b/11/umbraco-cms/extending/language-files.md
@@ -6,7 +6,9 @@ description: >-
 
 # Language Files & Localization
 
-Language files are used to translate the Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
+Language files are used to translate:
+- The Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
+- The member identity errors in an Umbraco website enabling end users to use Umbraco in the website language.
 
 If you are a package developer, [see here for docs on how to include translations for your own package](packages/language-files-for-packages.md).
 


### PR DESCRIPTION
The documentation now states that language files are only used by backoffice.
However, these files are used by member identity which in turn is also used by an Umbraco website. 