### PR TITLE
Add docs about `UmbracoApplicationUrl` in relation to licensing

### DIFF
--- a/10/umbraco-commerce/getting-started/licensing-model.md
+++ b/10/umbraco-commerce/getting-started/licensing-model.md
@@ -94,4 +94,5 @@ An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file lik
 }
 ```
 
-See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) docs for more details about this setting.
+See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) documentation for more details about this setting.
+

--- a/10/umbraco-commerce/getting-started/licensing-model.md
+++ b/10/umbraco-commerce/getting-started/licensing-model.md
@@ -75,9 +75,10 @@ You can verify that your license is successfully installed by logging into your 
 
 ### When and how to configure an `UmbracoApplicationUrl`
 
-If you are running on a single domain for both your front end and back end environments, it's not necesarry to configure a `UmbracoApplicationUrl`. 
+If you are running on a single domain for both your frontend and backend environments, it's not necessary to configure a `UmbracoApplicationUrl`. 
 
-If you have different domains for your front end and back end however, it is advised that you configure an `UmbracoApplicationUrl` set to your back office URL. This helps the licensing engine know which URL should be used for validation checks. Without this configuration setting, the licensing engine will try and work out the domain to validate from the HTTP request object and so can lead to errors when switching between domains.
+If you have different domains for your frontend and backend, then it's advised that you configure an `UmbracoApplicationUrl` set to your backoffice URL. This helps the licensing engine know which URL should be used for validation checks. Without this configuration setting, the licensing engine will try and work out the domain to validate from the HTTP request object. This can lead to errors when switching between domains.
+
 
 An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file like so:
 

--- a/10/umbraco-commerce/getting-started/licensing-model.md
+++ b/10/umbraco-commerce/getting-started/licensing-model.md
@@ -72,3 +72,25 @@ Once you have received your license code it needs to be installed on your site.
 You can verify that your license is successfully installed by logging into your projects back office and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.
 
 ![Umbraco Commerce License Dashboard](../media/license-dashboard.png)
+
+### When and how to configure an `UmbracoApplicationUrl`
+
+If you are running on a single domain for both your front end and back end environments, it's not necesarry to configure a `UmbracoApplicationUrl`. 
+
+If you have different domains for your front end and back end however, it is advised that you configure an `UmbracoApplicationUrl` set to your back office URL. This helps the licensing engine know which URL should be used for validation checks. Without this configuration setting, the licensing engine will try and work out the domain to validate from the HTTP request object and so can lead to errors when switching between domains.
+
+An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file like so:
+
+```json
+{
+    "Umbraco": {
+        "CMS": {
+            "WebRouting": {
+                "UmbracoApplicationUrl": "https://admin.my-custom-domain.com/"
+            }
+        }
+    }
+}
+```
+
+See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) docs for more details about this setting.

--- a/12/umbraco-commerce/getting-started/licensing-model.md
+++ b/12/umbraco-commerce/getting-started/licensing-model.md
@@ -94,4 +94,5 @@ An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file lik
 }
 ```
 
-See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) docs for more details about this setting.
+See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) documentation for more details about this setting.
+

--- a/12/umbraco-commerce/getting-started/licensing-model.md
+++ b/12/umbraco-commerce/getting-started/licensing-model.md
@@ -75,9 +75,10 @@ You can verify that your license is successfully installed by logging into your 
 
 ### When and how to configure an `UmbracoApplicationUrl`
 
-If you are running on a single domain for both your front end and back end environments, it's not necesarry to configure a `UmbracoApplicationUrl`. 
+If you are running on a single domain for both your frontend and backend environments, it's not necessary to configure a `UmbracoApplicationUrl`. 
 
-If you have different domains for your front end and back end however, it is advised that you configure an `UmbracoApplicationUrl` set to your back office URL. This helps the licensing engine know which URL should be used for validation checks. Without this configuration setting, the licensing engine will try and work out the domain to validate from the HTTP request object and so can lead to errors when switching between domains.
+If you have different domains for your frontend and backend, then it's advised that you configure an `UmbracoApplicationUrl` set to your backoffice URL. This helps the licensing engine know which URL should be used for validation checks. Without this configuration setting, the licensing engine will try and work out the domain to validate from the HTTP request object. This can lead to errors when switching between domains.
+
 
 An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file like so:
 

--- a/12/umbraco-commerce/getting-started/licensing-model.md
+++ b/12/umbraco-commerce/getting-started/licensing-model.md
@@ -72,3 +72,25 @@ Once you have received your license code it needs to be installed on your site.
 You can verify that your license is successfully installed by logging into your projects back office and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.
 
 ![Umbraco Commerce License Dashboard](../media/license-dashboard.png)
+
+### When and how to configure an `UmbracoApplicationUrl`
+
+If you are running on a single domain for both your front end and back end environments, it's not necesarry to configure a `UmbracoApplicationUrl`. 
+
+If you have different domains for your front end and back end however, it is advised that you configure an `UmbracoApplicationUrl` set to your back office URL. This helps the licensing engine know which URL should be used for validation checks. Without this configuration setting, the licensing engine will try and work out the domain to validate from the HTTP request object and so can lead to errors when switching between domains.
+
+An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file like so:
+
+```json
+{
+    "Umbraco": {
+        "CMS": {
+            "WebRouting": {
+                "UmbracoApplicationUrl": "https://admin.my-custom-domain.com/"
+            }
+        }
+    }
+}
+```
+
+See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) docs for more details about this setting.


### PR DESCRIPTION
This adds some extra docs about when and how to configure a `UmbracoApplicationUrl` in relation to licensing of Umbraco Commerce.

I've seen a few people having issues within licensing that this should resolve so I think it's worth documenting.