### PR TITLE
Update link to point to UI Builder page

### DIFF
--- a/12/umbraco-ui-builder/getting-started/licensing-model.md
+++ b/12/umbraco-ui-builder/getting-started/licensing-model.md
@@ -45,7 +45,7 @@ This is an add-on domain for existing licenses. Refunds will not be given for th
 
 ## Configuring your license
 
-You can purchase a license via the [Umbraco UI Builder]([https://umbraco.com/products/umbraco-commerce/](https://umbraco.com/products/add-ons/ui-builder) project page. A member of the [Sales team](mailto:suits@umbraco.com) will manage this process. In the process, you will need to provide all domains you wish to have covered by the license such as primary and staging/qa domains. You should then receive a license code to be installed in your solution.
+You can purchase a license via the [Umbraco UI Builder]([https://umbraco.com/products/umbraco-commerce/])(https://umbraco.com/products/add-ons/ui-builder) project page. A member of the [Sales team](mailto:suits@umbraco.com) will manage this process. In the process, you will need to provide all domains you wish to have covered by the license such as primary and staging/qa domains. You should then receive a license code to be installed in your solution.
 
 ### Add additional domains
 

--- a/12/umbraco-ui-builder/getting-started/licensing-model.md
+++ b/12/umbraco-ui-builder/getting-started/licensing-model.md
@@ -45,7 +45,7 @@ This is an add-on domain for existing licenses. Refunds will not be given for th
 
 ## Configuring your license
 
-You can purchase a license via the [Umbraco UI Builder]([https://umbraco.com/products/umbraco-commerce/])(https://umbraco.com/products/add-ons/ui-builder) project page. A member of the [Sales team](mailto:suits@umbraco.com) will manage this process. In the process, you will need to provide all domains you wish to have covered by the license such as primary and staging/qa domains. You should then receive a license code to be installed in your solution.
+You can purchase a license via the [Umbraco UI Builder](https://umbraco.com/products/add-ons/ui-builder) project page. A member of the [Sales team](mailto:suits@umbraco.com) will manage this process. In the process, you will need to provide all domains you wish to have covered by the license such as primary and staging/qa domains. You should then receive a license code to be installed in your solution.
 
 ### Add additional domains
 

--- a/12/umbraco-ui-builder/getting-started/licensing-model.md
+++ b/12/umbraco-ui-builder/getting-started/licensing-model.md
@@ -45,7 +45,7 @@ This is an add-on domain for existing licenses. Refunds will not be given for th
 
 ## Configuring your license
 
-You can purchase a license via the [Umbraco UI Builder](https://umbraco.com/products/umbraco-commerce/) project page. A member of the [Sales team](mailto:suits@umbraco.com) will manage this process. In the process, you will need to provide all domains you wish to have covered by the license such as primary and staging/qa domains. You should then receive a license code to be installed in your solution.
+You can purchase a license via the [Umbraco UI Builder]([https://umbraco.com/products/umbraco-commerce/](https://umbraco.com/products/add-ons/ui-builder) project page. A member of the [Sales team](mailto:suits@umbraco.com) will manage this process. In the process, you will need to provide all domains you wish to have covered by the license such as primary and staging/qa domains. You should then receive a license code to be installed in your solution.
 
 ### Add additional domains
 


### PR DESCRIPTION
The link was pointing to the Commerce page instead of UI Builder.

## Description

Update the link to point to the correct page

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

