### PR TITLE
Updated licensing docs with details of configuring an Umbraco application URL on Umbraco Cloud.

### DIFF
--- a/10/umbraco-commerce/getting-started/licensing-model.md
+++ b/10/umbraco-commerce/getting-started/licensing-model.md
@@ -100,7 +100,6 @@ See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/h
 
 If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). This overrides what is set via the `appSettings.json` file.
 
-
 There are two options in this case:
 - Either the domains for each of your Cloud environments can be added to your license.
 - Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.

--- a/10/umbraco-commerce/getting-started/licensing-model.md
+++ b/10/umbraco-commerce/getting-started/licensing-model.md
@@ -96,3 +96,21 @@ An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file lik
 
 See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) documentation for more details about this setting.
 
+#### Configuring `UmbracoApplicationUrl` on Umbraco Cloud
+
+If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). The overrides what is set via the `appSettings.json` file.
+
+You have two options here.
+
+Either the domains for each of your Cloud environments can be added to your license.
+
+Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
+
+For example, in your `Startup.cs` file, you can add the following to the `ConfigureServices` method:
+
+```csharp
+services.Configure<WebRoutingSettings>(o => o.UmbracoApplicationUrl = "<your application URL>");
+```
+
+In practice, you will probably want to make this a bit more sophisticated. You can read the value from another configuration key, removing the need to hard-code it and have it set as appropriate in different environments. You can also move this code into a composer or an extension method if you prefer not to clutter up the `Startup.ConfigureServices` method.
+

--- a/10/umbraco-commerce/getting-started/licensing-model.md
+++ b/10/umbraco-commerce/getting-started/licensing-model.md
@@ -98,13 +98,12 @@ See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/h
 
 #### Configuring `UmbracoApplicationUrl` on Umbraco Cloud
 
-If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). The overrides what is set via the `appSettings.json` file.
+If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). This overrides what is set via the `appSettings.json` file.
 
-You have two options here.
 
-Either the domains for each of your Cloud environments can be added to your license.
-
-Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
+There are two options in this case:
+- Either the domains for each of your Cloud environments can be added to your license.
+- Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
 
 For example, in your `Startup.cs` file, you can add the following to the `ConfigureServices` method:
 

--- a/10/umbraco-workflow/licensing.md
+++ b/10/umbraco-workflow/licensing.md
@@ -52,13 +52,11 @@ See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/h
 
 #### Configuring `UmbracoApplicationUrl` on Umbraco Cloud
 
-If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). The overrides what is set via the `appSettings.json` file.
+If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). This overrides what is set via the `appSettings.json` file.
 
-You have two options here.
-
-Either the domains for each of your Cloud environments can be added to your license.
-
-Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
+There are two options in this case:
+- Either the domains for each of your Cloud environments can be added to your license.
+- Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
 
 For example, in your `Startup.cs` file, you can add the following to the `ConfigureServices` method:
 

--- a/10/umbraco-workflow/licensing.md
+++ b/10/umbraco-workflow/licensing.md
@@ -50,6 +50,24 @@ An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file lik
 
 See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) documentation for more details about this setting.
 
+#### Configuring `UmbracoApplicationUrl` on Umbraco Cloud
+
+If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). The overrides what is set via the `appSettings.json` file.
+
+You have two options here.
+
+Either the domains for each of your Cloud environments can be added to your license.
+
+Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
+
+For example, in your `Startup.cs` file, you can add the following to the `ConfigureServices` method:
+
+```csharp
+services.Configure<WebRoutingSettings>(o => o.UmbracoApplicationUrl = "<your application URL>");
+```
+
+In practice, you will probably want to make this a bit more sophisticated. You can read the value from another configuration key, removing the need to hard-code it and have it set as appropriate in different environments. You can also move this code into a composer or an extension method if you prefer not to clutter up the `Startup.ConfigureServices` method.
+
 ### Using a Trial License
 
 The trial license introduces some restrictions around advanced features but is otherwise a full-featured workflow platform. The paid license is valid for one top-level domain and all its subdomains.

--- a/11/umbraco-workflow/licensing.md
+++ b/11/umbraco-workflow/licensing.md
@@ -52,13 +52,11 @@ See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/h
 
 #### Configuring `UmbracoApplicationUrl` on Umbraco Cloud
 
-If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). The overrides what is set via the `appSettings.json` file.
+If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). This overrides what is set via the `appSettings.json` file.
 
-You have two options here.
-
-Either the domains for each of your Cloud environments can be added to your license.
-
-Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
+There are two options in this case:
+- Either the domains for each of your Cloud environments can be added to your license.
+- Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
 
 For example, in your `Startup.cs` file, you can add the following to the `ConfigureServices` method:
 

--- a/11/umbraco-workflow/licensing.md
+++ b/11/umbraco-workflow/licensing.md
@@ -50,6 +50,24 @@ An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file lik
 
 See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) documentation for more details about this setting.
 
+#### Configuring `UmbracoApplicationUrl` on Umbraco Cloud
+
+If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). The overrides what is set via the `appSettings.json` file.
+
+You have two options here.
+
+Either the domains for each of your Cloud environments can be added to your license.
+
+Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
+
+For example, in your `Startup.cs` file, you can add the following to the `ConfigureServices` method:
+
+```csharp
+services.Configure<WebRoutingSettings>(o => o.UmbracoApplicationUrl = "<your application URL>");
+```
+
+In practice, you will probably want to make this a bit more sophisticated. You can read the value from another configuration key, removing the need to hard-code it and have it set as appropriate in different environments. You can also move this code into a composer or an extension method if you prefer not to clutter up the `Startup.ConfigureServices` method.
+
 ### Using a Trial License
 
 The trial license introduces some restrictions around advanced features but is otherwise a full-featured workflow platform. The paid license is valid for one top-level domain and all its subdomains.

--- a/12/umbraco-commerce/getting-started/licensing-model.md
+++ b/12/umbraco-commerce/getting-started/licensing-model.md
@@ -96,3 +96,20 @@ An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file lik
 
 See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) documentation for more details about this setting.
 
+#### Configuring `UmbracoApplicationUrl` on Umbraco Cloud
+
+If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). This overrides what is set via the `appSettings.json` file.
+
+There are two options in this case:
+- Either the domains for each of your Cloud environments can be added to your license.
+- Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
+
+For example, in your `Startup.cs` file, you can add the following to the `ConfigureServices` method:
+
+```csharp
+services.Configure<WebRoutingSettings>(o => o.UmbracoApplicationUrl = "<your application URL>");
+```
+
+In practice, you will probably want to make this a bit more sophisticated. You can read the value from another configuration key, removing the need to hard-code it and have it set as appropriate in different environments. You can also move this code into a composer or an extension method if you prefer not to clutter up the `Startup.ConfigureServices` method.
+
+

--- a/12/umbraco-workflow/licensing.md
+++ b/12/umbraco-workflow/licensing.md
@@ -52,13 +52,11 @@ See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/h
 
 #### Configuring `UmbracoApplicationUrl` on Umbraco Cloud
 
-If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). The overrides what is set via the `appSettings.json` file.
+If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). This overrides what is set via the `appSettings.json` file.
 
-You have two options here.
-
-Either the domains for each of your Cloud environments can be added to your license.
-
-Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
+There are two options in this case:
+- Either the domains for each of your Cloud environments can be added to your license.
+- Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
 
 For example, in your `Startup.cs` file, you can add the following to the `ConfigureServices` method:
 

--- a/12/umbraco-workflow/licensing.md
+++ b/12/umbraco-workflow/licensing.md
@@ -50,6 +50,24 @@ An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file lik
 
 See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) documentation for more details about this setting.
 
+#### Configuring `UmbracoApplicationUrl` on Umbraco Cloud
+
+If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). The overrides what is set via the `appSettings.json` file.
+
+You have two options here.
+
+Either the domains for each of your Cloud environments can be added to your license.
+
+Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
+
+For example, in your `Startup.cs` file, you can add the following to the `ConfigureServices` method:
+
+```csharp
+services.Configure<WebRoutingSettings>(o => o.UmbracoApplicationUrl = "<your application URL>");
+```
+
+In practice, you will probably want to make this a bit more sophisticated. You can read the value from another configuration key, removing the need to hard-code it and have it set as appropriate in different environments. You can also move this code into a composer or an extension method if you prefer not to clutter up the `Startup.ConfigureServices` method.
+
 ### Using a Trial License
 
 The trial license introduces some restrictions around advanced features but is otherwise a full-featured workflow platform. The paid license is valid for one top-level domain and all its subdomains.


### PR DESCRIPTION
## Description

Updated licensing docs with details of configuring an Umbraco application URL on Umbraco Cloud.  This is to clarify the situation and present options for the issue described in https://github.com/umbraco/Umbraco.Commerce.Issues/issues/440

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [X] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Workflow and Commerce

## Deadline (if relevant)

Can go live at any time.  Please can you wait for an approval from one or both of @mattbrailsford or @nathanwoulfe though.
