### PR TITLE
Update Algolia API keys docs

### DIFF
--- a/marketplace-and-integrations/integrations/algolia.md
+++ b/marketplace-and-integrations/integrations/algolia.md
@@ -56,6 +56,7 @@ The following configuration is required for working with the Algolia API:
 {% endcode %}
 
 Algolia comes with a set of predefined API keys:
+
 * Search-Only API key - a public API key used on the frontend for performing search queries.
 * Admin API key - used on the backend for create, update or delete operations on the indices. 
 

--- a/marketplace-and-integrations/integrations/algolia.md
+++ b/marketplace-and-integrations/integrations/algolia.md
@@ -43,7 +43,8 @@ The following configuration is required for working with the Algolia API:
           "Algolia": {
             "Settings": {
               "ApplicationId": "[your_application_id]",
-              "AdminApiKey": "[your_admin_api_key]]"
+              "AdminApiKey": "[your_admin_api_key]",
+              "SearchApiKey": "[your_search_api_key]"
             }
           }
         }
@@ -53,6 +54,12 @@ The following configuration is required for working with the Algolia API:
 }
 ```
 {% endcode %}
+
+Algolia comes with a set of predefined API keys:
+* Search-Only API key - a public API key used on the frontend for performing search queries.
+* Admin API key - used on the backend for create, update or delete operations on the indices. 
+
+More details on other use cases for the Algolia API keys can be found [here](https://www.algolia.com/doc/guides/security/api-keys/#predefined-api-keys).
 
 ## Working with the integration
 

--- a/marketplace-and-integrations/integrations/algolia.md
+++ b/marketplace-and-integrations/integrations/algolia.md
@@ -60,7 +60,7 @@ Algolia comes with a set of predefined API keys:
 * Search-Only API key - a public API key used on the frontend for performing search queries.
 * Admin API key - used on the backend for create, update or delete operations on the indices. 
 
-More details on other use cases for the Algolia API keys can be found [here](https://www.algolia.com/doc/guides/security/api-keys/#predefined-api-keys).
+More details on other use cases for the Algolia API keys can be found in [the Algolia Docs](https://www.algolia.com/doc/guides/security/api-keys/#predefined-api-keys).
 
 ## Working with the integration
 


### PR DESCRIPTION
Current PR contains updates to the Algolia documentation after adding the additional `Search API Key` as detailed [here](https://github.com/umbraco/Umbraco.Cms.Integrations/pull/98).