### PR TITLE
updated content template as per CMS PR #14454

### DIFF
--- a/10/umbraco-cms/fundamentals/backoffice/content-templates.md
+++ b/10/umbraco-cms/fundamentals/backoffice/content-templates.md
@@ -1,17 +1,21 @@
 ---
 meta.Title: Content Templates in Umbraco
-description: >-
-  In this article you can learn about how to create and use Content Templates in
-  Umbraco.
+description: In this article you can learn about how to create and use Content Templates in Umbraco.
 ---
 
 # Content Templates
 
-_This tutorial was last tested on **Umbraco 9.0**_
-
 Content Templates allows a content editor to create a blueprint for new content nodes based on an existing node.
 
+{% embed url="<https://youtu.be/tz7dRStOo2Y?>" %}
+Learn how to use the Content Templates in Umbraco.
+{% endembed %}
+
 ## Create - Method 1
+
+{% hint style="info" %}
+Before following this method you should have some [content](../data/defining-content.md) created beforehand.
+{% endhint %}
 
 Select a **Content node** from the **Content** menu:
 

--- a/11/umbraco-cms/fundamentals/backoffice/content-templates.md
+++ b/11/umbraco-cms/fundamentals/backoffice/content-templates.md
@@ -1,16 +1,21 @@
 ---
 description: >-
-  In this article you can learn about how to create and use Content Templates in
-  Umbraco.
+  In this article you can learn about how to create and use Content Templates in Umbraco.
 ---
 
 # Content Templates
 
-_This tutorial was last tested on **Umbraco 9.0**_
-
 Content Templates allows a content editor to create a blueprint for new content nodes based on an existing node.
 
+{% embed url="<https://youtu.be/tz7dRStOo2Y?>" %}
+Learn how to use the Content Templates in Umbraco.
+{% endembed %}
+
 ## Create - Method 1
+
+{% hint style="info" %}
+Before following this method you should have some [content](../data/defining-content.md) created beforehand.
+{% endhint %}
 
 Select a **Content node** from the **Content** menu:
 

--- a/12/umbraco-cms/fundamentals/backoffice/content-templates.md
+++ b/12/umbraco-cms/fundamentals/backoffice/content-templates.md
@@ -1,16 +1,20 @@
 ---
-description: >-
-  In this article you can learn about how to create and use Content Templates in
-  Umbraco.
+description: In this article you can learn about how to create and use Content Templates in Umbraco.
 ---
 
 # Content Templates
 
-_This tutorial was last tested on **Umbraco 9.0**_
-
 Content Templates allows a content editor to create a blueprint for new content nodes based on an existing node.
 
+{% embed url="<https://youtu.be/tz7dRStOo2Y?>" %}
+Learn how to use the Content Templates in Umbraco.
+{% endembed %}
+
 ## Create - Method 1
+
+{% hint style="info" %}
+Before following this method you should have some [content](../data/defining-content.md) created beforehand.
+{% endhint %}
 
 Select a **Content node** from the **Content** menu:
 
@@ -49,6 +53,10 @@ Right-click on the **Content Templates** tree and select the **Create** menu ite
 Select the Document Type you want to create a content template for:
 
 ![Select Content Type](../../../../10/umbraco-cms/fundamentals/backoffice/images/v8-09-Select-Content-Type.png)
+
+{% hint style="warning" %}
+You can create content templates only from **Document Types** or **Document Types with Templates**
+{% endhint %}
 
 Give your content template a **Name** and click the **Save** button:
 


### PR DESCRIPTION
## Description
Updated content template as per CMS PR: https://github.com/umbraco/Umbraco-CMS/pull/14454 where from 12.2.0 it is possible to create content templates from settings section only for "Document types" and "Document Types with Templates"

_What did you add/update/change?_
added a warning note on method 2 guide where it shows how to create content templates from settings section that "it is possible to create content templates from settings section only for "Document types" and "Document Types with Templates"" for v12

And as extra for other versions as well, I also added the video https://www.youtube.com/watch?v=tz7dRStOo2Y to the docs.

I have also tested the docs and checked the video and they are still working for v10 and above 👍 

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [x] New content
* [ ] Updates related to a new version
* [x] Other

## Product & version (if relevant)
CMS

## Deadline (if relevant)
before 21 September 2023 when v12.2.0 is out 

_When should the content be published?_
21 September 2023 when v12.2.0 is out 