### PR TITLE
Update rewrites-on-cloud.md

### DIFF
--- a/umbraco-cloud/set-up/project-settings/manage-hostnames/rewrites-on-cloud.md
+++ b/umbraco-cloud/set-up/project-settings/manage-hostnames/rewrites-on-cloud.md
@@ -93,6 +93,7 @@ For example, the following rule will redirect all requests for `https://mysite.c
     <add input="{REQUEST_URI}" pattern="^/DependencyHandler.axd" negate="true" />
     <add input="{REQUEST_URI}" pattern="^/App_Plugins" negate="true" />
     <add input="{REQUEST_URI}" pattern="^/\.well-known/acme-challenge" negate="true" />
+    <add input="{REQUEST_URI}" pattern="^/umbidlocallogin" negate="true" />
   </conditions>
   <action type="Redirect" url="{R:1}/" />
 </rule>


### PR DESCRIPTION
Need to exclude /umbidlocallogin from trailing slash, otherwise the 'Sign in with Umbraco ID' will not work on localhost.

## Description

_What did you add/update/change?_

Added "/umbidlocallogin" to the trailing slash redirect rule.

## Type of suggestion

Updated outdated content

## Product & version (if relevant)

Umbraco Cloud 10.4.2

