### PR TITLE
Updates our umbraco to docs umbraco

### DIFF
--- a/10/umbraco-cms/extending/backoffice-search.md
+++ b/10/umbraco-cms/extending/backoffice-search.md
@@ -100,4 +100,4 @@ You cannot use this to search on integer types in the index, as an example `pare
 
 ## More advanced extensions
 
-For further extensibility of the Umbraco Backoffice search implementation check [ISearchableTree](section-trees/searchable-trees.md "https://docs.umbraco.com/umbraco-cms/extending/section-trees/searchable-trees")
+For further extensibility of the Umbraco Backoffice search implementation check [ISearchableTree](section-trees/searchable-trees.md)

--- a/10/umbraco-cms/extending/backoffice-search.md
+++ b/10/umbraco-cms/extending/backoffice-search.md
@@ -100,4 +100,4 @@ You cannot use this to search on integer types in the index, as an example `pare
 
 ## More advanced extensions
 
-For further extensibility of the Umbraco Backoffice search implementation check [ISearchableTree](section-trees/searchable-trees.md "https://our.umbraco.com/Documentation/Extending/Section-Trees/Searchable-Trees/index.md")
+For further extensibility of the Umbraco Backoffice search implementation check [ISearchableTree](section-trees/searchable-trees.md "https://docs.umbraco.com/umbraco-cms/extending/section-trees/searchable-trees")

--- a/11/umbraco-cms/extending/backoffice-search.md
+++ b/11/umbraco-cms/extending/backoffice-search.md
@@ -97,4 +97,4 @@ You cannot use this to search on integer types in the index, as an example `pare
 
 ## More advanced extensions
 
-For further extensibility of the Umbraco Backoffice search implementation check [ISearchableTree](section-trees/searchable-trees.md "https://docs.umbraco.com/umbraco-cms/extending/section-trees/searchable-trees/")
+For further extensibility of the Umbraco Backoffice search implementation check [ISearchableTree](section-trees/searchable-trees.md)

--- a/11/umbraco-cms/extending/backoffice-search.md
+++ b/11/umbraco-cms/extending/backoffice-search.md
@@ -97,4 +97,4 @@ You cannot use this to search on integer types in the index, as an example `pare
 
 ## More advanced extensions
 
-For further extensibility of the Umbraco Backoffice search implementation check [ISearchableTree](section-trees/searchable-trees.md "https://our.umbraco.com/Documentation/Extending/Section-Trees/Searchable-Trees/index.md")
+For further extensibility of the Umbraco Backoffice search implementation check [ISearchableTree](section-trees/searchable-trees.md "https://docs.umbraco.com/umbraco-cms/extending/section-trees/searchable-trees/")

--- a/11/umbraco-cms/tutorials/starter-kit/lessons/4-help-and-community.md
+++ b/11/umbraco-cms/tutorials/starter-kit/lessons/4-help-and-community.md
@@ -11,7 +11,7 @@ Maybe you have even signed up to attend a local meetup!
 ## Steps
 
 1. Register on [our.umbraco.com](https://our.umbraco.com/member/Signup).
-2. Search the [forum](https://our.umbraco.com/forum/), or browse the extensive [documentation](https://our.umbraco.com/documentation/) if you prefer more structured learning.
+2. Search the [forum](https://our.umbraco.com/forum/), or browse the extensive [documentation](https://docs.umbraco.com/umbraco-cms/) if you prefer more structured learning.
 3. Please create a forum post if you don't know the best way to proceed. There are experienced community members online 24/7 so hopefully you won't have to wait long for a reply. We are always very excited to help out newcomers!
 4. Check the home page of Our for any upcoming meetups near you. If there aren't any, keep an eye out for any online community hangouts happening soon.
 5. Finally, do think about [contributing yourself](https://docs.umbraco.com/welcome/contribute/getting-started). Even if it's pointing out something in the documentation that could be made clearer, we'd love to hear from you.

--- a/12/umbraco-cms/extending/backoffice-search.md
+++ b/12/umbraco-cms/extending/backoffice-search.md
@@ -97,4 +97,4 @@ You cannot use this to search on integer types in the index, as an example `pare
 
 ## More advanced extensions
 
-For further extensibility of the Umbraco Backoffice search implementation check [ISearchableTree](section-trees/searchable-trees.md "https://docs.umbraco.com/umbraco-cms/extending/section-trees/searchable-trees/")
+For further extensibility of the Umbraco Backoffice search implementation check [ISearchableTree](section-trees/searchable-trees.md)

--- a/12/umbraco-cms/extending/backoffice-search.md
+++ b/12/umbraco-cms/extending/backoffice-search.md
@@ -97,4 +97,4 @@ You cannot use this to search on integer types in the index, as an example `pare
 
 ## More advanced extensions
 
-For further extensibility of the Umbraco Backoffice search implementation check [ISearchableTree](section-trees/searchable-trees.md "https://our.umbraco.com/Documentation/Extending/Section-Trees/Searchable-Trees/index.md")
+For further extensibility of the Umbraco Backoffice search implementation check [ISearchableTree](section-trees/searchable-trees.md "https://docs.umbraco.com/umbraco-cms/extending/section-trees/searchable-trees/")

--- a/12/umbraco-cms/tutorials/starter-kit/lessons/4-help-and-community.md
+++ b/12/umbraco-cms/tutorials/starter-kit/lessons/4-help-and-community.md
@@ -11,7 +11,7 @@ Maybe you have even signed up to attend a local meetup!
 ## Steps
 
 1. Register on [our.umbraco.com](https://our.umbraco.com/member/Signup).
-2. Search the [forum](https://our.umbraco.com/forum/), or browse the extensive [documentation](https://our.umbraco.com/documentation/) if you prefer more structured learning.
+2. Search the [forum](https://our.umbraco.com/forum/), or browse the extensive [documentation](https://docs.umbraco.com/umbraco-cms/) if you prefer more structured learning.
 3. Please create a forum post if you don't know the best way to proceed. There are experienced community members online 24/7 so hopefully you won't have to wait long for a reply. We are always very excited to help out newcomers!
 4. Check the home page of Our for any upcoming meetups near you. If there aren't any, keep an eye out for any online community hangouts happening soon.
 5. Finally, do think about [contributing yourself](https://docs.umbraco.com/welcome/contribute/getting-started). Even if it's pointing out something in the documentation that could be made clearer, we'd love to hear from you.

--- a/contribs.md
+++ b/contribs.md
@@ -44,7 +44,7 @@ First fork and clone the repository so that you have your own working copy. Then
 
 **Note:** It's a good idea to pull in upstream changes, merge and commit to your own fork before submitting a pull request. Instructions on how to set up a remote repo and pull from upstream can be found on this [page](https://help.github.com/articles/fork-a-repo).
 
-Everything in the main repository will merge onto the [docs.umbraco.com](https://docs.umbraco.com) site, which is why we have chosen a pull request workflow to keep everything straightforward.
+Everything in the main repository will merge onto [docs.umbraco.com](https://docs.umbraco.com), which is why we have chosen a pull request workflow to keep everything straightforward.
 
 ## Planning & discussions
 

--- a/contribs.md
+++ b/contribs.md
@@ -38,7 +38,7 @@ In this command, we're syncing with the `main` branch. You can choose another on
 
 ### Contributing documentation
 
-All documents are written in Markdown, using a basic structure and stored as .md files. These are then pulled to [docs.umbraco.com/umbraco-cms](https://docs.umbraco.com/umbraco-cms/) for browsing.
+All documents are written in Markdown, using a basic structure and stored as .md files. These are then pulled to [docs.umbraco.com](https://docs.umbraco.com) for browsing.
 
 First fork and clone the repository so that you have your own working copy. Then create a new branch on your local copy to make your changes. Once you are happy with your edits, use GitHub to issue a "pull request", which means your edits will be reviewed, and once accepted, merged into the main repository.
 

--- a/contribs.md
+++ b/contribs.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-To contribute to either the documentation or stubs, you can fork & clone our repository, make your edits, and push back to GitHub and send us a pull request. All items that get pulled into the main repository will automatically get pushed to [our.umbraco.com/documentation](https://our.umbraco.com/documentation).
+To contribute to either the documentation or stubs, you can fork & clone our repository, make your edits, and push back to GitHub and send us a pull request. All items that get pulled into the main repository will automatically get pushed to [docs.umbraco.com/umbraco-cms](https://docs.umbraco.com/umbraco-cms/).
 
 Find detailed instructions on how to work with and contribute to the Umbraco Documentation in the [Contribution section](Contribute/).
 
@@ -38,13 +38,13 @@ In this command, we're syncing with the `main` branch. You can choose another on
 
 ### Contributing documentation
 
-All documents are written in Markdown, using a basic structure and stored as .md files. These are then pulled to [our.umbraco.com/documentation](https://our.umbraco.com/documentation) for browsing.
+All documents are written in Markdown, using a basic structure and stored as .md files. These are then pulled to [docs.umbraco.com/umbraco-cms](https://docs.umbraco.com/umbraco-cms/) for browsing.
 
 First fork and clone the repository so that you have your own working copy. Then create a new branch on your local copy to make your changes. Once you are happy with your edits, use GitHub to issue a "pull request", which means your edits will be reviewed, and once accepted, merged into the main repository.
 
 **Note:** It's a good idea to pull in upstream changes, merge and commit to your own fork before submitting a pull request. Instructions on how to set up a remote repo and pull from upstream can be found on this [page](https://help.github.com/articles/fork-a-repo).
 
-Everything in the main repository will make it onto the [our.umbraco.com/documentation](https://our.umbraco.com/documentation) site, which is why we have chosen a pull request workflow to keep everything straightforward.
+Everything in the main repository will make it onto the [docs.umbraco.com/umbraco-cms](https://docs.umbraco.com/umbraco-cms/) site, which is why we have chosen a pull request workflow to keep everything straightforward.
 
 ## Planning & discussions
 

--- a/umbraco-cloud/frequently-asked-questions.md
+++ b/umbraco-cloud/frequently-asked-questions.md
@@ -95,7 +95,7 @@ We upgrade when we're very confident the release is solid.
 
 We automatically upgrade Cloud projects to the latest patch version of Umbraco CMS, Umbraco Forms, and Umbraco Deploy / Courier. For minor version upgrades of our products, you’ll get a button in the interface to decide if you want to move to that version when it is released. When we make a new patch version, we first run it through our test suite, then test it on 10 test-sites. When all that passes, we roll out the upgrade in batches of 100 to customer accounts.
 
-[Read more about upgrades](https://our.umbraco.com/documentation/Umbraco-Cloud/Upgrades/)
+[Read more about upgrades](https://docs.umbraco.com/umbraco-cloud/product-upgrades/product-upgrades)
 
 ### My project didn't receive the auto-upgrade. Why?
 

--- a/umbraco-heartcore/tutorials/querying-with-graphql.md
+++ b/umbraco-heartcore/tutorials/querying-with-graphql.md
@@ -369,7 +369,7 @@ In the query above we are also using field aliases, this means that in the respo
           "name": "Umbraco Heartcore Documentation",
           "target": "_blank",
           "type": "EXTERNAL",
-          "url": "https://our.umbraco.com/documentation/Umbraco-Heartcore/"
+          "url": "https://docs.umbraco.com/umbraco-heartcore/"
         }
       ]
     }


### PR DESCRIPTION
## Description

Updated some links to our.umbraco.com/documentation to their https://docs.umbraco.com/ counterpart, similar to #5338 from yesterday.

I searched the repo for `our.umbraco.com/documentation`, and updated any references I found, except those referencing earlier versions of Umbraco in section like "see our legacy documentation here..."

## Type of suggestion

* [ ] Typo/grammar fix
* [ ✅ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
v10, v11, v12


## Deadline (if relevant)

N/A
