### PR TITLE
Fix CustomIndex sample

### DIFF
--- a/11/umbraco-cms/reference/searching/examine/indexing.md
+++ b/11/umbraco-cms/reference/searching/examine/indexing.md
@@ -340,9 +340,9 @@ namespace Umbraco.Docs.Samples.Web.CustomIndexing
     {
         public void Compose(IUmbracoBuilder builder)
         {
-            builder.Services.ConfigureOptions<ConfigureProductIndexOptions>();
-
             builder.Services.AddExamineLuceneIndex<ProductIndex, ConfigurationEnabledDirectoryFactory>("ProductIndex");
+                    
+            builder.Services.ConfigureOptions<ConfigureProductIndexOptions>();
 
             builder.Services.AddSingleton<ProductIndexValueSetBuilder>();
 


### PR DESCRIPTION
The order that you do things in your ExamineComposer seems crucial...

basically, it seems you can't add the ConfigureOptions for the ProductIndex, before you have added the ProductIndex!

If we move that line to after the adding of the index then the 'Validator' rule in the example ConfigureOptions is applied.

If it's before we get the default Options (maybe calling AddExamineLuceneIndex resets the options?)