### PR TITLE
Update content app (remove Program.cs or Startup.cs examples)

### DIFF
--- a/10/umbraco-cms/extending/content-apps.md
+++ b/10/umbraco-cms/extending/content-apps.md
@@ -262,23 +262,6 @@ namespace My.Website
 }
 ```
 
-You can register a content app in the `ConfigureServices` method in the `Startup.cs` class:
-
-```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-
-    services.AddUmbraco(_env, _config)
-        .AddBackOffice()
-        .AddWebsite()
-        .AddComposers()
-        // Register the content app
-        .AddContentApp<WordCounterApp>()
-        .Build();
-
-}
-```
-
 You will still need to add all of the files you added above. However, because your C# code is adding the Content App, the `package.manifest` file can be simplified like this:
 
 ```json5

--- a/12/umbraco-cms/extending/content-apps.md
+++ b/12/umbraco-cms/extending/content-apps.md
@@ -259,23 +259,6 @@ public class WordCounterApp : IContentAppFactory
 }
 ```
 
-You can register a content app in the `ConfigureServices` method in the `Startup.cs` class:
-
-```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-
-    services.AddUmbraco(_env, _config)
-        .AddBackOffice()
-        .AddWebsite()
-        .AddComposers()
-        // Register the content app
-        .AddContentApp<WordCounterApp>()
-        .Build();
-
-}
-```
-
 You will still need to add all of the files you added above. However, because your C# code is adding the Content App, the `package.manifest` file can be simplified like this:
 
 ```json5

--- a/13/umbraco-cms/extending/content-apps.md
+++ b/13/umbraco-cms/extending/content-apps.md
@@ -281,19 +281,6 @@ public class WordCounterApp : IContentAppFactory
 }
 ```
 
-You can register a content app in the `Program.cs` class:
-
-```csharp
-builder.CreateUmbracoBuilder()
-    .AddBackOffice()
-    .AddWebsite()
-    .AddDeliveryApi()
-    .AddComposers()
-    // Register the content app
-    .AddContentApp<WordCounterApp>()
-    .Build();
-```
-
 You will still need to add all of the files you added above. However, because your C# code is adding the Content App, the `package.manifest` file can be simplified like this:
 
 ```json5


### PR DESCRIPTION
## Description

Update content app (remove Program.cs or Startup.cs examples). I only removed the `Program.cs`/`Startup.cs` example and did not add any new explanation because there is already an example with an `IComposer` in this article.

Belongs to: 
https://github.com/umbraco/UmbracoDocs/issues/5709 

Replaces: 
https://github.com/umbraco/UmbracoDocs/pull/5735 

## Type of suggestion
* [x] Updated 'wrong' content

## Product & version (if relevant)
Umbraco 10, 11, 12 & 13

