### PR TITLE
Added details of configuring the Umbraco application URL for licensing Workflow and Deploy.

### DIFF
--- a/10/umbraco-commerce/getting-started/licensing-model.md
+++ b/10/umbraco-commerce/getting-started/licensing-model.md
@@ -69,13 +69,13 @@ Once you have received your license code it needs to be installed on your site.
 
 ### Verify the license installation
 
-You can verify that your license is successfully installed by logging into your projects back office and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.
+You can verify that your license is successfully installed by logging into your project's backoffice and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.
 
 ![Umbraco Commerce License Dashboard](../media/license-dashboard.png)
 
 ### When and how to configure an `UmbracoApplicationUrl`
 
-If you are running on a single domain for both your frontend and backend environments, it's not necessary to configure a `UmbracoApplicationUrl`. 
+If you are running on a single domain for both your frontend and backend environments, it's not necessary to configure a `UmbracoApplicationUrl`.
 
 If you have different domains for your frontend and backend, then it's advised that you configure an `UmbracoApplicationUrl` set to your backoffice URL. This helps the licensing engine know which URL should be used for validation checks. Without this configuration setting, the licensing engine will try and work out the domain to validate from the HTTP request object. This can lead to errors when switching between domains.
 

--- a/10/umbraco-workflow/licensing.md
+++ b/10/umbraco-workflow/licensing.md
@@ -6,43 +6,49 @@ Umbraco Workflow is a licensed product that does not require a purchase. New ins
 
 If you want to buy an Umbraco Workflow license, reach out to the sales team at [**suits@umbraco.com**](mailto:suits@umbraco.com). Existing Plumber license holders who wish to upgrade to Umbraco Workflow should contact [**suits@umbraco.com**](mailto:suits@umbraco.com).
 
-To add the license to your site, follow these steps:
+## Installing your license
 
-1.  Update the `appSettings.json` file:
+Once you have received your license code it needs to be installed on your site.
 
-    ```
-    {
-      “Umbraco”: {
-        “Licenses”: {
-          “UmbracoWorkflow”: “YOUR-LICENSE-KEY”
-        }   
-      }  
-    }
-    ```
-2.  Create a class in your website, for example, `ServerRoleAccessor.cs` that implements the `IServerRoleAccessor` with `CurrentServerRole` set to either `Single` or `SchedulingPublisher` server role and register that class via a composer:
+1. Open the root directory for your project files.
+2. Locate and open the `appSettings.json` file.
+3. Add your Umbraco Commerce license key to `Umbraco:Licenses:Umbraco.Commerce`:
 
-    ```
-    using Umbraco.Cms.Core.Composing;
-    using Umbraco.Cms.Core.Sync;
-    using Umbraco.Cms.Infrastructure.DependencyInjection;
+```json
+"Umbraco": {
+  "Licenses": {
+    "Umbraco.Workflow": "YOUR_LICENSE_KEY"
+  }
+}
+```
 
-    public class SiteComposer : IComposer
-    {
-        public void Compose(IUmbracoBuilder builder)
-        {
-            builder.SetServerRegistrar<SingleServerRoleAccessor>();
+### Verify the license installation
+
+You can verify that your license is successfully installed by logging into your projects back office and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.
+
+### When and how to configure an `UmbracoApplicationUrl`
+
+The website domain used for validating the license is determined from your Umbraco instance. To ensure the correct one is used, you can configure the `UmbracoApplicationUrl`.
+
+If you are running on a single domain for both your frontend and backend environments, it's not necessary to configure a `UmbracoApplicationUrl`.
+
+If you have different domains for your frontend and backend, then it's advised that you configure an `UmbracoApplicationUrl` set to your backoffice URL. This helps the licensing engine know which URL should be used for validation checks. Without this configuration setting, the licensing engine will try and work out the domain to validate from the HTTP request object. This can lead to errors when switching between domains.
+
+An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file like so:
+
+```json
+{
+    "Umbraco": {
+        "CMS": {
+            "WebRouting": {
+                "UmbracoApplicationUrl": "https://admin.my-custom-domain.com/"
+            }
         }
     }
+}
+```
 
-    public class SingleServerRoleAccessor : IServerRoleAccessor
-    {
-        public ServerRole CurrentServerRole => ServerRole.Single;
-    }
-    ```
-
-{% hint style="info" %}
-License validation _only_ runs on `Single` or `SchedulingPublisher` servers.
-{% endhint %}
+See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) documentation for more details about this setting.
 
 ### Using a Trial License
 

--- a/10/umbraco-workflow/licensing.md
+++ b/10/umbraco-workflow/licensing.md
@@ -12,7 +12,7 @@ Once you have received your license code it needs to be installed on your site.
 
 1. Open the root directory for your project files.
 2. Locate and open the `appSettings.json` file.
-3. Add your Umbraco Commerce license key to `Umbraco:Licenses:Umbraco.Commerce`:
+3. Add your Umbraco Workflow license key to `Umbraco:Licenses:Umbraco.Workflow`:
 
 ```json
 "Umbraco": {

--- a/10/umbraco-workflow/licensing.md
+++ b/10/umbraco-workflow/licensing.md
@@ -24,7 +24,7 @@ Once you have received your license code it needs to be installed on your site.
 
 ### Verify the license installation
 
-You can verify that your license is successfully installed by logging into your projects back office and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.
+You can verify that your license is successfully installed by logging into your project's backoffice and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.
 
 ### When and how to configure an `UmbracoApplicationUrl`
 

--- a/11/umbraco-workflow/licensing.md
+++ b/11/umbraco-workflow/licensing.md
@@ -6,43 +6,49 @@ Umbraco Workflow is a licensed product that does not require a purchase. New ins
 
 If you want to buy an Umbraco Workflow license, reach out to the sales team at [**suits@umbraco.com**](mailto:suits@umbraco.com). Existing Plumber license holders who wish to upgrade to Umbraco Workflow should contact [**suits@umbraco.com**](mailto:suits@umbraco.com).
 
-To add the license to your site, follow these steps:
+## Installing your license
 
-1.  Update the `appSettings.json` file:
+Once you have received your license code it needs to be installed on your site.
 
-    ```
-    {
-      “Umbraco”: {
-        “Licenses”: {
-          “UmbracoWorkflow”: “YOUR-LICENSE-KEY”
-        }   
-      }  
-    }
-    ```
-2.  Create a class in your website, for example, `ServerRoleAccessor.cs` that implements the `IServerRoleAccessor` with `CurrentServerRole` set to either `Single` or `SchedulingPublisher` server role and register that class via a composer:
+1. Open the root directory for your project files.
+2. Locate and open the `appSettings.json` file.
+3. Add your Umbraco Commerce license key to `Umbraco:Licenses:Umbraco.Commerce`:
 
-    ```
-    using Umbraco.Cms.Core.Composing;
-    using Umbraco.Cms.Core.Sync;
-    using Umbraco.Cms.Infrastructure.DependencyInjection;
+```json
+"Umbraco": {
+  "Licenses": {
+    "Umbraco.Workflow": "YOUR_LICENSE_KEY"
+  }
+}
+```
 
-    public class SiteComposer : IComposer
-    {
-        public void Compose(IUmbracoBuilder builder)
-        {
-            builder.SetServerRegistrar<SingleServerRoleAccessor>();
+### Verify the license installation
+
+You can verify that your license is successfully installed by logging into your projects back office and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.
+
+### When and how to configure an `UmbracoApplicationUrl`
+
+The website domain used for validating the license is determined from your Umbraco instance. To ensure the correct one is used, you can configure the `UmbracoApplicationUrl`.
+
+If you are running on a single domain for both your frontend and backend environments, it's not necessary to configure a `UmbracoApplicationUrl`.
+
+If you have different domains for your frontend and backend, then it's advised that you configure an `UmbracoApplicationUrl` set to your backoffice URL. This helps the licensing engine know which URL should be used for validation checks. Without this configuration setting, the licensing engine will try and work out the domain to validate from the HTTP request object. This can lead to errors when switching between domains.
+
+An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file like so:
+
+```json
+{
+    "Umbraco": {
+        "CMS": {
+            "WebRouting": {
+                "UmbracoApplicationUrl": "https://admin.my-custom-domain.com/"
+            }
         }
     }
+}
+```
 
-    public class SingleServerRoleAccessor : IServerRoleAccessor
-    {
-        public ServerRole CurrentServerRole => ServerRole.Single;
-    }
-    ```
-
-{% hint style="info" %}
-License validation _only_ runs on `Single` or `SchedulingPublisher` servers.
-{% endhint %}
+See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) documentation for more details about this setting.
 
 ### Using a Trial License
 

--- a/11/umbraco-workflow/licensing.md
+++ b/11/umbraco-workflow/licensing.md
@@ -12,7 +12,7 @@ Once you have received your license code it needs to be installed on your site.
 
 1. Open the root directory for your project files.
 2. Locate and open the `appSettings.json` file.
-3. Add your Umbraco Commerce license key to `Umbraco:Licenses:Umbraco.Commerce`:
+3. Add your Umbraco Workflow license key to `Umbraco:Licenses:Umbraco.Workflow`:
 
 ```json
 "Umbraco": {

--- a/11/umbraco-workflow/licensing.md
+++ b/11/umbraco-workflow/licensing.md
@@ -24,7 +24,7 @@ Once you have received your license code it needs to be installed on your site.
 
 ### Verify the license installation
 
-You can verify that your license is successfully installed by logging into your projects back office and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.
+You can verify that your license is successfully installed by logging into your project's backoffice and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.
 
 ### When and how to configure an `UmbracoApplicationUrl`
 

--- a/12/umbraco-commerce/getting-started/licensing-model.md
+++ b/12/umbraco-commerce/getting-started/licensing-model.md
@@ -69,13 +69,13 @@ Once you have received your license code it needs to be installed on your site.
 
 ### Verify the license installation
 
-You can verify that your license is successfully installed by logging into your projects back office and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.
+You can verify that your license is successfully installed by logging into your project's backoffice and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.
 
 ![Umbraco Commerce License Dashboard](../media/license-dashboard.png)
 
 ### When and how to configure an `UmbracoApplicationUrl`
 
-If you are running on a single domain for both your frontend and backend environments, it's not necessary to configure a `UmbracoApplicationUrl`. 
+If you are running on a single domain for both your frontend and backend environments, it's not necessary to configure a `UmbracoApplicationUrl`.
 
 If you have different domains for your frontend and backend, then it's advised that you configure an `UmbracoApplicationUrl` set to your backoffice URL. This helps the licensing engine know which URL should be used for validation checks. Without this configuration setting, the licensing engine will try and work out the domain to validate from the HTTP request object. This can lead to errors when switching between domains.
 

--- a/12/umbraco-deploy/the-licensing-model.md
+++ b/12/umbraco-deploy/the-licensing-model.md
@@ -2,6 +2,8 @@
 
 Umbraco Deploy is a commercial product. You will need a **valid license** to use the product.
 
+A license for Umbraco Deploy is included when hosting on Umbraco Cloud.
+
 ## How does it work?
 
 Licenses are sold per domain and will also work on all subdomains. With every license, you will also be able to configure two development/testing domains.
@@ -74,6 +76,30 @@ On start-up and on a schedule, Umbraco running Deploy On-premise will call out t
 You can view the status of the Umbraco Deploy On-premise license in the backoffice. This is available via the _Settings_ section, listed along with any other products using the same licensing service:
 
 ![Licenses screen in Umbraco backoffice](./images/licenses-screen.png)
+
+### When and how to configure an `UmbracoApplicationUrl`
+
+The website domain used for validating the license is determined from your Umbraco instance. To ensure the correct one is used, you can configure the `UmbracoApplicationUrl`.
+
+If you are running on a single domain for both your frontend and backend environments, it's not necessary to configure a `UmbracoApplicationUrl`.
+
+If you have different domains for your frontend and backend, then it's advised that you configure an `UmbracoApplicationUrl` set to your backoffice URL. This helps the licensing engine know which URL should be used for validation checks. Without this configuration setting, the licensing engine will try and work out the domain to validate from the HTTP request object. This can lead to errors when switching between domains.
+
+An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file like so:
+
+```json
+{
+    "Umbraco": {
+        "CMS": {
+            "WebRouting": {
+                "UmbracoApplicationUrl": "https://admin.my-custom-domain.com/"
+            }
+        }
+    }
+}
+```
+
+See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) documentation for more details about this setting.
 
 
 


### PR DESCRIPTION
## Description

Following the addition of [this extra](https://github.com/umbraco/UmbracoDocs/pull/5417/) detail for licensing Umbraco Commerce, I've added similar for Workflow and Deploy.

@nathanwoulfe - can you review the changes for Workflow please?  I took out the part about setting the server role, as that won't be necessary with the latest version of the `Umbraco.Licenses` component.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [X] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Workflow 10, 11, 12 and Deploy 12

## Deadline (if relevant)

Can be reviewed and published at any time.
