### PR TITLE
Remove license comment for azurewebsites.net or umbraco.io

### DIFF
--- a/12/umbraco-commerce/getting-started/installation.md
+++ b/12/umbraco-commerce/getting-started/installation.md
@@ -57,8 +57,6 @@ You only need to install your license when you are ready to go live.
 
 Umbraco Commerce is fully functional during development, and whilst it is hosted on a local server (`localhost` or `.local` domains).
 
-You can also host a staging site on a `*.azurewebsite.net` or `*.umbraco.io` (Umbraco Cloud) domain without the need for a license.
-
 Hosting on any other public domain without a license will be limited to a maximum of 20 orders.
 
 If you require an unrestricted staging environment, all licenses support two methods of allowing this:

--- a/12/umbraco-commerce/getting-started/installation.md
+++ b/12/umbraco-commerce/getting-started/installation.md
@@ -64,5 +64,5 @@ If you require an unrestricted staging environment, all licenses support two met
 * `staging.client.com` - Licenses allow unlimited subdomains, meaning you can host the staging site on a subdomain of the licensed domain.
 * `clientcom.agency.com` - Licenses allow a concatenation of the licensed domain as a subdomain of any other domain.
 
-If you wish to host the site on any other URL such as a public dev / staging domain you want to access, please reach out to suits@umbraco.com for a test license.
+If you wish to host the site on any other URL like a public development domain, reach out to suits@umbraco.com for a test license.
 {% endhint %}

--- a/12/umbraco-commerce/getting-started/installation.md
+++ b/12/umbraco-commerce/getting-started/installation.md
@@ -64,5 +64,5 @@ If you require an unrestricted staging environment, all licenses support two met
 * `staging.client.com` - Licenses allow unlimited subdomains, meaning you can host the staging site on a subdomain of the licensed domain.
 * `clientcom.agency.com` - Licenses allow a concatenation of the licensed domain as a subdomain of any other domain.
 
-If you wish to host the site on any other URL, then an additional license file will be required for that domain.
+If you wish to host the site on any other URL such as a public dev / staging domain you want to access, please reach out to suits@umbraco.com for a test license.
 {% endhint %}


### PR DESCRIPTION
Umbraco Commerce doesn't support azurewebsites.net or umbraco.io as dev domains OOTB, these now need to be requested.