### PR TITLE
Add negation of preview Url for rewrite rules

### DIFF
--- a/umbraco-cloud/set-up/project-settings/manage-hostnames/rewrites-on-cloud.md
+++ b/umbraco-cloud/set-up/project-settings/manage-hostnames/rewrites-on-cloud.md
@@ -40,6 +40,7 @@ One approach for this is to add a new rewrite rule to the `<system.webServer><re
     <add input="{REQUEST_URI}" negate="true" pattern="^/DependencyHandler.axd" />
     <add input="{REQUEST_URI}" negate="true" pattern="^/App_Plugins" />
     <add input="{REQUEST_URI}" negate="true" pattern="localhost" />
+    <add input="{REQUEST_URI}" negate="true" pattern="^\/([0-9]*)$" />
   </conditions>
   <action type="Redirect" url="http://<your actual domain here>.com/{R:0}"
         appendQueryString="true" redirectType="Permanent" />


### PR DESCRIPTION
Currently if you are following the documentation on Umbraco Cloud to redirect the native backoffice io url to your front end url, you will encounter a problem!

You can't preview a page that hasn't been published yet, which might sound quite edge case, but actually most people want to see a preview before they publish something for a first time!

The reason for this is the suggested rewrite rules in this article, show how to put the redirect from the cloud backoffice url to the front end url, and has a list of patterns to negate, eg the Umbraco folder!

But what it doesn't consider is how 'preview' works

when you preview a page in the backoffice it appears to be loading a url from within the Umbraco Folder eg
/umbraco/preview/?id=3195
and therefore it doesn't get redirected

but underneath the hood it uses an iframe to load content from a url in the format
/3195 
where 3195 is the id of the page (pre v9, this would have been /3195.aspx)

and this request is not included in the list of negations, and so the 'redirect' to the front end domain kicks in for the iframe - and returns a 404, cos the page isn't published, of if page is published, returns a page that doesn't include the changes for preview!

Therefore I'm suggesting in your advice to include a negation for /anynumber pattern, and then preview will work again when you have this rule in place.

If you are enforcing a trailing slash in a different rule, you'd need to add a similar negation!