### PR TITLE
Add missing line in examinecomposer code sample 

### DIFF
--- a/10/umbraco-cms/reference/searching/examine/indexing.md
+++ b/10/umbraco-cms/reference/searching/examine/indexing.md
@@ -339,8 +339,7 @@ namespace Umbraco.Docs.Samples.Web.CustomIndexing
     {
         public void Compose(IUmbracoBuilder builder)
         {
-            builder.Services.AddExamineLuceneIndex<ProductIndex, ConfigurationEnabledDirectoryFactory>
-            ("ProductIndex");
+            builder.Services.AddExamineLuceneIndex<ProductIndex, ConfigurationEnabledDirectoryFactory>("ProductIndex");
             
             builder.Services.ConfigureOptions<ConfigureProductIndexOptions>();
 

--- a/10/umbraco-cms/reference/searching/examine/indexing.md
+++ b/10/umbraco-cms/reference/searching/examine/indexing.md
@@ -339,6 +339,8 @@ namespace Umbraco.Docs.Samples.Web.CustomIndexing
     {
         public void Compose(IUmbracoBuilder builder)
         {
+            builder.Services.ConfigureOptions<ConfigureProductIndexOptions>();
+            
             builder.Services.AddExamineLuceneIndex<ProductIndex, ConfigurationEnabledDirectoryFactory>("ProductIndex");
 
             builder.Services.AddSingleton<ProductIndexValueSetBuilder>();

--- a/10/umbraco-cms/reference/searching/examine/indexing.md
+++ b/10/umbraco-cms/reference/searching/examine/indexing.md
@@ -339,9 +339,10 @@ namespace Umbraco.Docs.Samples.Web.CustomIndexing
     {
         public void Compose(IUmbracoBuilder builder)
         {
-            builder.Services.ConfigureOptions<ConfigureProductIndexOptions>();
+            builder.Services.AddExamineLuceneIndex<ProductIndex, ConfigurationEnabledDirectoryFactory>
+            ("ProductIndex");
             
-            builder.Services.AddExamineLuceneIndex<ProductIndex, ConfigurationEnabledDirectoryFactory>("ProductIndex");
+            builder.Services.ConfigureOptions<ConfigureProductIndexOptions>();
 
             builder.Services.AddSingleton<ProductIndexValueSetBuilder>();
 


### PR DESCRIPTION
Add missing line: 

```
 builder.Services.ConfigureOptions<ConfigureProductIndexOptions>();
```

Fixes: https://github.com/umbraco/UmbracoDocs/issues/5067