### PR TITLE
Remove spurious link to old docs page

### DIFF
--- a/10/umbraco-cms/extending/backoffice-search.md
+++ b/10/umbraco-cms/extending/backoffice-search.md
@@ -59,8 +59,6 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Cms.Infrastructure.Search;
 
-//https://our.umbraco.com/documentation/Extending/Backoffice-Search/
-
 namespace Umbraco.Docs.Samples.Web.BackofficeSearch
 {
     public class CustomUmbracoTreeSearcherFields : UmbracoTreeSearcherFields, IUmbracoTreeSearcherFields

--- a/11/umbraco-cms/extending/backoffice-search.md
+++ b/11/umbraco-cms/extending/backoffice-search.md
@@ -56,8 +56,6 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Cms.Infrastructure.Search;
 
-//https://our.umbraco.com/documentation/Extending/Backoffice-Search/
-
 namespace Umbraco.Docs.Samples.Web.BackofficeSearch
 {
     public class CustomUmbracoTreeSearcherFields : UmbracoTreeSearcherFields, IUmbracoTreeSearcherFields

--- a/12/umbraco-cms/extending/backoffice-search.md
+++ b/12/umbraco-cms/extending/backoffice-search.md
@@ -56,8 +56,6 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Cms.Infrastructure.Search;
 
-//https://our.umbraco.com/documentation/Extending/Backoffice-Search/
-
 namespace Umbraco.Docs.Samples.Web.BackofficeSearch
 {
     public class CustomUmbracoTreeSearcherFields : UmbracoTreeSearcherFields, IUmbracoTreeSearcherFields


### PR DESCRIPTION
## Description

I removed a link in a comment to https://our.umbraco.com/documentation/Extending/Backoffice-Search/ That page links to a "we have moved" page. I'd considered updating the link to https://docs.umbraco.com/umbraco-cms/extending/backoffice-search/, but it seems like it's not relevant to the code block it's displayed in, so I removed it instead

## Type of suggestion

* [ ✅] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
Docs for v10, 11, 12


## Deadline (if relevant)

_When should the content be published?_
N/A