### PR TITLE
Updated API docs links to Umbraco 12

### DIFF
--- a/12/umbraco-cms/reference/api-documentation.md
+++ b/12/umbraco-cms/reference/api-documentation.md
@@ -10,13 +10,13 @@ A library of API Reference documentation is auto-generated from the comments wit
 
 C# API references for the Umbraco Core, Infrastructure, Extensions and Web libraries.
 
-### [Umbraco.Cms.Core](https://apidocs.umbraco.com/v11/csharp/api/Umbraco.Cms.Core.html)
+### [Umbraco.Cms.Core](https://apidocs.umbraco.com/v12/csharp/api/Umbraco.Cms.Core.html)
 
-### [Umbraco.Cms.Infrastructure](https://apidocs.umbraco.com/v11/csharp/api/Umbraco.Cms.Infrastructure.html)
+### [Umbraco.Cms.Infrastructure](https://apidocs.umbraco.com/v12/csharp/api/Umbraco.Cms.Infrastructure.html)
 
-### [Umbraco.Cms.Web](https://apidocs.umbraco.com/v11/csharp/api/Umbraco.Cms.Web.Common.html)
+### [Umbraco.Cms.Web](https://apidocs.umbraco.com/v12/csharp/api/Umbraco.Cms.Web.Common.html)
 
-### [Umbraco.Extensions](https://apidocs.umbraco.com/v11/csharp/api/Umbraco.Extensions.html)
+### [Umbraco.Extensions](https://apidocs.umbraco.com/v12/csharp/api/Umbraco.Extensions.html)
 
 {% hint style="info" %}
 Opens a documentation browser that is different from the documentation section you're viewing now.

--- a/12/umbraco-cms/reference/api-documentation.md
+++ b/12/umbraco-cms/reference/api-documentation.md
@@ -30,7 +30,7 @@ Angular, JavaScript, CSS & Less UI API references for building Umbraco backoffic
 * The umbraco.services
 * The umbraco.resources
 
-### [Backoffice UI](https://apidocs.umbraco.com/v11/ui)
+### [Backoffice UI](https://apidocs.umbraco.com/v12/ui)
 
 {% hint style="info" %}
 Opens a documentation browser that is different from the documentation section you're viewing now.


### PR DESCRIPTION
## Description

The [**API Documentation**](https://docs.umbraco.com/umbraco-cms/reference/api-documentation) page is part of the Umbraco 12 documentation, but I noticed that it's still linking to the Umbraco 11 API docs.

Since the API docs also exists for Umbraco 12, I've updated the links to point to these instead.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Umbraco 12

## Deadline (if relevant)

Somewhere between right now and some time next year 🙄 
