### PR TITLE
Add AdditionalAssemblyExclusionEntries to TypeFinderSettings

### DIFF
--- a/12/umbraco-cms/reference/configuration/typefindersettings.md
+++ b/12/umbraco-cms/reference/configuration/typefindersettings.md
@@ -7,7 +7,7 @@ description: "Information on the type finder settings section"
 The type finder settings allow you to specify assemblies that accept load exceptions when they are type scanned, for multiple assemblies separate them with a comma (`,`). 
 To accept load exceptions for all assemblies use an asterisk (`*`), like so:
 
-Furthermore it is possible to add additional assemblies to the exclusion filter. Thereby these assemblies will be ignored by umbraco. This can be useful depending on nuget packages that are not Umbraco packages.
+Furthermore it is possible to add additional assemblies to the exclusion filter. Thereby these assemblies will be ignored by Umbraco. This can be useful depending on nuget packages that are not Umbraco packages.
 ```json
 "Umbraco": {
   "CMS": {

--- a/12/umbraco-cms/reference/configuration/typefindersettings.md
+++ b/12/umbraco-cms/reference/configuration/typefindersettings.md
@@ -4,13 +4,16 @@ description: "Information on the type finder settings section"
 
 # Type finder settings
 
-The type finder settings allow you to specify assemblies that accept load exceptions when they are type scanned, for multiple assemblies separate them with a comma (`,`). To accept load exceptions for all assemblies use an asterisk (`*`), like so:
+The type finder settings allow you to specify assemblies that accept load exceptions when they are type scanned, for multiple assemblies separate them with a comma (`,`). 
+To accept load exceptions for all assemblies use an asterisk (`*`), like so:
 
+Furthermore it is possible to add additional assemblies to the exclusion filter. Thereby these assemblies will be ignored by umbraco. This can be useful depending on nuget packages that are not Umbraco packages.
 ```json
 "Umbraco": {
   "CMS": {
     "TypeFinder": {
-      "AssembliesAcceptingLoadExceptions": "*"
+      "AssembliesAcceptingLoadExceptions": "*",
+      "AdditionalAssemblyExclusionEntries": []
     }
   }
 }

--- a/12/umbraco-cms/reference/configuration/typefindersettings.md
+++ b/12/umbraco-cms/reference/configuration/typefindersettings.md
@@ -4,7 +4,7 @@ description: "Information on the type finder settings section"
 
 # Type finder settings
 
-The type finder settings allow you to specify assemblies that accept load exceptions when they are type scanned, for multiple assemblies separate them with a comma (`,`). 
+The type finder settings allows you to specify assemblies that accept load exceptions when they are type scanned. For multiple assemblies separate them with a comma (`,`). 
 To accept load exceptions for all assemblies use an asterisk (`*`), like so:
 
 Furthermore it is possible to add additional assemblies to the exclusion filter. Thereby these assemblies will be ignored by Umbraco. This can be useful depending on nuget packages that are not Umbraco packages.


### PR DESCRIPTION
## Description
Added the new AdditionalAssemblyExclusionEntries that is introduced in Umbraco 10.7, 11.5 and 12.2 to the  TypeFinderSettings

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [X] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
Umbraco 10.7, 11.5 and 12.2

## Deadline (if relevant)
When Umbraco 10.7, 11.5 and 12.2 is released
