### PR TITLE
Add docs for indexing settings

### DIFF
--- a/10/umbraco-cms/SUMMARY.md
+++ b/10/umbraco-cms/SUMMARY.md
@@ -213,6 +213,7 @@
   * [Health checks](reference/configuration/healthchecks.md)
   * [Hosting settings](reference/configuration/hostingsettings.md)
   * [Imaging settings](reference/configuration/imagingsettings.md)
+  * [Indexing settings](reference/configuration/indexingsettings.md)
   * [Install Default Data Settings](reference/configuration/installdefaultdatasettings.md)
   * [Keep alive settings](reference/configuration/keepalivesettings.md)
   * [Logging settings](reference/configuration/loggingsettings.md)

--- a/10/umbraco-cms/reference/configuration/README.md
+++ b/10/umbraco-cms/reference/configuration/README.md
@@ -121,6 +121,7 @@ A complete list of all the configuration sections included in Umbraco, by defaul
 * [Health checks settings](healthchecks.md)
 * [Hosting settings](hostingsettings.md)
 * [Imaging settings](imagingsettings.md)
+* [Indexing settings](indexingsettings.md)
 * [Install default data setting](installdefaultdatasettings.md)
 * [Keep alive settings](keepalivesettings.md)
 * [Logging settings](loggingsettings.md)

--- a/10/umbraco-cms/reference/configuration/indexingsettings.md
+++ b/10/umbraco-cms/reference/configuration/indexingsettings.md
@@ -1,0 +1,28 @@
+---
+description: "Information on the indexing section"
+---
+
+# Indexing Settings
+
+This section allows you to configure how content is indexed for Examine.
+
+```json
+"Umbraco": {
+  "CMS": {
+    "Indexing": {
+      "ExplicitlyIndexEachNestedProperty": true
+    }
+  }
+}
+```
+## ExplicitlyIndexEachNestedProperty
+
+When indexing content, each property contained within certain complex editors are indexed as separate fields by default. These complex editors include:
+
+- Block List
+- Block Grid
+- Nested Content
+
+The complex editors are also indexed to their own separate fields, which then contains "the sum" of all properties contained within.
+
+In some cases this yields a lot of fields in the index, which can lead to errors when performing searches. Changing this setting to `false` can mend that issue. It prevents each contained property from being written to the index in its own field.

--- a/11/umbraco-cms/SUMMARY.md
+++ b/11/umbraco-cms/SUMMARY.md
@@ -213,6 +213,7 @@
   * [Health checks](reference/configuration/healthchecks.md)
   * [Hosting settings](reference/configuration/hostingsettings.md)
   * [Imaging settings](reference/configuration/imagingsettings.md)
+  * [Indexing settings](reference/configuration/indexingsettings.md)
   * [Install Default Data Settings](reference/configuration/installdefaultdatasettings.md)
   * [Keep alive settings](reference/configuration/keepalivesettings.md)
   * [Logging settings](reference/configuration/loggingsettings.md)

--- a/11/umbraco-cms/reference/configuration/README.md
+++ b/11/umbraco-cms/reference/configuration/README.md
@@ -118,6 +118,7 @@ A complete list of all the configuration sections included in Umbraco, by defaul
 * [Health checks settings](healthchecks.md)
 * [Hosting settings](hostingsettings.md)
 * [Imaging settings](imagingsettings.md)
+* [Indexing settings](indexingsettings.md)
 * [Install default data setting](installdefaultdatasettings.md)
 * [Keep alive settings](keepalivesettings.md)
 * [Logging settings](loggingsettings.md)

--- a/11/umbraco-cms/reference/configuration/indexingsettings.md
+++ b/11/umbraco-cms/reference/configuration/indexingsettings.md
@@ -1,0 +1,28 @@
+---
+description: "Information on the indexing section"
+---
+
+# Indexing Settings
+
+This section allows you to configure how content is indexed for Examine.
+
+```json
+"Umbraco": {
+  "CMS": {
+    "Indexing": {
+      "ExplicitlyIndexEachNestedProperty": true
+    }
+  }
+}
+```
+## ExplicitlyIndexEachNestedProperty
+
+When indexing content, each property contained within certain complex editors are indexed as separate fields by default. These complex editors include:
+
+- Block List
+- Block Grid
+- Nested Content
+
+The complex editors are also indexed to their own separate fields, which then contains "the sum" of all properties contained within.
+
+In some cases this yields a lot of fields in the index, which can lead to errors when performing searches. Changing this setting to `false` can mend that issue. It prevents each contained property from being written to the index in its own field.

--- a/12/umbraco-cms/SUMMARY.md
+++ b/12/umbraco-cms/SUMMARY.md
@@ -213,6 +213,7 @@
   * [Health checks](reference/configuration/healthchecks.md)
   * [Hosting settings](reference/configuration/hostingsettings.md)
   * [Imaging settings](reference/configuration/imagingsettings.md)
+  * [Indexing settings](reference/configuration/indexingsettings.md)
   * [Install Default Data Settings](reference/configuration/installdefaultdatasettings.md)
   * [Keep alive settings](reference/configuration/keepalivesettings.md)
   * [Logging settings](reference/configuration/loggingsettings.md)

--- a/12/umbraco-cms/reference/configuration/README.md
+++ b/12/umbraco-cms/reference/configuration/README.md
@@ -118,6 +118,7 @@ A complete list of all the configuration sections included in Umbraco, by defaul
 * [Health checks settings](healthchecks.md)
 * [Hosting settings](hostingsettings.md)
 * [Imaging settings](imagingsettings.md)
+* [Indexing settings](indexingsettings.md)
 * [Install default data setting](installdefaultdatasettings.md)
 * [Keep alive settings](keepalivesettings.md)
 * [Logging settings](loggingsettings.md)

--- a/12/umbraco-cms/reference/configuration/indexingsettings.md
+++ b/12/umbraco-cms/reference/configuration/indexingsettings.md
@@ -1,0 +1,28 @@
+---
+description: "Information on the indexing section"
+---
+
+# Indexing Settings
+
+This section allows you to configure how content is indexed for Examine.
+
+```json
+"Umbraco": {
+  "CMS": {
+    "Indexing": {
+      "ExplicitlyIndexEachNestedProperty": true
+    }
+  }
+}
+```
+## ExplicitlyIndexEachNestedProperty
+
+When indexing content, each property contained within certain complex editors are indexed as separate fields by default. These complex editors include:
+
+- Block List
+- Block Grid
+- Nested Content
+
+The complex editors are also indexed to their own separate fields, which then contains "the sum" of all properties contained within.
+
+In some cases this yields a lot of fields in the index, which can lead to errors when performing searches. Changing this setting to `false` can mend that issue. It prevents each contained property from being written to the index in its own field.


### PR DESCRIPTION
## Description

[V10.7.0](https://our.umbraco.com/download/releases/1070) / [V11.5.0](https://our.umbraco.com/download/releases/1150) / [V12.1.0](https://our.umbraco.com/download/releases/1210) introduced a new settings section for controlling content indexing. Seems we missed the docs 🙈 so here they are.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [x] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

10.7, 11.5 & 12.1

## Deadline (if relevant)

This is not urgent. Whenever there is time 😄 
