### PR TITLE
Add example of using web routing settings in code

### DIFF
--- a/11/umbraco-cms/reference/configuration/webroutingsettings.md
+++ b/11/umbraco-cms/reference/configuration/webroutingsettings.md
@@ -26,6 +26,33 @@ An example of a web routing config with default values, and a placeholder for ap
 }
 ```
 
+## Using the webrouting options in code
+
+You can get the config values in code like thise:
+
+```csharp
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+
+namespace UmbracoDocs;
+
+public class TestService
+{
+    private readonly IOptionsMonitor<WebRoutingSettings> _webRoutingSettings;
+
+    public TestService(IOptionsMonitor<WebRoutingSettings> webRoutingSettings)
+    {
+        _webRoutingSettings = webRoutingSettings;
+    }
+
+    public void DocsExample()
+    {
+        var umbracoApplicationUrl = _webRoutingSettings.CurrentValue.UmbracoApplicationUrl;
+    }
+}
+```
+
+
 ## Try matching endpoints for all pages
 
 When set to `true` Umbraco will check if any routed endpoints match a front-end request. This happens before the Umbraco dynamic router tries to map the request to a Umbraco content item. This setting should not be necessary as long as the Umbraco catch-all route is registered last.

--- a/11/umbraco-cms/reference/configuration/webroutingsettings.md
+++ b/11/umbraco-cms/reference/configuration/webroutingsettings.md
@@ -28,7 +28,7 @@ An example of a web routing config with default values, and a placeholder for ap
 
 ## Using the webrouting options in code
 
-You can get the config values in code like thise:
+The following is an example of how you can use code to get the value for the `UmbracoApplicationUrl` configuration key:
 
 ```csharp
 using Microsoft.Extensions.Options;


### PR DESCRIPTION
It mentions on https://docs.umbraco.com/umbraco-cms/reference/configuration#reading-configuration-in-code how to read configuration in code, but it only shows the GlobalSettings config which doesn't contain everything.
I've added an example to show how to get options under the WebRoutingSettings.