### PR TITLE
Add culture to the "Creating content programmatically" article

### DIFF
--- a/11/umbraco-cms/reference/management/services/contentservice/create-content-programmatically.md
+++ b/11/umbraco-cms/reference/management/services/contentservice/create-content-programmatically.md
@@ -33,4 +33,4 @@ demoproduct.SetCultureName("Microphone", "en-us"); // this will set the english 
 demoproduct.SetCultureName("Mikrofon", "da"); // this will set the danish name
 ```
 
-For information on how to retrieve languages, see the [Retrieving languages](../localizationservice/retrieving-languages.md) article.
+For information on how to retrieve multilingual languages, see the [Retrieving languages](../localizationservice/retrieving-languages.md) article.

--- a/11/umbraco-cms/reference/management/services/contentservice/create-content-programmatically.md
+++ b/11/umbraco-cms/reference/management/services/contentservice/create-content-programmatically.md
@@ -1,31 +1,36 @@
 # Create content programmatically
 
-In the example below, a new page is programmatically created using the content service. It is assumed that there are two document types, namely people and person. In this case, a new person is added underneath the people page.
-
+In the example below, a new page is programmatically created using the content service. It is assumed that there are two document types, namely Catalogue and Product. In this case, a new Product is added underneath the Catalogue page. Add the below code in the Catalogue template.
 
 ```csharp
-// Get access to ContentService
-var contentService = Services.ContentService;
+// Get access to ContentService - Add this at the top of your razor view
+@inject IContentService ContentService
+@using Umbraco.Cms.Core.Services
 
-// Create a variable for the GUID of the parent where you want to add a child item.
-// In this case the people page. 
-var parentId = Guid.Parse("b6fbbb31-a77f-4f9c-85f7-2dc4835c7f31");
+// Add this anywhere in your Catalogue template
+@{
+    // Create a variable for the GUID of the parent page - Catalogue, where you want to add a child item.
+    var parentId = Guid.Parse("b6fbbb31-a77f-4f9c-85f7-2dc4835c7f31");
 
-// Create a new child item of type 'person'
-var person = contentService.Create("James", parentId, "person"); 
+    // Create a new child item of type 'Product'
+    var demoproduct = ContentService.Create("Microphone", parentId, "product"); 
 
-// Set the value of the property with alias 'email'
-person.SetValue("email" , "james@contact.com");
+    // Set the value of the property with alias 'category'
+    demoproduct.SetValue("category" , "audio");
 
-// Set the value of the property with alias 'isAuthor'
-person.SetValue("isAuthor", false);
+    // Set the value of the property with alias 'price'
+    demoproduct.SetValue("price", "1500");
 
-// Save the child item
-contentService.Save(person);
-```
+    // Save the child item
+    ContentService.SaveAndPublish(demoproduct);
+    ```
+}
 
 In a multilanguage setup, it is necessary to set the name of the content item for a specified culture:
 
 ```csharp
-person.SetCultureName("James" , "en-us");
+demoproduct.SetCultureName("Microphone", "en-us"); // this will set the english name
+demoproduct.SetCultureName("Mikrofon", "da"); // this will set the danish name
 ```
+
+For information on how to retrieve languages, see the [Retrieving languages](../localizationservice/retrieving-languages.md) article.

--- a/11/umbraco-cms/reference/management/services/contentservice/create-content-programmatically.md
+++ b/11/umbraco-cms/reference/management/services/contentservice/create-content-programmatically.md
@@ -21,7 +21,7 @@ In the example below, a new page is programmatically created using the content s
     // Set the value of the property with alias 'price'
     demoproduct.SetValue("price", "1500");
 
-    // Save the child item
+    // Save and publish the child item
     ContentService.SaveAndPublish(demoproduct);
     ```
 }


### PR DESCRIPTION
I've updated the sample to set the localized language and provided a reference to retrieve multilingual languages.

Further updated the sample to reflect "Catalogue"/"Product" instead of "People"/"Person"

Let me know if anything else needs to be added.