### PR TITLE
Updated details about retrieving record values in workflow execution.

### DIFF
--- a/10/umbraco-forms/developer/extending/adding-a-workflowtype.md
+++ b/10/umbraco-forms/developer/extending/adding-a-workflowtype.md
@@ -44,7 +44,7 @@ namespace MyFormsExtensions
                 List<object> vals = rf.Values;
 
                 // or get it as a string
-                rf.ValuesAsString();
+                rf.ValuesAsString(false);
             }
 
             //Change the state
@@ -64,9 +64,41 @@ namespace MyFormsExtensions
 }
 ```
 
-The `Execute()` method gets a `WorkflowExecutionContext` which has properties for the related `Form`, `Record` and `FormState`.  This parameter contains all information related to the workflow.  The `Record` contains all data and meta data submitted by the form. The `Form` references the form the record is from, and `FormState` provides its state.  Other context, such as the current `HttpContext`, if needed can be passed as constructor parameters (For example: the `HttpContext` can be accessed by injecting `IHttpContextAccessor`).
+## Information available to the workflow
 
-You will then need to register this new workflow type as a dependency.
+### Record information
+
+The `Execute()` method gets a `WorkflowExecutionContext` which has properties for the related `Form`, `Record`, and `FormState`.  This parameter contains all information related to the workflow.
+
+The `Record` contains all data and metadata submitted by the form.  As shown in the example above, you can iterate over all `RecordField` values in the form. You can also retrieve a specific record field by alias using the following method:
+
+```csharp
+RecordField? recordField = context.Record.GetRecordFieldByAlias("myalias");
+```
+
+Having obtained a reference to a record field, the submitted value can be retrieved via:
+
+```csharp
+var fieldValue = recordField.ValuesAsString(false);
+```
+
+The `ValuesAsString` will JSON escape the result by default. If you do not want this escaping to occur, pass `false` as the parameter.
+
+If the field stores multiple values, they are delimited with a comma. In many cases, you can safely split on that delimiter to obtain the individual values. However, this can lead to issues if the prevalues being selected also contain commas. If that's a concern, the following extension method is available in `Umbraco.Forms.Core.Extensions` to correctly parse the selected prevalues:
+
+```csharp
+IEnumerable<string> selectedPrevalues = recordField.GetSelectedPrevalues();
+```
+
+### Form and state information
+
+The `Form` references the form the record is from and `FormState` provides its state (submitted or approved).
+
+Other context, such as the current `HttpContext`, if needed can be passed as constructor parameters (for example: the `HttpContext` can be accessed by injecting `IHttpContextAccessor`).
+
+## Registering the workflow type
+
+To use the new workflow type, you will need to register it as part of application startup.
 
 ```csharp
 using Umbraco.Cms.Core.Composing;

--- a/11/umbraco-forms/developer/extending/adding-a-workflowtype.md
+++ b/11/umbraco-forms/developer/extending/adding-a-workflowtype.md
@@ -44,7 +44,7 @@ namespace MyFormsExtensions
                 List<object> vals = rf.Values;
 
                 // or get it as a string
-                rf.ValuesAsString();
+                rf.ValuesAsString(false);
             }
 
             //Change the state
@@ -79,8 +79,10 @@ RecordField? recordField = context.Record.GetRecordFieldByAlias("myalias");
 Having obtained a reference to a record field, the submitted value can be retrieved via:
 
 ```csharp
-var fieldValue = recordField.ValuesAsString();
+var fieldValue = recordField.ValuesAsString(false);
 ```
+
+The `ValuesAsString` will JSON escape the result by default. If you do not want this escaping to occur, pass `false` as the parameter.
 
 If the field stores multiple values, they are delimited with a comma. In many cases, you can safely split on that delimiter to obtain the individual values. However, this can lead to issues if the prevalues being selected also contain commas. If that's a concern, the following extension method is available in `Umbraco.Forms.Core.Extensions` to correctly parse the selected prevalues:
 


### PR DESCRIPTION
This adds some information about a method parameter that wasn't otherwise documented, and aligns the 10 and 11 versions.