### PR TITLE
Block Grid Editor is available from v10.4

### DIFF
--- a/10/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/README.md
+++ b/10/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/README.md
@@ -2,7 +2,7 @@
 
 The Block Editors are property editors that enables you to build advanced editor tools using a set of predefined Document Types.
 
-Umbraco 10 currently ships with one Block Editor: Block List.
+Umbraco 10 initially shipped with one Block Editor, Block List, with Block Grid introduced in Umbraco 10.4.
 
 ## [Block List](block-list-editor.md)
 

--- a/10/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/README.md
+++ b/10/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/README.md
@@ -2,7 +2,7 @@
 
 The Block Editors are property editors that enables you to build advanced editor tools using a set of predefined Document Types.
 
-Umbraco 10 initially shipped with one Block Editor, Block List, with Block Grid introduced in Umbraco 10.4.
+Umbraco 10 initially shipped with one Block Editor which is Block List. Block Grid editor has been introduced from version 10.4.0.
 
 ## [Block List](block-list-editor.md)
 


### PR DESCRIPTION
## Description

Updated documentation to reflect Block Grid was introduced to v10 in 10.4. Current documentation suggests only the Block List Block Editor is available in v10.

See the following links about the introduction of Block Grid into v10:

- https://umbraco.com/blog/umbraco-103-release-candidate/
- https://our.umbraco.com/download/releases/1040

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Documentation of v10.

## Deadline (if relevant)

It is not time-critical, but it is important to maintain v10 documentation as this version has LTS.
