### PR TITLE
Document existence of 'ShowDomainWarnings' setting

### DIFF
--- a/11/umbraco-cms/reference/configuration/contentsettings.md
+++ b/11/umbraco-cms/reference/configuration/contentsettings.md
@@ -173,7 +173,11 @@ By default this is set to `false`. To make the obsolete data types visible in th
 
 ### Show Domain Warnings
 
-If you have a multilingual Umbraco site and you haven't configured Domains correctly for each language then every time you publish you will get the following warning: "Content published: Domains are not configured for multilingual site, please contact an administrator, see log for more information" - if however, you have a legitimate use case for not setting a Domain for a certain circumstance, these warnings every time an editor publishes a page can be annoying. This setting ShowDomainWarnings can be set to 'false' to stop them from displaying.
+If you do not configure Domains for each language in a multilingual site then every time you publish your content you get this warning:
+
+`Content published: Domains are not configured for multilingual site, please contact an administrator, see log for more information.`
+
+If you have a use case for not setting the domains, you can set this setting **ShowDomainWarnings** to `false` to stop the warning from displaying.
 
 ## ContentVersionCleanupPolicy
 

--- a/11/umbraco-cms/reference/configuration/contentsettings.md
+++ b/11/umbraco-cms/reference/configuration/contentsettings.md
@@ -48,7 +48,8 @@ The following snippet will give an overview of the keys and values in the conten
       },
       "PreviewBadge": "<![CDATA[<b>My HTML here</b>]]>",
       "ResolveUrlsFromTextString": false,
-      "ShowDeprecatedPropertyEditors": false
+      "ShowDeprecatedPropertyEditors": false,
+      "ShowDomainWarnings": true
     }
   }
 }
@@ -169,6 +170,10 @@ This setting is used when you're running Umbraco in virtual directories. Setting
 This setting is used for controlling whether or not the Data Types marked as obsolete should be visible in the dropdown when creating new Data Types.
 
 By default this is set to `false`. To make the obsolete data types visible in the dropdown change the value to `true`.
+
+### Show Domain Warnings
+
+If you have a multilingual Umbraco site and you haven't configured Domains correctly for each language then every time you publish you will get the following warning: "Content published: Domains are not configured for multilingual site, please contact an administrator, see log for more information" - if however, you have a legitimate use case for not setting a Domain for a certain circumstance, these warnings every time an editor publishes a page can be annoying. This setting ShowDomainWarnings can be set to 'false' to stop them from displaying.
 
 ## ContentVersionCleanupPolicy
 

--- a/12/umbraco-cms/reference/configuration/contentsettings.md
+++ b/12/umbraco-cms/reference/configuration/contentsettings.md
@@ -173,7 +173,11 @@ By default this is set to `false`. To make the obsolete data types visible in th
 
 ### Show Domain Warnings
 
-If you have a multilingual Umbraco site and you haven't configured Domains correctly for each language then every time you publish you will get the following warning: "Content published: Domains are not configured for multilingual site, please contact an administrator, see log for more information" - if however, you have a legitimate use case for not setting a Domain for a certain circumstance, these warnings every time an editor publishes a page can be annoying. This setting ShowDomainWarnings can be set to 'false' to stop them from displaying.
+If you do not configure Domains for each language in a multilingual site then every time you publish your content you get this warning:
+
+`Content published: Domains are not configured for multilingual site, please contact an administrator, see log for more information.`
+
+If you have a use case for not setting the domains, you can set this setting **ShowDomainWarnings** to `false` to stop the warning from displaying.
 
 ## ContentVersionCleanupPolicy
 

--- a/12/umbraco-cms/reference/configuration/contentsettings.md
+++ b/12/umbraco-cms/reference/configuration/contentsettings.md
@@ -48,7 +48,8 @@ The following snippet will give an overview of the keys and values in the conten
       },
       "PreviewBadge": "<![CDATA[<b>My HTML here</b>]]>",
       "ResolveUrlsFromTextString": false,
-      "ShowDeprecatedPropertyEditors": false
+      "ShowDeprecatedPropertyEditors": false,
+      "ShowDomainWarnings": true
     }
   }
 }
@@ -169,6 +170,10 @@ This setting is used when you're running Umbraco in virtual directories. Setting
 This setting is used for controlling whether or not the Data Types marked as obsolete should be visible in the dropdown when creating new Data Types.
 
 By default this is set to `false`. To make the obsolete data types visible in the dropdown change the value to `true`.
+
+### Show Domain Warnings
+
+If you have a multilingual Umbraco site and you haven't configured Domains correctly for each language then every time you publish you will get the following warning: "Content published: Domains are not configured for multilingual site, please contact an administrator, see log for more information" - if however, you have a legitimate use case for not setting a Domain for a certain circumstance, these warnings every time an editor publishes a page can be annoying. This setting ShowDomainWarnings can be set to 'false' to stop them from displaying.
 
 ## ContentVersionCleanupPolicy
 


### PR DESCRIPTION
## Description

We added a new Content Setting in V11/v12 called ShowDomainWarnings, by default this is true, but can be set to false to turn off the warnings if they become annoying.

umbraco/Umbraco-CMS#13954

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [x] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

V11 and V12

## Deadline (if relevant)

can be now

This is the warning in orange that the setting refers to:

![image](https://github.com/umbraco/UmbracoDocs/assets/260802/fb80ebcf-cefa-4cfd-bf72-d0456cfb1f65)

