### PR TITLE
Update notifications README.md (v10)

### DIFF
--- a/10/umbraco-cms/reference/notifications/README.md
+++ b/10/umbraco-cms/reference/notifications/README.md
@@ -133,8 +133,8 @@ Now all the notifications you registered in your extension method will be handle
 
 ## Other notifications
 
-* See [ContentTypeService Notifications](contentservice-notifications.md) for a listing of the ContentTypeService object notifications.
-* See [MediaTypeService Notifications](mediaservice-notifications.md) for a listing of the MediaTypeService object notifications.
+* See [ContentTypeService Notifications](contentypeservice-notifications.md) for a listing of the ContentTypeService object notifications.
+* See [MediaTypeService Notifications](mediatypeservice-notifications.md) for a listing of the MediaTypeService object notifications.
 * See [MemberTypeService Notifications](membertypeservice-notifications.md) for a listing of the MemberTypeService object notifications.
 * See [DataTypeService Notifications](datatypeservice-notifications.md) for a listing of the DataTypeService object notifications
 * See [FileService Notifications](fileservice-notifications.md) for a listing of the FileService object notifications.


### PR DESCRIPTION
## Description
Under the `Other notifications` section further down the page, the links to the ContentTypeService Notifications and MediaTypeService Notifications have been updated to their respective pages.

These links were formerly directed to the ContentService Notifications and the MediaService Notifications, respectively

_This is the follow-up of pull request #5250 for v10.  I reviewed the other pull requests, I saw that it would make sense to duplicate this update for v10._

## Product & version (if relevant)
This is the v10 version of the update. 

## Deadline (if relevant)
None
