### PR TITLE
Added details of handling cache refresher notifications for operations after Umbraco items are deployed.

### DIFF
--- a/10/umbraco-deploy/SUMMARY.md
+++ b/10/umbraco-deploy/SUMMARY.md
@@ -4,6 +4,7 @@
 * [Getting started](get-started-with-deploy.md)
 * [Configuration](deploy-settings.md)
 * [Extending](extending.md)
+* [Handling Cache Refresher Notifications](handling-cache-refresher-notifications.md)
 * [Troubleshooting](troubleshooting.md)
 * [Licensing](the-licensing-model.md)
 * [Release notes](release-notes.md)

--- a/10/umbraco-deploy/handling-cache-refresher-notifications.md
+++ b/10/umbraco-deploy/handling-cache-refresher-notifications.md
@@ -13,15 +13,21 @@ For example, you may handle a `ContentPublishedNotification` to apply some custo
 
 This behavior is deliberate and done for performance and reliability reasons. A normal save and publish operation by an editor operates on one item at a time. With deployments, we may have many, and publishing these notifications may lead to at best slow operations, and at worst inconsistent data.
 
+The notification will also already be published on the environment where the actual operation was carried out. So repeating this with each content transfer might also result in unwanted behavior.
+
 However, what if you do want to run some code on an update, even if this is happening as part of a Deploy operation?
 
-There's an option here using cache refresher notifications. Not all events are suppressed by Umbraco Deploy. Some that are batched up and fired after the deploy operation is completed include those related to refreshing the Umbraco cache.
+Not all notifications are suppressed by Umbraco Deploy. Some are batched and fired after the deploy operation is complete. These include those related to refreshing the Umbraco cache and rebuilding indexes.
+
+You can use these cache refresher notifications to handle operations that should occur after a deployment is completed. All notification issued by the CMS are made available. So when deploying a set of content items, a refresher notification will be issued for each.
 
 ## Implementing a Cache Refresher Notification
 
 The following two code samples illustrate how this can be done.
 
 The first handles a content cache refresher, which takes a payload from where the content ID can be extracted. Using that the content can be retrieved in the local Umbraco instance and used as appropriate.
+
+For more details and further examples, please see the [CMS Cache Refresher Notifications documentation](https://docs.umbraco.com/umbraco-cms/reference/notifications/cacherefresher-notifications).
 
 ```csharp
 using Umbraco.Cms.Core.Cache;

--- a/10/umbraco-deploy/handling-cache-refresher-notifications.md
+++ b/10/umbraco-deploy/handling-cache-refresher-notifications.md
@@ -7,13 +7,13 @@ description: "How to respond to deployment events using cache refresher notifica
 
 ## Background
 
-When you deploy content or other Umbraco data between environments, several notifications that are normally fired in CMS operations are suppressed.
+When you deploy content or other Umbraco data between environments, some notifications that are normally fired in CMS operations are suppressed.
 
 For example, you may handle a `ContentPublishedNotification` to apply some custom logic when a content item is published. This code will run in a normal CMS publish operation. However, when deploying a content item into another environment and triggering it's publishing there, the notification will not be issued. And the custom logic in the notification handler will not run.
 
 This behavior is deliberate and done for performance and reliability reasons. A normal save and publish operation by an editor operates on one item at a time. With deployments, we may have many, and publishing these notifications may lead to at best slow operations, and at worst inconsistent data.
 
-However, what if you do want to run some code on the save of some Umbraco data, even if this is happening as part of a Deploy operation?
+However, what if you do want to run some code on an update, even if this is happening as part of a Deploy operation?
 
 There's an option here using cache refresher notifications. Not all events are suppressed by Umbraco Deploy. Some that are batched up and fired after the deploy operation is completed include those related to refreshing the Umbraco cache.
 
@@ -85,7 +85,7 @@ public class ContentCacheRefresherNotificationHandler : INotificationHandler<Con
 }
 ```
 
-The second example is similar, but handles an update to a dictionary item. With this one we get a parameter that consists of just the item's ID. Again we can retrieve it and carry out some further processing.
+The second example is similar, but handles an update to a dictionary item. With this one we get a parameter that consists of the item's ID. Again we can retrieve it and carry out some further processing.
 
 ```csharp
 using Umbraco.Cms.Core.Events;

--- a/10/umbraco-deploy/handling-cache-refresher-notifications.md
+++ b/10/umbraco-deploy/handling-cache-refresher-notifications.md
@@ -1,0 +1,162 @@
+---
+meta.Title: "Handling Cache Refresher Notifications"
+description: "How to respond to deployment events using cache refresher notifications"
+---
+
+# Handling Cache Refresher Notifications
+
+## Background
+
+When you deploy content or other Umbraco data between environments, several notifications that are normally fired in CMS operations are suppressed.
+
+For example, you may handle a `ContentPublishedNotification` to apply some custom logic when a content item is published. This code will run in a normal CMS publish operation. However, when deploying a content item into another environment and triggering it's publishing there, the notification will not be issued. And the custom logic in the notification handler will not run.
+
+This behavior is deliberate and done for performance and reliability reasons. A normal save and publish operation by an editor operates on one item at a time. With deployments, we may have many, and publishing these notifications may lead to at best slow operations, and at worst inconsistent data.
+
+However, what if you do want to run some code on the save of some Umbraco data, even if this is happening as part of a Deploy operation?
+
+There's an option here using cache refresher notifications. Not all events are suppressed by Umbraco Deploy. Some that are batched up and fired after the deploy operation is completed include those related to refreshing the Umbraco cache.
+
+## Implementing a Cache Refresher Notification
+
+The following two code samples illustrate how this can be done.
+
+The first handles a content cache refresher, which takes a payload from where the content ID can be extracted. Using that the content can be retrieved in the local Umbraco instance and used as appropriate.
+
+```csharp
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
+
+namespace TestSite.Business.NotificationHandlers;
+
+public class ContentCacheRefresherNotificationHandler : INotificationHandler<ContentCacheRefresherNotification>
+{
+    private readonly ILogger<ContentCacheRefresherNotificationHandler> _logger;
+    private readonly IContentService _contentService;
+
+    public ContentCacheRefresherNotificationHandler(
+        ILogger<ContentCacheRefresherNotificationHandler> logger,
+        IContentService contentService)
+    {
+        _logger = logger;
+        _contentService = contentService;
+    }
+
+    public void Handle(ContentCacheRefresherNotification notification)
+    {
+        // We only want to handle the RefreshByPayload message type.
+        if (notification.MessageType != MessageType.RefreshByPayload)
+        {
+            return;
+        }
+
+        // Cast the payload to the expected type.
+        var payload = (ContentCacheRefresher.JsonPayload[])notification.MessageObject;
+
+        // Handle each content item in the payload.
+        foreach (ContentCacheRefresher.JsonPayload item in payload)
+        {
+            // Retrieve the content item.
+            var contentItemId = item.Id;
+            IContent? contentItem = _contentService.GetById(contentItemId);
+            if (contentItem is null)
+            {
+                _logger.LogWarning(
+                    "ContentCacheRefresherNotification handled for type {MessageType} but content item with Id {Id} could not be found.",
+                    notification.MessageType,
+                    contentItemId);
+                return;
+            }
+
+            // Do something with the content item. Here we'll just log some details.
+            _logger.LogInformation(
+                "ContentCacheRefresherNotification handled for type {MessageType} and id {Id}. " +
+                "Key: {Key}, Name: {Name}",
+                notification.MessageType,
+                contentItemId,
+                contentItem.Key,
+                contentItem.Name);
+        }
+    }
+}
+```
+
+The second example is similar, but handles an update to a dictionary item. With this one we get a parameter that consists of just the item's ID. Again we can retrieve it and carry out some further processing.
+
+```csharp
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
+
+namespace TestSite.Business.NotificationHandlers;
+
+public class DictionaryCacheRefresherNotificationHandler : INotificationHandler<DictionaryCacheRefresherNotification>
+{
+    private readonly ILogger<DictionaryCacheRefresherNotificationHandler> _logger;
+    private readonly ILocalizationService _localizationService;
+
+    public DictionaryCacheRefresherNotificationHandler(
+        ILogger<DictionaryCacheRefresherNotificationHandler> logger,
+        ILocalizationService localizationService)
+    {
+        _logger = logger;
+        _localizationService = localizationService;
+    }
+
+    public void Handle(DictionaryCacheRefresherNotification notification)
+    {
+        // We only want to handle the RefreshById message type.
+        if (notification.MessageType != MessageType.RefreshById)
+        {
+            return;
+        }
+
+        // Retrieve the dictionary item.
+        var dictionaryItemId = (int)notification.MessageObject;
+        IDictionaryItem? dictionaryItem = _localizationService.GetDictionaryItemById(dictionaryItemId);
+        if (dictionaryItem is null)
+        {
+            _logger.LogWarning(
+                "DictionaryCacheRefresherNotification handled for type {MessageType} but dictionary item with Id {Id} could not be found.",
+                notification.MessageType,
+                dictionaryItemId);
+            return;
+        }
+
+        // Do something with the dictionary item. Here we'll just log some details.
+        _logger.LogInformation(
+            "DictionaryCacheRefresherNotification handled for type {MessageType} and id {Id}. " +
+            "Key: {Key}, Default Value: {DefaultValue}",
+            notification.MessageType,
+            dictionaryItemId,
+            dictionaryItem.ItemKey,
+            dictionaryItem.GetDefaultValue());
+    }
+}
+```
+
+In both cases, as is usual for notification handlers, you will need to register them via a composer:
+
+```csharp
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Notifications;
+using TestSite.Business.NotificationHandlers;
+
+namespace TestSite.Business;
+
+public class SiteComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.AddNotificationHandler<ContentCacheRefresherNotification, ContentCacheRefresherNotificationHandler>();
+        builder.AddNotificationHandler<DictionaryCacheRefresherNotification, DictionaryCacheRefresherNotificationHandler>();
+    }
+}
+```
+


### PR DESCRIPTION
## Description

Added details of handling cache refresher notifications for operations after Umbraco items are deployed.

Improving the documentation in this area was raised as an issue here: https://github.com/umbraco/Umbraco.Deploy.Issues/issues/183

I had something like this previously [published in a personal blog post](https://www.andybutland.dev/2022/11/handling-umbraco-events-after-deploy.html), but I think it makes sense to have in the documentation.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [X] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Deploy 10+

## Deadline (if relevant)

Can be reviewed and published at any time, but please wait for an approval from @ronaldbarendse first.

Once it is approved, the content should be copied to the 11 and 12 folders for Deploy.
