### PR TITLE
Block Grid custom view with image sample code bug

### DIFF
--- a/10/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/build-custom-view-for-blocks.md
+++ b/10/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/build-custom-view-for-blocks.md
@@ -87,7 +87,7 @@ With the setup of files above, you need to amend the `customBlock.controller.js`
 angular.module("umbraco").controller("customBlockController", function ($scope, mediaResource) {
 
     //your property is called image so the following will contain the udi:
-    var imageUdi = $scope.block.data.image;
+    var imageUdi = $scope.block.data.image[0].mediaKey;
     //the mediaResource has a getById method:
     mediaResource.getById(imageUdi).then(function (media) {
         console.log(media);


### PR DESCRIPTION
## Description

Sample code to display an image from a Media Picker throws some javascript errors:

  1. `https://localhost:44309/umbraco/backoffice/umbracoapi/media/GetById?id=%5Bobject%20Object%5D 404 (Not Found)`

  2. `Possibly unhandled rejection: {"errorMsg":"Failed to retrieve data for media id [object Object]","data":"","status":404,"xhrStatus":"complete"}`

The sample code `$scope.block.data.image` expects a single image to be returned whilst it returns a collection.

Additionally, the image ID is accessed via the `mediaKey` property.

## Possible solution

Appending `image[0].mediaKey` returns the media GUID which can be passed to the `mediaResource.getById` function, and resolves the error.

## My setup

Umbraco: 10.7.0 / .Net6
Rider: 2023.2.2
OS: MacOS 14.0 / Arm
Browser: Chrome 118.0.5993.70


## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [x] Other


## Deadline (if relevant)

No panic.
