### PR TITLE
Static IPs change on Umbraco Cloud

### DIFF
--- a/umbraco-cloud/set-up/project-settings/manage-hostnames/README.md
+++ b/umbraco-cloud/set-up/project-settings/manage-hostnames/README.md
@@ -41,19 +41,23 @@ The following Records will become obsolete in the near future. Please refrain fr
 * A Records
   * `104.19.191.28`
   * `104.19.208.28`
+  * `104.17.17.9`
+  * `104.17.18.9`
 * AAAA Records
   * `2606:4700::6813:bf1c`
   * `2606:4700::6813:d01c`
+  * `2606:4700:7::7d`
+  * `2a06:98c1:58::7d`
   
 If you are using the above Records please consider changing them to the new Records below
 </details>
 
 * A Records to either or both IPv4 addresses:
-  * `104.17.17.9`
-  * `104.17.18.9`
+  * `162.159.140.127`
+  * `172.66.0.125`
 * Optionally, AAAA Records to either or both IPv6 addresses (to support IPv6 connectivity):
-  * `2606:4700::6811:1209`
-  * `2606:4700::6811:1109`
+  * `2606:4700:7::7d`
+  * `2a06:98c1:58::7d`
 
 {% hint style="info" %}
 Once you have updated your DNS, we recommend that you check if the correct records are being picked up using a site like [whatsmydns.net](https://www.whatsmydns.net/) before adding the hostname on Umbraco Cloud.


### PR DESCRIPTION
Add new set of static IPs as A & AAAA records for Umbraco Cloud Websites. Move former records to the former section.

## Description
Add new set of static IPs as A & AAAA records for Umbraco Cloud Websites. Move former records to the former section. The new set of static IPs are static as long as we use Cloudflare. With the previous IPs we've risked "clawbacks" from previous providers.

Previous IPs used by customers will continue working but still carry the risk of eventual clawback with a short deadline. We don't have such risk with the new IPs.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
Umbraco Cloud

## Deadline (if relevant)
The merge needs to be timed. We need to merge this after we've enabled the new static IPs.
