### PR TITLE
Multinode Treepickers do generate schema in GraphQL

### DIFF
--- a/umbraco-heartcore/api-documentation/graphql/filtering-and-ordering.md
+++ b/umbraco-heartcore/api-documentation/graphql/filtering-and-ordering.md
@@ -6,7 +6,7 @@ description: Documentation for GraphQL filtering in Umbraco Heartcore.
 
 The GraphQL API allows for filtering and ordering root and traversion collections (ancestors, children and descendants).
 
-For information on the different filters available and how the filter ad order types are generated see [Schema Generation](schema-generation.md#filtering).
+For information on the different filters available and how the filter and order types are generated see [Schema Generation](schema-generation.md#filtering).
 
 ## Using filters
 

--- a/umbraco-heartcore/api-documentation/graphql/property-editors.md
+++ b/umbraco-heartcore/api-documentation/graphql/property-editors.md
@@ -197,6 +197,10 @@ This page contains a list of all the built-in Umbraco Property Editors and their
 **GraphQL Type**: [`[Media]`](schema-generation.md#media)\
 **Can be used for filtering**: `true`
 
+**Node type**: `Member`
+{% hint style="info" %} The Member editor configuration is not supported and will not be present in the generated schema {% endhint %}
+
+
 ## Nested Content
 
 **Editor Alias**: `Umbraco.NestedContent`\

--- a/umbraco-heartcore/api-documentation/graphql/property-editors.md
+++ b/umbraco-heartcore/api-documentation/graphql/property-editors.md
@@ -197,9 +197,6 @@ This page contains a list of all the built-in Umbraco Property Editors and their
 **GraphQL Type**: [`[Media]`](schema-generation.md#media)\
 **Can be used for filtering**: `true`
 
-**Node type**: `Member`
-{% hint style="info" %} This editor configuration is not supported and will not be present in the generated schema {% endhint %}
-
 ## Nested Content
 
 **Editor Alias**: `Umbraco.NestedContent`\


### PR DESCRIPTION
## Description

_What did you add/update/change?_
Deleted an outdated note about Schema not being generated for multinode treepickers in GraphQL.
and fixed a typo.

## Type of suggestion

* [x] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Heartcore

## Deadline (if relevant)

_When should the content be published?_
