### PR TITLE
Remove a line from the article

### DIFF
--- a/umbraco-cloud/set-up/project-settings/public-access.md
+++ b/umbraco-cloud/set-up/project-settings/public-access.md
@@ -15,9 +15,7 @@ The [Umbraco.Cloud.Cms.PublicAccess](https://www.nuget.org/packages/Umbraco.Clou
 When enabled only team members on the project and users whose IPs have been allowed, can access the frontend of the project.
 
 All environments on Umbraco Cloud projects can be protected by Public access. It requires you to enter your Cloud credentials in order to view the frontend.
-
-By default, we add **Basic Authentication** to all trials and non-live environments.      
-
+    
 ## How to enable Basic Authentication and allow IPs
 
 1. Go to **Public Access** in the **project settings** tab


### PR DESCRIPTION
Removed the following line: 
"By default, we add Basic Authentication to all trials and non-live environments."

This is not correct I checked with Søren and v9+ projects and all trials don't have the Basic Authentication enabled by default. The Public access option will be enabled on all the trials at some point in the next sprints.