### PR TITLE
Default value for AllowConcurrentLogins setting has changed (for v13)

### DIFF
--- a/12/umbraco-cms/reference/configuration/securitysettings.md
+++ b/12/umbraco-cms/reference/configuration/securitysettings.md
@@ -38,7 +38,7 @@ A full configuration with all default values can be seen here:
       },
       "UserDefaultLockoutTimeInMinutes": 43200,
       "MemberDefaultLockoutTimeInMinutes": 43200,
-      "AllowConcurrentLogins": true
+      "AllowConcurrentLogins": false
     }
   }
 }
@@ -124,9 +124,5 @@ Use this setting to configure how long time a Member is locked out of the Umbrac
 The default lockout time for users is 30 days (43200 minutes).
 
 ## Allow concurrent logins
-
-{% hint style="info" %}
-This setting was introduced in version 12.3.
-{% endhint %}
 
 When set to `false`, any user account is prevented from having multiple simultaneous sessions. In this mode, only one session per user can be active at any given time. This enhances security and prevents concurrent logins with the same user credentials.


### PR DESCRIPTION
## Description
- Related to Note in https://github.com/umbraco/UmbracoDocs/pull/5523 - the default value of `Umbraco:CMS:Security:AllowConcurrentLogins` will be changed from `true` to `false` in v13.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [X] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
CMS v13


## Deadline (if relevant)
1st Nov when 13RC is out
