### PR TITLE
Removed all versionFrom and versionTo meta tags from the docs

### DIFF
--- a/10/umbraco-cms/extending/backoffice-search.md
+++ b/10/umbraco-cms/extending/backoffice-search.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Backoffice Search"
 description: "A guide to customization of Backoffice Search"
 ---

--- a/10/umbraco-cms/extending/backoffice-tours.md
+++ b/10/umbraco-cms/extending/backoffice-tours.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Backoffice Tours
 description: A guide configuring backoffice tours in Umbraco
 ---

--- a/10/umbraco-cms/extending/backoffice-ui-api-documentation.md
+++ b/10/umbraco-cms/extending/backoffice-ui-api-documentation.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 10.0.0
+
 ---
 
 # Backoffice UI API Documentation

--- a/10/umbraco-cms/extending/content-apps.md
+++ b/10/umbraco-cms/extending/content-apps.md
@@ -1,6 +1,6 @@
 ---
 versionFrom: 9.2.0
-versionTo: 10.0.0
+
 meta.Title: Content Apps
 description: A guide configuring content apps in Umbraco
 ---

--- a/10/umbraco-cms/extending/dashboards.md
+++ b/10/umbraco-cms/extending/dashboards.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Custom Dashboards"
 description: "A guide to creating custom dashboards in Umbraco"
 ---

--- a/10/umbraco-cms/extending/database.md
+++ b/10/umbraco-cms/extending/database.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 10.0.0
+
 meta.Title: Umbraco Database
 description: A guide to creating a custom Database table in Umbraco
 ---

--- a/10/umbraco-cms/extending/filesystemproviders/README.md
+++ b/10/umbraco-cms/extending/filesystemproviders/README.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 10.0.0
+
 meta.Title: "Umbraco File System Providers"
 description: "A guide to creating custom file systems in Umbraco"
 ---

--- a/10/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
+++ b/10/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 10.0.0
+
 meta.Title: "Using Azure Blob Storage for Media and ImageSharp Cache"
 description: "Setup your site to use Azure Blob storage for media and ImageSharp cache"
 ---

--- a/10/umbraco-cms/extending/health-check/README.md
+++ b/10/umbraco-cms/extending/health-check/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Umbraco Healthcheck
 description: >-
   The Settings section of the Umbraco backoffice holds a dashboard named 'Health

--- a/10/umbraco-cms/extending/health-check/guides/README.md
+++ b/10/umbraco-cms/extending/health-check/guides/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Health Check Guides

--- a/10/umbraco-cms/extending/health-check/guides/clickjackingprotection.md
+++ b/10/umbraco-cms/extending/health-check/guides/clickjackingprotection.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Health check: Click-Jacking Protection

--- a/10/umbraco-cms/extending/health-check/guides/contentsniffingprotection.md
+++ b/10/umbraco-cms/extending/health-check/guides/contentsniffingprotection.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Health check: Content/MIME Sniffing Protection

--- a/10/umbraco-cms/extending/health-check/guides/crosssitescriptingprotection.md
+++ b/10/umbraco-cms/extending/health-check/guides/crosssitescriptingprotection.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Health check: Cross-site scripting Protection (X-XSS-Protection header)

--- a/10/umbraco-cms/extending/health-check/guides/debugcompilationmode.md
+++ b/10/umbraco-cms/extending/health-check/guides/debugcompilationmode.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Health check: Debug Compilation Mode

--- a/10/umbraco-cms/extending/health-check/guides/excessiveheaders.md
+++ b/10/umbraco-cms/extending/health-check/guides/excessiveheaders.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Health check: Excessive Headers

--- a/10/umbraco-cms/extending/health-check/guides/fixedapplicationurl.md
+++ b/10/umbraco-cms/extending/health-check/guides/fixedapplicationurl.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Health check: Fixed Application URL

--- a/10/umbraco-cms/extending/health-check/guides/folderandfilepermissions.md
+++ b/10/umbraco-cms/extending/health-check/guides/folderandfilepermissions.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Folder & File Permissions

--- a/10/umbraco-cms/extending/health-check/guides/httpsconfiguration.md
+++ b/10/umbraco-cms/extending/health-check/guides/httpsconfiguration.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Health check: HTTPS Configuration

--- a/10/umbraco-cms/extending/health-check/guides/macroerrors.md
+++ b/10/umbraco-cms/extending/health-check/guides/macroerrors.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Health check: Macro errors

--- a/10/umbraco-cms/extending/health-check/guides/notificationemail.md
+++ b/10/umbraco-cms/extending/health-check/guides/notificationemail.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Health check: Notification Email Settings

--- a/10/umbraco-cms/extending/health-check/guides/smtp.md
+++ b/10/umbraco-cms/extending/health-check/guides/smtp.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Health check: SMTP

--- a/10/umbraco-cms/extending/health-check/guides/stricttransportsecurityheader.md
+++ b/10/umbraco-cms/extending/health-check/guides/stricttransportsecurityheader.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Health check: Cookie hijacking and protocol downgrade attacks Protection (Strict-Transport-Security Header (HSTS))

--- a/10/umbraco-cms/extending/key-vault.md
+++ b/10/umbraco-cms/extending/key-vault.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 10.0.0
+
 meta.Title: Azure Key Vault
 description: A guide for configuring Azure Key Vault
 ---

--- a/10/umbraco-cms/extending/language-files.md
+++ b/10/umbraco-cms/extending/language-files.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Language Files & Localization
 description: >-
   Language files are used to translate the Umbraco backoffice user interface so

--- a/10/umbraco-cms/extending/macro-parameter-editors.md
+++ b/10/umbraco-cms/extending/macro-parameter-editors.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 9.0.0
+
 meta.Title: Macro Parameter Editors
 description: A guide to creating macro property editors in Umbraco
 ---

--- a/10/umbraco-cms/extending/packages/README.md
+++ b/10/umbraco-cms/extending/packages/README.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 9.0.0
+
 meta.Title: "Umbraco Packages"
 description: "A package extends the functionality of Umbraco to provide additional functionality to editors, developers, site visitors, and all other types of users of Umbraco."
 ---

--- a/10/umbraco-cms/extending/packages/creating-a-package.md
+++ b/10/umbraco-cms/extending/packages/creating-a-package.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 9.0.0
+
 meta.Title: Creating a package
 description: Tutorial to create a package in Umbraco
 ---

--- a/10/umbraco-cms/extending/packages/language-files-for-packages.md
+++ b/10/umbraco-cms/extending/packages/language-files-for-packages.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Language file for packages"
 description: "Information on how to use language files to make your Umbraco package UI support multiple languages"
 ---

--- a/10/umbraco-cms/extending/packages/maintaining-packages.md
+++ b/10/umbraco-cms/extending/packages/maintaining-packages.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Maintaining Umbraco Packages
 description: >-
   Once you've created and published your package, here is what's involved in

--- a/10/umbraco-cms/extending/packages/packages-on-umbraco-cloud.md
+++ b/10/umbraco-cms/extending/packages/packages-on-umbraco-cloud.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Packages on Umbraco Cloud
 v9-equivalent: >-
   https://github.com/umbraco/UmbracoCMSDocs/blob/main/Articles/Packages/packages-on-Umbraco-Cloud.md

--- a/10/umbraco-cms/extending/property-editors/build-a-block-editor.md
+++ b/10/umbraco-cms/extending/property-editors/build-a-block-editor.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 10.0.0
+
 ---
 
 # Build a Block Editor

--- a/10/umbraco-cms/extending/property-editors/declaring-your-property-editor.md
+++ b/10/umbraco-cms/extending/property-editors/declaring-your-property-editor.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Declaring your property editor

--- a/10/umbraco-cms/extending/property-editors/full-examples-value-converters.md
+++ b/10/umbraco-cms/extending/property-editors/full-examples-value-converters.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Content Picker Value Converter Example

--- a/10/umbraco-cms/extending/property-editors/package-manifest.md
+++ b/10/umbraco-cms/extending/property-editors/package-manifest.md
@@ -1,8 +1,8 @@
 ---
 state: partial
 updated-links: false
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Package Manifest

--- a/10/umbraco-cms/extending/property-editors/property-actions.md
+++ b/10/umbraco-cms/extending/property-editors/property-actions.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Umbraco Property Editors - Property Actions
 description: Guide on how to implement Property Actions for Property Editors in Umbraco
 ---

--- a/10/umbraco-cms/extending/property-editors/property-value-converters.md
+++ b/10/umbraco-cms/extending/property-editors/property-value-converters.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Property Value Converters"
 description: "A guide to creating a custom property value converter in Umbraco"
 ---

--- a/10/umbraco-cms/extending/property-editors/tracking.md
+++ b/10/umbraco-cms/extending/property-editors/tracking.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Umbraco Property Editors - Tracking References
 description: >-
   Guide on how to implement tracking entity references for Property Editors in

--- a/10/umbraco-cms/extending/section-trees/README.md
+++ b/10/umbraco-cms/extending/section-trees/README.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 9.0.0
+
 meta.Title: "Umbraco Sections & Trees"
 description: "An explanation on sections and trees in Umbraco"
 ---

--- a/10/umbraco-cms/extending/section-trees/searchable-trees.md
+++ b/10/umbraco-cms/extending/section-trees/searchable-trees.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 9.0.0
+
 ---
 
 # Searchable Trees (ISearchableTree)

--- a/10/umbraco-cms/extending/section-trees/trees/README.md
+++ b/10/umbraco-cms/extending/section-trees/trees/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Umbraco Tree
 description: A guide to creating a custom tree in Umbraco
 ---

--- a/10/umbraco-cms/extending/section-trees/trees/tree-actions.md
+++ b/10/umbraco-cms/extending/section-trees/trees/tree-actions.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Tree Actions"
 description: "A guide to creating a custom tree action in Umbraco"
 ---

--- a/10/umbraco-cms/implementation/controllers.md
+++ b/10/umbraco-cms/implementation/controllers.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 product: UmbracoCms
 complexity: Intermediate
 audience: Developers

--- a/10/umbraco-cms/implementation/default-routing/controller-selection.md
+++ b/10/umbraco-cms/implementation/default-routing/controller-selection.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Controller & Action Selection

--- a/10/umbraco-cms/implementation/default-routing/execute-request.md
+++ b/10/umbraco-cms/implementation/default-routing/execute-request.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Executing an Umbraco request

--- a/10/umbraco-cms/implementation/default-routing/inbound-pipeline.md
+++ b/10/umbraco-cms/implementation/default-routing/inbound-pipeline.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Umbraco's request pipeline

--- a/10/umbraco-cms/implementation/nullable-reference-types.md
+++ b/10/umbraco-cms/implementation/nullable-reference-types.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 10.0.0
+
 Meta.Title: Nullable Reference Types
 description: In this article we describe what Nullable reference types is.
 ---

--- a/10/umbraco-cms/implementation/services/circular-dependencies.md
+++ b/10/umbraco-cms/implementation/services/circular-dependencies.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Circular Dependencies

--- a/10/umbraco-cms/reference/angular/README.md
+++ b/10/umbraco-cms/reference/angular/README.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 9.0.0
+
 ---
 
 # AngularJS

--- a/10/umbraco-cms/reference/angular/directives/README.md
+++ b/10/umbraco-cms/reference/angular/directives/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 7.0.0
-versionTo: 9.0.0
+
+
 ---
 
 # Directives

--- a/10/umbraco-cms/reference/angular/directives/umblayoutselector.md
+++ b/10/umbraco-cms/reference/angular/directives/umblayoutselector.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 9.0.0
+
+
 ---
 
 # umbLayoutSelector

--- a/10/umbraco-cms/reference/angular/directives/umbloadindicator.md
+++ b/10/umbraco-cms/reference/angular/directives/umbloadindicator.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 9.0.0
+
 ---
 
 # umbLoadIndicator

--- a/10/umbraco-cms/reference/angular/directives/umbproperty.md
+++ b/10/umbraco-cms/reference/angular/directives/umbproperty.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 9.0.0
+
 ---
 
 # umbProperty

--- a/10/umbraco-cms/reference/angular/services/README.md
+++ b/10/umbraco-cms/reference/angular/services/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 7.0.0
-versionTo: 9.0.0
+
+
 ---
 
 # Services

--- a/10/umbraco-cms/reference/angular/services/editorservice.md
+++ b/10/umbraco-cms/reference/angular/services/editorservice.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 8.0.0
+
 ---
 
 # Editor Service

--- a/10/umbraco-cms/reference/angular/services/eventsservice/README.md
+++ b/10/umbraco-cms/reference/angular/services/eventsservice/README.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 8.0.0
+
 needsV9Update: "true"
 ---
 

--- a/10/umbraco-cms/reference/api-documentation.md
+++ b/10/umbraco-cms/reference/api-documentation.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 10.0.0
+
 meta.Title: "Umbraco API Documentation"
 description: "Information on Umbraco API Documentation"
 ---

--- a/10/umbraco-cms/reference/cache/README.md
+++ b/10/umbraco-cms/reference/cache/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Cache & Distributed Cache

--- a/10/umbraco-cms/reference/cache/application-cache.md
+++ b/10/umbraco-cms/reference/cache/application-cache.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Accessing the cache

--- a/10/umbraco-cms/reference/cache/examples/tags.md
+++ b/10/umbraco-cms/reference/cache/examples/tags.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 9.0.0
+
 meta.Title: "Working with the runtime cache in Umbraco"
 description: "Information on how to insert and delete from the runtime cache"
 ---

--- a/10/umbraco-cms/reference/cache/icacherefresher.md
+++ b/10/umbraco-cms/reference/cache/icacherefresher.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # ICacheRefresher

--- a/10/umbraco-cms/reference/cache/iservermessenger.md
+++ b/10/umbraco-cms/reference/cache/iservermessenger.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 7.0.0
+
 needsV8Update: "true"
 ---
 

--- a/10/umbraco-cms/reference/cache/updating-cache.md
+++ b/10/umbraco-cms/reference/cache/updating-cache.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Updating Cache

--- a/10/umbraco-cms/reference/common-pitfalls.md
+++ b/10/umbraco-cms/reference/common-pitfalls.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 9.0.0
+
 meta.Title: Common Pitfalls and Anti-Patterns in Umbraco
 description: Information on common Pitfalls and Anti-Patterns in Umbraco
 ---

--- a/10/umbraco-cms/reference/configuration/README.md
+++ b/10/umbraco-cms/reference/configuration/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco configuration"
 description: "Information on configuring Umbraco"
 ---

--- a/10/umbraco-cms/reference/configuration/basicauthsettings.md
+++ b/10/umbraco-cms/reference/configuration/basicauthsettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Basic Authentication Settings"
 description: "Information on the basic authentication section"
 ---

--- a/10/umbraco-cms/reference/configuration/connectionstringssettings.md
+++ b/10/umbraco-cms/reference/configuration/connectionstringssettings.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 10.0.0
+
 meta.Title: "Umbraco Connection Strings Settings"
 description: "Information on the connection strings settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/contentdashboard.md
+++ b/10/umbraco-cms/reference/configuration/contentdashboard.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Content Dashboard Settings"
 description: "Information on the content dashboard settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/datatypes.md
+++ b/10/umbraco-cms/reference/configuration/datatypes.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 10.0.0
+
 meta.Title: "Umbraco Data Types Settings"
 description: "Information on the data types settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/debugsettings.md
+++ b/10/umbraco-cms/reference/configuration/debugsettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Debug Settings"
 description: "Information on debug settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/examinesettings.md
+++ b/10/umbraco-cms/reference/configuration/examinesettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Examine Settings"
 description: "Information on the Examine settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/exceptionfiltersettings.md
+++ b/10/umbraco-cms/reference/configuration/exceptionfiltersettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Exception Filter Settings"
 description: "Information on the exception filter settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/filesystemproviders.md
+++ b/10/umbraco-cms/reference/configuration/filesystemproviders.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "FileSystemProviders in Umbraco"
 description: "Information on FileSystemProviders and how to configure them in Umbraco"
 ---

--- a/10/umbraco-cms/reference/configuration/globalsettings.md
+++ b/10/umbraco-cms/reference/configuration/globalsettings.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 10.0.0
+
 meta.Title: Umbraco Global Settings
 description: Information on the global settings section
 ---

--- a/10/umbraco-cms/reference/configuration/healthchecks.md
+++ b/10/umbraco-cms/reference/configuration/healthchecks.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Health Check Settings"
 description: "Information on the health check settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/hostingsettings.md
+++ b/10/umbraco-cms/reference/configuration/hostingsettings.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 9.0.0
+
 meta.Title: "Umbraco Hosting Settings"
 description: "Information on the hosting settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/imagingsettings.md
+++ b/10/umbraco-cms/reference/configuration/imagingsettings.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 10.0.0
+
 meta.Title: "Umbraco Imaging Settings"
 description: "Information on the imaging settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/installdefaultdatasettings.md
+++ b/10/umbraco-cms/reference/configuration/installdefaultdatasettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Umbraco Install Default Data Settings
 description: >-
   Information on configuration allowing for the modification of default data

--- a/10/umbraco-cms/reference/configuration/keepalivesettings.md
+++ b/10/umbraco-cms/reference/configuration/keepalivesettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Keep Alive Settings"
 description: "Information on the keep alive settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/loggingsettings.md
+++ b/10/umbraco-cms/reference/configuration/loggingsettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Logging Settings"
 description: "Information on the logging settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
+++ b/10/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Maximum upload size settings"
 description: "Information on how to change the default cap of upload size"
 ---

--- a/10/umbraco-cms/reference/configuration/modelsbuildersettings.md
+++ b/10/umbraco-cms/reference/configuration/modelsbuildersettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Models Builder Settings"
 description: "Information on the models builder settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/packagemigrationsettings.md
+++ b/10/umbraco-cms/reference/configuration/packagemigrationsettings.md
@@ -1,6 +1,6 @@
 ---
 versionFrom: 9.0.1
-versionTo: 10.0.0
+
 meta.Title: "Umbraco Package Migration Settings"
 description: "Information on the package migration settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/pluginssettings.md
+++ b/10/umbraco-cms/reference/configuration/pluginssettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Plugins Settings"
 description: "Information on the plugins settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/requesthandlersettings.md
+++ b/10/umbraco-cms/reference/configuration/requesthandlersettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Request Handler Settings"
 description: "Information on the request handler settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/richtexteditorsettings.md
+++ b/10/umbraco-cms/reference/configuration/richtexteditorsettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Rich Text Editor Settings"
 description: "Information on the Rich text editor settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/runtimeminificationsettings.md
+++ b/10/umbraco-cms/reference/configuration/runtimeminificationsettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Runtime Minification Settings"
 description: "Information on the runtime minification settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/runtimesettings.md
+++ b/10/umbraco-cms/reference/configuration/runtimesettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Umbraco Runtime Settings
 description: Information on the runtime settings section
 ---

--- a/10/umbraco-cms/reference/configuration/securitysettings.md
+++ b/10/umbraco-cms/reference/configuration/securitysettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Security Settings"
 description: "Information on the security settings section"
 ---

--- a/10/umbraco-cms/reference/configuration/typefindersettings.md
+++ b/10/umbraco-cms/reference/configuration/typefindersettings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Type Finder Settings"
 description: "Information on the type finder settings section"
 ---

--- a/10/umbraco-cms/reference/debugging.md
+++ b/10/umbraco-cms/reference/debugging.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Debugging with SourceLink
 description: >-
   Information on SourceLink and how to use it to debug the Umbraco CMS source

--- a/10/umbraco-cms/reference/language-variation.md
+++ b/10/umbraco-cms/reference/language-variation.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Language Variation

--- a/10/umbraco-cms/reference/mapping.md
+++ b/10/umbraco-cms/reference/mapping.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "UmbracoMapper"
 ---
 

--- a/10/umbraco-cms/reference/notifications/README.md
+++ b/10/umbraco-cms/reference/notifications/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Using notifications

--- a/10/umbraco-cms/reference/notifications/contentservice-notifications.md
+++ b/10/umbraco-cms/reference/notifications/contentservice-notifications.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # ContentService Notifications

--- a/10/umbraco-cms/reference/notifications/contentypeservice-notifications.md
+++ b/10/umbraco-cms/reference/notifications/contentypeservice-notifications.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # ContentTypeService Notifications

--- a/10/umbraco-cms/reference/notifications/creating-and-publishing-notifications.md
+++ b/10/umbraco-cms/reference/notifications/creating-and-publishing-notifications.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 10.0.0
+
 meta-title: Creating and Publishing Custom Notifications
 description: How to create and publish your own custom notifications
 ---

--- a/10/umbraco-cms/reference/notifications/datatypeservice-notifications.md
+++ b/10/umbraco-cms/reference/notifications/datatypeservice-notifications.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # DataTypeService Notifications

--- a/10/umbraco-cms/reference/notifications/determining-new-entity.md
+++ b/10/umbraco-cms/reference/notifications/determining-new-entity.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Determining if an entity is new

--- a/10/umbraco-cms/reference/notifications/editormodel-notifications/README.md
+++ b/10/umbraco-cms/reference/notifications/editormodel-notifications/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # EditorModel Notifications

--- a/10/umbraco-cms/reference/notifications/editormodel-notifications/customizing-the-links-box.md
+++ b/10/umbraco-cms/reference/notifications/editormodel-notifications/customizing-the-links-box.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Customizing the "Links" box

--- a/10/umbraco-cms/reference/notifications/fileservice-notifications.md
+++ b/10/umbraco-cms/reference/notifications/fileservice-notifications.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # FileService Notifications

--- a/10/umbraco-cms/reference/notifications/localizationservice-notifications.md
+++ b/10/umbraco-cms/reference/notifications/localizationservice-notifications.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # LocalizationService Events

--- a/10/umbraco-cms/reference/notifications/mediaservice-notifications.md
+++ b/10/umbraco-cms/reference/notifications/mediaservice-notifications.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # MediaService Notifications

--- a/10/umbraco-cms/reference/notifications/mediatypeservice-notifications.md
+++ b/10/umbraco-cms/reference/notifications/mediatypeservice-notifications.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # MediaTypeService Notifications

--- a/10/umbraco-cms/reference/notifications/memberservice-notifications.md
+++ b/10/umbraco-cms/reference/notifications/memberservice-notifications.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # MemberService Notifications

--- a/10/umbraco-cms/reference/notifications/membertypeservice-notifications.md
+++ b/10/umbraco-cms/reference/notifications/membertypeservice-notifications.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # MemberTypeService Notifications

--- a/10/umbraco-cms/reference/notifications/sendingallowedchildrennotifications.md
+++ b/10/umbraco-cms/reference/notifications/sendingallowedchildrennotifications.md
@@ -1,6 +1,6 @@
 ---
 versionFrom: 9.5.0
-versionTo: 10.0.0
+
 ---
 
 # Sending Allowed Children Notification

--- a/10/umbraco-cms/reference/notifications/umbracoapplicationlifetime-notifications.md
+++ b/10/umbraco-cms/reference/notifications/umbracoapplicationlifetime-notifications.md
@@ -1,6 +1,6 @@
 ---
 versionFrom: 9.3.0
-versionTo: 10.0.0
+
 meta-title: Umbraco Application Lifetime Notifications
 description: Represents an Umbraco application lifetime (starting, started, stopping, stopped) notification
 ---

--- a/10/umbraco-cms/reference/plugins/README.md
+++ b/10/umbraco-cms/reference/plugins/README.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 7.0.0
+
 needsV8Update: "false"
 needsV9Update: "false"
 ---

--- a/10/umbraco-cms/reference/plugins/creating-resolvers.md
+++ b/10/umbraco-cms/reference/plugins/creating-resolvers.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 7.0.0
+
 needsV8Update: "false"
 needsV9Update: "false"
 ---

--- a/10/umbraco-cms/reference/plugins/finding-types.md
+++ b/10/umbraco-cms/reference/plugins/finding-types.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 7.0.0
+
 needsV8Update: "false"
 needsV9Update: "false"
 ---

--- a/10/umbraco-cms/reference/querying/README.md
+++ b/10/umbraco-cms/reference/querying/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Querying & Models

--- a/10/umbraco-cms/reference/querying/imembermanager.md
+++ b/10/umbraco-cms/reference/querying/imembermanager.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Umbraco IMemberManager
 description: Using the IMemberManager1
 ---

--- a/10/umbraco-cms/reference/querying/ipublishedcontent/README.md
+++ b/10/umbraco-cms/reference/querying/ipublishedcontent/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # IPublishedContent

--- a/10/umbraco-cms/reference/querying/ipublishedcontent/collections.md
+++ b/10/umbraco-cms/reference/querying/ipublishedcontent/collections.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # IPublishedContent Collections

--- a/10/umbraco-cms/reference/querying/ipublishedcontent/ishelpers.md
+++ b/10/umbraco-cms/reference/querying/ipublishedcontent/ishelpers.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # IPublishedContent IsHelpers

--- a/10/umbraco-cms/reference/querying/ipublishedcontent/properties.md
+++ b/10/umbraco-cms/reference/querying/ipublishedcontent/properties.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # IPublishedContent Property Access & Extension Methods

--- a/10/umbraco-cms/reference/querying/ipublishedcontentquery.md
+++ b/10/umbraco-cms/reference/querying/ipublishedcontentquery.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco IPublishedContentQuery"
 description: "Querying in views with IPublishedContentQuery in Umbraco"
 ---

--- a/10/umbraco-cms/reference/querying/itagquery.md
+++ b/10/umbraco-cms/reference/querying/itagquery.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Tag Query"
 description: "Working with tags in Umbraco"
 ---

--- a/10/umbraco-cms/reference/querying/udi-identifiers.md
+++ b/10/umbraco-cms/reference/querying/udi-identifiers.md
@@ -1,6 +1,6 @@
 ---
 versionFrom: 7.6.0
-versionTo: 10.0.0
+
 ---
 
 # UDI Identifiers

--- a/10/umbraco-cms/reference/querying/umbraco-context.md
+++ b/10/umbraco-cms/reference/querying/umbraco-context.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 9.0.0
+
 meta.Title: "Umbraco Request Context"
 description: "The UmbracoContext is a helpful service provided on each request to the website"
 ---

--- a/10/umbraco-cms/reference/querying/umbracohelper.md
+++ b/10/umbraco-cms/reference/querying/umbracohelper.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Helper"
 description: "Using the Umbraco Helper"
 ---

--- a/10/umbraco-cms/reference/routing/README.md
+++ b/10/umbraco-cms/reference/routing/README.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 9.0.0
+
 meta.Title: "Routing & Controllers Reference"
 description: "All about Umbraco's routing pipeline & the types of Controllers used in Umbraco"
 ---

--- a/10/umbraco-cms/reference/routing/authorized.md
+++ b/10/umbraco-cms/reference/routing/authorized.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Routing Requirements for Backoffice authentication"
 description: "Requirements for authenticating requests for the backoffice"
 ---

--- a/10/umbraco-cms/reference/routing/custom-controllers.md
+++ b/10/umbraco-cms/reference/routing/custom-controllers.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta-title: Umbraco Route Hijacking
 description: >-
   Use a custom MVC controller to handle and control incoming requests for

--- a/10/umbraco-cms/reference/routing/custom-routes.md
+++ b/10/umbraco-cms/reference/routing/custom-routes.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Custom Umbraco Routes
 description: >-
   Setting up your own controllers and routes that exist alongside the Umbraco

--- a/10/umbraco-cms/reference/routing/request-pipeline/README.md
+++ b/10/umbraco-cms/reference/routing/request-pipeline/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Routing in Umbraco
 description: What the Umbraco Request Pipeline is
 ---

--- a/10/umbraco-cms/reference/routing/request-pipeline/find-publishedcontent-and-template.md
+++ b/10/umbraco-cms/reference/routing/request-pipeline/find-publishedcontent-and-template.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 7.0.0
+
 needsV8Update: 'true'
 ---
 

--- a/10/umbraco-cms/reference/routing/request-pipeline/icontentfinder.md
+++ b/10/umbraco-cms/reference/routing/request-pipeline/icontentfinder.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Creating content finders
 description: Information about creating your own content finders
 ---

--- a/10/umbraco-cms/reference/routing/request-pipeline/inbound-pipeline.md
+++ b/10/umbraco-cms/reference/routing/request-pipeline/inbound-pipeline.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Inbound request pipeline"
 description: "How the Umbraco inbound request pipeline works"
 ---

--- a/10/umbraco-cms/reference/routing/request-pipeline/published-content-request-preparation.md
+++ b/10/umbraco-cms/reference/routing/request-pipeline/published-content-request-preparation.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Published Content Request Preparation"
 description: "How Umbraco prepares content requests"
 ---

--- a/10/umbraco-cms/reference/routing/routing-properties.md
+++ b/10/umbraco-cms/reference/routing/routing-properties.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Special Property Type Aliases for Routing"
 description: "Describes special property type aliases which can be used to customise routing"
 ---

--- a/10/umbraco-cms/reference/routing/surface-controllers/README.md
+++ b/10/umbraco-cms/reference/routing/surface-controllers/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Surface Controllers"
 description: "Information about Surface Controllers in Umbraco"
 ---

--- a/10/umbraco-cms/reference/routing/surface-controllers/surface-controllers-actions.md
+++ b/10/umbraco-cms/reference/routing/surface-controllers/surface-controllers-actions.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Surface Controller Actions"
 description: "Information about Surface Controller Actions Result Helpers in Umbraco"
 ---

--- a/10/umbraco-cms/reference/routing/umbraco-api-controllers/README.md
+++ b/10/umbraco-cms/reference/routing/umbraco-api-controllers/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco WebApi"
 description: "A guide to implenting WebApi in Umbraco projects"
 ---

--- a/10/umbraco-cms/reference/routing/umbraco-api-controllers/authorization.md
+++ b/10/umbraco-cms/reference/routing/umbraco-api-controllers/authorization.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Umbraco WebApi Authorization
 description: How to secure your Umbraco Api controllers
 ---

--- a/10/umbraco-cms/reference/routing/umbraco-api-controllers/routing.md
+++ b/10/umbraco-cms/reference/routing/umbraco-api-controllers/routing.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco WebApi Routing & Urls"
 description: "How api controllers are routed and how to retrieve their URLs"
 ---

--- a/10/umbraco-cms/reference/routing/url-tracking.md
+++ b/10/umbraco-cms/reference/routing/url-tracking.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "URL Redirect Management"
 description: "URL redirect management in Umbraco"
 ---

--- a/10/umbraco-cms/reference/searching/README.md
+++ b/10/umbraco-cms/reference/searching/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 7.0.0
-versionTo: 8.0.0
+
+
 ---
 
 # Searching

--- a/10/umbraco-cms/reference/searching/examine/README.md
+++ b/10/umbraco-cms/reference/searching/examine/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Examine

--- a/10/umbraco-cms/reference/searching/examine/examine-management.md
+++ b/10/umbraco-cms/reference/searching/examine/examine-management.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 9.0.0
+
 ---
 
 # Examine Management

--- a/10/umbraco-cms/reference/searching/examine/examine-manager.md
+++ b/10/umbraco-cms/reference/searching/examine/examine-manager.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Examine Manager

--- a/10/umbraco-cms/reference/searching/examine/indexing.md
+++ b/10/umbraco-cms/reference/searching/examine/indexing.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Custom indexing

--- a/10/umbraco-cms/reference/searching/examine/pdfindex-multisearcher.md
+++ b/10/umbraco-cms/reference/searching/examine/pdfindex-multisearcher.md
@@ -1,6 +1,6 @@
 ﻿---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # PDF indexes and multisearchers

--- a/10/umbraco-cms/reference/searching/examine/quick-start.md
+++ b/10/umbraco-cms/reference/searching/examine/quick-start.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # quick-start

--- a/10/umbraco-cms/reference/security/authenticate-with-active-directory.md
+++ b/10/umbraco-cms/reference/security/authenticate-with-active-directory.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Authenticating the Umbraco backoffice with Azure Active Directory credentials

--- a/10/umbraco-cms/reference/security/backofficeusermanager-and-notifications.md
+++ b/10/umbraco-cms/reference/security/backofficeusermanager-and-notifications.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "BackOfficeUserManager and Notifications"
 description: "The BackOfficeUserManager is the ASP.NET Core Identity UserManager implementation in Umbraco. It exposes APIs for working with Umbraco User's via the ASP.NET Core Identity including password handling."
 ---

--- a/10/umbraco-cms/reference/security/cookies.md
+++ b/10/umbraco-cms/reference/security/cookies.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Cookies

--- a/10/umbraco-cms/reference/security/custom-password-check.md
+++ b/10/umbraco-cms/reference/security/custom-password-check.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Custom Password check

--- a/10/umbraco-cms/reference/security/external-login-providers.md
+++ b/10/umbraco-cms/reference/security/external-login-providers.md
@@ -1,6 +1,6 @@
 ---
 versionFrom: 9.3.0
-versionTo: 10.0.0
+
 keywords: oauth, security
 meta.Title: External login providers
 description: >-

--- a/10/umbraco-cms/reference/security/password-reset.md
+++ b/10/umbraco-cms/reference/security/password-reset.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Password reset

--- a/10/umbraco-cms/reference/security/reset-admin-password.md
+++ b/10/umbraco-cms/reference/security/reset-admin-password.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Reset admin password

--- a/10/umbraco-cms/reference/security/security-hardening.md
+++ b/10/umbraco-cms/reference/security/security-hardening.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 10.0.0
+
 ---
 
 # Umbraco Security Hardening

--- a/10/umbraco-cms/reference/security/security-settings.md
+++ b/10/umbraco-cms/reference/security/security-settings.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Umbraco Security Settings

--- a/10/umbraco-cms/reference/security/sensitive-data-on-members.md
+++ b/10/umbraco-cms/reference/security/sensitive-data-on-members.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Sensitive data

--- a/10/umbraco-cms/reference/security/serverside-sanitizing.md
+++ b/10/umbraco-cms/reference/security/serverside-sanitizing.md
@@ -1,6 +1,6 @@
 ---
 versionFrom: 9.3.0
-versionTo: 10.0.0
+
 meta.Title: "Serverside Sanitizing"
 description: "This section describes how to sanitize the Rich Text Editor serverside"
 ---

--- a/10/umbraco-cms/reference/security/setup-umbraco-for-a-fips-server.md
+++ b/10/umbraco-cms/reference/security/setup-umbraco-for-a-fips-server.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Setup Umbraco for a FIPS Compliant Server

--- a/10/umbraco-cms/reference/security/ssl-https.md
+++ b/10/umbraco-cms/reference/security/ssl-https.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Learn how to enforce the use of HTTPS (UseHttps) on your Umbraco websites.
 description: >-
   In production environments it is highly recommend that you enforce the use of

--- a/10/umbraco-cms/reference/security/two-factor-authentication.md
+++ b/10/umbraco-cms/reference/security/two-factor-authentication.md
@@ -1,6 +1,6 @@
 ---
 versionFrom: 9.5.0
-versionTo: 10.0.0
+
 keywords: 2fa, security, members, users
 meta.Title: Two-factor authentication
 description: >-

--- a/10/umbraco-cms/reference/templating/README.md
+++ b/10/umbraco-cms/reference/templating/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Templating

--- a/10/umbraco-cms/reference/templating/macros/README.md
+++ b/10/umbraco-cms/reference/templating/macros/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Macros

--- a/10/umbraco-cms/reference/templating/macros/managing-macros.md
+++ b/10/umbraco-cms/reference/templating/macros/managing-macros.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 8.0.0
+
 needsv9Update: 'true'
 ---
 

--- a/10/umbraco-cms/reference/templating/macros/partial-view-macros.md
+++ b/10/umbraco-cms/reference/templating/macros/partial-view-macros.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Partial View Macros

--- a/10/umbraco-cms/reference/templating/modelsbuilder/README.md
+++ b/10/umbraco-cms/reference/templating/modelsbuilder/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Modelsbuilder Reference"
 description: "Modelsbuilder reference"
 ---

--- a/10/umbraco-cms/reference/templating/modelsbuilder/builder-modes.md
+++ b/10/umbraco-cms/reference/templating/modelsbuilder/builder-modes.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Modelsbuilder Modes"
 description: "Modelsbuilder modes"
 ---

--- a/10/umbraco-cms/reference/templating/modelsbuilder/configuration.md
+++ b/10/umbraco-cms/reference/templating/modelsbuilder/configuration.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: ModelsBuilder Configuration
 description: Explanation of how to configure models builder
 ---

--- a/10/umbraco-cms/reference/templating/modelsbuilder/coolthingswithmodels.md
+++ b/10/umbraco-cms/reference/templating/modelsbuilder/coolthingswithmodels.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Cool Things to do With Models"
 description: "Cool things you can do with models"
 ---

--- a/10/umbraco-cms/reference/templating/modelsbuilder/install-models-builder.md
+++ b/10/umbraco-cms/reference/templating/modelsbuilder/install-models-builder.md
@@ -1,6 +1,6 @@
 ---
 versionFrom: 8.5.0
-versionTo: 10.0.0
+
 ---
 
 # Install the full version of the Models Builder

--- a/10/umbraco-cms/reference/templating/modelsbuilder/introduction.md
+++ b/10/umbraco-cms/reference/templating/modelsbuilder/introduction.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Modelsbuilder Introduction"
 description: "Modelsbuilder introduction"
 ---

--- a/10/umbraco-cms/reference/templating/modelsbuilder/understand-and-extend.md
+++ b/10/umbraco-cms/reference/templating/modelsbuilder/understand-and-extend.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Understand and Extend Modelsbuilder"
 description: "Understand and extend modelsbuilder"
 ---

--- a/10/umbraco-cms/reference/templating/modelsbuilder/using-interfaces.md
+++ b/10/umbraco-cms/reference/templating/modelsbuilder/using-interfaces.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Using Modelsbuilder interfaces"
 description: "Using interfaces with modelsbuilder"
 ---

--- a/10/umbraco-cms/reference/templating/mvc/README.md
+++ b/10/umbraco-cms/reference/templating/mvc/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 7.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Working with MVC in Umbraco

--- a/10/umbraco-cms/reference/templating/mvc/examples.md
+++ b/10/umbraco-cms/reference/templating/mvc/examples.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # View/Razor Examples

--- a/10/umbraco-cms/reference/templating/mvc/forms.md
+++ b/10/umbraco-cms/reference/templating/mvc/forms.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Creating Forms

--- a/10/umbraco-cms/reference/templating/mvc/partial-views.md
+++ b/10/umbraco-cms/reference/templating/mvc/partial-views.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Using MVC Partial Views in Umbraco

--- a/10/umbraco-cms/reference/templating/mvc/querying.md
+++ b/10/umbraco-cms/reference/templating/mvc/querying.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 

--- a/10/umbraco-cms/reference/templating/mvc/viewcomponents.md
+++ b/10/umbraco-cms/reference/templating/mvc/viewcomponents.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Using View Components in Umbraco

--- a/10/umbraco-cms/reference/templating/mvc/views.md
+++ b/10/umbraco-cms/reference/templating/mvc/views.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 

--- a/10/umbraco-cms/reference/using-ioc.md
+++ b/10/umbraco-cms/reference/using-ioc.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: "Umbraco Dependency Injection"
 description: "Inversion of Control/Dependency Injection in Umbraco"
 ---

--- a/10/umbraco-cms/tutorials/add-google-authentication.md
+++ b/10/umbraco-cms/tutorials/add-google-authentication.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Add Google Authentication
 description: A guide to set up a Google login for the Umbraco Backoffice.
 ---

--- a/10/umbraco-cms/tutorials/connecting-umbraco-forms-and-zapier.md
+++ b/10/umbraco-cms/tutorials/connecting-umbraco-forms-and-zapier.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 7.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Connecting Umbraco Forms and Zapier

--- a/10/umbraco-cms/tutorials/creating-a-basic-website/README.md
+++ b/10/umbraco-cms/tutorials/creating-a-basic-website/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 product: "CMS"
 meta.Title: "Creating a Basic Website using Umbraco"
 description: "A guide to creating a Basic Website using Umbraco"

--- a/10/umbraco-cms/tutorials/creating-a-basic-website/adding-language-variants.md
+++ b/10/umbraco-cms/tutorials/creating-a-basic-website/adding-language-variants.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Adding Language Variants

--- a/10/umbraco-cms/tutorials/creating-a-basic-website/article-parent-and-article-items.md
+++ b/10/umbraco-cms/tutorials/creating-a-basic-website/article-parent-and-article-items.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Articles and Article Items

--- a/10/umbraco-cms/tutorials/creating-a-basic-website/conclusion.md
+++ b/10/umbraco-cms/tutorials/creating-a-basic-website/conclusion.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Conclusions

--- a/10/umbraco-cms/tutorials/creating-a-basic-website/creating-master-template-part-1.md
+++ b/10/umbraco-cms/tutorials/creating-a-basic-website/creating-master-template-part-1.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Creating a Master Template

--- a/10/umbraco-cms/tutorials/creating-a-basic-website/creating-master-template-part-2.md
+++ b/10/umbraco-cms/tutorials/creating-a-basic-website/creating-master-template-part-2.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Creating Pages and Using the Master Template

--- a/10/umbraco-cms/tutorials/creating-a-basic-website/creating-your-first-template-and-content-node.md
+++ b/10/umbraco-cms/tutorials/creating-a-basic-website/creating-your-first-template-and-content-node.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Creating Your First Template

--- a/10/umbraco-cms/tutorials/creating-a-basic-website/css-and-images.md
+++ b/10/umbraco-cms/tutorials/creating-a-basic-website/css-and-images.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # CSS and Images

--- a/10/umbraco-cms/tutorials/creating-a-basic-website/displaying-the-document-type-properties.md
+++ b/10/umbraco-cms/tutorials/creating-a-basic-website/displaying-the-document-type-properties.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Displaying the Document Type Properties

--- a/10/umbraco-cms/tutorials/creating-a-basic-website/document-types.md
+++ b/10/umbraco-cms/tutorials/creating-a-basic-website/document-types.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Document Types

--- a/10/umbraco-cms/tutorials/creating-a-basic-website/getting-started.md
+++ b/10/umbraco-cms/tutorials/creating-a-basic-website/getting-started.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Getting Started

--- a/10/umbraco-cms/tutorials/creating-a-basic-website/setting-the-navigation-menu.md
+++ b/10/umbraco-cms/tutorials/creating-a-basic-website/setting-the-navigation-menu.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 # Setting the Navigation Menu
 

--- a/10/umbraco-cms/tutorials/creating-a-custom-dashboard.md
+++ b/10/umbraco-cms/tutorials/creating-a-custom-dashboard.md
@@ -1,7 +1,7 @@
 ---
 meta.Title: Creating a Custom Dashboard
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 description: A guide to creating a custom dashboard in Umbraco
 ---
 

--- a/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 8.0.0
+
 needsV9Update: "true"
 ---
 

--- a/10/umbraco-cms/tutorials/creating-and-distributing-a-package.md
+++ b/10/umbraco-cms/tutorials/creating-and-distributing-a-package.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 8.0.0
+
+
 ---
 
 # Creating And Distributing A Package

--- a/10/umbraco-cms/tutorials/creating-custom-views-for-blocklist.md
+++ b/10/umbraco-cms/tutorials/creating-custom-views-for-blocklist.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Custom Views for Block List

--- a/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/README.md
+++ b/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Getting started with Umbraco

--- a/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/copying-a-page.md
+++ b/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/copying-a-page.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Copying a Page

--- a/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/creating-saving-and-publishing-content.md
+++ b/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/creating-saving-and-publishing-content.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Creating, Saving and Publishing Content Options

--- a/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/deleting-and-restoring-pages.md
+++ b/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/deleting-and-restoring-pages.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Deleting and Restoring Pages

--- a/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/editing-existing-content.md
+++ b/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/editing-existing-content.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Editing Existing Content

--- a/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/finding-content.md
+++ b/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/finding-content.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Finding Content

--- a/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/logging-in-and-out.md
+++ b/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/logging-in-and-out.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Logging In and Out

--- a/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/moving-a-page.md
+++ b/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/moving-a-page.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 7.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Moving a Page

--- a/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/ordering-pages.md
+++ b/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/ordering-pages.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Sorting Pages

--- a/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/umbraco-interface.md
+++ b/10/umbraco-cms/tutorials/editors-manual/getting-started-with-umbraco/umbraco-interface.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Umbraco Interface

--- a/10/umbraco-cms/tutorials/editors-manual/media-management/README.md
+++ b/10/umbraco-cms/tutorials/editors-manual/media-management/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Media Management

--- a/10/umbraco-cms/tutorials/editors-manual/media-management/cropping-images.md
+++ b/10/umbraco-cms/tutorials/editors-manual/media-management/cropping-images.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Cropping Images

--- a/10/umbraco-cms/tutorials/editors-manual/media-management/working-with-folders.md
+++ b/10/umbraco-cms/tutorials/editors-manual/media-management/working-with-folders.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Working with Folders

--- a/10/umbraco-cms/tutorials/editors-manual/media-management/working-with-images-and-files.md
+++ b/10/umbraco-cms/tutorials/editors-manual/media-management/working-with-images-and-files.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Working with Media Types

--- a/10/umbraco-cms/tutorials/editors-manual/tips-and-tricks/README.md
+++ b/10/umbraco-cms/tutorials/editors-manual/tips-and-tricks/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 9.0.0
+
+
 ---
 
 # Tips & Tricks

--- a/10/umbraco-cms/tutorials/editors-manual/tips-and-tricks/audit-trail.md
+++ b/10/umbraco-cms/tutorials/editors-manual/tips-and-tricks/audit-trail.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Audit Trail

--- a/10/umbraco-cms/tutorials/editors-manual/tips-and-tricks/notifications.md
+++ b/10/umbraco-cms/tutorials/editors-manual/tips-and-tricks/notifications.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 9.0.0
+
+
 ---
 
 # Notifications

--- a/10/umbraco-cms/tutorials/editors-manual/tips-and-tricks/preview-pane-responsive-view.md
+++ b/10/umbraco-cms/tutorials/editors-manual/tips-and-tricks/preview-pane-responsive-view.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Preview Pane Responsive View

--- a/10/umbraco-cms/tutorials/editors-manual/tips-and-tricks/session-timeout.md
+++ b/10/umbraco-cms/tutorials/editors-manual/tips-and-tricks/session-timeout.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 7.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Session Timeout

--- a/10/umbraco-cms/tutorials/editors-manual/tips-and-tricks/working-with-folders.md
+++ b/10/umbraco-cms/tutorials/editors-manual/tips-and-tricks/working-with-folders.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Refreshing the Tree View

--- a/10/umbraco-cms/tutorials/editors-manual/version-management/README.md
+++ b/10/umbraco-cms/tutorials/editors-manual/version-management/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Version Management

--- a/10/umbraco-cms/tutorials/editors-manual/version-management/comparing-versions.md
+++ b/10/umbraco-cms/tutorials/editors-manual/version-management/comparing-versions.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Comparing Versions

--- a/10/umbraco-cms/tutorials/editors-manual/version-management/rollback-to-a-previous-version.md
+++ b/10/umbraco-cms/tutorials/editors-manual/version-management/rollback-to-a-previous-version.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Rollback to a Previous Version

--- a/10/umbraco-cms/tutorials/editors-manual/working-with-content/README.md
+++ b/10/umbraco-cms/tutorials/editors-manual/working-with-content/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Working with Rich Text Editor

--- a/10/umbraco-cms/tutorials/editors-manual/working-with-content/rich-text-editor.md
+++ b/10/umbraco-cms/tutorials/editors-manual/working-with-content/rich-text-editor.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 7.0.0
+
 ---
 
 # Rich Text Editor

--- a/10/umbraco-cms/tutorials/members-registration-and-login.md
+++ b/10/umbraco-cms/tutorials/members-registration-and-login.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 10.0.0
+
 meta.Title: Members Registration and Logins
 description: >-
   In this article you can learn about how to create Member registration and

--- a/10/umbraco-cms/tutorials/multilanguage-setup.md
+++ b/10/umbraco-cms/tutorials/multilanguage-setup.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Multilanguage setup in Umbraco
 product: CMS
 description: A guide to multilanguage setup in Umbraco

--- a/10/umbraco-cms/tutorials/multisite-setup.md
+++ b/10/umbraco-cms/tutorials/multisite-setup.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Multisite setup in Umbraco
 product: CMS
 description: A guide to multisite setup in Umbraco

--- a/10/umbraco-cms/tutorials/starter-kit/README.md
+++ b/10/umbraco-cms/tutorials/starter-kit/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 7.0.0
-versionTo: 10.0.0
+
+
 product: CMS
 meta.Title: Getting started with Umbraco using the Starter Kit
 description: A tutorial on getting started with Umbraco using the starter kit

--- a/10/umbraco-cms/tutorials/starter-kit/lessons/2-add-a-blog-post-publication-date/README.md
+++ b/10/umbraco-cms/tutorials/starter-kit/lessons/2-add-a-blog-post-publication-date/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Add a Blog Post Publication Date

--- a/10/umbraco-cms/tutorials/starter-kit/lessons/2-add-a-blog-post-publication-date/part-2.md
+++ b/10/umbraco-cms/tutorials/starter-kit/lessons/2-add-a-blog-post-publication-date/part-2.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Add a Blog Post Publication Date

--- a/10/umbraco-cms/tutorials/starter-kit/lessons/2-add-a-blog-post-publication-date/part-3.md
+++ b/10/umbraco-cms/tutorials/starter-kit/lessons/2-add-a-blog-post-publication-date/part-3.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Add a Blog Post Publication Date

--- a/10/umbraco-cms/tutorials/starter-kit/lessons/3-add-open-graph/README.md
+++ b/10/umbraco-cms/tutorials/starter-kit/lessons/3-add-open-graph/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Add Open Graph

--- a/10/umbraco-cms/tutorials/starter-kit/lessons/3-add-open-graph/step-1.md
+++ b/10/umbraco-cms/tutorials/starter-kit/lessons/3-add-open-graph/step-1.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Add Open Graph - Step 1

--- a/10/umbraco-cms/tutorials/starter-kit/lessons/3-add-open-graph/step-2.md
+++ b/10/umbraco-cms/tutorials/starter-kit/lessons/3-add-open-graph/step-2.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Add Open Graph - Step 2

--- a/10/umbraco-cms/tutorials/starter-kit/lessons/3-add-open-graph/step-3.md
+++ b/10/umbraco-cms/tutorials/starter-kit/lessons/3-add-open-graph/step-3.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Add Open Graph - Step 3

--- a/10/umbraco-cms/tutorials/starter-kit/lessons/3-add-open-graph/step-4.md
+++ b/10/umbraco-cms/tutorials/starter-kit/lessons/3-add-open-graph/step-4.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 9.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Add Open Graph - Step 4

--- a/10/umbraco-cms/tutorials/starter-kit/lessons/3-add-open-graph/summary.md
+++ b/10/umbraco-cms/tutorials/starter-kit/lessons/3-add-open-graph/summary.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Add Open Graph - Step 4

--- a/10/umbraco-cms/tutorials/starter-kit/lessons/4-help-and-community.md
+++ b/10/umbraco-cms/tutorials/starter-kit/lessons/4-help-and-community.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Ask For Help and Join the Community

--- a/10/umbraco-cms/tutorials/starter-kit/lessons/README.md
+++ b/10/umbraco-cms/tutorials/starter-kit/lessons/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 ---
 
 # Lessons

--- a/10/umbraco-deploy/deployment-workflow/README.md
+++ b/10/umbraco-deploy/deployment-workflow/README.md
@@ -1,6 +1,6 @@
 ---
-versionFrom: 8.0.0
-versionTo: 10.0.0
+
+
 meta.Title: Deployments in Umbraco Deploy
 description: A description of the proper workflow when working with Umbraco Deploy
 ---

--- a/12/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
+++ b/12/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
@@ -1,5 +1,5 @@
 ---
-versionFrom: 12.0.0
+
 meta.Title: Umbraco Database
 description: >-
   This tutorial will show you how to get started with creating custom database


### PR DESCRIPTION

## Description

_What did you add/update/change?_

The `versionFrom` and `versionTo` tags are not used anymore, since we moved to gitbook, hence they have been removed.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [x] Other

## Product & version (if relevant)


## Deadline (if relevant)

_When should the content be published?_
