### PR TITLE
Update label-property-configuration.md

### DIFF
--- a/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/label-property-configuration.md
+++ b/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/label-property-configuration.md
@@ -57,7 +57,7 @@ An example `package.manifest` file is:
     "version": "1.0.0",
     "allowPackageTelemetry": false,
     "javascript": [
-        "/App_Plugins/MyFilters/myFilter.filter.js"
+        "~/App_Plugins/MyFilters/myFilter.filter.js"
     ]
 }
 ```


### PR DESCRIPTION

Add missing tilde (~) in path to JS file, which was causing the example to not work.

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other
