### PR TITLE
Added notes for Forms 10.3.2 and 11.1.2 releases.

### DIFF
--- a/10/umbraco-forms/release-notes.md
+++ b/10/umbraco-forms/release-notes.md
@@ -21,7 +21,7 @@ In this section, you can find the release notes for each version of Umbraco Form
 ### [10.3.2](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.2) (April 18th 2023)
 
 * Fixed issue with field mapper in Umbraco nodes workflow not respecting magic string placeholders [#1005](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1005)
-* Fixed issue with range selector in back-office responding only to drag events and not click ones
+* Fixed issue with range selector in backoffice responding only to drag events and not click ones
 
 ### [10.3.1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.1) (April 4th 2023)
 

--- a/10/umbraco-forms/release-notes.md
+++ b/10/umbraco-forms/release-notes.md
@@ -18,6 +18,11 @@ In this section, you can find the release notes for each version of Umbraco Form
 
 <summary>Version 10</summary>
 
+### [10.3.2](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.2) (April 18th 2023)
+
+* Fixed issue with field mapper in Umbraco nodes workflow not respecting magic string placeholders [#1005](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1005)
+* Fixed issue with range selector in back-office responding only to drag events and not click ones
+
 ### [10.3.1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.1) (April 4th 2023)
 
 * Fixed UI issue with access to submit message workflow [#998](https://github.com/umbraco/Umbraco.Forms.Issues/issues/998)

--- a/11/umbraco-forms/release-notes.md
+++ b/11/umbraco-forms/release-notes.md
@@ -18,6 +18,11 @@ In this section, you can find the release notes for each version of Umbraco Form
 
 <summary>Version 11</summary>
 
+### [11.1.2](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.1.2) (April 18th 2023)
+
+* Fixed issue with field mapper in Umbraco nodes workflow not respecting magic string placeholders [#1005](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1005)
+* Fixed issue with range selector in back-office responding only to drag events and not click ones
+
 ### [11.1.1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.1.1) (April 4th 2023)
 
 * Fixed UI issue with access to submit message workflow [#998](https://github.com/umbraco/Umbraco.Forms.Issues/issues/998)
@@ -86,6 +91,11 @@ In this section, you can find the release notes for each version of Umbraco Form
 <details>
 
 <summary>Version 10</summary>
+
+### [10.3.2](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.2) (April 18th 2023)
+
+* Fixed issue with field mapper in Umbraco nodes workflow not respecting magic string placeholders [#1005](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1005)
+* Fixed issue with range selector in back-office responding only to drag events and not click ones
 
 ### [10.3.1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.1) (April 4th 2023)
 

--- a/11/umbraco-forms/release-notes.md
+++ b/11/umbraco-forms/release-notes.md
@@ -21,7 +21,7 @@ In this section, you can find the release notes for each version of Umbraco Form
 ### [11.1.2](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.1.2) (April 18th 2023)
 
 * Fixed issue with field mapper in Umbraco nodes workflow not respecting magic string placeholders [#1005](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1005)
-* Fixed issue with range selector in back-office responding only to drag events and not click ones
+* Fixed issue with range selector in backoffice responding only to drag events and not click ones
 
 ### [11.1.1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.1.1) (April 4th 2023)
 
@@ -95,7 +95,7 @@ In this section, you can find the release notes for each version of Umbraco Form
 ### [10.3.2](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.2) (April 18th 2023)
 
 * Fixed issue with field mapper in Umbraco nodes workflow not respecting magic string placeholders [#1005](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1005)
-* Fixed issue with range selector in back-office responding only to drag events and not click ones
+* Fixed issue with range selector in backoffice responding only to drag events and not click ones
 
 ### [10.3.1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.1) (April 4th 2023)
 


### PR DESCRIPTION
This release is due on 18th April, but can be reviewed and go live at any time.