### PR TITLE
Added details of Deploy settings included in recent versions of Deploy 4 (for Umbraco 8).

### DIFF
--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -281,10 +281,10 @@ When deploying content items, public access rules based on member groups are tra
 </settings>
 ```
 
-* `None` - no public access rules will be transferred</li>
-* `AddOrUpdate` - public access rules added or updated in a source environment will be transferred to the destination</li>
-* `Remove` - public access rules removed a source environment will be removed in the destination</li>
-* `All` - all public access information will be transferred</li>
+* `None` - no public access rules will be transferred
+* `AddOrUpdate` - public access rules added or updated in a source environment will be transferred to the destination
+* `Remove` - public access rules removed a source environment will be removed in the destination
+* `All` - all public access information will be transferred
 
 `AddOrUpdate` is the default setting used if no value is configured.
 

--- a/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
+++ b/Add-ons/Umbraco-Deploy/Deploy-Settings/index.md
@@ -258,17 +258,53 @@ Culture and hostname settings, defined per content item for culture invariant co
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <settings xmlns="urn:umbracodeploy-settings">
-    <deploy allowDomainsDeploymentOperations="None|Culture|Absolute|Hostname|All" />
+    <content allowDomainsDeploymentOperations="None|Culture|Absolute|Hostname|All" />
 </settings>
 ```
 
 To enable this, set the configuration value as appropriate for the types of domains you want to allow:
 
-- *Culture* - the language setting for the content, defined under "Culture"
-- *AbsolutePath* - values defined under "Domains" with an absolute path, e.g. "/en"
-- *Hostname* - values defined under "Domains" with a full host name, e.g. "en.mysite.com"
+- `Culture` - the language setting for the content, defined under "Culture"
+- `AbsolutePath` - values defined under "Domains" with an absolute path, e.g. "/en"
+- `Hostname` - values defined under "Domains" with a full host name, e.g. "en.mysite.com"
 
 Combinations of settings can be applied, e.g. `Hostname,AbsolutePath`.
+
+## Deployment of public access settings
+
+When deploying content items, public access rules based on member groups are transferred. You can amend this behavior using this setting.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<settings xmlns="urn:umbracodeploy-settings">
+    <content allowPublicAccessDeploymentOperations="None|AddOrUpdate|Remove|All" />
+</settings>
+```
+
+* `None` - no public access rules will be transferred</li>
+* `AddOrUpdate` - public access rules added or updated in a source environment will be transferred to the destination</li>
+* `Remove` - public access rules removed a source environment will be removed in the destination</li>
+* `All` - all public access information will be transferred</li>
+
+`AddOrUpdate` is the default setting used if no value is configured.
+
+## Deployment of trashed content
+
+Specifies options for handling trashed content (documents, media and members) on export or import:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<settings xmlns="urn:umbracodeploy-settings">
+    <content trashedContentDeploymentOperations="None|Export|Import|All" />
+</settings>
+```
+
+You can amend this behavior using this setting:
+
+* `None` - trashed content will not be exported or imported
+* `Export` - trashed content will be included in an export
+* `Import` - trashed content will be processed and moved to the recycle bin on import
+* `All` - trashed content will be included in an export, processed and moved to the recycle bin on import
 
 ## Media File Checksum Calculation Method
 


### PR DESCRIPTION
## Description

Added details of Deploy settings included in recent versions of Deploy 4 (for Umbraco 8).  This is for the legacy documentation hosted [at this page](https://our.umbraco.com/documentation/Add-ons/Umbraco-Deploy/Deploy-Settings/) on our.umbraco.com (the more recent versions have already been updated on docs.umbraco.com).

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [X] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Deploy 4

## Deadline (if relevant)

Can be published at any time.