### PR TITLE
Ignore rewrite of Smidge Bundle assets

### DIFF
--- a/12/umbraco-cms/reference/routing/iisrewriterules.md
+++ b/12/umbraco-cms/reference/routing/iisrewriterules.md
@@ -30,6 +30,7 @@ To use rewrites with Umbraco 9 you have to register the middleware in your `Star
         <add input="{HTTP_HOST}" pattern="\.umbraco\.io$" />
         <add input="{REQUEST_URI}" pattern="^/App_Plugins/" negate="true" />
         <add input="{REQUEST_URI}" pattern="^/umbraco" negate="true" />
+        <add input="{REQUEST_URI}" pattern="^/sb" negate="true" /> <!-- Don't redirect Smidge Bundle -->
       </conditions>
       <action type="Redirect" url="https://example.com/{R:0}" />
     </rule>


### PR DESCRIPTION
## Description

The recommended redirect rule for project Umbraco Cloud domain caused some font icons missing and different fonts due to rewrite of backoffice CSS, which caused the relative URL's to fonts to load from redirected domain and not requested domain. This caused CORS errors and thus the fonts wasn't loaded in backoffice.



## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [x] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
