### PR TITLE
Added release notes for Deploy 10.2.7, 11.1.7, 12.0.5.

### DIFF
--- a/10/umbraco-deploy/release-notes.md
+++ b/10/umbraco-deploy/release-notes.md
@@ -20,6 +20,10 @@ Under each major version, you can find details about minor and patch releases fo
 
 <summary>Version 10</summary>
 
+#### [10.2.7](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.7) (November 14th 2023)
+
+* Fixed action menu for queue for transfer with list view [#185](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/185).
+
 #### [10.2.6](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.6) (October 17th 2023)
 
 * Fixed issue with deployment of content when scheduled for a future release date.

--- a/11/umbraco-deploy/release-notes.md
+++ b/11/umbraco-deploy/release-notes.md
@@ -20,7 +20,7 @@ Under each major version, you can find details about minor and patch releases fo
 
 <summary>Version 11</summary>
 
-[**11.1.6**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.7) (**November 14th 2023**)
+[**11.1.7**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.1.7) (**November 14th 2023**)
 
 * Fixed action menu for queue for transfer with list view [#185](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/185).
 

--- a/11/umbraco-deploy/release-notes.md
+++ b/11/umbraco-deploy/release-notes.md
@@ -20,6 +20,10 @@ Under each major version, you can find details about minor and patch releases fo
 
 <summary>Version 11</summary>
 
+[**11.1.6**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.7) (**November 14th 2023**)
+
+* Fixed action menu for queue for transfer with list view [#185](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/185).
+
 [**11.1.6**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.1.6) **(October 17th 2023)**
 
 * Fixed issue with deployment of content when scheduled for a future release date.
@@ -106,6 +110,10 @@ Under each major version, you can find details about minor and patch releases fo
 <details>
 
 <summary>Version 10</summary>
+
+[**10.2.7**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.7) (**November 14th 2023**)
+
+* Fixed action menu for queue for transfer with list view [#185](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/185).
 
 [**10.2.6**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.6) **(October 17th 2023)**
 

--- a/12/umbraco-deploy/release-notes.md
+++ b/12/umbraco-deploy/release-notes.md
@@ -20,6 +20,11 @@ Under each major version, you can find details about minor and patch releases fo
 
 <summary>Version 12</summary>
 
+[**12.0.5**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.0.5) (**November 14th 2023**)
+
+* Fixed action menu for queue for transfer with list view [#185](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/185).
+* Omitted automatic relations from packages from default relations included in Deploy operations.
+
 [**12.0.4**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.0.4) **(October 17th 2023)**
 
 * Fixed issue with deployment of content when scheduled for a future release date.
@@ -63,6 +68,10 @@ Under each major version, you can find details about minor and patch releases fo
 <details>
 
 <summary>Version 11</summary>
+
+[**11.1.7**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.1.7) (**November 14th 2023**)
+
+* Fixed action menu for queue for transfer with list view [#185](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/185).
 
 [**11.1.6**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.1.6) **(October 17th 2023)**
 
@@ -150,6 +159,10 @@ Under each major version, you can find details about minor and patch releases fo
 <details>
 
 <summary>Version 10</summary>
+
+[**10.2.7**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.7) (**November 14th 2023**)
+
+* Fixed action menu for queue for transfer with list view [#185](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/185).
 
 [**10.2.6**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.6) **(October 17th 2023)**
 

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -32,6 +32,11 @@ Under each major version, you can find details about minor and patch releases fo
 
 <summary>Version 12</summary>
 
+[**12.0.5**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.0.5) (**November 14th 2023**)
+
+* Fixed action menu for queue for transfer with list view [#185](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/185).
+* Omitted automatic relations from packages from default relations included in Deploy operations.
+
 [**12.0.4**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.0.4) **(October 17th 2023)**
 
 * Fixed issue with deployment of content when scheduled for a future release date.
@@ -75,6 +80,10 @@ Under each major version, you can find details about minor and patch releases fo
 <details>
 
 <summary>Version 11</summary>
+
+[**11.1.7**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.1.7) (**November 14th 2023**)
+
+* Fixed action menu for queue for transfer with list view [#185](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/185).
 
 [**11.1.6**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F11.1.6) **(October 17th 2023)**
 
@@ -162,6 +171,10 @@ Under each major version, you can find details about minor and patch releases fo
 <details>
 
 <summary>Version 10</summary>
+
+[**10.2.7**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.7) (**November 14th 2023**)
+
+* Fixed action menu for queue for transfer with list view [#185](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/185).
 
 [**10.2.6**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.6) **(October 17th 2023)**
 


### PR DESCRIPTION
## Description

Added release notes for Deploy 10.2.7, 11.1.7, 12.0.5.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [X] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Deploy 10.2.7, 11.1.7, 12.0.5.

## Deadline (if relevant)

Today or tomorrow if possible please so we can link to them from the status page.
