### PR TITLE
Added clarification of text for Language translations

### DIFF
--- a/10/umbraco-cms/extending/language-files.md
+++ b/10/umbraco-cms/extending/language-files.md
@@ -12,7 +12,7 @@ description: >-
 Language files are XML files used to translate:
 - The Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
 - The member identity errors in an Umbraco website enabling end users to use Umbraco in the website language.
-- Add translations for your packages [see here for docs on how to include translations for your own package](packages/language-files-for-packages.md)
+-  Read [Add translations for your packages](packages/language-files-for-packages.md) article to see how to include translations for your own package.
 - Override existing language files
 
 This is an example of such a language file, the most important parts are the `alias` fields of the `<area>` and `<key>` elements. This is what you need to retrieve the values from .NET or Angular.

--- a/10/umbraco-cms/extending/language-files.md
+++ b/10/umbraco-cms/extending/language-files.md
@@ -109,7 +109,7 @@ Using core or custom language keys from your code:
 
 ### From .NET
 
-`ILocalizedTextService` is used to localize strings, and is available through dependency injection. First, inject the service, and then use the `Localize()` method available in the namespace `Umbraco.Extensions` to localize the string with the format \[area]/\[key]:
+`ILocalizedTextService` is used to localize strings, and is available through dependency injection. First, inject the service, and then use the `Localize()` method available in the namespace `Umbraco.Extensions` to localize the string with the format `\[area]/\[key]`:
 
 ```csharp
 public MyClass(ILocalizedTextService textservice)
@@ -120,7 +120,7 @@ public MyClass(ILocalizedTextService textservice)
 
 ### From Angular
 
-In the Umbraco backoffice UI, labels can be localized with the `localize` directive:
+In the Umbraco backoffice UI, labels can be localized with the `localize` directive. The syntax is slightly different when compared to the .NET variant. Here the syntax is `\[area]_\[key]`:
 
 ```xml
 <button>

--- a/10/umbraco-cms/extending/language-files.md
+++ b/10/umbraco-cms/extending/language-files.md
@@ -9,11 +9,31 @@ description: >-
 
 # Language Files & Localization
 
-Language files are used to translate:
+Language files are XML files used to translate:
 - The Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
 - The member identity errors in an Umbraco website enabling end users to use Umbraco in the website language.
+- Add translations for your packages [see here for docs on how to include translations for your own package](packages/language-files-for-packages.md)
+- Override existing language files
 
-If you are a package developer, [see here for docs on how to include translations for your own package](packages/language-files-for-packages.md).
+This is an example of such a language file, the most important parts are the `alias` fields of the `<area>` and `<key>` elements. This is what you need to retrieve the values from .NET or Angular.
+```xml
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
+    <creator>
+        <name>The Umbraco community</name>
+        <link>https://our.umbraco.com</link>
+    </creator>
+    <area alias="actions">
+        <key alias="assignDomain">Culture and Hostnames</key>
+        <key alias="auditTrail">Audit Trail</key>
+    </area>
+    <area alias="buttons">
+        <key alias="buttonSave">Save</key>
+        <key alias="buttonCancel">Cancel</key>
+    </area>
+    ...
+</language>
+```
 
 ## Supported Languages
 

--- a/10/umbraco-cms/extending/language-files.md
+++ b/10/umbraco-cms/extending/language-files.md
@@ -12,7 +12,7 @@ description: >-
 Language files are XML files used to translate:
 - The Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
 - The member identity errors in an Umbraco website enabling end users to use Umbraco in the website language.
--  Read [Add translations for your packages](packages/language-files-for-packages.md) article to see how to include translations for your own package.
+-  Read [Add translations for your packages](packages/language-files-for-packages.md) to see how to include translations for your own package.
 - Override existing language files
 
 This is an example of such a language file, the most important parts are the `alias` fields of the `<area>` and `<key>` elements. This is what you need to retrieve the values from .NET or Angular.

--- a/10/umbraco-cms/extending/language-files.md
+++ b/10/umbraco-cms/extending/language-files.md
@@ -21,7 +21,7 @@ This is an example of such a language file, the most important parts are the `al
 <language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
     <creator>
         <name>The Umbraco community</name>
-        <link>https://our.umbraco.com</link>
+        <link>https://community.umbraco.com/</link>
     </creator>
     <area alias="actions">
         <key alias="assignDomain">Culture and Hostnames</key>

--- a/11/umbraco-cms/extending/language-files.md
+++ b/11/umbraco-cms/extending/language-files.md
@@ -6,11 +6,31 @@ description: >-
 
 # Language Files & Localization
 
-Language files are used to translate:
+Language files are XML files used to translate:
 - The Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
 - The member identity errors in an Umbraco website enabling end users to use Umbraco in the website language.
+- Add translations for your packages [see here for docs on how to include translations for your own package](packages/language-files-for-packages.md)
+- Override existing language files
 
-If you are a package developer, [see here for docs on how to include translations for your own package](packages/language-files-for-packages.md).
+This is an example of such a language file, the most important parts are the `alias` fields of the `<area>` and `<key>` elements. This is what you need to retrieve the values from .NET or Angular.
+```xml
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
+    <creator>
+        <name>The Umbraco community</name>
+        <link>https://our.umbraco.com</link>
+    </creator>
+    <area alias="actions">
+        <key alias="assignDomain">Culture and Hostnames</key>
+        <key alias="auditTrail">Audit Trail</key>
+    </area>
+    <area alias="buttons">
+        <key alias="buttonSave">Save</key>
+        <key alias="buttonCancel">Cancel</key>
+    </area>
+    ...
+</language>
+```
 
 ## Supported Languages
 

--- a/11/umbraco-cms/extending/language-files.md
+++ b/11/umbraco-cms/extending/language-files.md
@@ -18,7 +18,7 @@ This is an example of such a language file, the most important parts are the `al
 <language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
     <creator>
         <name>The Umbraco community</name>
-        <link>https://our.umbraco.com</link>
+        <link>https://community.umbraco.com</link>
     </creator>
     <area alias="actions">
         <key alias="assignDomain">Culture and Hostnames</key>

--- a/11/umbraco-cms/extending/language-files.md
+++ b/11/umbraco-cms/extending/language-files.md
@@ -9,7 +9,7 @@ description: >-
 Language files are XML files used to translate:
 - The Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
 - The member identity errors in an Umbraco website enabling end users to use Umbraco in the website language.
--  Read [Add translations for your packages](packages/language-files-for-packages.md) article to see how to include translations for your own package.
+-  Read [Add translations for your packages](packages/language-files-for-packages.md) to see how to include translations for your own package.
 - Override existing language files
 
 This is an example of such a language file, the most important parts are the `alias` fields of the `<area>` and `<key>` elements. This is what you need to retrieve the values from .NET or Angular.

--- a/11/umbraco-cms/extending/language-files.md
+++ b/11/umbraco-cms/extending/language-files.md
@@ -107,7 +107,7 @@ Using core or custom language keys from your code:
 
 ### From .NET
 
-`ILocalizedTextService` is used to localize strings, and is available through dependency injection. First, inject the service, and then use the `Localize()` method available in the namespace `Umbraco.Extensions` to localize the string with the format \[area]/\[key]:
+`ILocalizedTextService` is used to localize strings, and is available through dependency injection. First, inject the service, and then use the `Localize()` method available in the namespace `Umbraco.Extensions` to localize the string with the format `\[area]/\[key]`:
 
 ```csharp
 public MyClass(ILocalizedTextService textservice)
@@ -115,10 +115,11 @@ public MyClass(ILocalizedTextService textservice)
     var localizedLabel = textservice.Localize("dialog/mykey");
 }
 ```
+In this example it will try to get the value of the key `mykey` in the area `dialog`.
 
 ### From Angular
 
-In the Umbraco backoffice UI, labels can be localized with the `localize` directive:
+In the Umbraco backoffice UI, labels can be localized with the `localize` directive. The syntax is slightly different when compared to the .NET variant. Here the syntax is `\[area]_\[key]`:
 
 ```xml
 <button>

--- a/11/umbraco-cms/extending/language-files.md
+++ b/11/umbraco-cms/extending/language-files.md
@@ -9,7 +9,7 @@ description: >-
 Language files are XML files used to translate:
 - The Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
 - The member identity errors in an Umbraco website enabling end users to use Umbraco in the website language.
-- Add translations for your packages [see here for docs on how to include translations for your own package](packages/language-files-for-packages.md)
+-  Read [Add translations for your packages](packages/language-files-for-packages.md) article to see how to include translations for your own package.
 - Override existing language files
 
 This is an example of such a language file, the most important parts are the `alias` fields of the `<area>` and `<key>` elements. This is what you need to retrieve the values from .NET or Angular.

--- a/12/umbraco-cms/extending/language-files.md
+++ b/12/umbraco-cms/extending/language-files.md
@@ -107,7 +107,7 @@ Using core or custom language keys from your code:
 
 ### From .NET
 
-`ILocalizedTextService` is used to localize strings, and is available through dependency injection. First, inject the service, and then use the `Localize()` method available in the namespace `Umbraco.Extensions` to localize the string with the format \[area]/\[key]:
+`ILocalizedTextService` is used to localize strings, and is available through dependency injection. First, inject the service, and then use the `Localize()` method available in the namespace `Umbraco.Extensions` to localize the string with the format `\[area]/\[key]`:
 
 ```csharp
 public MyClass(ILocalizedTextService textservice)
@@ -118,7 +118,7 @@ public MyClass(ILocalizedTextService textservice)
 
 ### From Angular
 
-In the Umbraco backoffice UI, labels can be localized with the `localize` directive:
+In the Umbraco backoffice UI, labels can be localized with the `localize` directive. The syntax is slightly different when compared to the .NET variant. Here the syntax is `\[area]_\[key]`:
 
 ```xml
 <button>

--- a/12/umbraco-cms/extending/language-files.md
+++ b/12/umbraco-cms/extending/language-files.md
@@ -6,11 +6,31 @@ description: >-
 
 # Language Files & Localization
 
-Language files are used to translate:
+Language files are XML files used to translate:
 - The Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
 - The member identity errors in an Umbraco website enabling end users to use Umbraco in the website language.
+- Add translations for your packages [see here for docs on how to include translations for your own package](packages/language-files-for-packages.md)
+- Override existing language files
 
-If you are a package developer, [see here for docs on how to include translations for your own package](packages/language-files-for-packages.md).
+This is an example of such a language file, the most important parts are the `alias` fields of the `<area>` and `<key>` elements. This is what you need to retrieve the values from .NET or Angular.
+```xml
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
+    <creator>
+        <name>The Umbraco community</name>
+        <link>https://our.umbraco.com</link>
+    </creator>
+    <area alias="actions">
+        <key alias="assignDomain">Culture and Hostnames</key>
+        <key alias="auditTrail">Audit Trail</key>
+    </area>
+    <area alias="buttons">
+        <key alias="buttonSave">Save</key>
+        <key alias="buttonCancel">Cancel</key>
+    </area>
+    ...
+</language>
+```
 
 ## Supported Languages
 

--- a/12/umbraco-cms/extending/language-files.md
+++ b/12/umbraco-cms/extending/language-files.md
@@ -18,7 +18,7 @@ This is an example of such a language file, the most important parts are the `al
 <language alias="en" intName="English (UK)" localName="English (UK)" lcid="" culture="en-GB">
     <creator>
         <name>The Umbraco community</name>
-        <link>https://our.umbraco.com</link>
+        <link>https://community.umbraco.com</link>
     </creator>
     <area alias="actions">
         <key alias="assignDomain">Culture and Hostnames</key>

--- a/12/umbraco-cms/extending/language-files.md
+++ b/12/umbraco-cms/extending/language-files.md
@@ -9,7 +9,7 @@ description: >-
 Language files are XML files used to translate:
 - The Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
 - The member identity errors in an Umbraco website enabling end users to use Umbraco in the website language.
--  Read [Add translations for your packages](packages/language-files-for-packages.md) article to see how to include translations for your own package.
+-  Read [Add translations for your packages](packages/language-files-for-packages.md) to see how to include translations for your own package.
 - Override existing language files
 
 This is an example of such a language file, the most important parts are the `alias` fields of the `<area>` and `<key>` elements. This is what you need to retrieve the values from .NET or Angular.

--- a/12/umbraco-cms/extending/language-files.md
+++ b/12/umbraco-cms/extending/language-files.md
@@ -9,7 +9,7 @@ description: >-
 Language files are XML files used to translate:
 - The Umbraco backoffice user interface so that end users can use Umbraco in their native language. This is particularly important for content editors who do not speak English.
 - The member identity errors in an Umbraco website enabling end users to use Umbraco in the website language.
-- Add translations for your packages [see here for docs on how to include translations for your own package](packages/language-files-for-packages.md)
+-  Read [Add translations for your packages](packages/language-files-for-packages.md) article to see how to include translations for your own package.
 - Override existing language files
 
 This is an example of such a language file, the most important parts are the `alias` fields of the `<area>` and `<key>` elements. This is what you need to retrieve the values from .NET or Angular.


### PR DESCRIPTION
## Description

I've clarified the introduction of the language file page. I noticed that some had a tough time finding the correct syntax and explanation on how to get and create the files. I hope that by first giving a short explanation and clearly describing the `key` and `area` elements it will be easier to pickup.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [x] Other
