### PR TITLE
Add OnParseCommandsAsync example

### DIFF
--- a/10/umbraco-cms/reference/configuration/imagingsettings.md
+++ b/10/umbraco-cms/reference/configuration/imagingsettings.md
@@ -87,3 +87,22 @@ Contains configuration for image resizing.
 ### Max width/max height
 
 Specifies the maximum width and height an image can be resized to. If the requested width and height are _both_ above the configured maximums, no resizing will be performed. This adds very basic security to prevent resizing to very big dimensions and using a lot of server CPU/memory to do so.
+
+The maximum width and height settings are enforced by setting the `ImageSharpMiddlewareOptions.OnParseCommandsAsync` option of ImageSharp to an Umbraco-specific function. If you want to add your own logic without overwriting this behaviour, use the following code:
+
+```csharp
+public class ConfigureImageSharpMiddlewareOptionsComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+        => builder.Services.Configure<ImageSharpMiddlewareOptions>(options =>
+        {
+            // Capture existing task to not overwrite it
+            var onParseCommandsAsync = options.OnParseCommandsAsync;
+            options.OnParseCommandsAsync = async context =>
+            {
+                // Custom logic before
+                await onParseCommandsAsync(context);
+                // Custom logic after
+            };
+        });
+}

--- a/11/umbraco-cms/reference/configuration/imagingsettings.md
+++ b/11/umbraco-cms/reference/configuration/imagingsettings.md
@@ -60,3 +60,25 @@ Contains configuration for image resizing.
 ### Max width/max height
 
 Specifies the maximum width and height an image can be resized to. If the requested width and height are _both_ above the configured maximums, no resizing will be performed. This adds very basic security to prevent resizing to very big dimensions and using a lot of server CPU/memory to do so.
+
+The maximum width and height settings are enforced by setting the `ImageSharpMiddlewareOptions.OnParseCommandsAsync` option of ImageSharp to an Umbraco-specific function. If you want to add your own logic without overwriting this behaviour, use the following code:
+
+```c#
+public class ConfigureImageSharpMiddlewareOptionsComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+        => builder.Services.Configure<ImageSharpMiddlewareOptions>(options =>
+        {
+            // Capture existing task to not overwrite it
+            var onParseCommandsAsync = options.OnParseCommandsAsync;
+            options.OnParseCommandsAsync = async context =>
+            {
+                // Custom logic before
+
+                await onParseCommandsAsync(context);
+
+                // Custom logic after
+            };
+        });
+}
+```

--- a/11/umbraco-cms/reference/configuration/imagingsettings.md
+++ b/11/umbraco-cms/reference/configuration/imagingsettings.md
@@ -63,7 +63,7 @@ Specifies the maximum width and height an image can be resized to. If the reques
 
 The maximum width and height settings are enforced by setting the `ImageSharpMiddlewareOptions.OnParseCommandsAsync` option of ImageSharp to an Umbraco-specific function. If you want to add your own logic without overwriting this behaviour, use the following code:
 
-```c#
+```csharp
 public class ConfigureImageSharpMiddlewareOptionsComposer : IComposer
 {
     public void Compose(IUmbracoBuilder builder)


### PR DESCRIPTION
This adds some context and example code on how to add your custom ImageSharp command parsing logic without overriding the build-in maximum width/height validation.