### PR TITLE
Update icontentfinder.md to reflect 404 code example

### DIFF
--- a/11/umbraco-cms/reference/routing/request-pipeline/icontentfinder.md
+++ b/11/umbraco-cms/reference/routing/request-pipeline/icontentfinder.md
@@ -138,9 +138,9 @@ namespace RoutingDocs.ContentFinders
 
 ## NotFoundHandlers
 
-To set your own 404 finder create an IContentLastChanceFinder and set it as the ContentLastChanceFinder. (perhaps you have a multilingual site and need to find the appropriate 404 page in the correct language)
+To set your own 404 finder create an IContentLastChanceFinder and set it as the ContentLastChanceFinder. (perhaps you have a multilingual site and need to find the appropriate 404 page in the correct language). 
 
-A ContentLastChanceFinder will always return a 404 status code. This example creates a new implementation of the IContentLastChanceFinder and checks whether the requested content could not be found by using the default `Is404` property presented in the `PublishedRequest` class.
+A `IContentLastChanceFinder` will always return a 404 status code. This example creates a new implementation of the `IContentLastChanceFinder` and gets the 404 page for the current language of the request. 
 
 ```csharp
 using System.Linq;


### PR DESCRIPTION
## Description

PR for #4671. Updates the 404 content finder explanation text which did not match the code example.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other
