### PR TITLE
Release notes for Deploy 4.8/9.6/10.2/11.1

### DIFF
--- a/10/umbraco-deploy/release-notes.md
+++ b/10/umbraco-deploy/release-notes.md
@@ -20,6 +20,13 @@ Under each major version, you can find details about minor and patch releases fo
 
 <summary>Version 10</summary>
 
+#### [10.2.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.0) (April 11th 2023)
+
+* Restricted languages available to editors when deploying variant content to those allowed via the user permissions for languages.
+* Tidied up the Deploy dialogs for transfer, compare and restore to align with CMS conventions and remove redundant options.
+* Added a database lock to the persistent transfer queue, removing any risk of concurrency issues when adding or removing items from the queue.
+* Added support for new form properties introduced in the most recent minor release of Forms 10.
+
 #### [10.1.4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.1.4) (March 21st 2023)
 
 * Fixed issue with transfer of form workflow's "sensitive data" property. [#159](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/159)
@@ -87,6 +94,11 @@ Under each major version, you can find details about minor and patch releases fo
 <details>
 
 <summary>Version 9</summary>
+
+#### [9.6.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F9.6.0) (April 11th 2023)
+
+* Tidied up the Deploy dialogs for transfer, compare and restore to align with CMS conventions and remove redundant options.
+* Added a database lock to the persistent transfer queue, removing any risk of concurrency issues when adding or removing items from the queue.
 
 #### [9.5.4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F9.5.4) (March 21st 2023)
 
@@ -223,6 +235,11 @@ Under each major version, you can find details about minor and patch releases fo
 <details>
 
 <summary>Version 4</summary>
+
+#### [4.8.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.8.0) (April 11th 2023)
+
+* Tidied up the Deploy dialogs for transfer, compare and restore to align with CMS conventions and remove redundant options.
+* Added a database lock to the persistent transfer queue, removing any risk of concurrency issues when adding or removing items from the queue.
 
 #### [4.7.4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.7.4) (March 21st 2023)
 

--- a/10/umbraco-deploy/release-notes.md
+++ b/10/umbraco-deploy/release-notes.md
@@ -25,7 +25,7 @@ Under each major version, you can find details about minor and patch releases fo
 * Restricted languages available to editors when deploying variant content to those allowed via the user permissions for languages.
 * Tidied up the Deploy dialogs for transfer, compare and restore to align with CMS conventions and remove redundant options.
 * Added a database lock to the persistent transfer queue, removing any risk of concurrency issues when adding or removing items from the queue.
-* Added support for new form properties introduced in the most recent minor release of Forms 10.
+* Added support for new form properties introduced in the most recent minor release of Forms 11. [#161](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/161)
 
 #### [10.1.4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.1.4) (March 21st 2023)
 

--- a/11/umbraco-deploy/release-notes.md
+++ b/11/umbraco-deploy/release-notes.md
@@ -25,7 +25,7 @@ Under each major version, you can find details about minor and patch releases fo
 * Restricted languages available to editors when deploying variant content to those allowed via the user permissions for languages.
 * Tidied up the Deploy dialogs for transfer, compare and restore to align with CMS conventions and remove redundant options.
 * Added a database lock to the persistent transfer queue, removing any risk of concurrency issues when adding or removing items from the queue.
-* Added support for new form properties introduced in the most recent minor release of Forms 11.
+* Added support for new form properties introduced in the most recent minor release of Forms 11. [#161](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/161)
 
 #### [11.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.0.2) (March 21st 2023)
 
@@ -63,7 +63,7 @@ Under each major version, you can find details about minor and patch releases fo
 * Restricted languages available to editors when deploying variant content to those allowed via the user permissions for languages.
 * Tidied up the Deploy dialogs for transfer, compare and restore to align with CMS conventions and remove redundant options.
 * Added a database lock to the persistent transfer queue, removing any risk of concurrency issues when adding or removing items from the queue.
-* Added support for new form properties introduced in the most recent minor release of Forms 10.
+* Added support for new form properties introduced in the most recent minor release of Forms 11. [#161](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/161)
 
 #### [10.1.4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.1.4) (March 21st 2023)
 

--- a/11/umbraco-deploy/release-notes.md
+++ b/11/umbraco-deploy/release-notes.md
@@ -20,6 +20,13 @@ Under each major version, you can find details about minor and patch releases fo
 
 <summary>Version 11</summary>
 
+#### [11.1.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.1.0) (April 11th 2023)
+
+* Restricted languages available to editors when deploying variant content to those allowed via the user permissions for languages.
+* Tidied up the Deploy dialogs for transfer, compare and restore to align with CMS conventions and remove redundant options.
+* Added a database lock to the persistent transfer queue, removing any risk of concurrency issues when adding or removing items from the queue.
+* Added support for new form properties introduced in the most recent minor release of Forms 11.
+
 #### [11.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.0.2) (March 21st 2023)
 
 * Fixed issue with transfer of form workflow's "sensitive data" property. [#159](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/159)
@@ -50,6 +57,13 @@ Under each major version, you can find details about minor and patch releases fo
 <details>
 
 <summary>Version 10</summary>
+
+#### [10.2.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.0) (April 11th 2023)
+
+* Restricted languages available to editors when deploying variant content to those allowed via the user permissions for languages.
+* Tidied up the Deploy dialogs for transfer, compare and restore to align with CMS conventions and remove redundant options.
+* Added a database lock to the persistent transfer queue, removing any risk of concurrency issues when adding or removing items from the queue.
+* Added support for new form properties introduced in the most recent minor release of Forms 10.
 
 #### [10.1.4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.1.4) (March 21st 2023)
 
@@ -118,6 +132,11 @@ Under each major version, you can find details about minor and patch releases fo
 <details>
 
 <summary>Version 9</summary>
+
+#### [9.6.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F9.6.0) (April 11th 2023)
+
+* Tidied up the Deploy dialogs for transfer, compare and restore to align with CMS conventions and remove redundant options.
+* Added a database lock to the persistent transfer queue, removing any risk of concurrency issues when adding or removing items from the queue.
 
 #### [9.5.4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F9.5.4) (March 21st 2023)
 
@@ -254,6 +273,11 @@ Under each major version, you can find details about minor and patch releases fo
 <details>
 
 <summary>Version 4</summary>
+
+#### [4.8.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.8.0) (April 11th 2023)
+
+* Tidied up the Deploy dialogs for transfer, compare and restore to align with CMS conventions and remove redundant options.
+* Added a database lock to the persistent transfer queue, removing any risk of concurrency issues when adding or removing items from the queue.
 
 #### [4.7.4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.7.4) (March 21st 2023)
 

--- a/11/umbraco-deploy/release-notes.md
+++ b/11/umbraco-deploy/release-notes.md
@@ -26,6 +26,7 @@ Under each major version, you can find details about minor and patch releases fo
 * Tidied up the Deploy dialogs for transfer, compare and restore to align with CMS conventions and remove redundant options.
 * Added a database lock to the persistent transfer queue, removing any risk of concurrency issues when adding or removing items from the queue.
 * Added support for new form properties introduced in the most recent minor release of Forms 11. [#161](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/161)
+* Retained sort order introduced in Umbraco 11 for domains when deploying between environments.
 
 #### [11.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.0.2) (March 21st 2023)
 


### PR DESCRIPTION
These are the release notes for the next Deploy minor, aiming to go out on April 11th.

If it's possible to have these reviewed and published one week before please, that would be perfect.

I'll create another PR with the docs update for the release, as those should be published after the release notes (on the day of the release itself).