### PR TITLE
Document "Timestamp" constraint for minification

### DIFF
--- a/10/umbraco-cms/reference/configuration/runtimeminificationsettings.md
+++ b/10/umbraco-cms/reference/configuration/runtimeminificationsettings.md
@@ -19,9 +19,13 @@ This section allows you to configure the runtime minifications (defaults shown),
   }
 }
 ```
-## Use 'in memory' cache 
+## Use 'in memory' cache
 
 This setting determines whether Smidge should save it's cached output in memory, or in a file on disk. If set to false, then the folder will be created at the wwwroot of your Umbraco site in a folder called 'Smidge'/
+
+{% hint style="info" %}
+It is not possible to disable in memory caching when `Timestamp` is chosen as `CacheBuster` method.
+{% endhint %}
 
 ## Cache buster
 

--- a/11/umbraco-cms/reference/configuration/runtimeminificationsettings.md
+++ b/11/umbraco-cms/reference/configuration/runtimeminificationsettings.md
@@ -16,9 +16,13 @@ This section allows you to configure the runtime minifications (defaults shown),
   }
 }
 ```
-## Use 'in memory' cache 
+## Use 'in memory' cache
 
 This setting determines whether Smidge should save it's cached output in memory, or in a file on disk. If set to false, then the folder will be created at the wwwroot of your Umbraco site in a folder called 'Smidge'/
+
+{% hint style="info" %}
+It is not possible to disable in memory caching when `Timestamp` is chosen as `CacheBuster` method.
+{% endhint %}
 
 ## Cache buster
 

--- a/12/umbraco-cms/reference/configuration/runtimeminificationsettings.md
+++ b/12/umbraco-cms/reference/configuration/runtimeminificationsettings.md
@@ -16,9 +16,13 @@ This section allows you to configure the runtime minifications (defaults shown),
   }
 }
 ```
-## Use 'in memory' cache 
+## Use 'in memory' cache
 
 This setting determines whether Smidge should save it's cached output in memory, or in a file on disk. If set to false, then the folder will be created at the wwwroot of your Umbraco site in a folder called 'Smidge'/
+
+{% hint style="info" %}
+It is not possible to disable in memory caching when `Timestamp` is chosen as `CacheBuster` method.
+{% endhint %}
 
 ## Cache buster
 

--- a/12/umbraco-cms/reference/configuration/runtimeminificationsettings.md
+++ b/12/umbraco-cms/reference/configuration/runtimeminificationsettings.md
@@ -21,7 +21,7 @@ This section allows you to configure the runtime minifications (defaults shown),
 This setting determines whether Smidge should save it's cached output in memory, or in a file on disk. If set to false, then the folder will be created at the wwwroot of your Umbraco site in a folder called 'Smidge'/
 
 {% hint style="info" %}
-It is not possible to disable in memory caching when `Timestamp` is chosen as `CacheBuster` method.
+It is not possible to disable in-memory caching when the `CacheBuster` method has `Timestamp` as the value.
 {% endhint %}
 
 ## Cache buster


### PR DESCRIPTION
## Description

The runtime minification configuration has some undocumented constraints. Hopefully the PR changes make those constraints abundantly clear, otherwise this PR should not be accepted 😄 

I have updated the docs for v10, v11 and v12.

Cross-linking the origin for future reference: https://github.com/umbraco/Umbraco-CMS/issues/14608

## Type of suggestion

* [x] Other

## Product & version (if relevant)

v10+

## Deadline (if relevant)

Not relevant.
