### PR TITLE
Alert people to the drop in support for UmbracoPath configuration in V10

### DIFF
--- a/11/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
+++ b/11/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
@@ -620,7 +620,7 @@ This setting has been superseded by `DistributedLockingWriteLockDefaultTimeout`.
 
 #### GlobalSetting UmbracoPath cannot be configured
 
-It is no longer possible to rename the /Umbraco folder path by configuration, the property still exists but is hardcoded to /Umbraco and will be removed in V12.    
+It is no longer possible to rename the `/Umbraco` folder path using configuration. The property still exists but is hardcoded to `/Umbraco` and will be removed in Umbraco 12, planned for release in June 2023.    
     
 </details>
 

--- a/11/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
+++ b/11/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
@@ -618,6 +618,10 @@ StackQueue has been moved from `Umbraco.Core.Collections` to the `Umbraco.Cms.Co
 
 This setting has been superseded by `DistributedLockingWriteLockDefaultTimeout`.
 
+#### GlobalSetting UmbracoPath cannot be configured
+
+It is no longer possible to rename the /Umbraco folder path by configuration, the property still exists but is hardcoded to /Umbraco and will be removed in V12.    
+    
 </details>
 
 ## Find your upgrade path


### PR DESCRIPTION
If you are upgrading from V7/V8/V9 and have used the UmbracoPath property to rename your /Umbraco backoffice path, then it's super useful to know this isn't possible in V10, and in that context, people might see this is a 'breaking change' - but I understand there may be strict rules about what can be put in the 'breaking changes' section here - and technically the property is 'still there' on the Global settings, the only change is people can't use it for its purpose! - even though it might not be deemed a 'breaking change' - anyway I ask if you would consider listing it here as I do think it will help people prepare for the migration/upgrade to V10 if they can see that this change has been made.

The discussion of the removal is on this issue:
https://github.com/umbraco/Umbraco-CMS/issues/12593 and the change was made in this commit and released in 10.3 https://github.com/umbraco/Umbraco-CMS/pull/13032
(but it didn't work in 10/10.1/10.2 etc it is the razor class library stuff what broke it - so fine to say this is a breaking change in V10 I think)