### PR TITLE
Define minimum SQL Server version

### DIFF
--- a/10/umbraco-commerce/getting-started/introduction.md
+++ b/10/umbraco-commerce/getting-started/introduction.md
@@ -17,7 +17,7 @@ Find detailed instructions on how to install the latest version of Umbraco in th
 The minimum requirements for using Umbraco Commerce are as follows:
 
 * Umbraco CMS version 10+
-* SQL Server Database
+* SQL Server 2015+ Database
   * **SQLite** is fine for testing, but not recommended for live deployments. See [Configuring SQLite support](../how-to-guides/configure-sqlite-support.md) for more details.
 
 ## Versioning


### PR DESCRIPTION
Umbraco supports SQL 2012+, but Umbraco Commerce requires 2015+ so we should be explicit