### PR TITLE
Wrong url and path in Get Deployment diff in UmbracoCloudApi.md

### DIFF
--- a/umbraco-cloud/set-up/project-settings/umbraco-cicd/UmbracoCloudApi.md
+++ b/umbraco-cloud/set-up/project-settings/umbraco-cicd/UmbracoCloudApi.md
@@ -305,7 +305,7 @@ Sometimes updates are done directly on the Umbraco Cloud repository. We encourag
 Using a curl command, fetching the potential differences would look like this:
 
 ```sh
-url="https://apim-dev-global.azure-api.net/projects/$projectId/deployments/$latestCompletedDeploymentId/diff"
+url="https://api.cloud.umbraco.com/v1/projects/$projectId/deployments/$latestCompletedDeploymentId/diff"
 downloadFolder="tmp"
 mkdir -p $downloadFolder # ensure folder exists
 


### PR DESCRIPTION
## Description

_What did you add/update/change?_

The URL in the code snippet for https://docs.umbraco.com/umbraco-cloud/set-up/project-settings/umbraco-cicd/umbracocloudapi#get-deployment-diff is incorrect.

## Type of suggestion

* [x ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Umbraco Cloud

## Deadline (if relevant)

As long as it counts as a hacktoberfest contribution 😄 
