### PR TITLE
Remove non breaking change

### DIFF
--- a/13/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
+++ b/13/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
@@ -19,7 +19,7 @@ Use the [general upgrade guide](../) to complete the upgrade of your project.
 
 <summary>Umbraco 13</summary>
 
-Below you can find the list of breaking changes introduced in Umbraco 13 Release Candidate. The list will be updated if more breaking changes are introduced the further we get to the final release of Umbraco 13.
+Below you can find the list of breaking changes introduced in Umbraco 13. 
 
 * [Use ISO codes instead of language IDs for fallback languages and translations](https://github.com/umbraco/Umbraco-CMS/issues/13751)
 * [Breaking changes for the Delivery API](https://github.com/umbraco/Umbraco-CMS/issues/14745)
@@ -31,7 +31,6 @@ Below you can find the list of breaking changes introduced in Umbraco 13 Release
 * [Updates and support for re-use of CMS logic in Deploy](https://github.com/umbraco/Umbraco-CMS/issues/14990)
 * [Dont explicitly index nested property by default](https://github.com/umbraco/Umbraco-CMS/issues/15028)
 * [Blocks in the Rich Text Editor](https://github.com/umbraco/Umbraco-CMS/issues/15029)
-* [Fix FurthestAncestorOrSelfDynamicRootQueryStep and FurthestDescendantOrSelfDynamicRootQueryStep](https://github.com/umbraco/Umbraco-CMS/issues/15113)
 * [Remove parameter value/return nullability in \`IImageSourceParser\`, \`ILocalLinkParser\` and \`IMacroParser\`](https://github.com/umbraco/Umbraco-CMS/issues/15130)
 * [Update PackageMigrationsPlans collection to be Weighted and not Lazy](https://github.com/umbraco/Umbraco-CMS/issues/15138)
 * &#x20;[Move IContextCache parameter to base Deploy interfaces and add checksum to artifact dependency](https://github.com/umbraco/Umbraco-CMS/issues/15144)


### PR DESCRIPTION
## Description

In the Umbraco 13 documentation, there is still mention of the release candidate. I think this can now be changed to Umbraco 13? I also removed an item from the list because it is not a breaking change when upgrading from v12 to 13 (only from Umbraco 13 rc1 to 13 rc2). Maybe the list needs further adjustments?

https://docs.umbraco.com/umbraco-cms/fundamentals/setup/upgrading/version-specific#umbraco-13

See also comments in https://github.com/umbraco/Umbraco-CMS/pull/15113#issuecomment-1862681128

## Type of suggestion

* [x] Updated outdated content


## Product & version (if relevant)
Umbraco CMS
