### PR TITLE
Fixed details on fallback behaviour to find sender email address in workflows.

### DIFF
--- a/10/umbraco-forms/editor/attaching-workflows/workflow-types.md
+++ b/10/umbraco-forms/editor/attaching-workflows/workflow-types.md
@@ -121,7 +121,7 @@ If that is not set, the [Global Settings](https://docs.umbraco.com/umbraco-cms/v
     }
 ```
 
-The fallback behavior to find the sender email address described also applies to the other email workflows.
+The fallback behavior also applies to the other email workflows.
 
 ## **Send Email with Template (Razor)**
 

--- a/10/umbraco-forms/editor/attaching-workflows/workflow-types.md
+++ b/10/umbraco-forms/editor/attaching-workflows/workflow-types.md
@@ -87,7 +87,27 @@ Sends the result of the Form to the specified email address. The following confi
 * Recipient Email (required)
 * CC Email
 * BCC Email
-* SenderEmail - also configurable in `appsettings.json` under `Umbraco:CMS:Global:Smtp`. For more information, see the [Global Settings](https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/reference/configuration/globalsettings) article.
+* Sender Email
+* Reply To Email
+* Subject of the email (required)
+
+If the _Sender Email_ field is not populated, the address used will be read from CMS configuration.
+
+The [Content Settings](https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/reference/configuration/contentsettings) value configured at `Umbraco:CMS:Content:Notifications:Email` will be used if provided.
+
+```json
+    "Umbraco": {
+         "CMS": {
+            "Content": {
+                "Notifications": {
+                    "Email": "person@umbraco.dk"
+                }
+            }
+        }
+    }
+```
+
+If that is not set, the [Global Settings](https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/reference/configuration/globalsettings) value configured at `Umbraco:CMS:Global:Smtp` will be used.
 
 ```json
     "Umbraco": {
@@ -95,14 +115,13 @@ Sends the result of the Form to the specified email address. The following confi
             "Global": {
                 "Smtp": {
                     "From": "person@umbraco.dk"
-                        }
-                    }
                 }
             }
+        }
+    }
 ```
 
-* Reply To Email
-* Subject of the email (required)
+The fallback behavior to find the sender email address described also applies to the other email workflows.
 
 ## **Send Email with Template (Razor)**
 
@@ -122,20 +141,7 @@ The following configuration can be set:
 * Recipient Email (required)
 * CC Email
 * BCC Email
-* SenderEmail - also configurable in `appsettings.json` under `Umbraco:CMS:Global:Smtp`. For more information, see the [Global Settings](https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/reference/configuration/globalsettings) article.
-
-```json
-"Umbraco": {
-    "CMS": {
-        "Global": {
-            "Smtp": {
-                "From": "person@umbraco.dk"
-                    }
-                }
-           }
-       }
-```
-
+* SenderEmail
 * Reply To Email
 * Subject of the email (required)
 
@@ -207,20 +213,7 @@ Sends the result of the Form to an email address with full control over the emai
 * Recipient Email (required)
 * CC Email
 * BCC Email
-* SenderEmail - also configurable in `appsettings.json` under `Umbraco:CMS:Global:Smtp`. For more information, see the [Global Settings](https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/reference/configuration/globalsettings) article.
-
-```json
-"Umbraco": {
-    "CMS": {
-        "Global": {
-            "Smtp": {
-                "From": "person@umbraco.dk"
-                    }
-                }
-            }
-        }
-```
-
+* SenderEmail
 * Reply To Email
 * Subject of the email (required)
 

--- a/11/umbraco-forms/editor/attaching-workflows/workflow-types.md
+++ b/11/umbraco-forms/editor/attaching-workflows/workflow-types.md
@@ -117,7 +117,7 @@ If that is not set, the [Global Settings](https://docs.umbraco.com/umbraco-cms/r
     }
 ```
 
-The fallback behavior to find the sender email address described also applies to the other email workflows.
+The fallback behavior also applies to the other email workflows.
 
 ## **Send Email with Template (Razor)**
 

--- a/11/umbraco-forms/editor/attaching-workflows/workflow-types.md
+++ b/11/umbraco-forms/editor/attaching-workflows/workflow-types.md
@@ -16,13 +16,13 @@ Workflow Types in Umbraco Forms
 
 ## **Change Record State**
 
-![Change Record state](../../../../10/umbraco-forms/editor/attaching-workflows/images/change-record-state.png)
+![Change Record state](images/change-record-state.png)
 
 Used to automatically **Approve Record** or **Delete Record** once it is submitted. Configure words that you want to match and select whether these words should trigger an approval or deletion of the record.
 
 ## **Post as XML**
 
-![Post as XML](../../../../10/umbraco-forms/editor/attaching-workflows/images/post-as-xml.png)
+![Post as XML](images/post-as-xml.png)
 
 Used to post the Form as an XML to a specified URL. The following configuration can be set:
 
@@ -36,7 +36,7 @@ Used to post the Form as an XML to a specified URL. The following configuration 
 
 ## **Save as an XML file**
 
-![Save as XML](../../../../10/umbraco-forms/editor/attaching-workflows/images/save-as-an-xml-file.png)
+![Save as XML](images/save-as-an-xml-file.png)
 
 Saves the result of the Form as an XML file by using XSLT. The following configuration can be set:
 
@@ -53,13 +53,13 @@ When storing the files within the `wwwroot` or `App_Plugins` folders, the files 
 
 ## **Save as Umbraco Content Node**
 
-![Save as content node](../../../../10/umbraco-forms/editor/attaching-workflows/images/save-as-content-node.png)
+![Save as content node](images/save-as-content-node.png)
 
 Saves a submitted Form as a new content node. You need to choose a Document type and match the fields in the Form with the properties on the selected Document Type.
 
 You can also choose to set a static value to fill in the properties:
 
-![Save as content node](../../../../10/umbraco-forms/editor/attaching-workflows/images/create-new-node.png)
+![Save as content node](images/create-new-node.png)
 
 In the example above, a Document Type called **Blogpost** is selected for creating the new Content node.
 
@@ -73,7 +73,7 @@ The following configuration can be set:
 
 ## **Send Email**
 
-![Send email](../../../../10/umbraco-forms/editor/attaching-workflows/images/send-email.png)
+![Send email](images/send-email.png)
 
 Sends the result of the Form to the specified email address. The following configuration can be set:
 
@@ -89,7 +89,7 @@ Sends the result of the Form to the specified email address. The following confi
 
 If the _Sender Email_ field is not populated, the address used will be read from CMS configuration.
 
-The [Content Settings](https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/reference/configuration/contentsettings) value configured at `Umbraco:CMS:Content:Notifications:Email` will be used if provided.
+The [Content Settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/contentsettings) value configured at `Umbraco:CMS:Content:Notifications:Email` will be used if provided.
 
 ```json
     "Umbraco": {
@@ -103,7 +103,7 @@ The [Content Settings](https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/refe
     }
 ```
 
-If that is not set, the [Global Settings](https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/reference/configuration/globalsettings) value configured at `Umbraco:CMS:Global:Smtp` will be used.
+If that is not set, the [Global Settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/globalsettings) value configured at `Umbraco:CMS:Global:Smtp` will be used.
 
 ```json
     "Umbraco": {
@@ -121,7 +121,7 @@ The fallback behavior to find the sender email address described also applies to
 
 ## **Send Email with Template (Razor)**
 
-![Send email with template](../../../../10/umbraco-forms/editor/attaching-workflows/images/send-email-razor.png)
+![Send email with template](images/send-email-razor.png)
 
 Uses a template to send the results of the Form to a specified email address.
 
@@ -143,7 +143,7 @@ The following configuration can be set:
 
 ## **Send Form to URL**
 
-![Send to URL](../../../../10/umbraco-forms/editor/attaching-workflows/images/send-to-URL.png)
+![Send to URL](images/send-to-URL.png)
 
 Sends the Form to a URL either as a HTTP POST or GET. The following configuration can be set:
 
@@ -200,7 +200,7 @@ namespace RequestSaver.Controllers
 
 ## **Send XSLT Transformed Email**
 
-![Send XSLT Email](../../../../10/umbraco-forms/editor/attaching-workflows/images/xslt-email.png)
+![Send XSLT Email](images/xslt-email.png)
 
 Sends the result of the Form to an email address with full control over the email contents by providing an xslt file. The following configuration can be set:
 
@@ -215,7 +215,7 @@ Sends the result of the Form to an email address with full control over the emai
 
 ## **Slack**
 
-![Send to Slack](../../../../10/umbraco-forms/editor/attaching-workflows/images/email-slack.png)
+![Send to Slack](images/email-slack.png)
 
 Allows to post the Form data to a specific channel on Slack. The following configuration can be set:
 

--- a/11/umbraco-forms/editor/attaching-workflows/workflow-types.md
+++ b/11/umbraco-forms/editor/attaching-workflows/workflow-types.md
@@ -83,7 +83,27 @@ Sends the result of the Form to the specified email address. The following confi
 * Recipient Email (required)
 * CC Email
 * BCC Email
-* SenderEmail - also configurable in `appsettings.json` under `Umbraco:CMS:Global:Smtp`. For more information, see the [Global Settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/globalsettings) article.
+* SenderEmail
+* Reply To Email
+* Subject of the email (required)
+
+If the _Sender Email_ field is not populated, the address used will be read from CMS configuration.
+
+The [Content Settings](https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/reference/configuration/contentsettings) value configured at `Umbraco:CMS:Content:Notifications:Email` will be used if provided.
+
+```json
+    "Umbraco": {
+         "CMS": {
+            "Content": {
+                "Notifications": {
+                    "Email": "person@umbraco.dk"
+                }
+            }
+        }
+    }
+```
+
+If that is not set, the [Global Settings](https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/reference/configuration/globalsettings) value configured at `Umbraco:CMS:Global:Smtp` will be used.
 
 ```json
     "Umbraco": {
@@ -91,14 +111,13 @@ Sends the result of the Form to the specified email address. The following confi
             "Global": {
                 "Smtp": {
                     "From": "person@umbraco.dk"
-                        }
-                    }
                 }
             }
+        }
+    }
 ```
 
-* Reply To Email
-* Subject of the email (required)
+The fallback behavior to find the sender email address described also applies to the other email workflows.
 
 ## **Send Email with Template (Razor)**
 
@@ -118,20 +137,7 @@ The following configuration can be set:
 * Recipient Email (required)
 * CC Email
 * BCC Email
-* SenderEmail - also configurable in `appsettings.json` under `Umbraco:CMS:Global:Smtp`. For more information, see the [Global Settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/globalsettings) article.
-
-```json
-"Umbraco": {
-    "CMS": {
-        "Global": {
-            "Smtp": {
-                "From": "person@umbraco.dk"
-                    }
-                }
-           }
-       }
-```
-
+* SenderEmail
 * Reply To Email
 * Subject of the email (required)
 
@@ -203,20 +209,7 @@ Sends the result of the Form to an email address with full control over the emai
 * Recipient Email (required)
 * CC Email
 * BCC Email
-* SenderEmail - also configurable in `appsettings.json` under `Umbraco:CMS:Global:Smtp`. For more information, see the [Global Settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/globalsettings) article.
-
-```json
-"Umbraco": {
-    "CMS": {
-        "Global": {
-            "Smtp": {
-                "From": "person@umbraco.dk"
-                    }
-                }
-            }
-        }
-```
-
+* SenderEmail
 * Reply To Email
 * Subject of the email (required)
 


### PR DESCRIPTION
This came up in a support issue from where I realised we were missing some detail of the fallback behaviour here.  Can be reviewed and published at any time.