### PR TITLE
Update notifications README.md

### DIFF
--- a/11/umbraco-cms/reference/notifications/README.md
+++ b/11/umbraco-cms/reference/notifications/README.md
@@ -181,8 +181,8 @@ public class NotificationHandlersComposer : IComposer
 
 ## Other notifications
 
-* See [ContentTypeService Notifications](contentservice-notifications.md) for a listing of the ContentTypeService object notifications.
-* See [MediaTypeService Notifications](mediaservice-notifications.md) for a listing of the MediaTypeService object notifications.
+* See [ContentTypeService Notifications](contentypeservice-notifications.md) for a listing of the ContentTypeService object notifications.
+* See [MediaTypeService Notifications](mediatypeservice-notifications.md) for a listing of the MediaTypeService object notifications.
 * See [MemberTypeService Notifications](membertypeservice-notifications.md) for a listing of the MemberTypeService object notifications.
 * See [DataTypeService Notifications](datatypeservice-notifications.md) for a listing of the DataTypeService object notifications
 * See [FileService Notifications](fileservice-notifications.md) for a listing of the FileService object notifications.


### PR DESCRIPTION
## Description
Under the `Other notifications` section further down the page, the links to the ContentTypeService Notifications and MediaTypeService Notifications have been updated to their respective pages.

These links were formerly directed to the ContentService Notifications and the MediaService Notifications, respectively

## Product & version (if relevant)
I see this appears to be under the 11 folder, but I can go back and see if the others would need updates too.  Please let me know and I'd be happy to help.

## Deadline (if relevant)
None
