### PR TITLE
Hint when property editor will be removed in the future

### DIFF
--- a/11/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout/README.md
+++ b/11/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout/README.md
@@ -3,7 +3,7 @@
 {% hint style="info" %}
 We highly recommend that you use the [Block Grid](../block-editor/block-grid-editor.md) instead.
 
-Grid Layout has been marked as obsolete and development on the property editor has been discontinued. It will be removed completely as a core property editor in Umbraco 13.
+The Grid Layout has been marked as obsolete and development on the property editor has been discontinued. It will be removed as a core property editor with the release of Umbraco 13, planned for December 2023.
 {% endhint %}
 
 `Returns: JSON`

--- a/11/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout/README.md
+++ b/11/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout/README.md
@@ -3,7 +3,7 @@
 {% hint style="info" %}
 We highly recommend that you use the [Block Grid](../block-editor/block-grid-editor.md) instead.
 
-Grid Layout has been marked as obsolete and development on the property editor has been discontinued.
+Grid Layout has been marked as obsolete and development on the property editor has been discontinued. It will be removed completely as a core property editor in Umbraco 13.
 {% endhint %}
 
 `Returns: JSON`


### PR DESCRIPTION
This is just a thought, based on a forum question I saw...

A lot of people are migrating V7->V10 at the moment and wondering about the wonderful new block grid editor, they can see the current grid layout is considered 'legacy', but it still works... so it's not clear on the consequences of continuing to use it. 'I think' (but I don't know where this has been officially said, maybe it hasn't been and this is just word on the street) that in V13, there won't be a Grid Layout property editor... which would make sense with the new backoffice.... so if that is the roadmap for obsoletion, and we are pretty sure it's going to happen, then having that info somewhere, (Maybe it's in a blog post?) perhaps here... will help people decide on whether they should or should not migrate to the Block Grid...