### PR TITLE
Adding new AllowConcurrentLogins setting (for 12.3)

### DIFF
--- a/12/umbraco-cms/reference/configuration/securitysettings.md
+++ b/12/umbraco-cms/reference/configuration/securitysettings.md
@@ -37,7 +37,8 @@ A full configuration with all default values can be seen here:
         "MaxFailedAccessAttemptsBeforeLockout": 5
       },
       "UserDefaultLockoutTimeInMinutes": 43200,
-      "MemberDefaultLockoutTimeInMinutes": 43200
+      "MemberDefaultLockoutTimeInMinutes": 43200,
+      "AllowConcurrentLogins": true
     }
   }
 }
@@ -121,3 +122,11 @@ The default lockout time for users is 30 days (43200 minutes).
 Use this setting to configure how long time a Member is locked out of the Umbraco website when a lockout occurs. The setting accepts an integer which defines the lockout in minutes.
 
 The default lockout time for users is 30 days (43200 minutes).
+
+## Allow concurrent logins
+
+{% hint style="info" %}
+This setting was introduced in version 12.3.
+{% endhint %}
+
+When set to `false`, user accounts are prevented from creating simultaneous sessions. In this mode, only one session can be active at a time, enhancing security and preventing multiple concurrent logins with the same user credentials.

--- a/12/umbraco-cms/reference/configuration/securitysettings.md
+++ b/12/umbraco-cms/reference/configuration/securitysettings.md
@@ -129,4 +129,4 @@ The default lockout time for users is 30 days (43200 minutes).
 This setting was introduced in version 12.3.
 {% endhint %}
 
-When set to `false`, any user account is prevented from having several simultaneous sessions. In this mode, only one session per user can be active at any given time. This enhances security and prevents multiple concurrent logins with the same user credentials.
+When set to `false`, any user account is prevented from having multiple simultaneous sessions. In this mode, only one session per user can be active at any given time. This enhances security and prevents concurrent logins with the same user credentials.

--- a/12/umbraco-cms/reference/configuration/securitysettings.md
+++ b/12/umbraco-cms/reference/configuration/securitysettings.md
@@ -129,4 +129,4 @@ The default lockout time for users is 30 days (43200 minutes).
 This setting was introduced in version 12.3.
 {% endhint %}
 
-When set to `false`, user accounts are prevented from creating simultaneous sessions. In this mode, only one session can be active at a time, enhancing security and preventing multiple concurrent logins with the same user credentials.
+When set to `false`, any user account is prevented from having several simultaneous sessions. In this mode, only one session per user can be active at any given time. This enhances security and prevents multiple concurrent logins with the same user credentials.


### PR DESCRIPTION
## Description
- Adding documentation about a new configuration setting that will be introduced with v12.3;

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [X] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
CMS v12.3

## Deadline (if relevant)
Between 19th Oct and 2nd Nov 🙂 - 12.3RC is out on 19th Oct and the final release is out on 2nd Nov. So, it is fine to merge it in this period (at latest on 2nd Nov).

---

> **Note**
> In v13.0.0 we will change the default value of `Umbraco:CMS:Security:AllowConcurrentLogins` from `true` to `false` - related to https://github.com/umbraco/Umbraco-CMS/pull/14989. So after we merge this PR we need to make sure that the following changes are made and available for 1st Nov:

Indicate that the default value of `AllowConcurrentLogins` is changed to `false`:
```json
      "MemberDefaultLockoutTimeInMinutes": 43200,
      "AllowConcurrentLogins": false
```

And remove the hint and keep the description:
```md
## Allow concurrent logins

When set to `false`, any user account is prevented from having multiple simultaneous sessions. In this mode, only one session per user can be active at any given time. This enhances security and prevents concurrent logins with the same user credentials.
```