### PR TITLE
docs (Typo) address grammar issues in github-actions.md

### DIFF
--- a/umbraco-cloud/set-up/project-settings/umbraco-cicd/samplecicdpipeline/github-actions.md
+++ b/umbraco-cloud/set-up/project-settings/umbraco-cicd/samplecicdpipeline/github-actions.md
@@ -90,7 +90,7 @@ Next up it setting up the actual pipeline.
 
 ### Allow GitHub to commit to your repository
 
-The sample pipelines have a job called `cloud-sync`. This job is responsible for checking for changes in you Umbraco Cloud project, fetch them and apply them back to your repository. 
+The sample pipelines have a job called `cloud-sync`. This job is responsible for checking for changes in your Umbraco Cloud project, fetching them, and applying them back to your repository.
 In order for this to work, you need to give the `GITHUB_TOKEN` write permissions to the repository during workflow runs.
 
 This is how you can grant these permissions:


### PR DESCRIPTION
## Description

There was an awkwardly phrased sentence with a few incorrect bits. I've adjusted it with some minor edits. I also removed a trailing space from that same sentence.

The diff preview I can see now also shows a change on a later line (line 237), but I'm not sure why. Maybe the online editor modified a line break character or something.

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other
