### PR TITLE
Update manage-cdn-caching.md

### DIFF
--- a/umbraco-cloud/set-up/project-settings/manage-cdn-caching.md
+++ b/umbraco-cloud/set-up/project-settings/manage-cdn-caching.md
@@ -44,6 +44,10 @@ The following example adds a cache-control header with 'no-cache' as the value w
 The webpage itself is not cached when CDN Caching is enabled.
 {% endhint %}
 
+{% hint style="info" %}
+Everything under the path /umbraco, is not being cached
+{% endhint %}
+
 ## Cache Everything
 
 ![Cache Everything](../images/CDN-caching-everything.png)
@@ -76,6 +80,10 @@ In the Purge Cache section, you can see how many Purge requests you have availab
 
 {% hint style="info" %}
 The available number of Purge requests varies depending on your Cloud Plan. For more information, see the [Plan specific features](manage-cdn-caching.md#plan-specific-features).
+{% endhint %}
+
+{% hint style="info" %}
+Everything under the path /umbraco is not being cached. Even 
 {% endhint %}
 
 ## Plan specific features


### PR DESCRIPTION
## Description

Missing in documentation that anything under the reserved path /umbraco* is not part of the CDN cache do to the server response incl. cache-control: no-cache reponse header parameter

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ x] Other

