### PR TITLE
Correct installer syntax

### DIFF
--- a/13/umbraco-cms/fundamentals/setup/install/install-umbraco-with-templates.md
+++ b/13/umbraco-cms/fundamentals/setup/install/install-umbraco-with-templates.md
@@ -11,7 +11,7 @@ Video Tutorial
 ## Install the template
 
 1. Install the latest [.NET SDK](https://dotnet.microsoft.com/download).
-2. Run `dotnet new install Umbraco.Templates` to install the project templates.\
+2. Run `dotnet new --install Umbraco.Templates` to install the project templates.\
    _The solution is packaged up into the NuGet package_ [_Umbraco.Templates_](https://www.nuget.org/packages/Umbraco.Templates) _and can be installed into the dotnet CLI_.
 
 > Once that is complete, you can see that Umbraco was added to the list of available projects types by running `dotnet new --list`:


### PR DESCRIPTION
## Description

The switch should be `--install`. Using just `install` as the docs currently say results in "Error: Invalid option(s):  Umbraco.Templates"

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

