### PR TITLE
Update README.md

### DIFF
--- a/13/umbraco-cms/fundamentals/setup/upgrading/README.md
+++ b/13/umbraco-cms/fundamentals/setup/upgrading/README.md
@@ -102,7 +102,7 @@ Add a package reference to your project by executing the `dotnet add package Umb
 Run `dotnet restore` to install the package.
 
 {% hint style="warning" %}
-If you are using SQL CE in your project you will need to run `dotnet add package Umbraco.Cms.SqlCe --version <VERSION>` too before running the `dotnet restore` command.
+If you are using SQL CE in your project you will need to run `dotnet add package Umbraco.Cms.Persistence.Sqlite --version <VERSION>` too before running the `dotnet restore` command.
 {% endhint %}
 
 When the command completes, open the **.csproj** file to make sure the package reference was updated:


### PR DESCRIPTION
Latest version of Umbraco.Cms.SqlCe is 9.5.4. to get Umbraco 13.0.1 to work I had to use Umbraco.Cms.Persistence.Sqlite instead.

Another thing unrelated, I had to include Umbraco.Cms.Core in the project when nuget restoring, as I got some errors when not included.

## Description

updated a package reference

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

