### PR TITLE
Fixed error in configuration of forms EnableAntiForgeryTokenForFormsApi value.

### DIFF
--- a/10/umbraco-forms/developer/configuration/README.md
+++ b/10/umbraco-forms/developer/configuration/README.md
@@ -398,7 +398,7 @@ A value of `form-creator` will give access to all the user groups that the user 
 
 Available from Forms 10.2.1, the `FormsApiKey` configuration setting can be used to secure the Forms Headless API in server-to-server integrations. When set, API calls will be rejected unless the value of this setting is provided in an HTTP header.
 
-Setting the value of `EnableAntiForgeryTokenForFormsApi` to `true` will disable the anti-forgery protection for the Forms Headless/AJAX API. You need to do this for server-to-server integrations where it's not possible to provide a valid anti-forgery token in the request.
+Setting the value of `EnableAntiForgeryTokenForFormsApi` to `false` will disable the anti-forgery protection for the Forms Headless/AJAX API. You need to do this for server-to-server integrations where it's not possible to provide a valid anti-forgery token in the request.
 
 For more information, see the [Headless/AJAX Forms](../ajaxforms.md) article.
 

--- a/11/umbraco-forms/developer/configuration/README.md
+++ b/11/umbraco-forms/developer/configuration/README.md
@@ -397,7 +397,7 @@ A value of `form-creator` will give access to all the user groups that the user 
 
 Available from Forms 10.2.1, the `FormsApiKey` configuration setting can be used to secure the Forms Headless API in server-to-server integrations. When set, API calls will be rejected unless the value of this setting is provided in an HTTP header.
 
-Setting the value of `EnableAntiForgeryTokenForFormsApi` to `true` will disable the anti-forgery protection for the Forms Headless/AJAX API. You need to do this for server-to-server integrations where it's not possible to provide a valid anti-forgery token in the request.
+Setting the value of `EnableAntiForgeryTokenForFormsApi` to `false` will disable the anti-forgery protection for the Forms Headless/AJAX API. You need to do this for server-to-server integrations where it's not possible to provide a valid anti-forgery token in the request.
 
 For more information, see the [Headless/AJAX Forms](../ajaxforms.md) article.
 


### PR DESCRIPTION
This fixes an error [raised on the Forms issue tracker](https://github.com/umbraco/Umbraco.Forms.Issues/issues/915#issuecomment-1515392718).