### PR TITLE
Added release notes for Deploy 4.9.2, 10.3.2, 12.1.2, 13.0.2.

### DIFF
--- a/10/umbraco-deploy/deploy-settings.md
+++ b/10/umbraco-deploy/deploy-settings.md
@@ -260,7 +260,7 @@ By upgrading to the most recent available version of the CMS major you are runni
 
 ### Deployment of culture & hostnames settings
 
-Culture and hostname settings, defined per content item for culture invariant content, are not deployed between environments by default but can be opted into via configuration.
+Culture and hostname settings, defined per content item for culture invariant content, are not deployed between environments by default. They can be opted into via configuration.
 
 ```json
     "AllowDomainsDeploymentOperations": "None|Culture|AbsolutePath|Hostname|All",

--- a/10/umbraco-deploy/deploy-settings.md
+++ b/10/umbraco-deploy/deploy-settings.md
@@ -59,6 +59,7 @@ For illustration purposes, the following structure represents the full set of op
             "ReloadMemoryCacheFollowingDiskReadOperation": false,
             "AllowDomainsDeploymentOperations": "None",
             "AllowPublicAccessDeploymentOperations": "AddOrUpdate",
+            "TrashedContentDeploymentOperations": "Import",
             "PreferLocalDbConnectionString": false,
             "NumberOfSignaturesToUseAllRelationCache": 100,
             "ContinueOnMediaFilePathTooLongException": false,
@@ -257,7 +258,7 @@ Some customers have reported intermittent issues related to Umbraco's memory cac
 
 By upgrading to the most recent available version of the CMS major you are running, you'll be able to benefit from the latest bug fixes and optimizations in this area. That should be your first option if encountering cache related issues. Failing that, or if a CMS upgrade is not an option, then this workaround can be considered.
 
-## Deployment of culture & hostnames settings
+### Deployment of culture & hostnames settings
 
 Culture and hostname settings, defined per content item for culture invariant content, are not deployed between environments by default but can be opted into via configuration.
 
@@ -267,9 +268,9 @@ Culture and hostname settings, defined per content item for culture invariant co
 
 To enable this, set the configuration value as appropriate for the types of domains you want to allow:
 
-* _Culture_ - the language setting for the content, defined under "Culture"
-* _AbsolutePath_ - values defined under "Domains" with an absolute path, e.g. "/en"
-* _Hostname_ - values defined under "Domains" with a full host name, e.g. "en.mysite.com"
+* `Culture` - the language setting for the content, defined under "Culture"
+* `AbsolutePath` - values defined under "Domains" with an absolute path, e.g. "/en"
+* `Hostname` - values defined under "Domains" with a full host name, e.g. "en.mysite.com"
 
 Combinations of settings can be applied, e.g. `Hostname,AbsolutePath`.
 
@@ -281,12 +282,27 @@ When deploying content items, public access rules based on member groups are tra
     "AllowPublicAccessDeploymentOperations": "None|AddOrUpdate|Remove|All",
 ```
 
-* _None_ - no public access rules will be transferred</li>
-* _AddOrUpdate_ - public access rules added or updated in a source environment will be transferred to the destination</li>
-* _Remove_ - public access rules removed a source environment will be removed in the destination</li>
-* _All_ - all public access information will be transferred</li>
+* `None` - no public access rules will be transferred</li>
+* `AddOrUpdate` - public access rules added or updated in a source environment will be transferred to the destination</li>
+* `Remove` - public access rules removed a source environment will be removed in the destination</li>
+* `All` - all public access information will be transferred</li>
 
 `AddOrUpdate` is the default setting used if no value is configured.
+
+## Deployment of trashed content
+
+Specifies options for handling trashed content (documents, media and members) on export or import:
+
+```json
+"TrashedContentDeploymentOperations": "None|Export|Import|All"
+```
+
+You can amend this behavior using this setting:
+
+* `None` - trashed content will not be exported or imported
+* `Export` - trashed content will be included in an export
+* `Import` - trashed content will be processed and moved to the recycle bin on import
+* `All` - trashed content will be included in an export, processed and moved to the recycle bin on import
 
 ## PreferLocalDbConnectionString
 

--- a/10/umbraco-deploy/release-notes.md
+++ b/10/umbraco-deploy/release-notes.md
@@ -20,15 +20,33 @@ Under each major version, you can find details about minor and patch releases fo
 
 <summary>Version 10</summary>
 
-[**10.3.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.0) **(December 11th  2023)**
+[**10.3.2**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.2) **(January 9th 2023)**
+
+* Fixed issue with transfer of content using language variants [#193](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/193)
+
+[**10.3.1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.1) **(December 21th 2023)**
+
+* Fixes the display of the selected schedule date on queue for transfer.
+* Fixes parsing property values within Nested Content and Block List that were previously saved by the Contrib value connectors.
+* Fixed incorrectly including media files in export when 'Content files' wasn't selected.
+* Add maximum file size validation to import file upload.
+
+[**10.3.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.0) **(December 11th 2023)**
 
 * All items from 10.3.0-rc1.
+* Fixed a regression in 10.3.0-rc1 where content restore/transfers didn't use the same JSON converters when deserializing Deploy artifacts.
+* Fixed permissions not being correctly set for administrators on initial install.
+* Moved permissions from the Content to a new Deploy category (only affecting the UI).
+* Add support for migrating property values within Nested Content, Block List and Block Grid, and include Multi URL Picker value connector (an explicit value connector binding is used to override the ones provided in Deploy Contrib).
+* Added new configuration option of `TrashedContentDeploymentOperations` to allow exporting/importing of trashed content, ensuring referenced content in the recycle bin isn't exported by default and otherwise imports back into the recycle bin.
+* Changed the default value connector to use the property storage type, instead of using custom value prefixes to store the object type.
 
 [**10.3.0-rc1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.0) **(November 27th 2023)**
 
 * Added feature of [content import and export with migrations](./deployment-workflow/import-export.md).
 * Added a new configuration option of `ResolveUserInTargetEnvironment` to allow resolving of user accounts in target environments (see [Deploy Settings](./deploy-settings.md)).
 * Added a new configuration option of `AllowPublicAccessDeploymentOperations` to amend the behavior of public access rule transfer (see [Deploy Settings](./deploy-settings.md)).
+* Improve performance of publishing multi-language content during restore/transfer and import.
 
 [**10.2.7**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.7) (**November 14th 2023**)
 
@@ -295,6 +313,17 @@ Under each major version, you can find details about minor and patch releases fo
 <details>
 
 <summary>Version 4</summary>
+
+[**4.9.2**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.9.2) **(January 9th 2023)**
+
+* Fixed issue with transfer of content using language variants [#193](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/193)
+
+[**4.9.1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.9.1) **(December 21th  2023)**
+
+* Fixes the display of the selected schedule date on queue for transfer.
+* Fixes parsing property values within Nested Content and Block List that were previously saved by the Contrib value connectors.
+* Fixed incorrectly including media files in export when 'Content files' wasn't selected.
+* Add maximum file size validation to import file upload.
 
 [**4.9.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.9.0) **(December 11th  2023)**
 

--- a/11/umbraco-deploy/release-notes.md
+++ b/11/umbraco-deploy/release-notes.md
@@ -111,15 +111,33 @@ Under each major version, you can find details about minor and patch releases fo
 
 <summary>Version 10</summary>
 
-[**10.3.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.0) **(December 11th  2023)**
+[**10.3.2**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.2) **(January 9th 2023)**
+
+* Fixed issue with transfer of content using language variants [#193](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/193)
+
+[**10.3.1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.1) **(December 21th 2023)**
+
+* Fixes the display of the selected schedule date on queue for transfer.
+* Fixes parsing property values within Nested Content and Block List that were previously saved by the Contrib value connectors.
+* Fixed incorrectly including media files in export when 'Content files' wasn't selected.
+* Add maximum file size validation to import file upload.
+
+[**10.3.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.0) **(December 11th 2023)**
 
 * All items from 10.3.0-rc1.
+* Fixed a regression in 10.3.0-rc1 where content restore/transfers didn't use the same JSON converters when deserializing Deploy artifacts.
+* Fixed permissions not being correctly set for administrators on initial install.
+* Moved permissions from the Content to a new Deploy category (only affecting the UI).
+* Add support for migrating property values within Nested Content, Block List and Block Grid, and include Multi URL Picker value connector (an explicit value connector binding is used to override the ones provided in Deploy Contrib).
+* Added new configuration option of `TrashedContentDeploymentOperations` to allow exporting/importing of trashed content, ensuring referenced content in the recycle bin isn't exported by default and otherwise imports back into the recycle bin.
+* Changed the default value connector to use the property storage type, instead of using custom value prefixes to store the object type.
 
 [**10.3.0-rc1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.0) **(November 27th 2023)**
 
 * Added feature of [content import and export with migrations](./deployment-workflow/import-export.md).
 * Added a new configuration option of `ResolveUserInTargetEnvironment` to allow resolving of user accounts in target environments (see [Deploy Settings](./deploy-settings.md)).
 * Added a new configuration option of `AllowPublicAccessDeploymentOperations` to amend the behavior of public access rule transfer (see [Deploy Settings](./deploy-settings.md)).
+* Improve performance of publishing multi-language content during restore/transfer and import.
 
 [**10.2.7**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.7) (**November 14th 2023**)
 
@@ -387,6 +405,17 @@ Under each major version, you can find details about minor and patch releases fo
 <details>
 
 <summary>Version 4</summary>
+
+[**4.9.2**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.9.2) **(January 9th 2023)**
+
+* Fixed issue with transfer of content using language variants [#193](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/193)
+
+[**4.9.1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.9.1) **(December 21th  2023)**
+
+* Fixes the display of the selected schedule date on queue for transfer.
+* Fixes parsing property values within Nested Content and Block List that were previously saved by the Contrib value connectors.
+* Fixed incorrectly including media files in export when 'Content files' wasn't selected.
+* Add maximum file size validation to import file upload.
 
 [**4.9.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.9.0) **(December 11th  2023)**
 

--- a/12/umbraco-deploy/deploy-settings.md
+++ b/12/umbraco-deploy/deploy-settings.md
@@ -296,7 +296,7 @@ Combinations of settings can be applied, e.g. `Hostname,AbsolutePath`.
 
 ### Deployment of culture & hostnames settings
 
-Culture and hostname settings, defined per content item for culture invariant content, are not deployed between environments by default but can be opted into via configuration.
+Culture and hostname settings, defined per content item for culture invariant content, are not deployed between environments by default. They can be opted into via configuration.
 
 ```json
     "AllowDomainsDeploymentOperations": "None|Culture|AbsolutePath|Hostname|All",

--- a/12/umbraco-deploy/deploy-settings.md
+++ b/12/umbraco-deploy/deploy-settings.md
@@ -61,6 +61,7 @@ For illustration purposes, the following structure represents the full set of op
             "ReloadMemoryCacheFollowingDiskReadOperation": false,
             "AllowDomainsDeploymentOperations": "None",
             "AllowPublicAccessDeploymentOperations": "AddOrUpdate",
+            "TrashedContentDeploymentOperations": "Import",
             "PreferLocalDbConnectionString": false,
             "MediaFileChecksumCalculationMethod": "PartialFileContents",
             "NumberOfSignaturesToUseAllRelationCache": 100,
@@ -293,6 +294,22 @@ To enable this, set the configuration value as appropriate for the types of doma
 
 Combinations of settings can be applied, e.g. `Hostname,AbsolutePath`.
 
+### Deployment of culture & hostnames settings
+
+Culture and hostname settings, defined per content item for culture invariant content, are not deployed between environments by default but can be opted into via configuration.
+
+```json
+    "AllowDomainsDeploymentOperations": "None|Culture|AbsolutePath|Hostname|All",
+```
+
+To enable this, set the configuration value as appropriate for the types of domains you want to allow:
+
+* `Culture` - the language setting for the content, defined under "Culture"
+* `AbsolutePath` - values defined under "Domains" with an absolute path, e.g. "/en"
+* `Hostname` - values defined under "Domains" with a full host name, e.g. "en.mysite.com"
+
+Combinations of settings can be applied, e.g. `Hostname,AbsolutePath`.
+
 ## Deployment of public access settings
 
 When deploying content items, public access rules based on member groups are transferred. You can amend this behavior using this setting.
@@ -301,12 +318,27 @@ When deploying content items, public access rules based on member groups are tra
     "AllowPublicAccessDeploymentOperations": "None|AddOrUpdate|Remove|All",
 ```
 
-* _None_ - no public access rules will be transferred</li>
-* _AddOrUpdate_ - public access rules added or updated in a source environment will be transferred to the destination</li>
-* _Remove_ - public access rules removed a source environment will be removed in the destination</li>
-* _All_ - all public access information will be transferred</li>
+* `None` - no public access rules will be transferred</li>
+* `AddOrUpdate` - public access rules added or updated in a source environment will be transferred to the destination</li>
+* `Remove` - public access rules removed a source environment will be removed in the destination</li>
+* `All` - all public access information will be transferred</li>
 
 `AddOrUpdate` is the default setting used if no value is configured.
+
+## Deployment of trashed content
+
+Specifies options for handling trashed content (documents, media and members) on export or import:
+
+```json
+"TrashedContentDeploymentOperations": "None|Export|Import|All"
+```
+
+You can amend this behavior using this setting:
+
+* `None` - trashed content will not be exported or imported
+* `Export` - trashed content will be included in an export
+* `Import` - trashed content will be processed and moved to the recycle bin on import
+* `All` - trashed content will be included in an export, processed and moved to the recycle bin on import
 
 ## PreferLocalDbConnectionString
 

--- a/12/umbraco-deploy/release-notes.md
+++ b/12/umbraco-deploy/release-notes.md
@@ -20,15 +20,33 @@ Under each major version, you can find details about minor and patch releases fo
 
 <summary>Version 12</summary>
 
-[**12.1.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.1.0) **(December 11th  2023)**
+[**12.2.2**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.2.2) **(January 9th 2023)**
+
+* Fixed issue with transfer of content using language variants [#193](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/193)
+
+[**12.2.1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.2.1) **(December 21th 2023)**
+
+* Fixes the display of the selected schedule date on queue for transfer.
+* Fixes parsing property values within Nested Content and Block List that were previously saved by the Contrib value connectors.
+* Fixed incorrectly including media files in export when 'Content files' wasn't selected.
+* Add maximum file size validation to import file upload.
+
+[**12.1.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.1.0) **(December 11th 2023)**
 
 * All items from 12.1.0-rc1.
+* Fixed a regression in 12.1.0-rc1 where content restore/transfers didn't use the same JSON converters when deserializing Deploy artifacts.
+* Fixed permissions not being correctly set for administrators on initial install.
+* Moved permissions from the Content to a new Deploy category (only affecting the UI).
+* Add support for migrating property values within Nested Content, Block List and Block Grid, and include Multi URL Picker value connector (an explicit value connector binding is used to override the ones provided in Deploy Contrib).
+* Added new configuration option of `TrashedContentDeploymentOperations` to allow exporting/importing of trashed content, ensuring referenced content in the recycle bin isn't exported by default and otherwise imports back into the recycle bin.
+* Changed the default value connector to use the property storage type, instead of using custom value prefixes to store the object type.
 
-[**12.1.0-rc1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.1.0) **(November 27th  2023)**
+[**12.1.0-rc1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.1.0) **(November 27th 2023)**
 
 * Added feature of [content import and export with migrations](./deployment-workflow/import-export.md).
 * Added a new configuration option of `ResolveUserInTargetEnvironment` to allow resolving of user accounts in target environments (see [Deploy Settings](./deploy-settings.md)).
 * Added a new configuration option of `AllowPublicAccessDeploymentOperations` to amend the behavior of public access rule transfer (see [Deploy Settings](./deploy-settings.md)).
+* Improve performance of publishing multi-language content during restore/transfer and import.
 
 [**12.0.5**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.0.5) (**November 14th 2023**)
 
@@ -170,15 +188,33 @@ Under each major version, you can find details about minor and patch releases fo
 
 <summary>Version 10</summary>
 
-[**10.3.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.0) **(December 11th  2023)**
+[**10.3.2**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.2) **(January 9th 2023)**
+
+* Fixed issue with transfer of content using language variants [#193](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/193)
+
+[**10.3.1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.1) **(December 21th 2023)**
+
+* Fixes the display of the selected schedule date on queue for transfer.
+* Fixes parsing property values within Nested Content and Block List that were previously saved by the Contrib value connectors.
+* Fixed incorrectly including media files in export when 'Content files' wasn't selected.
+* Add maximum file size validation to import file upload.
+
+[**10.3.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.0) **(December 11th 2023)**
 
 * All items from 10.3.0-rc1.
+* Fixed a regression in 10.3.0-rc1 where content restore/transfers didn't use the same JSON converters when deserializing Deploy artifacts.
+* Fixed permissions not being correctly set for administrators on initial install.
+* Moved permissions from the Content to a new Deploy category (only affecting the UI).
+* Add support for migrating property values within Nested Content, Block List and Block Grid, and include Multi URL Picker value connector (an explicit value connector binding is used to override the ones provided in Deploy Contrib).
+* Added new configuration option of `TrashedContentDeploymentOperations` to allow exporting/importing of trashed content, ensuring referenced content in the recycle bin isn't exported by default and otherwise imports back into the recycle bin.
+* Changed the default value connector to use the property storage type, instead of using custom value prefixes to store the object type.
 
 [**10.3.0-rc1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.0) **(November 27th 2023)**
 
 * Added feature of [content import and export with migrations](./deployment-workflow/import-export.md).
 * Added a new configuration option of `ResolveUserInTargetEnvironment` to allow resolving of user accounts in target environments (see [Deploy Settings](./deploy-settings.md)).
 * Added a new configuration option of `AllowPublicAccessDeploymentOperations` to amend the behavior of public access rule transfer (see [Deploy Settings](./deploy-settings.md)).
+* Improve performance of publishing multi-language content during restore/transfer and import.
 
 [**10.2.7**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.7) (**November 14th 2023**)
 
@@ -442,6 +478,17 @@ Under each major version, you can find details about minor and patch releases fo
 <details>
 
 <summary>Version 4</summary>
+
+[**4.9.2**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.9.2) **(January 9th 2023)**
+
+* Fixed issue with transfer of content using language variants [#193](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/193)
+
+[**4.9.1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.9.1) **(December 21th  2023)**
+
+* Fixes the display of the selected schedule date on queue for transfer.
+* Fixes parsing property values within Nested Content and Block List that were previously saved by the Contrib value connectors.
+* Fixed incorrectly including media files in export when 'Content files' wasn't selected.
+* Add maximum file size validation to import file upload.
 
 [**4.9.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.9.0) **(December 11th  2023)**
 

--- a/13/umbraco-deploy/deploy-settings.md
+++ b/13/umbraco-deploy/deploy-settings.md
@@ -60,13 +60,14 @@ For illustration purposes, the following structure represents the full set of op
             "ExportMemberGroups": true,
             "ReloadMemoryCacheFollowingDiskReadOperation": false,
             "AllowDomainsDeploymentOperations": "None",
+            "AllowWebhooksDeploymentOperations": "None",
+            "TrashedContentDeploymentOperations": "Import",
             "PreferLocalDbConnectionString": false,
             "MediaFileChecksumCalculationMethod": "PartialFileContents",
             "NumberOfSignaturesToUseAllRelationCache": 100,
             "ContinueOnMediaFilePathTooLongException": false,
             "SuppressCacheRefresherNotifications": false,
-            "HideConfigurationDetails": false,
-            "AllowWebhooksDeploymentOperations": "None"
+            "HideConfigurationDetails": false
         }
     }
   }
@@ -281,11 +282,26 @@ Culture and hostname settings, defined per content item for culture invariant co
 
 To enable this, set the configuration value as appropriate for the types of domains you want to allow:
 
-* _Culture_ - the language setting for the content, defined under "Culture"
-* _AbsolutePath_ - values defined under "Domains" with an absolute path, e.g. "/en"
-* _Hostname_ - values defined under "Domains" with a full host name, e.g. "en.mysite.com"
+* `Culture` - the language setting for the content, defined under "Culture"
+* `AbsolutePath` - values defined under "Domains" with an absolute path, e.g. "/en"
+* `Hostname` - values defined under "Domains" with a full host name, e.g. "en.mysite.com"
 
 Combinations of settings can be applied, e.g. `Hostname,AbsolutePath`.
+
+## Deployment of public access settings
+
+When deploying content items, public access rules based on member groups are transferred. You can amend this behavior using this setting.
+
+```json
+    "AllowPublicAccessDeploymentOperations": "None|AddOrUpdate|Remove|All",
+```
+
+* `None` - no public access rules will be transferred</li>
+* `AddOrUpdate` - public access rules added or updated in a source environment will be transferred to the destination</li>
+* `Remove` - public access rules removed a source environment will be removed in the destination</li>
+* `All` - all public access information will be transferred</li>
+
+`AddOrUpdate` is the default setting used if no value is configured.
 
 ### Deployment of webhooks
 
@@ -297,8 +313,23 @@ Webhooks may be considered environment specific or schema information that you w
 
 If you would like you include them you can adjust this setting:
 
-* _None_ - webhooks are not deployed and are expected to be managed independently in each environment.
-* _All_ - webhooks included in schema deployments.
+* `None` - webhooks are not deployed and are expected to be managed independently in each environment.
+* `All` - webhooks included in schema deployments.
+
+## Deployment of trashed content
+
+Specifies options for handling trashed content (documents, media and members) on export or import:
+
+```json
+"TrashedContentDeploymentOperations": "None|Export|Import|All"
+```
+
+You can amend this behavior using this setting:
+
+* `None` - trashed content will not be exported or imported
+* `Export` - trashed content will be included in an export
+* `Import` - trashed content will be processed and moved to the recycle bin on import
+* `All` - trashed content will be included in an export, processed and moved to the recycle bin on import
 
 ### PreferLocalDbConnectionString
 

--- a/13/umbraco-deploy/deploy-settings.md
+++ b/13/umbraco-deploy/deploy-settings.md
@@ -274,7 +274,7 @@ By upgrading to the most recent available version of the CMS major you are runni
 
 ### Deployment of culture & hostnames settings
 
-Culture and hostname settings, defined per content item for culture invariant content, are not deployed between environments by default but can be opted into via configuration.
+Culture and hostname settings, defined per content item for culture invariant content, are not deployed between environments by default. They can be opted into via configuration.
 
 ```json
     "AllowDomainsDeploymentOperations": "None|Culture|AbsolutePath|Hostname|All",

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -20,17 +20,45 @@ Under each major version, you can find details about minor and patch releases fo
 
 <summary>Version 13</summary>
 
-[**13.0.0-rc3**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0)
-(November 28th 2023)
+[**13.0.2**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.2) **(January 9th 2023)**
+
+* Fixed issue with transfer of content using language variants [#193](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/193)
+
+[**13.0.1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.1) **(December 21th 2023)**
+
+* Fixes the display of the selected schedule date on queue for transfer.
+* Fixes parsing property values within Nested Content and Block List that were previously saved by the Contrib value connectors.
+* Fixed incorrectly including media files in export when 'Content files' wasn't selected.
+* Add maximum file size validation to import file upload.
+
+[**13.0.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) **(December 14th 2023)**
+
+* All items from the 13.0.0 RCs and latest 12.2 features.
+
+[**13.0.0-rc5**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) **(December 12th 2023)**
+
+* Align with latest CMS RC.
+
+[**13.0.0-rc4**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) **(December 11th 2023)**
+
+* Add weight -100 to Deploy package migration (ensuring Deploy database tables are available before other package migrations are executed).
+* Add fluent API for Deploy webhooks.
+
+[**13.0.0-rc3**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) **(November 29th 2023)**
 
 * Added optional deployment of webhooks as part of schema updates.
 * Added Deploy specific webhook events.
 
-[**13.0.0-rc1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0)
-(November 6th 2023)
+[**13.0.0-rc2**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) **(November 15th 2023)**
 
-* Compatibility with Umbraco 13
+* Exclude automatic relation type aliases (used for reference tracking) from deployment.
+* Fix cyclic dependency between configuring `DeploySettings` and `ConnectionStrings`.
+
+[**13.0.0-rc1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) **(November 6th 2023)**
+
+* Compatibility with Umbraco 13:
   * See full details of breaking changes under the [version specific upgrade guide](upgrades/version-specific.md).
+  * Update Richtext value connector to handle references in blocks.
 
 </details>
 
@@ -38,15 +66,33 @@ Under each major version, you can find details about minor and patch releases fo
 
 <summary>Version 12</summary>
 
-[**12.1.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.1.0) **(December 11th  2023)**
+[**12.2.2**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.2.2) **(January 9th 2023)**
+
+* Fixed issue with transfer of content using language variants [#193](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/193)
+
+[**12.2.1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.2.1) **(December 21th 2023)**
+
+* Fixes the display of the selected schedule date on queue for transfer.
+* Fixes parsing property values within Nested Content and Block List that were previously saved by the Contrib value connectors.
+* Fixed incorrectly including media files in export when 'Content files' wasn't selected.
+* Add maximum file size validation to import file upload.
+
+[**12.1.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.1.0) **(December 11th 2023)**
 
 * All items from 12.1.0-rc1.
+* Fixed a regression in 12.1.0-rc1 where content restore/transfers didn't use the same JSON converters when deserializing Deploy artifacts.
+* Fixed permissions not being correctly set for administrators on initial install.
+* Moved permissions from the Content to a new Deploy category (only affecting the UI).
+* Add support for migrating property values within Nested Content, Block List and Block Grid, and include Multi URL Picker value connector (an explicit value connector binding is used to override the ones provided in Deploy Contrib).
+* Added new configuration option of `TrashedContentDeploymentOperations` to allow exporting/importing of trashed content, ensuring referenced content in the recycle bin isn't exported by default and otherwise imports back into the recycle bin.
+* Changed the default value connector to use the property storage type, instead of using custom value prefixes to store the object type.
 
-[**12.1.0-rc1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.1.0) **(November 27th  2023)**
+[**12.1.0-rc1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.1.0) **(November 27th 2023)**
 
 * Added feature of [content import and export with migrations](./deployment-workflow/import-export.md).
 * Added a new configuration option of `ResolveUserInTargetEnvironment` to allow resolving of user accounts in target environments (see [Deploy Settings](./deploy-settings.md)).
 * Added a new configuration option of `AllowPublicAccessDeploymentOperations` to amend the behavior of public access rule transfer (see [Deploy Settings](./deploy-settings.md)).
+* Improve performance of publishing multi-language content during restore/transfer and import.
 
 [**12.0.5**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.0.5) (**November 14th 2023**)
 
@@ -188,15 +234,33 @@ Under each major version, you can find details about minor and patch releases fo
 
 <summary>Version 10</summary>
 
-[**10.3.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.0) **(December 11th  2023)**
+[**10.3.2**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.2) **(January 9th 2023)**
+
+* Fixed issue with transfer of content using language variants [#193](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/193)
+
+[**10.3.1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.1) **(December 21th 2023)**
+
+* Fixes the display of the selected schedule date on queue for transfer.
+* Fixes parsing property values within Nested Content and Block List that were previously saved by the Contrib value connectors.
+* Fixed incorrectly including media files in export when 'Content files' wasn't selected.
+* Add maximum file size validation to import file upload.
+
+[**10.3.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.0) **(December 11th 2023)**
 
 * All items from 10.3.0-rc1.
+* Fixed a regression in 10.3.0-rc1 where content restore/transfers didn't use the same JSON converters when deserializing Deploy artifacts.
+* Fixed permissions not being correctly set for administrators on initial install.
+* Moved permissions from the Content to a new Deploy category (only affecting the UI).
+* Add support for migrating property values within Nested Content, Block List and Block Grid, and include Multi URL Picker value connector (an explicit value connector binding is used to override the ones provided in Deploy Contrib).
+* Added new configuration option of `TrashedContentDeploymentOperations` to allow exporting/importing of trashed content, ensuring referenced content in the recycle bin isn't exported by default and otherwise imports back into the recycle bin.
+* Changed the default value connector to use the property storage type, instead of using custom value prefixes to store the object type.
 
 [**10.3.0-rc1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.3.0) **(November 27th 2023)**
 
 * Added feature of [content import and export with migrations](./deployment-workflow/import-export.md).
 * Added a new configuration option of `ResolveUserInTargetEnvironment` to allow resolving of user accounts in target environments (see [Deploy Settings](./deploy-settings.md)).
 * Added a new configuration option of `AllowPublicAccessDeploymentOperations` to amend the behavior of public access rule transfer (see [Deploy Settings](./deploy-settings.md)).
+* Improve performance of publishing multi-language content during restore/transfer and import.
 
 [**10.2.7**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.2.7) (**November 14th 2023**)
 
@@ -461,9 +525,26 @@ Under each major version, you can find details about minor and patch releases fo
 
 <summary>Version 4</summary>
 
+[**4.9.2**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.9.2) **(January 9th 2023)**
+
+* Fixed issue with transfer of content using language variants [#193](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/193)
+
+[**4.9.1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.9.1) **(December 21th  2023)**
+
+* Fixes the display of the selected schedule date on queue for transfer.
+* Fixes parsing property values within Nested Content and Block List that were previously saved by the Contrib value connectors.
+* Fixed incorrectly including media files in export when 'Content files' wasn't selected.
+* Add maximum file size validation to import file upload.
+
 [**4.9.0**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.9.0) **(December 11th  2023)**
 
 * All items from 4.9.0-rc1.
+* Fixed a regression in 4.9.0-rc1 where content restore/transfers didn't use the same JSON converters when deserializing Deploy artifacts.
+* Fixed permissions not being correctly set for administrators on initial install.
+* Moved permissions from the Content to a new Deploy category (only affecting the UI).
+* Add support for migrating property values within Nested Content and Block List, and include Multi URL Picker value connector (an explicit value connector binding is used to override the ones provided in Deploy Contrib).
+* Added new configuration option of `TrashedContentDeploymentOperations` to allow exporting/importing of trashed content, ensuring referenced content in the recycle bin isn't exported by default and otherwise imports back into the recycle bin.
+* Changed the default value connector to use the property storage type, instead of using custom value prefixes to store the object type.
 
 [**4.9.0-rc1**](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.9.0) **(November 27th 2023)**
 


### PR DESCRIPTION
## Description

Added release notes for Deploy 4.9.2, 10.3.2, 12.1.2, 13.0.2.

Note that I've also copied over the essential changes from https://github.com/umbraco/UmbracoDocs/pull/5732, which contains release notes for the previous patch and isn't yet published as there are some unresolved comments.

Please can you merge this one first, and then what's remaining in the PR from Ronald can be picked up with him when he's back next week?

Note that for now at least I've continued with the existing pattern of copying release notes to all versions.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [X] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Deploy 4.9.2, 10.3.2, 12.1.2, 13.0.2.

## Deadline (if relevant)

Can go live at any time, ideally today or tomorrow please.
