### PR TITLE
Add instructions for enabling Azure Blob Storage ImageSharp cache

### DIFF
--- a/11/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
+++ b/11/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
@@ -86,7 +86,7 @@ Invoke the `.AddAzureBlobMediaFileSystem()` and the `.AddAzureBlobImageSharpCach
 
 As of [version 11.0.0](https://github.com/umbraco/Umbraco.StorageProviders/releases/tag/release-11.0.0) of `Umbraco.StorageProviders`, the ImageSharp dependency has been separated into its own package.
 
-Therefore, if you're planning on upgrading your site from Umbraco 9/10 to 11+, then don't forget to install and setup the new `Umbraco.StorageProviders.AzureBlob.ImageSharp` package; this will ensure that your ImageSharp cache continues to be stored in your blob storage container.
+Therefore, if you're planning on upgrading your site from Umbraco 9/10 to 11+, don't forget to install and setup the new `Umbraco.StorageProviders.AzureBlob.ImageSharp` package. This will ensure that your ImageSharp cache continues to be stored in your blob storage container.
 
 {% endhint %}
 

--- a/11/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
+++ b/11/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
@@ -14,7 +14,7 @@ See the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/storage
 
 Before you begin, you need to install the `Umbraco.StorageProviders.AzureBlob` and the `Umbraco.StorageProviders.AzureBlob.ImageSharp` NuGet packages. There are two approaches to installing the packages:
 
-1. Use your favorite IDE and open up the NuGet Package Manager to search and install the packages
+1. Use your favorite Integrated Development Environment (IDE) and open up the NuGet Package Manager to search and install the packages
 2. Use the command line to install the packages
 
 ### Installing through command line

--- a/11/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
+++ b/11/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
@@ -12,20 +12,21 @@ See the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/storage
 
 ## Installing the package
 
-Before you begin, you need to install the `Umbraco.StorageProviders.AzureBlob` NuGet package. There are two approaches to installing the package:
+Before you begin, you need to install the `Umbraco.StorageProviders.AzureBlob` and the `Umbraco.StorageProviders.AzureBlob.ImageSharp` NuGet packages. There are two approaches to installing the packages:
 
-1. Use your favorite IDE and open up the NuGet Package Manager to search and install the package
-2. Use the command line to install the package
+1. Use your favorite IDE and open up the NuGet Package Manager to search and install the packages
+2. Use the command line to install the packages
 
 ### Installing through command line
 
-Navigate to your project folder, which is the folder that contains your `.csproj` file. Now use the following `dotnet add package` command to install the package:
+Navigate to your project folder, which is the folder that contains your `.csproj` file. Now use the following `dotnet add package` commands to install the packages:
 
 ```
 dotnet add package Umbraco.StorageProviders.AzureBlob
+dotnet add package Umbraco.StorageProviders.AzureBlob.ImageSharp
 ```
 
-The correct package will have be installed in your project.
+The correct packages will have been installed in your project.
 
 ## Configuring Blob storage
 
@@ -62,7 +63,7 @@ You can get your connection string from your Azure Portal under "Access Keys".
 
 You're almost there. The last step is to set up the required services and middleware. This may sound daunting, but thankfully there are extension methods that do all this for you. All you need to do is invoke them in the `ConfigureServices` and `Configure` methods in the `startup.cs` file.
 
-Invoke the `.AddAzureBlobMediaFileSystem()` extention method in the `ConfigureServices` method:
+Invoke the `.AddAzureBlobMediaFileSystem()` and the `.AddAzureBlobImageSharpCache()` extension methods in the `ConfigureServices` method:
 
 ```
         public void ConfigureServices(IServiceCollection services)
@@ -72,7 +73,8 @@ Invoke the `.AddAzureBlobMediaFileSystem()` extention method in the `ConfigureSe
                 .AddBackOffice()
                 .AddWebsite()
                 .AddComposers()
-                .AddAzureBlobMediaFileSystem() // This configures the required services 
+                .AddAzureBlobMediaFileSystem() // This configures the required services for Media
+                .AddAzureBlobImageSharpCache() // This configures the required services for the Image Sharp cache
                 .Build();
 #pragma warning restore IDE0022 // Use expression body for methods
 
@@ -96,9 +98,8 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         .WithMiddleware(u =>
         {
             u.UseBackOffice();
-            u.UseWebsite();
-            // This enables the Azure Blob storage middleware for media.
-            u.UseAzureBlobMediaFileSystem();
+            u.UseWebsite();         
+            u.UseAzureBlobMediaFileSystem(); // This enables the Azure Blob storage middleware for media.
         })
         .WithEndpoints(u =>
         {

--- a/11/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
+++ b/11/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
@@ -82,33 +82,12 @@ Invoke the `.AddAzureBlobMediaFileSystem()` and the `.AddAzureBlobImageSharpCach
 ```
 
 {% hint style="info" %}
-**If you are using Umbraco 9, follow this step before moving on**:
+**Upgrading from Umbraco 9/10**:
 
-Next invoke `UseAzureBlobMediaFileSystem();` in the `.WithMiddleware` call, like so:
+As of [version 11.0.0](https://github.com/umbraco/Umbraco.StorageProviders/releases/tag/release-11.0.0) of `Umbraco.StorageProviders`, the ImageSharp dependency has been separated into its own package.
 
-```
-public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-{
-    if (env.IsDevelopment())
-    {
-        app.UseDeveloperExceptionPage();
-    }
+Therefore, if you're planning on upgrading your site from Umbraco 9/10 to 11+, then don't forget to install and setup the new `Umbraco.StorageProviders.AzureBlob.ImageSharp` package; this will ensure that your ImageSharp cache continues to be stored in your blob storage container.
 
-    app.UseUmbraco()
-        .WithMiddleware(u =>
-        {
-            u.UseBackOffice();
-            u.UseWebsite();         
-            u.UseAzureBlobMediaFileSystem(); // This enables the Azure Blob storage middleware for media.
-        })
-        .WithEndpoints(u =>
-        {
-            u.UseInstallerEndpoints();
-            u.UseBackOfficeEndpoints();
-            u.UseWebsiteEndpoints();
-        });
-}
-```
 {% endhint %}
 
 Now when you launch your site again, the blob storage will be used to store media items as well as the ImageSharp cache. Do note though that the `/media` and `/cache` folders do not get created until a piece of media is uploaded.


### PR DESCRIPTION
With v11.0.0 of the Umbraco.StorageProviders, the ImageSharp cache was split out into a separate package, which means it now needs to be installed and added to the startup file separately.

I have therefore updated the documentation to include instructions for the new way of enabling the ImageSharp Azure Blob storage cache using the `Umbraco.StorageProviders.AzureBlob.ImageSharp` package.

Updates were based on the instructions found here: https://github.com/umbraco/Umbraco.StorageProviders#umbracostorageprovidersazureblobimagesharp