### PR TITLE
Ignore Umbraco case when used in a URL

### DIFF
--- a/.github/styles/UmbracoDocs/UmbracoTerms.yml
+++ b/.github/styles/UmbracoDocs/UmbracoTerms.yml
@@ -9,7 +9,7 @@ swap:
   doc-type: "'Document Type'"
   data-type: "'Data Type'"
   data type: "'Data Type'"
-  umbraco: "'Umbraco'"
+  '(?<![\.\/])umbraco': "'Umbraco'"
   umbraco cloud: "'Umbraco Cloud'"
   umbraco forms: "'Umbraco Forms'"
   umbraco deploy: "'Umbraco Deploy'"


### PR DESCRIPTION
Vale should only warn when `umbraco` is not used in a URL - changes here add a regular expression to only match `umbraco` when it is NOT preceded by a `.` or `/` character.