### PR TITLE
Add SQL snippets example on Database Account Roles

### DIFF
--- a/10/umbraco-cms/fundamentals/setup/requirements.md
+++ b/10/umbraco-cms/fundamentals/setup/requirements.md
@@ -107,5 +107,5 @@ The database account used in the connection string will need permissions to read
 For more information on the Database-level roles, see the [Microsoft documentation](https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#fixed-database-roles).
 
 {% hint style="info" %}
-For more information on how to create a db user via SQL, you can check the [Microsoft documentation](https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#a--adding-a-user-to-a-database-level-role).
+For more information on how to create a database user via SQL, you can check the [Microsoft documentation](https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#a--adding-a-user-to-a-database-level-role).
 {% endhint %}

--- a/10/umbraco-cms/fundamentals/setup/requirements.md
+++ b/10/umbraco-cms/fundamentals/setup/requirements.md
@@ -105,3 +105,7 @@ The database account used in the connection string will need permissions to read
 * To use an account with more restricted permissions, the `db_datareader` and `db_datawriter` roles will be needed for normal use to read from and write to the database. The `db_ddladmin` role, which can modify the database schema, is required for installs and upgrades of the CMS and/or any packages that create database tables.
 
 For more information on the Database-level roles, see the [Microsoft documentation](https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#fixed-database-roles).
+
+{% hint style="info" %}
+For more information on how to create a db user via SQL, you can check the [Microsoft documentation](https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#a--adding-a-user-to-a-database-level-role).
+{% endhint %}

--- a/11/umbraco-cms/fundamentals/setup/requirements.md
+++ b/11/umbraco-cms/fundamentals/setup/requirements.md
@@ -65,5 +65,5 @@ The database account used in the connection string will need permissions to read
 For more information on the Database-level roles, see the [Microsoft documentation](https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#fixed-database-roles).
 
 {% hint style="info" %}
-For more information on how to create a db user via SQL, you can check the [Microsoft documentation](https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#a--adding-a-user-to-a-database-level-role).
+For more information on how to create a database user via SQL, you can check the [Microsoft documentation](https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#a--adding-a-user-to-a-database-level-role).
 {% endhint %}

--- a/11/umbraco-cms/fundamentals/setup/requirements.md
+++ b/11/umbraco-cms/fundamentals/setup/requirements.md
@@ -63,3 +63,7 @@ The database account used in the connection string will need permissions to read
 * To use an account with more restricted permissions, the `db_datareader` and `db_datawriter` roles will be needed for normal use to read from and write to the database. The `db_ddladmin` role, which can modify the database schema, is required for installs and upgrades of the CMS and/or any packages that create database tables.
 
 For more information on the Database-level roles, see the [Microsoft documentation](https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#fixed-database-roles).
+
+{% hint style="info" %}
+For more information on how to create a db user via SQL, you can check the [Microsoft documentation](https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#a--adding-a-user-to-a-database-level-role).
+{% endhint %}

--- a/12/umbraco-cms/fundamentals/setup/requirements.md
+++ b/12/umbraco-cms/fundamentals/setup/requirements.md
@@ -65,5 +65,5 @@ The database account used in the connection string will need permissions to read
 For more information on the Database-level roles, see the [Microsoft documentation](https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#fixed-database-roles).
 
 {% hint style="info" %}
-For more information on how to create a db user via SQL, you can check the [Microsoft documentation](https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#a--adding-a-user-to-a-database-level-role).
+For more information on how to create a database user via SQL, you can check the [Microsoft documentation](https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#a--adding-a-user-to-a-database-level-role).
 {% endhint %}

--- a/12/umbraco-cms/fundamentals/setup/requirements.md
+++ b/12/umbraco-cms/fundamentals/setup/requirements.md
@@ -63,3 +63,7 @@ The database account used in the connection string will need permissions to read
 * To use an account with more restricted permissions, the `db_datareader` and `db_datawriter` roles will be needed for normal use to read from and write to the database. The `db_ddladmin` role, which can modify the database schema, is required for installs and upgrades of the CMS and/or any packages that create database tables.
 
 For more information on the Database-level roles, see the [Microsoft documentation](https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#fixed-database-roles).
+
+{% hint style="info" %}
+For more information on how to create a db user via SQL, you can check the [Microsoft documentation](https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#a--adding-a-user-to-a-database-level-role).
+{% endhint %}


### PR DESCRIPTION
## Description

Pull request for fixing #5488

I added SQL Snippets example on [Database Account Roles section](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/requirements#database-account-roles) of Umbraco CMS Requirements blog. I have used info note for adding the example. And, I have added it to all versions of Umbraco blog so that the blog is consistent.

## Type of suggestion

* [x] New content

## Product & version (if relevant)

Umbraco CMS Docs ❤( v10,v11,v12)


