### PR TITLE
Fix Custom Search Indexing Sample 2

### DIFF
--- a/11/umbraco-cms/reference/searching/examine/indexing.md
+++ b/11/umbraco-cms/reference/searching/examine/indexing.md
@@ -230,7 +230,12 @@ namespace Umbraco.Docs.Samples.Web.CustomIndexing
 
                 options.FieldDefinitions = new(
                     new("id", FieldDefinitionTypes.Integer),
-                    new("name", FieldDefinitionTypes.FullText)
+                    new("name", FieldDefinitionTypes.FullText),
+                    //the examine dashboard uses nodeName in search results
+                    new("nodeName", FieldDefinitionTypes.InvariantCultureIgnoreCase),
+                    //__Published and path both required if using the ContentValueSetValidator
+                    new("__Published", FieldDefinitionTypes.Raw),
+                    new("path",FieldDefinitionTypes.InvariantCultureIgnoreCase)
                     );
 
                 options.UnlockIndex = true;
@@ -273,6 +278,11 @@ namespace Umbraco.Docs.Samples.Web.CustomIndexing
                 {
                     ["name"] = content.Name,
                     ["id"] = content.Id,
+                    // nodeName used in the Examine Dashboard backoffice search results
+                    ["nodeName"] = content.Name,
+                    //__Published and path are required if using core ContentValueSetValidator to apply a Validation option to filter results
+                    ["__Published"] = content.Published ? "y" : "n",
+                    ["path"] = content.Path
                 };
 
                 yield return new ValueSet(content.Id.ToString(), IndexTypes.Content, content.ContentType.Alias, indexValues);


### PR DESCRIPTION
The sample on this page won't work for creating a filtered index by 'product', this is because the core 'ContentValueSetValidator' is used in the example to apply the 'validator' rules to the index options. and this validator requires there to be both a 'path' and a value for '__Published' in the index to apply its validation.

https://github.com/umbraco/Umbraco-CMS/blob/0765a2ebbb6fd452b6543a349f5d0c1f157e5588/src/Umbraco.Infrastructure/Examine/ContentValueSetValidator.cs#L155

But the example has removed those fields from the index. by defining a custom list of FieldDefinitions and a custom populator.

This PR adds those two fields into this custom index, which is the minimum required for the example to work 'as is'.

There is an argument that says this example 'exists' in order to 'show off' ALL the extension points, rather than showing the best way to create a filtered index of 'Umbraco content'. (and we'd generally recommend using the ExternalIndex and filtering anyway, rather than creating individual indexes like this one for that purpose). But if so then adding these properties as I've done to make it work, is confusing, what is the notion of Published and Path, when creating a totally custom index? if that is the aim then perhaps showing off a custom IValueSetValidator that didn't rely on the Path/__Publiished properties being present would be the complete example for flexibility, or maybe that is a 'go further' example.

or maybe there is a simpler example where you define the index like so

` public class ProductIndex : UmbracoExamineIndex, IUmbracoContentIndex`

(which automatically does the population of the index with Umbraco Content and all the usual Umbraco Fields.

And then create a Custom IValueSetValidator to pass the list of include/exclude fields to Examine (which does the inclusion and exclusion of fields natively...)

```
 public SuperContentValueSetValidator(
            bool publishedValuesOnly,
            bool supportProtectedContent,
            IPublicAccessService? publicAccessService,
            IScopeProvider? scopeProvider,
            int? parentId = null,
            IEnumerable<string>? includeItemTypes = null,
            IEnumerable<string>? excludeItemTypes = null,
            IEnumerable<string>? includeFields = null,
            IEnumerable<string>? excludeFields = null)
            : base(includeItemTypes, excludeItemTypes,includeFields, excludeFields)
        {
            PublishedValuesOnly = publishedValuesOnly;
            SupportProtectedContent = supportProtectedContent;
            ParentId = parentId;
            _publicAccessService = publicAccessService;
            _scopeProvider = scopeProvider;
        }
```

and

` options.Validator = new SuperContentValueSetValidator(true,false, _publicAccessService, _scopeProvider, includeItemTypes: new[] { "product" },includeFields: new[] {"nodeName","id","__Published","path", "__NodeTypeAlias"});`

is that easier? just worried people going to a lot of effort to create a populator when they don't need to, but then we don't really want to encourage people to create custom indexes for Umbraco content anyhow!

Anyway these fixes in the PR, at least make the examples work, if someone wanted to try them - I'll update the Samples project too.

