### PR TITLE
Link to Umbraco backoffice site from CMS

### DIFF
--- a/10/umbraco-cms/extending/backoffice-ui-api-documentation.md
+++ b/10/umbraco-cms/extending/backoffice-ui-api-documentation.md
@@ -6,6 +6,14 @@ versionFrom: 10.0.0
 
 A library of API Reference documentation is auto-generated from the comments within the Umbraco Source Code.
 
+{% hint style="info" %}
+A new backoffice for Umbraco CMS is currently being worked on. It is planned for release with Umbraco 13 i December of 2023.
+
+We have gathered all information and resources about the project in one place, giving you a full overview of what we're working on. You will also be able to find information about how to get involved in the project.
+
+You can find it all on [docs.umbraco.com/umbraco-backoffice](https://docs.umbraco.com/umbraco-backoffice).
+{% endhint %}
+
 ## [Backoffice UI](https://apidocs.umbraco.com/v10/ui)
 
 Angular, JavaScript, CSS & Less UI API references for building Umbraco backoffice components. V10 is using minified versions of the following files:

--- a/10/umbraco-cms/extending/backoffice-ui-api-documentation.md
+++ b/10/umbraco-cms/extending/backoffice-ui-api-documentation.md
@@ -7,7 +7,7 @@ versionFrom: 10.0.0
 A library of API Reference documentation is auto-generated from the comments within the Umbraco Source Code.
 
 {% hint style="info" %}
-A new backoffice for Umbraco CMS is currently being worked on. It is planned for release with Umbraco 13 i December of 2023.
+A new backoffice for Umbraco CMS is currently being worked upon. It is planned to release with Umbraco version 13 in December 2023.
 
 We have gathered all information and resources about the project in one place, giving you a full overview of what we're working on. You will also be able to find information about how to get involved in the project.
 

--- a/10/umbraco-cms/extending/ui-library.md
+++ b/10/umbraco-cms/extending/ui-library.md
@@ -5,12 +5,7 @@ description: A guide for getting started working with the Umbraco UI Library
 # UI Library
 
 {% hint style="info" %}
-Please be aware that the topic covered in this document is currently only available in the following versions of Umbraco:
-
-* The latest version of Umbraco 10.
-* The Release Candidate (RC) for Umbraco 11.
-
-The new UI Library is currently _opt-in_ and something we recommend Backoffice and package developers start getting familiar with.
+The UI Library is currently _opt-in_ and something we recommend Backoffice and package developers start getting familiar with
 
 In the [Backoffice UI API Documentation](backoffice-ui-api-documentation.md) article you can find links to relevant resources for working with the Umbraco backoffice.
 {% endhint %}

--- a/10/umbraco-cms/extending/ui-library.md
+++ b/10/umbraco-cms/extending/ui-library.md
@@ -5,7 +5,7 @@ description: A guide for getting started working with the Umbraco UI Library
 # UI Library
 
 {% hint style="info" %}
-The UI Library is currently _opt-in_ and something we recommend Backoffice and package developers start getting familiar with
+The UI Library is currently _opt-in_. We recommend Backoffice and package developers start getting familiar with it.
 
 In the [Backoffice UI API Documentation](backoffice-ui-api-documentation.md) article you can find links to relevant resources for working with the Umbraco backoffice.
 {% endhint %}

--- a/11/umbraco-cms/extending/backoffice-ui-api-documentation.md
+++ b/11/umbraco-cms/extending/backoffice-ui-api-documentation.md
@@ -2,6 +2,14 @@
 
 A library of API Reference documentation is auto-generated from the comments within the Umbraco Source Code.
 
+{% hint style="info" %}
+A new backoffice for Umbraco CMS is currently being worked on. It is planned for release with Umbraco 13 i December of 2023.
+
+We have gathered all information and resources about the project in one place, giving you a full overview of what we're working on. You will also be able to find information about how to get involved in the project.
+
+You can find it all on [docs.umbraco.com/umbraco-backoffice](https://docs.umbraco.com/umbraco-backoffice).
+{% endhint %}
+
 ## [Backoffice UI](https://apidocs.umbraco.com/v10/ui)
 
 Angular, JavaScript, CSS & Less UI API references for building Umbraco backoffice components. V10 is using minified versions of the following files:

--- a/11/umbraco-cms/extending/backoffice-ui-api-documentation.md
+++ b/11/umbraco-cms/extending/backoffice-ui-api-documentation.md
@@ -3,7 +3,7 @@
 A library of API Reference documentation is auto-generated from the comments within the Umbraco Source Code.
 
 {% hint style="info" %}
-A new backoffice for Umbraco CMS is currently being worked on. It is planned for release with Umbraco 13 i December of 2023.
+A new backoffice for Umbraco CMS is currently being worked upon. It is planned to release with Umbraco version 13 in December 2023.
 
 We have gathered all information and resources about the project in one place, giving you a full overview of what we're working on. You will also be able to find information about how to get involved in the project.
 

--- a/11/umbraco-cms/extending/ui-library.md
+++ b/11/umbraco-cms/extending/ui-library.md
@@ -5,7 +5,7 @@ description: "A guide for getting started working with the Umbraco UI Library"
 # UI Library
 
 {% hint style="info" %}
-The UI Library is currently _opt-in_ and something we recommend Backoffice and package developers start getting familiar with.
+The UI Library is currently _opt-in_ and something we recommend Backoffice and package developers start getting familiar with
 
 In the [Backoffice UI API Documentation](backoffice-ui-api-documentation.md) article you can find links to relevant resources for working with the Umbraco backoffice.
 {% endhint %}

--- a/11/umbraco-cms/extending/ui-library.md
+++ b/11/umbraco-cms/extending/ui-library.md
@@ -5,7 +5,7 @@ description: "A guide for getting started working with the Umbraco UI Library"
 # UI Library
 
 {% hint style="info" %}
-The UI Library is currently _opt-in_ and something we recommend Backoffice and package developers start getting familiar with
+The UI Library is currently _opt-in_. We recommend Backoffice and package developers start getting familiar with it.
 
 In the [Backoffice UI API Documentation](backoffice-ui-api-documentation.md) article you can find links to relevant resources for working with the Umbraco backoffice.
 {% endhint %}


### PR DESCRIPTION
I've created a link to the new Umbraco Backoffice site from the article about the Backoffice UI API docs in the CMS docs.