### PR TITLE
Fix link to Azure Web Apps in Load Balancing docs

### DIFF
--- a/11/umbraco-cms/fundamentals/setup/server-setup/load-balancing/README.md
+++ b/11/umbraco-cms/fundamentals/setup/server-setup/load-balancing/README.md
@@ -100,7 +100,7 @@ _The below section applies to all ASP.NET load balancing configurations._
 
 This section describes the configuration options depending on your hosting setup:
 
-1. [Azure Web Apps](file-system-replication.md#mixture-of-standalone--synchronised) - _You use cloud based auto-scaling appliances like_ [_Microsoft's Azure Web Apps_](https://azure.microsoft.com/en-us/services/app-service/web/)
+1. [Azure Web Apps](azure-web-apps.md) - _You use cloud based auto-scaling appliances like_ [_Microsoft's Azure Web Apps_](https://azure.microsoft.com/en-us/services/app-service/web/)
 2. [File Replication](file-system-replication.md#synchronised-file-system) - _Each server hosts copies of the load balanced website files and a file replication service is running to ensure that all files on all servers are up to date_
 3. [Centralized file share](file-system-replication.md#synchronised-file-system) - _The load balanced website files are located on a centralized file share (SAN/NAS/Clustered File Server/Network Share)_
 

--- a/umbraco-cloud/frequently-asked-questions.md
+++ b/umbraco-cloud/frequently-asked-questions.md
@@ -75,7 +75,7 @@ HTTP requests headers can be useful for for example multilingual purposes to red
 - `cf-ipcontinent`: The visitor's continent
 - `cf-iplongitude`: The visitor's longitude
 - `cf-iplatitude`: The visitor's latitude
-- `uc-ipcountry`: The visitor’s country. `uc-ipcountry` header is a carbon copy of [uf-ipcountry](https://developers.cloudflare.com/fundamentals/get-started/reference/http-request-headers/#cf-ipcountry).
+- `uc-ipcountry`: The visitor’s country. `uc-ipcountry` header is a carbon copy of [cf-ipcountry](https://developers.cloudflare.com/fundamentals/get-started/reference/http-request-headers/#cf-ipcountry).
 
 Note, the HTTP requests headers are available on all custom hostnames created through Umbraco Cloud. But not the default hostname for the Umbraco Cloud project such as project.euwest01.umbraco.io.
 


### PR DESCRIPTION
Does what it says on the tin. The link currently points to the file system replication docs.