### PR TITLE
New backoffice: Fix a few glitches in the dashboard tutorial

### DIFF
--- a/new-backoffice/tutorials/creating-a-custom-dashboard.md
+++ b/new-backoffice/tutorials/creating-a-custom-dashboard.md
@@ -12,7 +12,7 @@ This page is a work in progress. It will be updated as the software evolves.
 
 This guide takes you through the steps to set up a Custom Dashboard in Umbraco.
 
-The steps we will go through session 1 are:
+The guide is divided into several parts. In this first part will go through:
 
 1. [Setting up a package](creating-a-custom-dashboard.md#1.-setting-up-a-package)
 2. [Creating the dashboard web component](creating-a-custom-dashboard.md#2.-creating-the-dashboard-web-component)
@@ -106,12 +106,12 @@ Please note that the file`umbraco-package.json` is loaded into memory when Umbra
 
 Next, let's create a new ts file called `welcome-dashboard.element.ts`. This file is our web component and will contain all our HTML, CSS, and logic.
 
-Let's start with setting the web component with some simple HTML and CSS:
+Let's start with setting the web component with some HTML and CSS:
 
 {% code title="welcome-dashboard.element.ts" lineNumbers="true" %}
 ```typescript
 import { LitElement, css, html } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement } from "lit/decorators.js";
 import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";
 
 @customElement("my-welcome-dashboard")
@@ -119,7 +119,7 @@ export class MyWelcomeDashboardElement extends UmbElementMixin(LitElement) {
 
   render() {
     return html`
-      <h1>Welcome Dashboard<h1>
+      <h1>Welcome Dashboard</h1>
       <div>
         <p>
           This is the Backoffice. From here, you can modify the content,
@@ -129,6 +129,15 @@ export class MyWelcomeDashboardElement extends UmbElementMixin(LitElement) {
       </div>
     `;
   }
+
+  static styles = [
+    css`
+      :host {
+        display: block;
+        padding: 24px;
+      }
+    `,
+  ];
 }
 
 declare global {
@@ -139,7 +148,7 @@ declare global {
 ```
 {% endcode %}
 
-Build the `ts` file and make sure the new `.js` file is in the correct path.
+Build the `ts` file and make sure to copy the output file to `dashboard.js` under `/App_Plugins/WelcomeDashboard/`.
 
 You can now start up the Backoffice and see our new dashboard in the content section:
 
@@ -147,6 +156,6 @@ You can now start up the Backoffice and see our new dashboard in the content sec
 
 ## Going Further
 
-With all the steps completed, you should have a simple dashboard welcoming your users to the Backoffice.
+With all the steps completed, you should have a dashboard welcoming your users to the Backoffice.
 
-In the next session, we will look into how to add localization to the dashboard using our own custom translations.
+In the next part, we will look into how to add localization to the dashboard using our own custom translations.

--- a/new-backoffice/tutorials/creating-a-custom-dashboard.md
+++ b/new-backoffice/tutorials/creating-a-custom-dashboard.md
@@ -12,7 +12,7 @@ This page is a work in progress. It will be updated as the software evolves.
 
 This guide takes you through the steps to set up a Custom Dashboard in Umbraco.
 
-The guide is divided into several parts. In this first part will go through:
+The guide is divided into four parts. The first part will go through the following:
 
 1. [Setting up a package](creating-a-custom-dashboard.md#1.-setting-up-a-package)
 2. [Creating the dashboard web component](creating-a-custom-dashboard.md#2.-creating-the-dashboard-web-component)

--- a/new-backoffice/tutorials/creating-a-custom-dashboard/adding-functionality-to-the-dashboard.md
+++ b/new-backoffice/tutorials/creating-a-custom-dashboard/adding-functionality-to-the-dashboard.md
@@ -10,16 +10,16 @@ This page is a work in progress. It will be updated as the software evolves.
 
 ## Overview
 
-This is session 3 in our guide to building a custom dashboard. This session continues work on the dashboard we built in session 2: [Add localization to the dashboard](adding-localization-to-the-dashboard.md). But it goes further to show how to add functionality and data to our dashboard.
+This is the third part of our guide to building a custom dashboard. This part continues work on the dashboard we built in part two: [Add localization to the dashboard](adding-localization-to-the-dashboard.md). But it goes further to show how to add functionality and data to our dashboard.
 
-The steps we will go through in session 3 are:
+The steps we will go through in this part are:
 
 1. [Resources and services](adding-functionality-to-the-dashboard.md#1.-resources-and-services)
 2. [Getting data from the server](adding-functionality-to-the-dashboard.md#2.-getting-data-from-the-server)
 
 ## Step 1: Resources and services
 
-Umbraco has a fine selection of resources and services that you can use in your custom property editors and dashboards. For this example, it would be nice to welcome the editor by name. To achieve this we can make use of the Umbraco resources.
+Umbraco has a large selection of resources and services that you can use in your custom property editors and dashboards. For this example, it would be nice to welcome the editor by name. To achieve this we can make use of the Umbraco resources.
 
 To get information on the current user that's currently logged in, we first need to get the context and its token. We use the Auth context to receive the user that is currently logged in.
 
@@ -32,8 +32,9 @@ import { UMB_AUTH, UmbLoggedInUser } from '@umbraco-cms/backoffice/auth';
 ```
 {% endcode %}
 
-Now that we have the token, we can consume it in the constructor. We already have the  `consumeContext` method available on our element since we extended using `UmbElementMixin`&#x20;
+Now that we have the Auth token, we can consume it in the constructor to obtain the current user. We do this using the `consumeContext` method, which is available on our element because we extended using `UmbElementMixin`. Add the following to the element implementation:
 
+{% code title="welcome-dashboard.element.ts" %}
 ```typescript
 ...
 
@@ -59,6 +60,7 @@ private async _observeCurrentUser() {
 
 ...
 ```
+{% endcode %}
 
 Now that we have the current user, we can access a few different things. Let's get the `name` of the current user, so that we can welcome the user:
 
@@ -71,7 +73,7 @@ render() {
        ${this._currentUser?.name ?? "Unknown"}!
     </h1>
     <div>
-      <p> 
+      <p>
        <umb-localize key="welcomeDashboard_bodytext">
          This is the Backoffice. From here, you can modify the content,
          media, and settings of your website.
@@ -198,7 +200,7 @@ private _userRepository = new UmbUserRepository(this);
 
 constructor() {
 	...
-	
+
 	this._getDataFromRepository();
 }
 
@@ -321,7 +323,7 @@ render() {
     return html`
         ...
         ...
-        
+
 	<div id="users-wrapper">${this._userData?.map((user) => this._renderUser(user))}</div>
     `;
 }
@@ -346,7 +348,7 @@ static styles = [
 			display: block;
 			padding: 24px;
 		}
-		
+
 		#users-wrapper {
 			border: 1px solid lightgray;
 		}
@@ -362,7 +364,7 @@ static styles = [
 {% endcode %}
 
 {% hint style="info" %}
-We recommend using variables for colors and sizing. See why and how you could achieve this in the next session where we will use the Umbraco UI Library.
+We recommend using variables for colors and sizing. See why and how you could achieve this in the next part where we will use the Umbraco UI Library.
 {% endhint %}
 
 We now should have something that looks like this:

--- a/new-backoffice/tutorials/creating-a-custom-dashboard/adding-localization-to-the-dashboard.md
+++ b/new-backoffice/tutorials/creating-a-custom-dashboard/adding-localization-to-the-dashboard.md
@@ -10,7 +10,7 @@ This page is a work in progress. It will be updated as the software evolves.
 
 ## Overview
 
-This is session 2 of our guide to building a Custom Dashboard. This session continues work on the dashboard we built in session 1: [Creating a Custom Dashboard](../creating-a-custom-dashboard.md), but further shows how to handle localization in a custom dashboard.
+This is the second part of our guide to building a Custom Dashboard. This part continues work on the dashboard we built in part one: [Creating a Custom Dashboard](../creating-a-custom-dashboard.md), but further shows how to handle localization in a custom dashboard.
 
 ## Localization
 
@@ -21,7 +21,7 @@ To register localizations to a language, you need to add a new manifest to the E
 {% code title="umbraco-package.json" %}
 ```typescript
 {
-  ...  
+  ...
   "extensions": [
     {
       "type": "localization",
@@ -150,7 +150,7 @@ Now let's update our `umbraco-package.json` extensions object to register our ne
       "js": "/App_Plugins/WelcomeDashboard/Localization/da-dk.js"
     }
   ]
-} 
+}
 ```
 {% endcode %}
 
@@ -255,7 +255,7 @@ This is how our dashboard should now look like:
 
 <figure><img src="../../.gitbook/assets/welcome-eng.png" alt=""><figcaption><p>Dashboard if the user's language is English / Fallback</p></figcaption></figure>
 
- 
+
 
 <figure><img src="../../.gitbook/assets/welcome-da.png" alt=""><figcaption><p>Dashboard if the user's language is Danish</p></figcaption></figure>
 
@@ -263,6 +263,6 @@ This is how our dashboard should now look like:
 
 ## Going Further
 
-With the session completed, you should have a dashboard welcoming your users' language.
+With the part completed, you should have a dashboard welcoming your users' language.
 
-In the next session, we will look into how to add more functionality to the dashboard using some of the resources and services that Umbraco offers.
+In the next part, we will look into how to add more functionality to the dashboard using some of the resources and services that Umbraco offers.

--- a/new-backoffice/tutorials/creating-a-custom-dashboard/extending-the-dashboard-using-umbraco-ui-library.md
+++ b/new-backoffice/tutorials/creating-a-custom-dashboard/extending-the-dashboard-using-umbraco-ui-library.md
@@ -12,7 +12,7 @@ This page is a work in progress. It will be updated as the software evolves.
 
 ## Overview
 
-This is session 4 and is the final session of the guide to building a Custom Dashboard. This session continues work on the dashboard we built in session 3: [Adding functionality to the Dashboard](adding-functionality-to-the-dashboard.md). But it goes further to showcase how we can use the UI Library in our extension.&#x20;
+This is the fourth and final part of the guide to building a Custom Dashboard. This part continues work on the dashboard we built in part three: [Adding functionality to the Dashboard](adding-functionality-to-the-dashboard.md). But it goes further to showcase how we can use the UI Library in our extension.&#x20;
 
 ## Umbraco UI Library
 
@@ -27,9 +27,9 @@ Let's start by wrapping `uui-box` around our render output. This makes our dashb
 render() {
     return html`
         <uui-box>
-        
+
             // rest of the render code
-        
+
         </uui-box>
     `;
 }
@@ -43,9 +43,9 @@ The `uui-box` has a headline property. Let's move our headline into the headline
  render() {
     return html`
         <uui-box headline="${this.localize.term('welcomeDashboard_heading')} ${this._currentUser?.name ?? 'Unknown'}!">
-    
+
             // rest of the render code
-            
+
         </uui-box>
     `;
 }
@@ -63,9 +63,9 @@ render() {
                 <umb-localize key="welcomeDashboard_heading">Welcome</umb-localize>
                 ${this._currentUser?.name ?? 'Unknown'}!
             </span>
-    
+
             // rest of the render code
-            
+
         </uui-box>
     `;
 }
@@ -82,7 +82,7 @@ static styles = [
 			display: block;
 			padding: var(--uui-size-layout-1);
 		}
-		
+
 		...
 
 	`,
@@ -214,9 +214,9 @@ Since we have a lot of information from the users, it could be a good idea to in
 render() {
 	return html`
 		<uui-box>
-			
+
 			...
-		
+
 			<uui-table id="users-wrapper">
 				<uui-table-row>
 					<uui-table-head-cell>Name</uui-table-head-cell>
@@ -250,7 +250,7 @@ static styles = [
 			display: block;
 			padding: var(--uui-size-layout-1);
 		}
-		
+
 		uui-table-head-cell {
 			font-weight: bold;
 		}


### PR DESCRIPTION
## Description

The multi-part dashboard tutorial for the new backoffice has a few glitches and errors. While these are somewhat simple to fix, they do pose an unnecessary barrier to get started.

While I was there, I also opted to use "part" instead of "session" when referring to the different parts of the tutorial, and cleaned up a few wordings.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

V14

## Deadline (if relevant)

Not relevant 😄 