### PR TITLE
Update quick-start.md

### DIFF
--- a/12/umbraco-cms/reference/searching/examine/quick-start.md
+++ b/12/umbraco-cms/reference/searching/examine/quick-start.md
@@ -131,7 +131,7 @@ namespace MyStarterKitSite.Services;
 public class SearchService : ISearchService
 {
     private readonly IExamineManager _examineManager;
-    public SearchServices(IExamineManager examineManager)
+    public SearchService(IExamineManager examineManager)
     {
         _examineManager = examineManager;
     }


### PR DESCRIPTION
Typo in SearchService constructor

## Description

Renamed `SearchServices` constructor to `SearchService` to match class name.

## Type of suggestion

* [x] Typo/grammar fix