### PR TITLE
Made note about introduced configuration option for the Forms headless API more prominent in the release notes.

### DIFF
--- a/10/umbraco-forms/release-notes.md
+++ b/10/umbraco-forms/release-notes.md
@@ -45,6 +45,10 @@ In this section, you can find the release notes for each version of Umbraco Form
 
 ### [10.4.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.4.0) (June 13th 2023)
 
+:::note
+If upgrading from a previous version and already using the headless API, please ensure to [enable the API via configuration](./developer/configuration/README.md#enableformsapi).
+:::
+
 * Ensured a case insensitive request check for protecting access to files uploaded to the media system.
 * Updated dependency on `aspnet-client-validation` to resolve an issue with validation of mandatory radio button or checkbox lists [#1028](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1028)
 * All updates noted under 10.4.0-rc1.
@@ -62,8 +66,6 @@ In this section, you can find the release notes for each version of Umbraco Form
 * Added tag helper for rendering a form
 * Provided messaging when using rich text fields in case of a missing rich text Data Type
 * Fixed an issue with the configurable removal of the default form templates [#1025](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1025)
-
-If upgrading from a previous version and already using the headless API, please ensure to [enable the API via configuration](./developer/configuration/README.md#enableformsapi).
 
 ### [10.3.3](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.3) (May 30th 2023)
 

--- a/11/umbraco-forms/release-notes.md
+++ b/11/umbraco-forms/release-notes.md
@@ -20,6 +20,10 @@ In this section, you can find the release notes for each version of Umbraco Form
 
 #### [11.2.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.2.0) (June 13th 2023)
 
+:::note
+If upgrading from a previous version and already using the headless API, please ensure to [enable the API via configuration](./developer/configuration/README.md#enableformsapi).
+:::
+
 * Ensured a case insensitive request check for protecting access to files uploaded to the media system.
 * Updated dependency on `aspnet-client-validation` to resolve an issue with validation of mandatory radio button or checkbox lists [#1028](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1028)
 * All updates noted under 11.2.0-rc1.
@@ -37,8 +41,6 @@ In this section, you can find the release notes for each version of Umbraco Form
 * Added tag helper for rendering a form
 * Provided messaging when using rich text fields in case of a missing rich text Data Type
 * Fixed an issue with the configurable removal of the default form templates [#1025](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1025)
-
-If upgrading from a previous version and already using the headless API, please ensure to [enable the API via configuration](developer/configuration/#enableformsapi).
 
 #### [11.1.3](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.1.2) (May 30th 2023)
 
@@ -156,6 +158,10 @@ If upgrading from a previous version and already using the headless API, please 
 
 #### [10.4.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.4.0) (June 13th 2023)
 
+:::note
+If upgrading from a previous version and already using the headless API, please ensure to [enable the API via configuration](./developer/configuration/README.md#enableformsapi).
+:::
+
 * Ensured a case insensitive request check for protecting access to files uploaded to the media system.
 * Updated dependency on `aspnet-client-validation` to resolve an issue with validation of mandatory radio button or checkbox lists [#1028](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1028)
 * All updates noted under 10.4.0-rc1.
@@ -173,8 +179,6 @@ If upgrading from a previous version and already using the headless API, please 
 * Added tag helper for rendering a form
 * Provided messaging when using rich text fields in case of a missing rich text Data Type
 * Fixed an issue with the configurable removal of the default form templates [#1025](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1025)
-
-If upgrading from a previous version and already using the headless API, please ensure to [enable the API via configuration](developer/configuration/#enableformsapi).
 
 #### [10.3.3](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.3) (May 30th 2023)
 

--- a/12/umbraco-forms/release-notes.md
+++ b/12/umbraco-forms/release-notes.md
@@ -56,6 +56,10 @@ In this section, you can find the release notes for each version of Umbraco Form
 
 ### [11.2.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.2.0) (June 13th 2023)
 
+:::note
+If upgrading from a previous version and already using the headless API, please ensure to [enable the API via configuration](./developer/configuration/README.md#enableformsapi).
+:::
+
 * Ensured a case insensitive request check for protecting access to files uploaded to the media system.
 * Updated dependency on `aspnet-client-validation` to resolve an issue with validation of mandatory radio button or checkbox lists [#1028](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1028)
 * All updates noted under 11.2.0-rc1.
@@ -188,6 +192,10 @@ In this section, you can find the release notes for each version of Umbraco Form
 
 ### [10.4.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.4.0) (June 13th 2023)
 
+:::note
+If upgrading from a previous version and already using the headless API, please ensure to [enable the API via configuration](./developer/configuration/README.md#enableformsapi).
+:::
+
 * Ensured a case insensitive request check for protecting access to files uploaded to the media system.
 * Updated dependency on `aspnet-client-validation` to resolve an issue with validation of mandatory radio button or checkbox lists [#1028](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1028)
 * All updates noted under 10.4.0-rc1.
@@ -203,8 +211,6 @@ In this section, you can find the release notes for each version of Umbraco Form
 * Performance optimizations for tree rendering, form submission and workflow execution
 * Added tag helper for rendering a form
 * Provided messaging when using rich text fields in case of a missing rich text datatype
-
-If upgrading from a previous version and already using the headless API, please ensure to [enable the API via configuration](./developer/configuration/README.md#enableformsapi).
 
 ### [10.3.3](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.3) (May 30th 2023)
 


### PR DESCRIPTION
## Description

Made note about introduced configuration option for the Forms headless API more prominent in the release notes.  I heard about someone getting caught out by this so wanted to flag it so it's a bit clearer when scanning the release notes.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [X] Other

## Product & version (if relevant)

Forms 10.4 and 11.2

## Deadline (if relevant)

Can go live at any time.
