### PR TITLE
adding information about xpath being obsolete in v12

### DIFF
--- a/12/umbraco-cms/extending/property-editors/full-examples-value-converters.md
+++ b/12/umbraco-cms/extending/property-editors/full-examples-value-converters.md
@@ -96,4 +96,11 @@ namespace MyConverters
         }
     }
 }
+
+{% hint style="warning" %}
+
+The current implementation of XPath is suboptimal and will be removed entirely in a future version. It is currently obsolete and scheduled for removal in v14.
+
+{% endhint %}
+
 ```

--- a/12/umbraco-cms/extending/property-editors/property-value-converters.md
+++ b/12/umbraco-cms/extending/property-editors/property-value-converters.md
@@ -12,9 +12,15 @@ For example the standard Umbraco Core "Content Picker" stores a nodeId as `Strin
 Published property values have four "Values":
 
 - **Source** - The raw data stored in the database, this is generally a `String`
-- **Intermediate** - An object of a type that is appropriate to the property, e.g. a nodeId should be an `Int` or a collection of nodeIds would be an integer array, `Int[]`
-- **Object** - The object to be used when accessing the property using a Published Content API, e.g. UmbracoHelper's `GetPropertyValue<T>` method
+- **Intermediate** - An object of a type that is appropriate to the property, for example a nodeId should be an `Int` or a collection of nodeIds would be an integer array, `Int[]`
+- **Object** - The object to be used when accessing the property using a Published Content API, for example UmbracoHelper's `GetPropertyValue<T>` method
 - **XPath** - The object to be used when the property is accessed by XPath; This should generally be a `String` or an `XPathNodeIterator`
+
+{% hint style="warning" %}
+
+The current implementation of XPath is suboptimal and will be removed entirely in a future version. It is currently obsolete and scheduled for removal in v14.
+
+{% endhint %}
 
 ## Registering PropertyValueConverters
 

--- a/12/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/multinode-treepicker.md
+++ b/12/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/multinode-treepicker.md
@@ -26,6 +26,12 @@ $root
 $site: Ancestor node at level 1
 ```
 
+{% hint style="warning" %}
+
+The current implementation of XPath is suboptimal and will be removed entirely in a future version. It is currently obsolete and scheduled for removal in v14.
+
+{% endhint %}
+
 It is important to notice that all placeholders above act against published content only. So if you, therefore, try to fetch `$parent` of the current document, then Umbraco will return that or its closest published ancestor. So in case, the parent is not published, it will try the parent of that parent, and so on.
 
 **Filter out items with type:** allow or disallow tree nodes with a certain content type alias.

--- a/12/umbraco-cms/reference/configuration/contentsettings.md
+++ b/12/umbraco-cms/reference/configuration/contentsettings.md
@@ -112,6 +112,12 @@ The above example shows what you need to do if you only have a single site that 
 * When using XPath, there is no "context" (like, you can't find the node based on "currentPage") so needs to be a global absolute path.
 {% endhint %}
 
+{% hint style="warning" %}
+
+The current implementation of XPath is suboptimal and will be removed entirely in a future version. It is currently obsolete and scheduled for removal in v14.
+
+{% endhint %}
+
 If you have multiple sites, with different cultures, setup in your tree then you will need to setup the errors section like below:
 
 ```json

--- a/12/umbraco-cms/reference/configuration/index-10.0.0.md
+++ b/12/umbraco-cms/reference/configuration/index-10.0.0.md
@@ -93,13 +93,18 @@ The above example shows what you need to do if you only have a single site that 
 2. Enter the node's **GUID** (`"ContentKey": "4f96ffdd-b969-46a8-949e-7935c41fabc0"`)
 3. Enter the XPath to find the node (`"ContentXPath": "/root/Home//TextPage[@urlName = 'error404'"`)
 
-:::note
+{% hint style="info" %}
 
-- Ids are usually local to the specific solution (so won't point to the same node in two different environments if you're using Umbraco Cloud).
-- GUIDs are universal and will point to the same node on different environments, provided the content was created in one environment and deployed to the other(s).
-- When using XPath, there is no "context" (like, you can't find the node based on "currentPage") so needs to be a global absolute path.
+* Ids are usually local to the specific solution (so won't point to the same node in two different environments if you're using Umbraco Cloud).
+* GUIDs are universal and will point to the same node on different environments, provided the content was created in one environment and deployed to the other(s).
+* When using XPath, there is no "context" (like, you can't find the node based on "currentPage") so needs to be a global absolute path.
+{% endhint %}
 
-:::
+{% hint style="warning" %}
+
+The current implementation of XPath is suboptimal and will be removed entirely in a future version. It is currently obsolete and scheduled for removal in v14.
+
+{% endhint %}
 
 If you have multiple sites, with different cultures, setup in your tree then you will need to setup the errors section like below:
 

--- a/12/umbraco-cms/reference/querying/umbracohelper.md
+++ b/12/umbraco-cms/reference/querying/umbracohelper.md
@@ -92,6 +92,12 @@ Returns a collection of `IPublishedContent` objects from the Content tree.
 
 ### .ContentAtXPath(string xpath)
 
+{% hint style="warning" %}
+
+The current implementation of XPath is suboptimal and will be removed entirely in a future version. It is currently obsolete and scheduled for removal in v14.
+
+{% endhint %}
+
 Queries the cache for content matching a given XPath query and returns a collection of `IPublishedContent` objects.
 
 ```csharp

--- a/12/umbraco-cms/reference/routing/authorized.md
+++ b/12/umbraco-cms/reference/routing/authorized.md
@@ -83,8 +83,13 @@ public static void MapUmbracoRoute<T>(
 * `includeControllerNameInRoute` - If this is false the controller name will be excluded from the route, so in this case the route would be `umbraco/backoffice/mypackagename/{action}/{id?}` if this was set to false.
 * `constraints` - Any routing constraints passed to this will be used when mapping the route see [Microsoft documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/routing?view=aspnetcore-5.0#route-constraint-reference) for more information.
 
+{% hint style="warning" %}
 
-Using the `MapUmbracoRoute` extension method is optional though, it's a neat helper to ensure controllers get routed in the same way. If your controller uses an area, like in this example, you need to specify this using the `Area` attribute. In this example the controller looks like this: 
+The current implementation of XPath is suboptimal and will be removed entirely in a future version. It is currently obsolete and scheduled for removal in v14.
+
+{% endhint %}
+
+Using the `MapUmbracoRoute` extension method is optional though, it's a neat helper to ensure controllers get routed in the same way. If your controller uses an area, like in this example, you need to specify this using the `Area` attribute. In this example the controller looks like this:
 
 ```csharp
 using Microsoft.AspNetCore.Mvc;

--- a/12/umbraco-cms/tutorials/custom-error-page.md
+++ b/12/umbraco-cms/tutorials/custom-error-page.md
@@ -34,6 +34,12 @@ The value for error pages can be:
 * An XPath statement (example: //errorPages\[@nodeName='My cool error']
 * A content item's integer ID (example: 1234)
 
+{% hint style="warning" %}
+
+The current implementation of XPath is suboptimal and will be removed entirely in a future version. It is currently obsolete and scheduled for removal in v14.
+
+{% endhint %}
+
 That is where the value you grabbed earlier comes in. Fill it out like so:
 
 ```json


### PR DESCRIPTION
## Description

_What did you add/update/change?_
Added a warning note where XPath is mentioned in the CMS v12 documentation as per issue [#5394 
](https://github.com/umbraco/UmbracoDocs/issues/5394)

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
CMS v12

## Deadline (if relevant)
anytime
_When should the content be published?_
anytime