### PR TITLE
Color Picker - add explicit comment defining "Color" property

### DIFF
--- a/10/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/color-picker.md
+++ b/10/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/color-picker.md
@@ -22,6 +22,7 @@ It's possible to add a label to use with the color.
 
 ```csharp
 @{
+    // Model has a property called "Color" which holds a Color Picker editor
     var hexColor = Model.Color;
     // Define the label if you've included it
     String colorLabel = Model.Color.Label;
@@ -38,6 +39,7 @@ It's possible to add a label to use with the color.
 ```csharp
 @using Umbraco.Cms.Core.PropertyEditors.ValueConverters
 @{
+    // Model has a property called "Color" which holds a Color Picker editor
     var hexColor = Model.Value("Color");
     // Define the label if you've included it
     var colorLabel = Model.Value<ColorPickerValueConverter.PickedColor>("Color").Label;

--- a/11/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/color-picker.md
+++ b/11/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/color-picker.md
@@ -22,6 +22,7 @@ It's possible to add a label to use with the color.
 
 ```csharp
 @{
+    // Model has a property called "Color" which holds a Color Picker editor
     var hexColor = Model.Color;
     // Define the label if you've included it
     String colorLabel = Model.Color.Label;
@@ -38,6 +39,7 @@ It's possible to add a label to use with the color.
 ```csharp
 @using Umbraco.Cms.Core.PropertyEditors.ValueConverters
 @{
+    // Model has a property called "Color" which holds a Color Picker editor
     var hexColor = Model.Value("Color");
     // Define the label if you've included it
     var colorLabel = Model.Value<ColorPickerValueConverter.PickedColor>("Color").Label;

--- a/12/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/color-picker.md
+++ b/12/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/color-picker.md
@@ -22,6 +22,7 @@ It's possible to add a label to use with the color.
 
 ```csharp
 @{
+    // Model has a property called "Color" which holds a Color Picker editor
     var hexColor = Model.Color;
     // Define the label if you've included it
     String colorLabel = Model.Color.Label;
@@ -38,6 +39,7 @@ It's possible to add a label to use with the color.
 ```csharp
 @using Umbraco.Cms.Core.PropertyEditors.ValueConverters
 @{
+    // Model has a property called "Color" which holds a Color Picker editor
     var hexColor = Model.Value("Color");
     // Define the label if you've included it
     var colorLabel = Model.Value<ColorPickerValueConverter.PickedColor>("Color").Label;


### PR DESCRIPTION
## Description

In Color Picker docs I'd suggest adding an explicit comment specifying that "Color" is a user-created property on the model.

Other editor examples use naming such as "myColorPicker" (example - [Toggle](https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/true-false) uses "myCheckBox") to imply that the property was created by the user. This naming schema might also be more appropriate to use.

In my opinion the problem with just having Model.Color is that "Color" is quite generic, so it might not be obvious that there's the prerequisite steps of creating the property called "Color".

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [x] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
10-12


## Deadline (if relevant)
N/A, just a suggestion