### PR TITLE
Fixed incorrect forms configuration key name

### DIFF
--- a/10/umbraco-forms/developer/configuration/README.md
+++ b/10/umbraco-forms/developer/configuration/README.md
@@ -60,6 +60,7 @@ For illustration purposes, the following structure represents the full set of op
         "DaysToRetainApprovedRecordsFor": 0
       },
       "RemoveProvidedEmailTemplate": false,
+      "RemoveProvidedFormTemplates": false,
       "FormElementHtmlIdPrefix": "",
       "SettingsCustomization": {
         "DataSourceTypes": {},
@@ -140,7 +141,7 @@ If you have created a custom template and would like to use that as the default 
 
 From Forms 10.2, the provided template can be removed from the selection if you have created email templates for the "send Razor email" workflow. To do this, set this value to `true`.
 
-### RemoveProvidedFormsTemplates
+### RemoveProvidedFormTemplates
 
 Similarly, from Forms 10.2, the provided form templates available from the form creation dialog can be removed from selection. To do this, set this configuration value to `true`.
 

--- a/11/umbraco-forms/developer/configuration/README.md
+++ b/11/umbraco-forms/developer/configuration/README.md
@@ -59,6 +59,7 @@ For illustration purposes, the following structure represents the full set of op
         "DaysToRetainApprovedRecordsFor": 0
       },
       "RemoveProvidedEmailTemplate": false,
+      "RemoveProvidedFormTemplates": false,
       "FormElementHtmlIdPrefix": "",
       "SettingsCustomization": {
         "DataSourceTypes": {},
@@ -139,7 +140,7 @@ If you have created a custom template and would like to use that as the default 
 
 The provided template can be removed from the selection if you have created email templates for the "send Razor email" workflow. To do this, set this value to `true`.
 
-### RemoveProvidedFormsTemplates
+### RemoveProvidedFormTemplates
 
 Similarly, the provided form templates available from the form creation dialog can be removed from selection. To do this, set this configuration value to `true`.
 


### PR DESCRIPTION
This fixes an incorrect configuration key as raised in support issue https://github.com/umbraco/Umbraco.Forms.Issues/issues/1025.