### PR TITLE
Include legacy versions for upgrading

### DIFF
--- a/umbraco-cloud/product-upgrades/manual-upgrades/manual-upgrade-deploy.md
+++ b/umbraco-cloud/product-upgrades/manual-upgrades/manual-upgrade-deploy.md
@@ -43,7 +43,7 @@ Make sure that everything works on the local clone and that you can **run the pr
 
 <details>
 
-<summary>Upgrading Deploy Legacy Version 7 & 8</summary>
+<summary>Manually Upgrade Umbraco Deploy Legacy versions 7 and 8</summary>
   If you are on Umbraco 7 or Umbraco 8, follow the steps below to manually upgrade Umbraco Deploy to a later version of your project.
 1.   Download the latest version of Umbraco Deploy here: [http://nightly.umbraco.org/?container=umbraco-deploy-release](https://nightly.umbraco.org/?container=umbraco-deploy-release)
     Check [Product Dependencies](https://docs.umbraco.com/umbraco-cloud/product-upgrades/product-dependencies) to be sure you download the correct version of Deploy

--- a/umbraco-cloud/product-upgrades/manual-upgrades/manual-upgrade-deploy.md
+++ b/umbraco-cloud/product-upgrades/manual-upgrades/manual-upgrade-deploy.md
@@ -44,7 +44,9 @@ Make sure that everything works on the local clone and that you can **run the pr
 <details>
 
 <summary>Manually Upgrade Umbraco Deploy Legacy versions 7 and 8</summary>
+
   If you are on Umbraco 7 or Umbraco 8, follow the steps below to manually upgrade Umbraco Deploy to a later version of your project.
+  
 1.   Download the latest version of Umbraco Deploy here: [http://nightly.umbraco.org/?container=umbraco-deploy-release](https://nightly.umbraco.org/?container=umbraco-deploy-release)
     Check [Product Dependencies](https://docs.umbraco.com/umbraco-cloud/product-upgrades/product-dependencies) to be sure you download the correct version of Deploy
     

--- a/umbraco-cloud/product-upgrades/manual-upgrades/manual-upgrade-deploy.md
+++ b/umbraco-cloud/product-upgrades/manual-upgrades/manual-upgrade-deploy.md
@@ -41,6 +41,29 @@ When the command completes, open the `.csproj` file to make sure the package ref
 
 Make sure that everything works on the local clone and that you can **run the project without any errors**.
 
+<details>
+
+<summary>Upgrading Deploy Legacy Version 7 & 8</summary>
+  
+1.   Download the latest version of Umbraco Deploy here: [http://nightly.umbraco.org/?container=umbraco-deploy-release](https://nightly.umbraco.org/?container=umbraco-deploy-release)
+    Check [Product Dependencies](https://docs.umbraco.com/umbraco-cloud/product-upgrades/product-dependencies) to be sure you download the correct version of Deploy
+    
+2.   Unzip the file on your computer
+    
+3.   Copy/Paste the files from the unzipped folder to your local project folder
+    You should not overwrite the following files:
+```
+    Config/UmbracoDeploy.config
+    Config/UmbracoDeploy.Settings.config
+```
+4.   Run the project locally - make sure it runs without any errors
+
+5.   Commit and deploy the changes to the Cloud environment
+
+6.   Again, make sure everything runs without errors before deploying to the next Cloud environment
+
+</details>
+
 ## Push upgrade to Cloud
 
 When you've upgraded everything locally, and made sure that everything runs without any errors, you are ready to deploy the upgrade to Umbraco Cloud.

--- a/umbraco-cloud/product-upgrades/manual-upgrades/manual-upgrade-deploy.md
+++ b/umbraco-cloud/product-upgrades/manual-upgrades/manual-upgrade-deploy.md
@@ -44,7 +44,7 @@ Make sure that everything works on the local clone and that you can **run the pr
 <details>
 
 <summary>Upgrading Deploy Legacy Version 7 & 8</summary>
-  
+  If you are on Umbraco 7 or Umbraco 8, follow the steps below to manually upgrade Umbraco Deploy to a later version of your project.
 1.   Download the latest version of Umbraco Deploy here: [http://nightly.umbraco.org/?container=umbraco-deploy-release](https://nightly.umbraco.org/?container=umbraco-deploy-release)
     Check [Product Dependencies](https://docs.umbraco.com/umbraco-cloud/product-upgrades/product-dependencies) to be sure you download the correct version of Deploy
     


### PR DESCRIPTION
A lot of people are still on v8, and although we no longer support it I still believe it's good to have included how you can upgrade your project manually, as the steps are not the same compared to v9+

Here, I have made a little dropdown to include them, its not intrusive, however still available info for those that need it.

Not sure about the wording on the "Summary" though.