### PR TITLE
Fix syntax formatting of JSON snippet

### DIFF
--- a/12/umbraco-cms/reference/configuration/debugsettings.md
+++ b/12/umbraco-cms/reference/configuration/debugsettings.md
@@ -12,8 +12,8 @@ The debug section has two settings you can configure, `"LogIncompletedScopes"` a
 "Umbraco": {
   "CMS": {
     "Debug": {
-      "DumpOnTimeoutThreadAbort": false
-      "LogIncompletedScopes": false,
+      "DumpOnTimeoutThreadAbort": false,
+      "LogIncompletedScopes": false
     }
   }
 }


### PR DESCRIPTION
The comma was invalid.

## Description

Correction of JSON syntax.

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Not relevant.

## Deadline (if relevant)

Not relevant.