### PR TITLE
Added a link to Examine events

### DIFF
--- a/10/umbraco-cms/reference/searching/examine/indexing.md
+++ b/10/umbraco-cms/reference/searching/examine/indexing.md
@@ -9,7 +9,7 @@ versionTo: 10.0.0
 
 You can modify the built-in indexes in the following ways:
 
-* Events - giving you control over exactly what data goes into them and how the fields are configured
+* [Events](https://shazwazza.github.io/Examine/indexing) - giving you control over exactly what data goes into them and how the fields are configured
 * Changing the field value types to change how values are stored in the index
 * Changing the `IValueSetValidator` to change what goes into the index
 * Take control of the entire index creation pipeline to change the implementation

--- a/10/umbraco-cms/reference/searching/examine/indexing.md
+++ b/10/umbraco-cms/reference/searching/examine/indexing.md
@@ -9,7 +9,7 @@ versionTo: 10.0.0
 
 You can modify the built-in indexes in the following ways:
 
-* [Events](https://shazwazza.github.io/Examine/indexing) - giving you control over exactly what data goes into them and how the fields are configured
+* [Events](https://shazwazza.github.io/Examine/indexing#events) - giving you control over exactly what data goes into them and how the fields are configured
 * Changing the field value types to change how values are stored in the index
 * Changing the `IValueSetValidator` to change what goes into the index
 * Take control of the entire index creation pipeline to change the implementation

--- a/10/umbraco-cms/reference/searching/examine/indexing.md
+++ b/10/umbraco-cms/reference/searching/examine/indexing.md
@@ -9,7 +9,7 @@ versionTo: 10.0.0
 
 You can modify the built-in indexes in the following ways:
 
-* [Events](https://shazwazza.github.io/Examine/indexing#events) - giving you control over exactly what data goes into them and how the fields are configured
+* [Events](https://shazwazza.github.io/Examine/articles/indexing.html#events) - giving you control over exactly what data goes into them and how the fields are configured
 * Changing the field value types to change how values are stored in the index
 * Changing the `IValueSetValidator` to change what goes into the index
 * Take control of the entire index creation pipeline to change the implementation

--- a/11/umbraco-cms/reference/searching/examine/indexing.md
+++ b/11/umbraco-cms/reference/searching/examine/indexing.md
@@ -10,7 +10,7 @@ description: >-
 
 You can modify the built-in indexes in the following ways:
 
-* [Events](https://shazwazza.github.io/Examine/indexing) - giving you control over exactly what data goes into them and how the fields are configured
+* [Events](https://shazwazza.github.io/Examine/indexing#events) - giving you control over exactly what data goes into them and how the fields are configured
 * Changing the field value types to change how values are stored in the index
 * Changing the `IValueSetValidator` to change what goes into the index
 * Take control of the entire index creation pipeline to change the implementation

--- a/11/umbraco-cms/reference/searching/examine/indexing.md
+++ b/11/umbraco-cms/reference/searching/examine/indexing.md
@@ -10,7 +10,7 @@ description: >-
 
 You can modify the built-in indexes in the following ways:
 
-* Events - giving you control over exactly what data goes into them and how the fields are configured
+* [Events](https://shazwazza.github.io/Examine/indexing) - giving you control over exactly what data goes into them and how the fields are configured
 * Changing the field value types to change how values are stored in the index
 * Changing the `IValueSetValidator` to change what goes into the index
 * Take control of the entire index creation pipeline to change the implementation

--- a/11/umbraco-cms/reference/searching/examine/indexing.md
+++ b/11/umbraco-cms/reference/searching/examine/indexing.md
@@ -10,7 +10,7 @@ description: >-
 
 You can modify the built-in indexes in the following ways:
 
-* [Events](https://shazwazza.github.io/Examine/indexing#events) - giving you control over exactly what data goes into them and how the fields are configured
+* [Events](https://shazwazza.github.io/Examine/articles/indexing.html#events) - giving you control over exactly what data goes into them and how the fields are configured
 * Changing the field value types to change how values are stored in the index
 * Changing the `IValueSetValidator` to change what goes into the index
 * Take control of the entire index creation pipeline to change the implementation


### PR DESCRIPTION
Our Umbraco docs used to cover the Examine events `TransformingIndexValues` with the view to allowing developers to customise the External index. This has been dropped because we're not seeking to document Examine, but it leaves developers a little unsure how to achieve customisation of indexes.

I've sort a minimal update to avoid this confusion by adding a link to the Examine events documentation, where they are briefly mentioned.