### PR TITLE
Add note about Umbraco application URL

### DIFF
--- a/10/umbraco-cms/reference/configuration/webroutingsettings.md
+++ b/10/umbraco-cms/reference/configuration/webroutingsettings.md
@@ -74,3 +74,7 @@ Will set the URL provider mode, options are:
 ## Umbraco application URL
 
 Defines the Umbraco application URL that the server should reach itself. By default, Umbraco will guess that URL from the first request made to the server. Use this setting if the guess is not correct (because you are behind a load-balancer, for example). Format is: `http://www.mysite.com/`, ensure to contain the scheme (http/https) and complete hostname.
+
+{% hint style="info" %}
+Previously before v9, it was required to specify **backofffice** path as this was customizable (`/umbraco` by default). However, from v9+ this is no longer possible, so it's sufficient to use the URL that contains the scheme (http/https) and complete hostname.
+{% endhint %}

--- a/11/umbraco-cms/reference/configuration/webroutingsettings.md
+++ b/11/umbraco-cms/reference/configuration/webroutingsettings.md
@@ -100,3 +100,7 @@ Will set the URL provider mode, options are:
 ## Umbraco application URL
 
 Defines the Umbraco application URL that the server should reach itself. By default, Umbraco will guess that URL from the first request made to the server. Use this setting if the guess is not correct (because you are behind a load-balancer, for example). Format is: `http://www.mysite.com/`, ensure to contain the scheme (http/https) and complete hostname.
+
+{% hint style="info" %}
+Previously before v9, it was required to specify **backofffice** path as this was customizable (`/umbraco` by default). However, from v9+ this is no longer possible, so it's sufficient to use the URL that contains the scheme (http/https) and complete hostname.
+{% endhint %}

--- a/12/umbraco-cms/reference/configuration/webroutingsettings.md
+++ b/12/umbraco-cms/reference/configuration/webroutingsettings.md
@@ -101,4 +101,4 @@ Will set the URL provider mode, options are:
 
 Defines the Umbraco application URL that the server should reach itself. By default, Umbraco will guess that URL from the first request made to the server. Use this setting if the guess is not correct (because you are behind a load-balancer, for example). Format is: `http://www.mysite.com/`, ensure to contain the scheme (http/https) and complete hostname.
 
-Note that previously it was also to specify BackOffice path as this was customizable (`/umbraco` by default), but this is no longer possible in Umbraco 9+ so using the full URL including scheme and hostname is sufficient.
+Note that previously it was also required to specify BackOffice path as this was customizable (`/umbraco` by default), but this is no longer possible in Umbraco 9+ so using the full URL including scheme and hostname is sufficient.

--- a/12/umbraco-cms/reference/configuration/webroutingsettings.md
+++ b/12/umbraco-cms/reference/configuration/webroutingsettings.md
@@ -101,4 +101,6 @@ Will set the URL provider mode, options are:
 
 Defines the Umbraco application URL that the server should reach itself. By default, Umbraco will guess that URL from the first request made to the server. Use this setting if the guess is not correct (because you are behind a load-balancer, for example). Format is: `http://www.mysite.com/`, ensure to contain the scheme (http/https) and complete hostname.
 
-Note that previously it was also required to specify BackOffice path as this was customizable (`/umbraco` by default), but this is no longer possible in Umbraco 9+ so using the full URL including scheme and hostname is sufficient.
+{% hint style="info" %}
+Previously before v9, it was required to specify **backofffice** path as this was customizable (`/umbraco` by default). However, from v9+ this is no longer possible, so it's sufficient to use the URL that contains the scheme (http/https) and complete hostname.
+{% endhint %}

--- a/12/umbraco-cms/reference/configuration/webroutingsettings.md
+++ b/12/umbraco-cms/reference/configuration/webroutingsettings.md
@@ -100,3 +100,5 @@ Will set the URL provider mode, options are:
 ## Umbraco application URL
 
 Defines the Umbraco application URL that the server should reach itself. By default, Umbraco will guess that URL from the first request made to the server. Use this setting if the guess is not correct (because you are behind a load-balancer, for example). Format is: `http://www.mysite.com/`, ensure to contain the scheme (http/https) and complete hostname.
+
+Note that previously it was also to specify BackOffice path as this was customizable (`/umbraco` by default), but this is no longer possible in Umbraco 9+ so using the full URL including scheme and hostname is sufficient.


### PR DESCRIPTION
## Description

In Umbraco 7 and 8 we had the following:

```
<web.routing
  trySkipIisCustomErrors="true"
  internalRedirectPreservesTemplate="false" disableAlternativeTemplates="false" validateAlternativeTemplates="false" disableFindContentByIdPath="false"
  umbracoApplicationUrl="">
</web.routing>
```

where the comment says:

```
@umbracoApplicationUrl
  The url of the Umbraco application. By default, Umbraco will figure it out from the first request.
  Configure it here if you need anything specific. Needs to be a complete url with scheme and umbraco
  path, eg http://mysite.com/umbraco. NOT just "mysite.com" or "mysite.com/umbraco" or "http://mysite.com".
```

However @nul800sebastiaan pointed out it isn't required as the BackOffice path on no longer configurable in Umbraco 9+
https://discord.com/channels/869656431308189746/1146380570398568478

Not sure what happens I including `/umbraco` though - maybe it is just ignored, when Umbraco parse the URL and only use the domain and append `/umbraco` even though `http://mysite.com/admin` was set in this setting?

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [x] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
