### PR TITLE
Update package manifest and property editor docs

### DIFF
--- a/10/umbraco-cms/extending/property-editors/package-manifest.md
+++ b/10/umbraco-cms/extending/property-editors/package-manifest.md
@@ -1,10 +1,3 @@
----
-state: partial
-updated-links: false
-
-
----
-
 # Package Manifest
 
 The `package.manifest` JSON file format is used to describe one or more custom Umbraco property editors, grid editors or parameter editors. This page outlines the file format and properties found in the JSON.
@@ -15,17 +8,17 @@ This is a sample manifest, it is always stored in a folder in `/App_Plugins/{You
 
 ```json
 {
-    "name": "Sir Trevor",
+    "name": "Suggestions",
     "version": "1.0.0 beta",
     "allowPackageTelemetry": true,
     "bundleOptions": "Default",
-    "packageView": "/App_Plugins/SirTrevor/SirTrevor-config.html",
+    "packageView": "/App_Plugins/Suggestions/suggestion-config.html",
     "propertyEditors": [
         {
-            "alias": "Sir.Trevor",
-            "name": "Sir Trevor",
+            "alias": "Suggestions",
+            "name": "Suggestions",
             "editor": {
-                "view": "/App_Plugins/SirTrevor/SirTrevor.html",
+                "view": "/App_Plugins/Suggestions/suggestion.html",
                 "hideLabel": true,
                 "valueType": "JSON",
                 "supportsReadOnly": true
@@ -33,44 +26,54 @@ This is a sample manifest, it is always stored in a folder in `/App_Plugins/{You
         }
     ],
     "javascript": [
-        "/App_Plugins/SirTrevor/SirTrevor.controller.js"
+        "/App_Plugins/Suggestions/suggestion.controller.js"
     ]
 }
 ```
 
 ## Sample Manifest with Csharp
 
-You can also register your files by implementing a `IManifestFilter` instead of creating a `package.manifest`. Create a `ManifestFilter.cs` file and implement the `IManifestFilter` interface.
+You can also register your files by implementing a `IManifestFilter` instead of creating a `package.manifest`. Create a `ManifestFilter.cs` file and implement the `IManifestFilter` interface. Then define the composer using the `IComposer` interface.
 
 ```csharp
-public class ManifestFilter : IManifestFilter
+namespace MyProject
 {
-    public void Filter(List<PackageManifest> manifests)
-    {
-        manifests.Add(new PackageManifest
-        {
-            PackageName = "Sir Trevor",
-            Scripts = new[]
-            {
-                "/App_Plugins/SirTrevor/SirTrevor.controller.js"
-            }, 
-            Version = "1.0.0"
-        });
-    }
+	public class ManifestComposer : IComposer
+	{
+		//composer
+		public void Compose(IUmbracoBuilder builder)
+		{
+			builder.ManifestFilters().Append<ManifestFilter>();
+		}
+	}
+	public class ManifestFilter : IManifestFilter
+	{
+		private readonly IDataValueEditorFactory _dataValueEditorFactory;
+
+		public ManifestFilter(IDataValueEditorFactory dataValueEditorFactory)
+		{
+			_dataValueEditorFactory = dataValueEditorFactory;
+		}
+
+		public void Filter(List<PackageManifest> manifests)
+		{
+			manifests.Add(new PackageManifest
+			{
+				PackageName = "Suggestions",
+				Scripts = new[]
+				{
+					"/App_Plugins/Suggestions/suggestion.controller.js"
+				},				
+				Version = "1.0.0"
+			});
+		}
+	}
 }
 ```
 
-Then add the `ManifestFilter.cs` to the `CollectionBuilder`.
-
-```csharp
-public class ManifestComposer : IComposer
-{
-    public void Compose(IUmbracoBuilder builder)
-    {
-        builder.ManifestFilters().Append<ManifestFilter>();
-    }
-}
-```
+{% hint style="info" %}
+    For a functional example, you will need to register the editor and create the `HTML`, `JS` and `CSS` files in `App_Plugin/Suggestions` folder as well. Some examples of registering the editor is found in the `Suggestions.cs` along with the files from `App_Plugin` from the [Creating a property Editor article](https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-property-editor#setting-up-a-property-editor-with-csharp)
+{% endhint %}
 
 ## Root elements
 
@@ -91,7 +94,7 @@ The manifest can contain seven root collections, none of them are mandatory:
 
 ### Telemetry elements
 
-In version 9.2 some additional root elements was added, the purpose of these are to control and facilitate telemetry about the package, none of these are mandatory. The properties are:
+From version 9.2 some additional root elements was added, the purpose of these are to control and facilitate telemetry about the package, none of these are mandatory. The properties are:
 
 * `name` - Allows you to specify a friendly name for your package that will be used for telemetry, if no name is specified the name of the folder will be used instead
 * `version` - The version of your package, if this is not specified there will be no version specific information for your package
@@ -118,7 +121,7 @@ The basic values on any editor are `alias`, `name` and `editor`. These three **m
     "alias": "my.editor.alias",
     "name": "My friendly editor name",
     "editor": {
-        "view": "/App_Plugins/SirTrevor/view.html"
+        "view": "/App_Plugins/MyEditorName/view.html"
     },
     "prevalues": {
         "fields": []
@@ -142,7 +145,7 @@ The basic values on any editor are `alias`, `name` and `editor`. These three **m
 
 ```json
 "editor": {
-    "view": "/App_Plugins/SirTrevor/view.html",
+    "view": "/App_Plugins/MyEditorName/view.html",
     "hideLabel": true,
     "valueType": "TEXT",
     "validation": {},
@@ -253,8 +256,8 @@ The parameter editors array follows the same format as the property editors desc
 ```json
 {
   "javascript": [
-    "/App_Plugins/SirTrevor/SirTrevor.controller.js",
-    "/App_Plugins/SirTrevor/service.js"
+    "/App_Plugins/MyEditorName/MyEditorName.controller.js",
+    "/App_Plugins/MyEditorName/MyEditorName.js"
   ]
 }
 ```
@@ -266,8 +269,8 @@ The parameter editors array follows the same format as the property editors desc
 ```json
 {
   "css": [
-    "/App_Plugins/SirTrevor/SirTrevor.css",
-    "/App_Plugins/SirTrevor/hibba.css"
+    "/App_Plugins/MyEditorName/MyEditorName.css",
+    "/App_Plugins/MyEditorName/hibba.css"
   ]
 }
 ```
@@ -313,7 +316,9 @@ To associate the hosted JSON schema file to all package.manifest files you will 
 To associate the hosted JSON schema file to all package.manifest files you will need to perform the following inside of Visual Studio Code editor.
 
 * File -> Preferences -> Settings. The **Settings** window opens.
-* In the **User** or **Workspace** tab, go to **Extensions** -> **JSON** -> **Schemas**. ![JSON Schemas](../../../../11/umbraco-cms/extending/property-editors/images/JSON-schema.png)
+*   In the **User** or **Workspace** tab, go to **Extensions** -> **JSON** -> **Schemas**.
+
+    <figure><img src="../../../../10/umbraco-cms/extending/property-editors/images/JSON-schema.png" alt=""><figcaption></figcaption></figure>
 * Select **Edit in settings.json** from the **Schemas** section.
 *   Add the following snippet in the `settings.json` file:
 
@@ -332,7 +337,7 @@ To associate the hosted JSON schema file to all package.manifest files you will 
 
 ### Adding inline schema
 
-Editors like visual studio can use the `$schema` notation in your file.
+Editors like Visual Studio can use the `$schema` notation in your file.
 
 ```json
 {

--- a/10/umbraco-cms/extending/property-editors/package-manifest.md
+++ b/10/umbraco-cms/extending/property-editors/package-manifest.md
@@ -36,6 +36,10 @@ This is a sample manifest, it is always stored in a folder in `/App_Plugins/{You
 You can also register your files by implementing a `IManifestFilter` instead of creating a `package.manifest`. Create a `ManifestFilter.cs` file and implement the `IManifestFilter` interface. Then define the composer using the `IComposer` interface.
 
 ```csharp
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Manifest;
+using Umbraco.Cms.Core.PropertyEditors;
+
 namespace MyProject
 {
 	public class ManifestComposer : IComposer
@@ -72,7 +76,9 @@ namespace MyProject
 ```
 
 {% hint style="info" %}
-    For a functional example, you will need to register the editor and create the `HTML`, `JS` and `CSS` files in `App_Plugin/Suggestions` folder as well. Some examples of registering the editor is found in the `Suggestions.cs` along with the files from `App_Plugin` from the [Creating a property Editor article](https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-property-editor#setting-up-a-property-editor-with-csharp)
+
+For a functional example, you will need to register the editor and create the `HTML`, `JS`, and `CSS` files in the `App_Plugins/Suggestions` folder. You can find some examples of registering the editor in the `Suggestions.cs` file and within the files in the `App_Plugins` folder. For more information, see the [Creating a Property Editor article](https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-property-editor#setting-up-a-property-editor-with-csharp).
+
 {% endhint %}
 
 ## Root elements
@@ -94,7 +100,7 @@ The manifest can contain seven root collections, none of them are mandatory:
 
 ### Telemetry elements
 
-From version 9.2 some additional root elements was added, the purpose of these are to control and facilitate telemetry about the package, none of these are mandatory. The properties are:
+From version 9.2, some additional root elements were added. Their purpose is to control and facilitate telemetry for the package but none of these are mandatory. The properties are:
 
 * `name` - Allows you to specify a friendly name for your package that will be used for telemetry, if no name is specified the name of the folder will be used instead
 * `version` - The version of your package, if this is not specified there will be no version specific information for your package
@@ -316,7 +322,7 @@ To associate the hosted JSON schema file to all package.manifest files you will 
 To associate the hosted JSON schema file to all package.manifest files you will need to perform the following inside of Visual Studio Code editor.
 
 * File -> Preferences -> Settings. The **Settings** window opens.
-*   In the **User** or **Workspace** tab, go to **Extensions** -> **JSON** -> **Schemas**.
+*   In the **User** tab, go to **Extensions** -> **JSON** -> **Schemas**.
 
     <figure><img src="../../../../10/umbraco-cms/extending/property-editors/images/JSON-schema.png" alt=""><figcaption></figcaption></figure>
 * Select **Edit in settings.json** from the **Schemas** section.

--- a/10/umbraco-cms/tutorials/creating-a-property-editor/README.md
+++ b/10/umbraco-cms/tutorials/creating-a-property-editor/README.md
@@ -4,7 +4,7 @@ description: A guide to creating a property editor in Umbraco
 
 # Creating a Property Editor
 
-This guide explains how to set up a property editor, hook it into Umbraco's Data Types, AngularJS modules, and its injector, and finally how we can test our property editor.
+This tutorial guides you through creating a property editor, integrating it with Umbraco's Data Types, AngularJS modules and its injector. Finally, it explains how we can test our property editor.
 
 The steps we will go through in part 1 are:
 
@@ -23,14 +23,14 @@ This tutorial covers how to use AngularJS with Umbraco, so it does not cover Ang
 
 ## The End Result
 
-By the end of this tutorial, we will have a "suggestions" data type running inside of Umbraco, registered as a Data Type in the backoffice, and assigned to a Document Type. The data type can create and suggest values.
+We will have a "Suggestions" Data Type in Umbraco. It is registered as a Data Type in the backoffice, and assigned to a Document Type. The Data Type can create and suggest values.
 
 ## Setting up a plugin
 
 To begin with, let's create a new folder inside `/App_Plugins` folder. We will call it `Suggestions`.
 
 {% hint style="warning" %}
-If you do not have an `/App_Plugins` folded, you can create it at the root of your project.
+If you do not have an `/App_Plugins` folder, you can create it at the root of your project.
 {% endhint %}
 
 Next, we will create a Package Manifest file to describe what the plugin does. This manifest will tell Umbraco about our new Property Editor and allow us to inject any needed files into the application.
@@ -199,7 +199,7 @@ angular.module("umbraco")
 ```
 
 {% hint style="info" %}
-Visit the [Property Editors page](../../extending/property-editors/) for more details about extending this service.
+Visit the [Property Editors page](../../extending/property-editors/README.md) for more details about extending this service.
 {% endhint %}
 
 Then update the HTML file with the following, where we add the id to the button:
@@ -218,4 +218,4 @@ Now, clear the cache, reload the document, and see the Suggestions Data Type run
 
 When we save or publish, the value of the Data Type is automatically synced to the current content object and sent to the server, all through the power of Angular and the `ng-model` attribute.
 
-Learn more about extending this service by visiting the [Property Editors page](../../extending/property-editors/).
+Learn more about extending this service by visiting the [Property Editors page](../../extending/property-editors/README.md).

--- a/10/umbraco-cms/tutorials/creating-a-property-editor/README.md
+++ b/10/umbraco-cms/tutorials/creating-a-property-editor/README.md
@@ -4,11 +4,7 @@ description: A guide to creating a property editor in Umbraco
 
 # Creating a Property Editor
 
-{% hint style="warning" %}
-This tutorial has last been last tested on v8 and therefore might not work as intended for v10 and above.
-{% endhint %}
-
-This guide explains how to set up a property editor, hook it into Umbraco's Data Types, AngularJS' modules, and its injector, and finally how we can test our property editor.
+This guide explains how to set up a property editor, hook it into Umbraco's Data Types, AngularJS modules, and its injector, and finally how we can test our property editor.
 
 The steps we will go through in part 1 are:
 
@@ -27,11 +23,15 @@ This tutorial covers how to use AngularJS with Umbraco, so it does not cover Ang
 
 ## The End Result
 
-By the end of this tutorial, we will have a suggestion data type running inside of Umbraco, registered as a Data Type in the backoffice, and assigned to a Document Type. The data type can create and suggest values.
+By the end of this tutorial, we will have a "suggestions" data type running inside of Umbraco, registered as a Data Type in the backoffice, and assigned to a Document Type. The data type can create and suggest values.
 
 ## Setting up a plugin
 
 To begin with, let's create a new folder inside `/App_Plugins` folder. We will call it `Suggestions`.
+
+{% hint style="warning" %}
+If you do not have an `/App_Plugins` folded, you can create it at the root of your project.
+{% endhint %}
 
 Next, we will create a Package Manifest file to describe what the plugin does. This manifest will tell Umbraco about our new Property Editor and allow us to inject any needed files into the application.
 
@@ -56,7 +56,7 @@ Inside the `package.manifest` file, we will add the following JSON to describe t
             "group": "Common",
             /*the HTML file we will load for the editor*/
             "editor": {
-                "view": "~/App_Plugins/Suggestions/suggestion.html",
+                "view": "/App_Plugins/Suggestions/suggestion.html",
                 /*Optional: Add 'read-only' support. Available from Umbraco 10.2+*/
                 "supportsReadOnly": true
             }
@@ -64,56 +64,55 @@ Inside the `package.manifest` file, we will add the following JSON to describe t
     ],
      // array of files we want to inject into the application on app_start
     "css": [
-        "~/App_Plugins/Suggestions/suggestion.css"
+        "/App_Plugins/Suggestions/suggestion.css"
     ],
     "javascript": [
-        "~/App_Plugins/Suggestions/suggestion.controller.js"
+        "/App_Plugins/Suggestions/suggestion.controller.js"
     ]
 }
 ```
 
 ## Setting up a Property Editor with Csharp
 
-You can also create a property editor with C# instead of defining it in a `package.manifest`. Create a `Suggestion.cs` file in `/App_Code/` to register the editor this way.
+You can also create a property editor with C# instead of defining it in a `package.manifest`. Create a `Suggestion.cs` file at the root of your project to register the editor this way.
 
 ```csharp
-using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.PropertyEditors;
 
-namespace Umbraco.Cms.Core.PropertyEditors
+namespace YourProjectName;
+
+[DataEditor(
+    alias: "Suggestions editor",
+    name: "Suggestions",
+    view: "/App_Plugins/Suggestions/suggestion.html",
+    Group = "Common",
+    Icon = "icon-list")]
+public class Suggestions : DataEditor
 {
-    [DataEditor(
-        alias: "Suggestions editor",
-        name: "Suggestions",
-        view: "~/App_Plugins/Suggestions/suggestion.html",
-        Group = "Common",
-        Icon = "icon-list")]
-    public class Suggestions : DataEditor
-    {
-        public Suggestions(IDataValueEditorFactory dataValueEditorFactory)
-            : base(dataValueEditorFactory)
-        {            
-        }
+    public Suggestions(IDataValueEditorFactory dataValueEditorFactory)
+        : base(dataValueEditorFactory)
+    {            
     }
 }
 ```
 
-You will still need to add all of the files you added above but, because your `C#` code is adding the Property Editor, the `package.manifest` file can be simplified like this:
+As the above `C#` code is adding the Property Editor, the `package.manifest` file can be simplified like this:
 
 ```json
 {
     // array of files we want to inject into the application on app_start
     "css": [
-        "~/App_Plugins/Suggestions/suggestion.css"
+        "/App_Plugins/Suggestions/suggestion.css"
     ],
     "javascript": [
-        "~/App_Plugins/Suggestions/suggestion.controller.js"
+        "/App_Plugins/Suggestions/suggestion.controller.js"
     ]
 }
 ```
 
 ## Writing basic HTML and JavaScript
 
-Now, we will add 3 files to the /App\_Plugins/Suggestions/ folder:
+Now, we will add 3 files to the `/App_Plugins/Suggestions/` folder:
 
 * `suggestion.html`
 * `suggestion.controller.js`
@@ -165,13 +164,13 @@ Now our basic parts of the editor are done, namely:
 
 ## Registering the Data Type in Umbraco
 
-We will now restart our application. In the Document Type, let's add our newly added property editor "Suggestions" and save it.
+We will now restart our application. In the Document Type, add a new property called  "Suggestion" and add to it the newly created property editor "Suggestions" and save it.
 
-![Suggestion Property Editor](images/suggestion-property-editor.png)
+![Suggestion Property Editor](../../../../10/umbraco-cms/tutorials/creating-a-property-editor/images/suggestion-property-editor.png)
 
 Now open the content item of that Document Type and there will be an alert message saying "The controller has landed", which means all is well.
 
-![Controller Landed](images/Controller-landed.png)
+![Controller Landed](../../../../10/umbraco-cms/tutorials/creating-a-property-editor/images/Controller-landed.png)
 
 We can now edit the assigned property's value with our new property editor.
 
@@ -203,7 +202,7 @@ angular.module("umbraco")
 Visit the [Property Editors page](../../extending/property-editors/) for more details about extending this service.
 {% endhint %}
 
-and add that id to the button in the HTML:
+Then update the HTML file with the following, where we add the id to the button:
 
 ```html
 <div class="suggestion" ng-controller="SuggestionPluginController">
@@ -215,7 +214,7 @@ and add that id to the button in the HTML:
 
 Now, clear the cache, reload the document, and see the Suggestions Data Type running.
 
-![Example of the Suggestions Data Type running](images/suggestion-editor-backoffice.png)
+![Example of the Suggestions Data Type running](../../../../10/umbraco-cms/tutorials/creating-a-property-editor/images/suggestion-editor-backoffice.png)
 
 When we save or publish, the value of the Data Type is automatically synced to the current content object and sent to the server, all through the power of Angular and the `ng-model` attribute.
 

--- a/10/umbraco-cms/tutorials/creating-a-property-editor/part-2.md
+++ b/10/umbraco-cms/tutorials/creating-a-property-editor/part-2.md
@@ -19,29 +19,29 @@ To add configuration options to our Suggestion Data Type, open the `package.mani
 ```json
 ...
 "editor": {
-                "view": "~/App_Plugins/Suggestions/suggestion.html"
-            }, // Remember a comma separator here at the end of the editor block!
- "prevalues": {
-                "fields": [
-                    {
-                        "label": "Enabled?",
-                        "description": "Provides Suggestions",
-                        "key": "isEnabled",
-                        "view": "boolean"
-                     },
-                    {
-                        "label": "Default value",
-                        "description": "Provide a default value for the property editor",
-                        "key": "defaultValue",
-                        "view": "textarea"
-                    }
-                ]
-            }
+    "view": "/App_Plugins/Suggestions/suggestion.html"
+}, // Remember a comma separator here at the end of the editor block!
+"prevalues": {
+    "fields": [
+        {
+            "label": "Enabled?",
+            "description": "Provides Suggestions",
+            "key": "isEnabled",
+            "view": "boolean"
+            },
+        {
+            "label": "Default value",
+            "description": "Provide a default value for the property editor",
+            "key": "defaultValue",
+            "view": "textarea"
+        }
+    ]
+}
 ```
 
 So what did we add? We added a prevalue editor, with a `fields` collection. This collection contains information about the UI we will render on the Data Type configuration for this editor.
 
-The label "Enabled?" uses the "boolean" view. This will allow us to turn the suggestions on/off and will provide the user with a toggle button. The name "boolean" comes from the convention that all preview editors are stored in `/umbraco/views/prevalueeditors/` and then found via `boolean.html`.
+The label "Enabled?" uses the "boolean" view. This will allow us to turn the suggestions on/off and will provide the user with a toggle button. The name "boolean" comes from the convention of all preview editors.
 
 Same with the "Default value" label, it will provide the user with a textarea. The user can input a default value for the property editor that should be displayed when the property editor is blank.
 
@@ -49,7 +49,7 @@ To hide the property editor label, add the `hideLabel` parameter in the `editor`
 
 ```json
  "editor": {
-        "view": "~/App_Plugins/Suggestions/suggestion.html",
+        "view": "/App_Plugins/Suggestions/suggestion.html",
         //Turn the label on or off by using true or false, respectively.
         "hideLabel": true,
         /*Optional: Add 'read-only' support. Available from Umbraco 10.2+*/
@@ -74,7 +74,7 @@ Your `package.manifest` file should now look something like this:
       "group": "Common",
       /*the HTML file we will load for the editor*/
       "editor": {
-        "view": "~/App_Plugins/Suggestions/suggestion.html",
+        "view": "/App_Plugins/Suggestions/suggestion.html",
         //Turn the label on or off by using true or false, respectively.
         "hideLabel": true,
         /*Optional: Add 'read-only' support. Available from Umbraco 10.2+*/
@@ -100,52 +100,53 @@ Your `package.manifest` file should now look something like this:
   ],
   // array of files we want to inject into the application on app_start
   "css": [
-    "~/App_Plugins/Suggestions/suggestion.css"
+    "/App_Plugins/Suggestions/suggestion.css"
   ],
   "javascript": [
-    "~/App_Plugins/Suggestions/suggestion.controller.js"
+    "/App_Plugins/Suggestions/suggestion.controller.js"
   ]
 }
 ```
 
 ## Csharp
 
-It is also possible to add configuration if you have chosen to create a property editor using C#. Create two new files in the `/App_Code/` folder and update the existing `Suggestion.cs` file to add configuration to the property editor.
+It is also possible to add configuration if you have chosen to create a property editor using C#. Create two new files at the root of your project and update the existing `Suggestion.cs` file to add configuration to the property editor.
 
 First create a `SuggestionConfiguration.cs` file with three configuration options: `Enabled?`, `Default Value`, and `Hide Label?`:
 
 ```csharp
-namespace Umbraco.Cms.Core.PropertyEditors
-{
-    public class SuggestionConfiguration
-    {
-        [ConfigurationField("isEnabled", "Enabled?", "boolean", Description = "Provides Suggestions")]
-        public bool Enabled { get; set; }
+using Umbraco.Cms.Core.PropertyEditors;
 
-        [ConfigurationField("defaultValue", "Default Value", "textarea", Description = "Provide a default value for the property")]
-        public string? DefaultValue { get; set; }
-        
-        [ConfigurationField("hideLabel", "Hide Label?", "boolean", Description = "Hide the property label.")]
-        public bool HideLabel { get; set; }
-    }
+namespace YourProjectName;
+
+public class SuggestionConfiguration
+{
+    [ConfigurationField("isEnabled", "Enabled?", "boolean", Description = "Provides Suggestions")]
+    public bool Enabled { get; set; }
+
+    [ConfigurationField("defaultValue", "Default Value", "textarea", Description = "Provide a default value for the property")]
+    public string? DefaultValue { get; set; }
+    
+    [ConfigurationField("hideLabel", "Hide Label?", "boolean", Description = "Hide the property label.")]
+    public bool HideLabel { get; set; }
 }
+
 ```
 
 Then create a `SuggestionConfigurationEditor.cs` file:
 
 ```csharp
 using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.PropertyEditors;
 
-namespace Umbraco.Cms.Core.PropertyEditors
-{
-    public class SuggestionConfigurationEditor : ConfigurationEditor<SuggestionConfiguration>
+namespace MyProject;
+public class SuggestionConfigurationEditor : ConfigurationEditor<SuggestionConfiguration>
     {
-         public SuggestionConfigurationEditor(IIOHelper ioHelper) : base(ioHelper)
+        [Obsolete]
+        public SuggestionConfigurationEditor(IIOHelper ioHelper) : base(ioHelper)
         {
         }
     }
-
-}
 ```
 
 Finally, edit the `Suggestion.cs` file from step one until it looks like the example below:
@@ -153,28 +154,28 @@ Finally, edit the `Suggestion.cs` file from step one until it looks like the exa
 ```csharp
 using Umbraco.Cms.Core.IO;
 
-namespace Umbraco.Cms.Core.PropertyEditors
+namespace YourProjectName;
+
+[DataEditor(
+    alias: "Suggestions editor",
+    name: "Suggestions Editor",
+    view: "/App_Plugins/Suggestions/suggestion.html",
+    Group = "Common",
+    Icon = "icon-list")]
+public class Suggestions : DataEditor
 {
-    [DataEditor(
-        alias: "Suggestions editor",
-        name: "Suggestions Editor",
-        view: "~/App_Plugins/Suggestions/suggestion.html",
-        Group = "Common",
-        Icon = "icon-list")]
-    public class Suggestions : DataEditor
+    private readonly IIOHelper _ioHelper;
+    public Suggestions(IDataValueEditorFactory dataValueEditorFactory,
+        IIOHelper ioHelper)
+        : base(dataValueEditorFactory)
+
     {
-        private readonly IIOHelper _ioHelper;
-        public Suggestions(IDataValueEditorFactory dataValueEditorFactory,
-            IIOHelper ioHelper)
-            : base(dataValueEditorFactory)
-
-        {
-            _ioHelper = ioHelper;
-        }
-        protected override IConfigurationEditor CreateConfigurationEditor() => new SuggestionConfigurationEditor(_ioHelper);
-
+        _ioHelper = ioHelper;
     }
+    protected override IConfigurationEditor CreateConfigurationEditor() => new SuggestionConfigurationEditor(_ioHelper);
+
 }
+
 ```
 
 Save the file, rebuild the application and have a look at the Suggestions Data Type. You should see that you have one configuration option.
@@ -185,63 +186,65 @@ Save the file, rebuild the application and have a look at the Suggestions Data T
 
 The next step is to gain access to our new configuration options. For this, open the `suggestion.controller.js` file.
 
-1.  Let's add the `isEnabled` functionality. Before the closing tag, we will add a `getState` method:
+1. Let's add the `isEnabled` functionality. Before the closing tag, we will add a `getState` method:
 
-    ```javascript
-    // The controller assigns the behavior to scope as defined by the getState method, which is invoked when the user toggles the enable button in the data type settings.
-    $scope.getState = function () {
-                
-    //If the data type is enabled in the Settings the 'Give me Suggestions!' button is enabled
-        if (Boolean(Number($scope.model.config.isEnabled))) {
-                return false;
+```javascript
+// The controller assigns the behavior to scope as defined by the getState method, which is invoked when the user toggles the enable button in the data type settings.
+$scope.getState = function () {
+            
+//If the data type is enabled in the Settings the 'Give me Suggestions!' button is enabled
+    if (Boolean(Number($scope.model.config.isEnabled))) {
+            return false;
+        }
+    return true;
+}
+```
+
+2. Next, we'll add the `defaultValue` functionality. When the `$scope.model.value` is empty or null, we want to use the default value. To do that, we add the following to the start of the controller:
+
+```js
+if($scope.model.value === null || $scope.model.value === ""){
+    $scope.model.value = $scope.model.config.defaultValue;
+}
+```
+
+See what's new? The `$scope.model.config` object. Also, because of this configuration, we now have access to `$scope.model.config.defaultValue` which contains the configuration value for that key.
+
+Your `suggestion.controller.js` file should now look like:
+
+```javascript
+angular.module("umbraco")
+    .controller("SuggestionPluginController",
+        // Scope object is the main object which is used to pass information from the controller to the view.
+        function ($scope) {
+            if ($scope.model.value === null || $scope.model.value === "") {
+                $scope.model.value = $scope.model.config.defaultValue;
             }
-        return true;
-    }
-    ```
-2.  Next, we'll add the `defaultValue` functionality. When the `$scope.model.value` is empty or null, we want to use the default value. To do that, we add the following to the start of the controller:
+            // SuggestionPluginController assigns the suggestions list to the aSuggestions property of the scope
+            $scope.aSuggestions = ["You should take a break", "I suggest that you visit the Eiffel Tower", "How about starting a book club today or this week?", "Are you hungry?"];
 
-    ```js
-    if($scope.model.value === null || $scope.model.value === ""){
-        $scope.model.value = $scope.model.config.defaultValue;
-    }
-    ```
+            // The controller assigns the behavior to scope as defined by the getSuggestion method, which is invoked when the user clicks on the 'Give me Suggestions!' button.
+            $scope.getSuggestion = function () {
 
-    See what's new? The `$scope.model.config` object. Also, because of this configuration, we now have access to `$scope.model.config.defaultValue` which contains the configuration value for that key.
+                // The getSuggestion method reads a random value from an array and provides a Suggestion. 
+                $scope.model.value = $scope.aSuggestions[$scope.aSuggestions.length * Math.random() | 0];
+            }
+        
+            // The controller assigns the behavior to scope as defined by the getState method, which is invoked when the user toggles the enable button in the data type settings.
 
-    Your `suggestion.controller.js` file should now look like:
+            $scope.getState = function () {
 
-    ```javascript
-    angular.module("umbraco")
-       .controller("SuggestionPluginController",
-           // Scope object is the main object which is used to pass information from the controller to the view.
-           function ($scope) {
-               if ($scope.model.value === null || $scope.model.value === "") {
-                   $scope.model.value = $scope.model.config.defaultValue;
-               }
-               // SuggestionPluginController assigns the suggestions list to the aSuggestions property of the scope
-               $scope.aSuggestions = ["You should take a break", "I suggest that you visit the Eiffel Tower", "How about starting a book club today or this week?", "Are you hungry?"];
+                //If the data type is enabled in the Settings the 'Give me Suggestions!' button is enabled
+                if (Boolean(Number($scope.model.config.isEnabled))) {
+                    return false;
+                }
+                return true;
+            }
 
-                // The controller assigns the behavior to scope as defined by the getSuggestion method, which is invoked when the user clicks on the 'Give me Suggestions!' button.
-               $scope.getSuggestion = function () {
+});
+```
 
-                   // The getSuggestion method reads a random value from an array and provides a Suggestion. 
-                   $scope.model.value = $scope.aSuggestions[$scope.aSuggestions.length * Math.random() | 0];
-               }
-           
-               // The controller assigns the behavior to scope as defined by the getState method, which is invoked when the user toggles the enable button in the data type settings.
-
-               $scope.getState = function () {
-
-                   //If the data type is enabled in the Settings the 'Give me Suggestions!' button is enabled
-                    if (Boolean(Number($scope.model.config.isEnabled))) {
-                       return false;
-                   }
-                   return true;
-               }
-
-    });
-    ```
-3.  Finally, we'll add the `hideLabel` functionality. For this, we'll open the `Suggestion.cs` file and override the GetValueEditor method with configuration as a parameter.
+3. Finally, we'll add the `hideLabel` functionality. For this, we'll open the `Suggestion.cs` file and override the GetValueEditor method with configuration as a parameter.
 
     ```cs
     public override IDataValueEditor GetValueEditor(object? configuration)
@@ -264,42 +267,42 @@ The next step is to gain access to our new configuration options. For this, open
     ```cs
     using Umbraco.Cms.Core.IO;
     using Umbraco.Cms.Core.Models;
+    using Umbraco.Cms.Core.PropertyEditors;
 
-    namespace Umbraco.Cms.Core.PropertyEditors
+    namespace YourProjectName;
+
+    [DataEditor(
+	alias: "Suggestions editor",
+	name: "Suggestions Editor",
+	view: "/App_Plugins/Suggestions/suggestion.html",
+	Group = "Common",
+	Icon = "icon-list")]
+    public class Suggestions : DataEditor
     {
-        [DataEditor(
-            alias: "Suggestions editor",
-            name: "Suggestions Editor",
-            view: "~/App_Plugins/Suggestions/suggestion.html",
-            Group = "Common",
-            Icon = "icon-list")]
-        public class Suggestions : DataEditor
-        {
-            private readonly IIOHelper _ioHelper;
-            public Suggestions(IDataValueEditorFactory dataValueEditorFactory,
-                IIOHelper ioHelper)
-                : base(dataValueEditorFactory)
+        private readonly IIOHelper _ioHelper;
+        public Suggestions(IDataValueEditorFactory dataValueEditorFactory,
+            IIOHelper ioHelper)
+            : base(dataValueEditorFactory)
 
-            {
-                _ioHelper = ioHelper;
-            }
-            protected override IConfigurationEditor CreateConfigurationEditor() => new SuggestionConfigurationEditor(_ioHelper);
-            
-            public override IDataValueEditor GetValueEditor(object? configuration)
-            {
-                
-                var editor = base.GetValueEditor(configuration);
-                
-                if (editor is DataValueEditor valueEditor && configuration is SuggestionConfiguration config)
-                {
-                    valueEditor.HideLabel = config.HideLabel;
-                }
-                
-                return editor;
-            
-            }
-        
+        {
+            _ioHelper = ioHelper;
         }
+        protected override IConfigurationEditor CreateConfigurationEditor() => new SuggestionConfigurationEditor(_ioHelper);
+
+        public override IDataValueEditor GetValueEditor(object? configuration)
+        {
+
+            var editor = base.GetValueEditor(configuration);
+
+            if (editor is DataValueEditor valueEditor && configuration is SuggestionConfiguration config)
+            {
+                valueEditor.HideLabel = config.HideLabel;
+            }
+
+            return editor;
+
+        }
+    }
     ```
 
 Save the files and rebuild the application. To access the configuration options, enable/disable the `Enabled?` and `Hide Label?` options. Additionally, you can set a default value in the `Default Value` field and see the Suggestions Data Type at play.

--- a/10/umbraco-cms/tutorials/creating-a-property-editor/part-3.md
+++ b/10/umbraco-cms/tutorials/creating-a-property-editor/part-3.md
@@ -59,27 +59,27 @@ angular.module("umbraco")
                 $scope.model.value = $scope.model.config.defaultValue;
             }
 
-      // SuggestionPluginController assigns the suggestions list to the aSuggestions property of the scope
-        $scope.aSuggestions = ["You should take a break", "I suggest that you visit the Eiffel Tower", "How about starting a book club today or this week?", "Are you hungry?"];
-    
-        // The controller assigns the behavior to scope as defined by the getSuggestion method, which is invoked when the user clicks on the 'Give me Suggestions!' button.
-        $scope.getSuggestion = function () {
+            // SuggestionPluginController assigns the suggestions list to the aSuggestions property of the scope
+            $scope.aSuggestions = ["You should take a break", "I suggest that you visit the Eiffel Tower", "How about starting a book club today or this week?", "Are you hungry?"];
 
-        // The getSuggestion method reads a random value from an array and provides a Suggestion. 
-        $scope.model.value = $scope.aSuggestions[$scope.aSuggestions.length * Math.random() | 0];
+            // The controller assigns the behavior to scope as defined by the getSuggestion method, which is invoked when the user clicks on the 'Give me Suggestions!' button.
+            $scope.getSuggestion = function () {
 
-        }
-         
-        // The controller assigns the behavior to scope as defined by the getState method, which is invoked when the user toggles the enable button in the data type settings.
-        $scope.getState = function () {
+                // The getSuggestion method reads a random value from an array and provides a Suggestion. 
+                $scope.model.value = $scope.aSuggestions[$scope.aSuggestions.length * Math.random() | 0];
 
-        //If the data type is enabled in the Settings the 'Give me Suggestions!' button is enabled
-        if (Boolean(Number($scope.model.config.isEnabled))) {
-            return false;
-        }
-        return true;
             }
-            
+         
+            // The controller assigns the behavior to scope as defined by the getState method, which is invoked when the user toggles the enable button in the data type settings.
+            $scope.getState = function () {
+
+                //If the data type is enabled in the Settings the 'Give me Suggestions!' button is enabled
+                 if (Boolean(Number($scope.model.config.isEnabled))) {
+                    return false;
+                }
+                return true;
+            }
+
             //// function to show custom notification
             $scope.showNotification = function () {
                 if ($scope.model.value.length > 35) {
@@ -93,13 +93,13 @@ angular.module("umbraco")
                         }
                     });
                 }
-            };   
+            };
 
             // function to trim the text to a length of 35.
             $scope.TrimText = function () {
                 $scope.model.value = $scope.model.value.substring(0, 35);
             };
-            
+
         });
 ```
 
@@ -114,15 +114,15 @@ angular.module("umbraco")
 ```json
 {
  "javascript": [
-        "~/App_Plugins/Suggestions/suggestion.controller.js",
-        "~/App_Plugins/Suggestions/notification.controller.js"
+        "/App_Plugins/Suggestions/suggestion.controller.js",
+        "/App_Plugins/Suggestions/notification.controller.js"
     ]
 }
 ```
 
 ## Creating custom Notification View and Controller
 
-We will add 2 files to the /App\_Plugins/Suggestions/ folder:
+We will add 2 files to the `/App_Plugins/Suggestions/` folder:
 
 * `notification.html`
 * `notification.controller.js`
@@ -162,7 +162,7 @@ angular.module('umbraco')
 
 Restart the application and either enter a suggestion longer than 35 characters or click on the `Get Suggestions` button. When you do so and click in the textarea, you will be presented with a notification like this:
 
-![Suggestion Notification](images/suggestion-notification.png)
+![Suggestion Notification](../../../../10/umbraco-cms/tutorials/creating-a-property-editor/images/suggestion-notification.png)
 
 The notification object contains the `args` object that we passed to the view in our `suggestion.controller.js`. When we click the `Yes` button in the notification, we use the callback function from the Suggestions controller which is executed in the scope of our Suggestions Property Editor.
 

--- a/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -38,27 +38,20 @@ INSERT INTO people(name,town,country) VALUES('Aimee Sampson','Hawera','Antigua a
 
 Next we need to define an `ApiController` to expose a server-side route which our application will use to fetch the data.
 
-For this, we will create a file at: `/App_Code/PersonApiController.cs`. It must be in `App_Code` since we want our app to compile it on start. Alternatively, you can add it to a normal .NET project and compile it into a DLL as usual.
+For this, you can create a new class at the root of the project called `PersonApiController.cs`
 
 In the `PersonApiController.cs` file, add:
 
 ```csharp
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
+    using Umbraco.Cms.Web.BackOffice.Controllers;
+    using Umbraco.Cms.Core.Web.Mvc;
 
-using Umbraco.Cms.Web.BackOffice.Controllers;
-using Umbraco.Cms.Web.Common.Attributes;
-
-namespace My.Controllers
-{
-    [Umbraco.Web.Mvc.PluginController("My")]
+    namespace YourProjectName;
+    [PluginControllerMetadata("My")]
     public class PersonApiController : UmbracoAuthorizedJsonController
     {
         // we will add a method here later
     }
-}
 ```
 
 This is a very basic API controller which inherits from `UmbracoAuthorizedJsonController` this specific class will only return JSON data and only to requests which are authorized to access the backoffice.

--- a/12/umbraco-cms/extending/property-editors/package-manifest.md
+++ b/12/umbraco-cms/extending/property-editors/package-manifest.md
@@ -36,6 +36,10 @@ This is a sample manifest, it is always stored in a folder in `/App_Plugins/{You
 You can also register your files by implementing a `IManifestFilter` instead of creating a `package.manifest`. Create a `ManifestFilter.cs` file and implement the `IManifestFilter` interface. Then define the composer using the `IComposer` interface.
 
 ```csharp
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Manifest;
+using Umbraco.Cms.Core.PropertyEditors;
+
 namespace MyProject
 {
 	public class ManifestComposer : IComposer
@@ -72,7 +76,9 @@ namespace MyProject
 ```
 
 {% hint style="info" %}
-    For a functional example, you will need to register the editor and create the `HTML`, `JS` and `CSS` files in `App_Plugin/Suggestions` folder as well. Some examples of registering the editor is found in the `Suggestions.cs` along with the files from `App_Plugin` from the [Creating a property Editor article](https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-property-editor#setting-up-a-property-editor-with-csharp)
+
+For a functional example, you will need to register the editor and create the `HTML`, `JS`, and `CSS` files in the `App_Plugins/Suggestions` folder. You can find some examples of registering the editor in the `Suggestions.cs` file and within the files in the `App_Plugins` folder. For more information, see the [Creating a Property Editor article](https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-property-editor#setting-up-a-property-editor-with-csharp).
+
 {% endhint %}
 
 ## Root elements
@@ -94,7 +100,7 @@ The manifest can contain seven root collections, none of them are mandatory:
 
 ### Telemetry elements
 
-From version 9.2 some additional root elements was added, the purpose of these are to control and facilitate telemetry about the package, none of these are mandatory. The properties are:
+From version 9.2, some additional root elements were added. Their purpose is to control and facilitate telemetry for the package but none of these are mandatory. The properties are:
 
 * `name` - Allows you to specify a friendly name for your package that will be used for telemetry, if no name is specified the name of the folder will be used instead
 * `version` - The version of your package, if this is not specified there will be no version specific information for your package
@@ -316,7 +322,7 @@ To associate the hosted JSON schema file to all package.manifest files you will 
 To associate the hosted JSON schema file to all package.manifest files you will need to perform the following inside of Visual Studio Code editor.
 
 * File -> Preferences -> Settings. The **Settings** window opens.
-*   In the **User** or **Workspace** tab, go to **Extensions** -> **JSON** -> **Schemas**.
+*   In the **User** tab, go to **Extensions** -> **JSON** -> **Schemas**.
 
     <figure><img src="../../../../10/umbraco-cms/extending/property-editors/images/JSON-schema.png" alt=""><figcaption></figcaption></figure>
 * Select **Edit in settings.json** from the **Schemas** section.

--- a/12/umbraco-cms/extending/property-editors/package-manifest.md
+++ b/12/umbraco-cms/extending/property-editors/package-manifest.md
@@ -8,17 +8,17 @@ This is a sample manifest, it is always stored in a folder in `/App_Plugins/{You
 
 ```json
 {
-    "name": "Sir Trevor",
+    "name": "Suggestions",
     "version": "1.0.0 beta",
     "allowPackageTelemetry": true,
     "bundleOptions": "Default",
-    "packageView": "/App_Plugins/SirTrevor/SirTrevor-config.html",
+    "packageView": "/App_Plugins/Suggestions/suggestion-config.html",
     "propertyEditors": [
         {
-            "alias": "Sir.Trevor",
-            "name": "Sir Trevor",
+            "alias": "Suggestions",
+            "name": "Suggestions",
             "editor": {
-                "view": "/App_Plugins/SirTrevor/SirTrevor.html",
+                "view": "/App_Plugins/Suggestions/suggestion.html",
                 "hideLabel": true,
                 "valueType": "JSON",
                 "supportsReadOnly": true
@@ -26,44 +26,54 @@ This is a sample manifest, it is always stored in a folder in `/App_Plugins/{You
         }
     ],
     "javascript": [
-        "/App_Plugins/SirTrevor/SirTrevor.controller.js"
+        "/App_Plugins/Suggestions/suggestion.controller.js"
     ]
 }
 ```
 
 ## Sample Manifest with Csharp
 
-You can also register your files by implementing a `IManifestFilter` instead of creating a `package.manifest`. Create a `ManifestFilter.cs` file and implement the `IManifestFilter` interface.
+You can also register your files by implementing a `IManifestFilter` instead of creating a `package.manifest`. Create a `ManifestFilter.cs` file and implement the `IManifestFilter` interface. Then define the composer using the `IComposer` interface.
 
 ```csharp
-public class ManifestFilter : IManifestFilter
+namespace MyProject
 {
-    public void Filter(List<PackageManifest> manifests)
-    {
-        manifests.Add(new PackageManifest
-        {
-            PackageName = "Sir Trevor",
-            Scripts = new[]
-            {
-                "/App_Plugins/SirTrevor/SirTrevor.controller.js"
-            }, 
-            Version = "1.0.0"
-        });
-    }
+	public class ManifestComposer : IComposer
+	{
+		//composer
+		public void Compose(IUmbracoBuilder builder)
+		{
+			builder.ManifestFilters().Append<ManifestFilter>();
+		}
+	}
+	public class ManifestFilter : IManifestFilter
+	{
+		private readonly IDataValueEditorFactory _dataValueEditorFactory;
+
+		public ManifestFilter(IDataValueEditorFactory dataValueEditorFactory)
+		{
+			_dataValueEditorFactory = dataValueEditorFactory;
+		}
+
+		public void Filter(List<PackageManifest> manifests)
+		{
+			manifests.Add(new PackageManifest
+			{
+				PackageName = "Suggestions",
+				Scripts = new[]
+				{
+					"/App_Plugins/Suggestions/suggestion.controller.js"
+				},				
+				Version = "1.0.0"
+			});
+		}
+	}
 }
 ```
 
-Then add the `ManifestFilter.cs` to the `CollectionBuilder`.
-
-```csharp
-public class ManifestComposer : IComposer
-{
-    public void Compose(IUmbracoBuilder builder)
-    {
-        builder.ManifestFilters().Append<ManifestFilter>();
-    }
-}
-```
+{% hint style="info" %}
+    For a functional example, you will need to register the editor and create the `HTML`, `JS` and `CSS` files in `App_Plugin/Suggestions` folder as well. Some examples of registering the editor is found in the `Suggestions.cs` along with the files from `App_Plugin` from the [Creating a property Editor article](https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-property-editor#setting-up-a-property-editor-with-csharp)
+{% endhint %}
 
 ## Root elements
 
@@ -84,7 +94,7 @@ The manifest can contain seven root collections, none of them are mandatory:
 
 ### Telemetry elements
 
-In version 9.2 some additional root elements was added, the purpose of these are to control and facilitate telemetry about the package, none of these are mandatory. The properties are:
+From version 9.2 some additional root elements was added, the purpose of these are to control and facilitate telemetry about the package, none of these are mandatory. The properties are:
 
 * `name` - Allows you to specify a friendly name for your package that will be used for telemetry, if no name is specified the name of the folder will be used instead
 * `version` - The version of your package, if this is not specified there will be no version specific information for your package
@@ -111,7 +121,7 @@ The basic values on any editor are `alias`, `name` and `editor`. These three **m
     "alias": "my.editor.alias",
     "name": "My friendly editor name",
     "editor": {
-        "view": "/App_Plugins/SirTrevor/view.html"
+        "view": "/App_Plugins/MyEditorName/view.html"
     },
     "prevalues": {
         "fields": []
@@ -135,7 +145,7 @@ The basic values on any editor are `alias`, `name` and `editor`. These three **m
 
 ```json
 "editor": {
-    "view": "/App_Plugins/SirTrevor/view.html",
+    "view": "/App_Plugins/MyEditorName/view.html",
     "hideLabel": true,
     "valueType": "TEXT",
     "validation": {},
@@ -246,8 +256,8 @@ The parameter editors array follows the same format as the property editors desc
 ```json
 {
   "javascript": [
-    "/App_Plugins/SirTrevor/SirTrevor.controller.js",
-    "/App_Plugins/SirTrevor/service.js"
+    "/App_Plugins/MyEditorName/MyEditorName.controller.js",
+    "/App_Plugins/MyEditorName/MyEditorName.js"
   ]
 }
 ```
@@ -259,8 +269,8 @@ The parameter editors array follows the same format as the property editors desc
 ```json
 {
   "css": [
-    "/App_Plugins/SirTrevor/SirTrevor.css",
-    "/App_Plugins/SirTrevor/hibba.css"
+    "/App_Plugins/MyEditorName/MyEditorName.css",
+    "/App_Plugins/MyEditorName/hibba.css"
   ]
 }
 ```

--- a/12/umbraco-cms/tutorials/creating-a-property-editor/README.md
+++ b/12/umbraco-cms/tutorials/creating-a-property-editor/README.md
@@ -4,11 +4,7 @@ description: A guide to creating a property editor in Umbraco
 
 # Creating a Property Editor
 
-{% hint style="warning" %}
-This tutorial has last been last tested on v8 and therefore might not work as intended for v10 and above.
-{% endhint %}
-
-This guide explains how to set up a property editor, hook it into Umbraco's Data Types, AngularJS' modules, and its injector, and finally how we can test our property editor.
+This guide explains how to set up a property editor, hook it into Umbraco's Data Types, AngularJS modules, and its injector, and finally how we can test our property editor.
 
 The steps we will go through in part 1 are:
 
@@ -27,11 +23,15 @@ This tutorial covers how to use AngularJS with Umbraco, so it does not cover Ang
 
 ## The End Result
 
-By the end of this tutorial, we will have a suggestion data type running inside of Umbraco, registered as a Data Type in the backoffice, and assigned to a Document Type. The data type can create and suggest values.
+By the end of this tutorial, we will have a "suggestions" data type running inside of Umbraco, registered as a Data Type in the backoffice, and assigned to a Document Type. The data type can create and suggest values.
 
 ## Setting up a plugin
 
 To begin with, let's create a new folder inside `/App_Plugins` folder. We will call it `Suggestions`.
+
+{% hint style="warning" %}
+If you do not have an `/App_Plugins` folded, you can create it at the root of your project.
+{% endhint %}
 
 Next, we will create a Package Manifest file to describe what the plugin does. This manifest will tell Umbraco about our new Property Editor and allow us to inject any needed files into the application.
 
@@ -56,7 +56,7 @@ Inside the `package.manifest` file, we will add the following JSON to describe t
             "group": "Common",
             /*the HTML file we will load for the editor*/
             "editor": {
-                "view": "~/App_Plugins/Suggestions/suggestion.html",
+                "view": "/App_Plugins/Suggestions/suggestion.html",
                 /*Optional: Add 'read-only' support. Available from Umbraco 10.2+*/
                 "supportsReadOnly": true
             }
@@ -64,27 +64,27 @@ Inside the `package.manifest` file, we will add the following JSON to describe t
     ],
      // array of files we want to inject into the application on app_start
     "css": [
-        "~/App_Plugins/Suggestions/suggestion.css"
+        "/App_Plugins/Suggestions/suggestion.css"
     ],
     "javascript": [
-        "~/App_Plugins/Suggestions/suggestion.controller.js"
+        "/App_Plugins/Suggestions/suggestion.controller.js"
     ]
 }
 ```
 
 ## Setting up a Property Editor with Csharp
 
-You can also create a property editor with C# instead of defining it in a `package.manifest`. Create a `Suggestion.cs` file in `/App_Code/` to register the editor this way.
+You can also create a property editor with C# instead of defining it in a `package.manifest`. Create a `Suggestion.cs` file at the root of your project to register the editor this way.
 
 ```csharp
-using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.PropertyEditors;
 
-namespace Umbraco.Cms.Core.PropertyEditors;
+namespace YourProjectName;
 
 [DataEditor(
     alias: "Suggestions editor",
     name: "Suggestions",
-    view: "~/App_Plugins/Suggestions/suggestion.html",
+    view: "/App_Plugins/Suggestions/suggestion.html",
     Group = "Common",
     Icon = "icon-list")]
 public class Suggestions : DataEditor
@@ -96,23 +96,23 @@ public class Suggestions : DataEditor
 }
 ```
 
-You will still need to add all of the files you added above but, because your `C#` code is adding the Property Editor, the `package.manifest` file can be simplified like this:
+As the above `C#` code is adding the Property Editor, the `package.manifest` file can be simplified like this:
 
 ```json
 {
     // array of files we want to inject into the application on app_start
     "css": [
-        "~/App_Plugins/Suggestions/suggestion.css"
+        "/App_Plugins/Suggestions/suggestion.css"
     ],
     "javascript": [
-        "~/App_Plugins/Suggestions/suggestion.controller.js"
+        "/App_Plugins/Suggestions/suggestion.controller.js"
     ]
 }
 ```
 
 ## Writing basic HTML and JavaScript
 
-Now, we will add 3 files to the /App\_Plugins/Suggestions/ folder:
+Now, we will add 3 files to the `/App_Plugins/Suggestions/` folder:
 
 * `suggestion.html`
 * `suggestion.controller.js`
@@ -164,7 +164,7 @@ Now our basic parts of the editor are done, namely:
 
 ## Registering the Data Type in Umbraco
 
-We will now restart our application. In the Document Type, let's add our newly added property editor "Suggestions" and save it.
+We will now restart our application. In the Document Type, add a new property called  "Suggestion" and add to it the newly created property editor "Suggestions" and save it.
 
 ![Suggestion Property Editor](../../../../10/umbraco-cms/tutorials/creating-a-property-editor/images/suggestion-property-editor.png)
 
@@ -202,7 +202,7 @@ angular.module("umbraco")
 Visit the [Property Editors page](../../extending/property-editors/) for more details about extending this service.
 {% endhint %}
 
-and add that id to the button in the HTML:
+Then update the HTML file with the following, where we add the id to the button:
 
 ```html
 <div class="suggestion" ng-controller="SuggestionPluginController">

--- a/12/umbraco-cms/tutorials/creating-a-property-editor/README.md
+++ b/12/umbraco-cms/tutorials/creating-a-property-editor/README.md
@@ -4,7 +4,7 @@ description: A guide to creating a property editor in Umbraco
 
 # Creating a Property Editor
 
-This guide explains how to set up a property editor, hook it into Umbraco's Data Types, AngularJS modules, and its injector, and finally how we can test our property editor.
+This tutorial guides you through creating a property editor, integrating it with Umbraco's Data Types, AngularJS modules and its injector. Finally, it explains how we can test our property editor.
 
 The steps we will go through in part 1 are:
 
@@ -23,14 +23,14 @@ This tutorial covers how to use AngularJS with Umbraco, so it does not cover Ang
 
 ## The End Result
 
-By the end of this tutorial, we will have a "suggestions" data type running inside of Umbraco, registered as a Data Type in the backoffice, and assigned to a Document Type. The data type can create and suggest values.
+We will have a "Suggestions" Data Type in Umbraco. It is registered as a Data Type in the backoffice, and assigned to a Document Type. The Data Type can create and suggest values.
 
 ## Setting up a plugin
 
 To begin with, let's create a new folder inside `/App_Plugins` folder. We will call it `Suggestions`.
 
 {% hint style="warning" %}
-If you do not have an `/App_Plugins` folded, you can create it at the root of your project.
+If you do not have an `/App_Plugins` folder, you can create it at the root of your project.
 {% endhint %}
 
 Next, we will create a Package Manifest file to describe what the plugin does. This manifest will tell Umbraco about our new Property Editor and allow us to inject any needed files into the application.
@@ -199,7 +199,7 @@ angular.module("umbraco")
 ```
 
 {% hint style="info" %}
-Visit the [Property Editors page](../../extending/property-editors/) for more details about extending this service.
+Visit the [Property Editors page](../../extending/property-editors/README.md) for more details about extending this service.
 {% endhint %}
 
 Then update the HTML file with the following, where we add the id to the button:
@@ -218,4 +218,4 @@ Now, clear the cache, reload the document, and see the Suggestions Data Type run
 
 When we save or publish, the value of the Data Type is automatically synced to the current content object and sent to the server, all through the power of Angular and the `ng-model` attribute.
 
-Learn more about extending this service by visiting the [Property Editors page](../../extending/property-editors/).
+Learn more about extending this service by visiting the [Property Editors page](../../extending/property-editors/README.md).

--- a/12/umbraco-cms/tutorials/creating-a-property-editor/part-2.md
+++ b/12/umbraco-cms/tutorials/creating-a-property-editor/part-2.md
@@ -19,29 +19,29 @@ To add configuration options to our Suggestion Data Type, open the `package.mani
 ```json
 ...
 "editor": {
-                "view": "~/App_Plugins/Suggestions/suggestion.html"
-            }, // Remember a comma separator here at the end of the editor block!
- "prevalues": {
-                "fields": [
-                    {
-                        "label": "Enabled?",
-                        "description": "Provides Suggestions",
-                        "key": "isEnabled",
-                        "view": "boolean"
-                    },
-                    {
-                        "label": "Default value",
-                        "description": "Provide a default value for the property editor",
-                        "key": "defaultValue",
-                        "view": "textarea"
-                    }
-                ]
-            }
+    "view": "/App_Plugins/Suggestions/suggestion.html"
+}, // Remember a comma separator here at the end of the editor block!
+"prevalues": {
+    "fields": [
+        {
+            "label": "Enabled?",
+            "description": "Provides Suggestions",
+            "key": "isEnabled",
+            "view": "boolean"
+            },
+        {
+            "label": "Default value",
+            "description": "Provide a default value for the property editor",
+            "key": "defaultValue",
+            "view": "textarea"
+        }
+    ]
+}
 ```
 
 So what did we add? We added a prevalue editor, with a `fields` collection. This collection contains information about the UI we will render on the Data Type configuration for this editor.
 
-The label "Enabled?" uses the "boolean" view. This will allow us to turn the suggestions on/off and will provide the user with a toggle button. The name "boolean" comes from the convention that all preview editors are stored in `/umbraco/views/prevalueeditors/` and then found via `boolean.html`.
+The label "Enabled?" uses the "boolean" view. This will allow us to turn the suggestions on/off and will provide the user with a toggle button. The name "boolean" comes from the convention of all preview editors.
 
 Same with the "Default value" label, it will provide the user with a textarea. The user can input a default value for the property editor that should be displayed when the property editor is blank.
 
@@ -49,7 +49,7 @@ To hide the property editor label, add the `hideLabel` parameter in the `editor`
 
 ```json
  "editor": {
-        "view": "~/App_Plugins/Suggestions/suggestion.html",
+        "view": "/App_Plugins/Suggestions/suggestion.html",
         //Turn the label on or off by using true or false, respectively.
         "hideLabel": true,
         /*Optional: Add 'read-only' support. Available from Umbraco 10.2+*/
@@ -74,7 +74,7 @@ Your `package.manifest` file should now look something like this:
       "group": "Common",
       /*the HTML file we will load for the editor*/
       "editor": {
-        "view": "~/App_Plugins/Suggestions/suggestion.html",
+        "view": "/App_Plugins/Suggestions/suggestion.html",
         //Turn the label on or off by using true or false, respectively.
         "hideLabel": true,
         /*Optional: Add 'read-only' support. Available from Umbraco 10.2+*/
@@ -100,22 +100,24 @@ Your `package.manifest` file should now look something like this:
   ],
   // array of files we want to inject into the application on app_start
   "css": [
-    "~/App_Plugins/Suggestions/suggestion.css"
+    "/App_Plugins/Suggestions/suggestion.css"
   ],
   "javascript": [
-    "~/App_Plugins/Suggestions/suggestion.controller.js"
+    "/App_Plugins/Suggestions/suggestion.controller.js"
   ]
 }
 ```
 
 ## Csharp
 
-It is also possible to add configuration if you have chosen to create a property editor using C#. Create two new files in the `/App_Code/` folder and update the existing `Suggestion.cs` file to add configuration to the property editor.
+It is also possible to add configuration if you have chosen to create a property editor using C#. Create two new files at the root of your project and update the existing `Suggestion.cs` file to add configuration to the property editor.
 
 First create a `SuggestionConfiguration.cs` file with three configuration options: `Enabled?`, `Default Value`, and `Hide Label?`:
 
 ```csharp
-namespace Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PropertyEditors;
+
+namespace YourProjectName;
 
 public class SuggestionConfiguration
 {
@@ -124,25 +126,27 @@ public class SuggestionConfiguration
 
     [ConfigurationField("defaultValue", "Default Value", "textarea", Description = "Provide a default value for the property")]
     public string? DefaultValue { get; set; }
-
+    
     [ConfigurationField("hideLabel", "Hide Label?", "boolean", Description = "Hide the property label.")]
     public bool HideLabel { get; set; }
 }
+
 ```
 
 Then create a `SuggestionConfigurationEditor.cs` file:
 
 ```csharp
 using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.PropertyEditors;
 
-namespace Umbraco.Cms.Core.PropertyEditors;
-
+namespace MyProject;
 public class SuggestionConfigurationEditor : ConfigurationEditor<SuggestionConfiguration>
-{
-    public SuggestionConfigurationEditor(IIOHelper ioHelper) : base(ioHelper)
     {
+        [Obsolete]
+        public SuggestionConfigurationEditor(IIOHelper ioHelper) : base(ioHelper)
+        {
+        }
     }
-}
 ```
 
 Finally, edit the `Suggestion.cs` file from step one until it looks like the example below:
@@ -150,12 +154,12 @@ Finally, edit the `Suggestion.cs` file from step one until it looks like the exa
 ```csharp
 using Umbraco.Cms.Core.IO;
 
-namespace Umbraco.Cms.Core.PropertyEditors;
+namespace YourProjectName;
 
 [DataEditor(
     alias: "Suggestions editor",
     name: "Suggestions Editor",
-    view: "~/App_Plugins/Suggestions/suggestion.html",
+    view: "/App_Plugins/Suggestions/suggestion.html",
     Group = "Common",
     Icon = "icon-list")]
 public class Suggestions : DataEditor
@@ -171,73 +175,76 @@ public class Suggestions : DataEditor
     protected override IConfigurationEditor CreateConfigurationEditor() => new SuggestionConfigurationEditor(_ioHelper);
 
 }
+
 ```
 
-Save the file, rebuild the application, and have a look at the Suggestions Data Type. You should see that you have three configuration options.
+Save the file, rebuild the application and have a look at the Suggestions Data Type. You should see that you have one configuration option.
 
-![An example of how the configuration will look](../../../../10/umbraco-cms/tutorials/creating-a-property-editor/images/suggestion-editor-config\_1.png)
+![An example of how the configuration will look](images/suggestion-editor-config\_1.png)
 
 ## Using the configuration
 
 The next step is to gain access to our new configuration options. For this, open the `suggestion.controller.js` file.
 
-1.  Let's add the `isEnabled` functionality. Before the closing tag, we will add a `getState` method:
+1. Let's add the `isEnabled` functionality. Before the closing tag, we will add a `getState` method:
 
-    ```javascript
-        // The controller assigns the behavior to scope as defined by the getState method, which is invoked when the user toggles the enable button in the data type settings.
-        $scope.getState = function () {
+```javascript
+// The controller assigns the behavior to scope as defined by the getState method, which is invoked when the user toggles the enable button in the data type settings.
+$scope.getState = function () {
             
-            //If the data type is enabled in the Settings the 'Give me Suggestions!' button is enabled
-             if (Boolean(Number($scope.model.config.isEnabled))) {
-                return false;
-            }
-            return true;
+//If the data type is enabled in the Settings the 'Give me Suggestions!' button is enabled
+    if (Boolean(Number($scope.model.config.isEnabled))) {
+            return false;
         }
-    ```
-2.  Next, we'll add the `defaultValue` functionality. When the `$scope.model.value` is empty or null, we want to use the default value. To do that, we add the following to the start of the controller:
+    return true;
+}
+```
 
-    ```js
-    if($scope.model.value === null || $scope.model.value === ""){
-        $scope.model.value = $scope.model.config.defaultValue;
-    }
-    ```
+2. Next, we'll add the `defaultValue` functionality. When the `$scope.model.value` is empty or null, we want to use the default value. To do that, we add the following to the start of the controller:
 
-    See what's new? The `$scope.model.config` object. Also, because of this configuration, we now have access to `$scope.model.config.defaultValue` which contains the configuration value for that key.
+```js
+if($scope.model.value === null || $scope.model.value === ""){
+    $scope.model.value = $scope.model.config.defaultValue;
+}
+```
 
-    Your `suggestion.controller.js` file should now look like:
+See what's new? The `$scope.model.config` object. Also, because of this configuration, we now have access to `$scope.model.config.defaultValue` which contains the configuration value for that key.
 
-    ```javascript
-    angular.module("umbraco")
-        .controller("SuggestionPluginController",
-            // Scope object is the main object which is used to pass information from the controller to the view.
-            function ($scope) {
-                if ($scope.model.value === null || $scope.model.value === "") {
-                    $scope.model.value = $scope.model.config.defaultValue;
+Your `suggestion.controller.js` file should now look like:
+
+```javascript
+angular.module("umbraco")
+    .controller("SuggestionPluginController",
+        // Scope object is the main object which is used to pass information from the controller to the view.
+        function ($scope) {
+            if ($scope.model.value === null || $scope.model.value === "") {
+                $scope.model.value = $scope.model.config.defaultValue;
+            }
+            // SuggestionPluginController assigns the suggestions list to the aSuggestions property of the scope
+            $scope.aSuggestions = ["You should take a break", "I suggest that you visit the Eiffel Tower", "How about starting a book club today or this week?", "Are you hungry?"];
+
+            // The controller assigns the behavior to scope as defined by the getSuggestion method, which is invoked when the user clicks on the 'Give me Suggestions!' button.
+            $scope.getSuggestion = function () {
+
+                // The getSuggestion method reads a random value from an array and provides a Suggestion. 
+                $scope.model.value = $scope.aSuggestions[$scope.aSuggestions.length * Math.random() | 0];
+            }
+        
+            // The controller assigns the behavior to scope as defined by the getState method, which is invoked when the user toggles the enable button in the data type settings.
+
+            $scope.getState = function () {
+
+                //If the data type is enabled in the Settings the 'Give me Suggestions!' button is enabled
+                if (Boolean(Number($scope.model.config.isEnabled))) {
+                    return false;
                 }
-                // SuggestionPluginController assigns the suggestions list to the aSuggestions property of the scope
-                $scope.aSuggestions = ["You should take a break", "I suggest that you visit the Eiffel Tower", "How about starting a book club today or this week?", "Are you hungry?"];
+                return true;
+            }
 
-                // The controller assigns the behavior to scope as defined by the getSuggestion method, which is invoked when the user clicks on the 'Give me Suggestions!' button.
-                $scope.getSuggestion = function () {
+});
+```
 
-                    // The getSuggestion method reads a random value from an array and provides a Suggestion. 
-                    $scope.model.value = $scope.aSuggestions[$scope.aSuggestions.length * Math.random() | 0];
-
-                }
-            
-                // The controller assigns the behavior to scope as defined by the getState method, which is invoked when the user toggles the enable button in the data type settings.
-                $scope.getState = function () {
-
-                    //If the data type is enabled in the Settings the 'Give me Suggestions!' button is enabled
-                     if (Boolean(Number($scope.model.config.isEnabled))) {
-                        return false;
-                    }
-                    return true;
-                }
-
-            });
-    ```
-3.  Finally, we'll add the `hideLabel` functionality. For this, we'll open the `Suggestion.cs` file and override the GetValueEditor method with configuration as a parameter.
+3. Finally, we'll add the `hideLabel` functionality. For this, we'll open the `Suggestion.cs` file and override the GetValueEditor method with configuration as a parameter.
 
     ```cs
     public override IDataValueEditor GetValueEditor(object? configuration)
@@ -260,15 +267,16 @@ The next step is to gain access to our new configuration options. For this, open
     ```cs
     using Umbraco.Cms.Core.IO;
     using Umbraco.Cms.Core.Models;
+    using Umbraco.Cms.Core.PropertyEditors;
 
-    namespace Umbraco.Cms.Core.PropertyEditors;
+    namespace YourProjectName;
 
     [DataEditor(
-        alias: "Suggestions editor",
-        name: "Suggestions Editor",
-        view: "~/App_Plugins/Suggestions/suggestion.html",
-        Group = "Common",
-        Icon = "icon-list")]
+	alias: "Suggestions editor",
+	name: "Suggestions Editor",
+	view: "/App_Plugins/Suggestions/suggestion.html",
+	Group = "Common",
+	Icon = "icon-list")]
     public class Suggestions : DataEditor
     {
         private readonly IIOHelper _ioHelper;
@@ -299,6 +307,6 @@ The next step is to gain access to our new configuration options. For this, open
 
 Save the files and rebuild the application. To access the configuration options, enable/disable the `Enabled?` and `Hide Label?` options. Additionally, you can set a default value in the `Default Value` field and see the Suggestions Data Type at play.
 
-![An example of setting the configuration](../../../../10/umbraco-cms/tutorials/creating-a-property-editor/images/suggestion-editor-config\_2.png)
+![An example of setting the configuration](images/suggestion-editor-config\_2.png)
 
-![Backoffice view](../../../../10/umbraco-cms/tutorials/creating-a-property-editor/images/suggestion-editor-backoffice\_1.png)
+![Backoffice view](images/suggestion-editor-backoffice\_1.png)

--- a/12/umbraco-cms/tutorials/creating-a-property-editor/part-3.md
+++ b/12/umbraco-cms/tutorials/creating-a-property-editor/part-3.md
@@ -114,15 +114,15 @@ angular.module("umbraco")
 ```json
 {
  "javascript": [
-        "~/App_Plugins/Suggestions/suggestion.controller.js",
-        "~/App_Plugins/Suggestions/notification.controller.js"
+        "/App_Plugins/Suggestions/suggestion.controller.js",
+        "/App_Plugins/Suggestions/notification.controller.js"
     ]
 }
 ```
 
 ## Creating custom Notification View and Controller
 
-We will add 2 files to the /App\_Plugins/Suggestions/ folder:
+We will add 2 files to the `/App_Plugins/Suggestions/` folder:
 
 * `notification.html`
 * `notification.controller.js`

--- a/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -1,3 +1,8 @@
+---
+
+needsV9Update: "true"
+---
+
 # Adding server-side data to a property editor
 
 ## Overview
@@ -33,26 +38,20 @@ INSERT INTO people(name,town,country) VALUES('Aimee Sampson','Hawera','Antigua a
 
 Next we need to define an `ApiController` to expose a server-side route which our application will use to fetch the data.
 
-For this, we will create a file at: `/App_Code/PersonApiController.cs`. It must be in `App_Code` since we want our app to compile it on start. Alternatively, you can add it to a normal .NET project and compile it into a DLL as usual.
+For this, you can create a new class at the root of the project called `PersonApiController.cs`
 
 In the `PersonApiController.cs` file, add:
 
 ```csharp
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
+    using Umbraco.Cms.Web.BackOffice.Controllers;
+    using Umbraco.Cms.Core.Web.Mvc;
 
-using Umbraco.Cms.Web.BackOffice.Controllers;
-using Umbraco.Cms.Web.Common.Attributes;
-
-namespace My.Controllers;
-
-[Umbraco.Web.Mvc.PluginController("My")]
-public class PersonApiController : UmbracoAuthorizedJsonController
-{
-    // we will add a method here later
-}
+    namespace YourProjectName;
+    [PluginControllerMetadata("My")]
+    public class PersonApiController : UmbracoAuthorizedJsonController
+    {
+        // we will add a method here later
+    }
 ```
 
 This is a very basic API controller which inherits from `UmbracoAuthorizedJsonController` this specific class will only return JSON data and only to requests which are authorized to access the backoffice.

--- a/13/umbraco-cms/extending/property-editors/package-manifest.md
+++ b/13/umbraco-cms/extending/property-editors/package-manifest.md
@@ -36,6 +36,10 @@ This is a sample manifest, it is always stored in a folder in `/App_Plugins/{You
 You can also register your files by implementing a `IManifestFilter` instead of creating a `package.manifest`. Create a `ManifestFilter.cs` file and implement the `IManifestFilter` interface. Then define the composer using the `IComposer` interface.
 
 ```csharp
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Manifest;
+using Umbraco.Cms.Core.PropertyEditors;
+
 namespace MyProject
 {
 	public class ManifestComposer : IComposer
@@ -72,7 +76,9 @@ namespace MyProject
 ```
 
 {% hint style="info" %}
-    For a functional example, you will need to register the editor and create the `HTML`, `JS` and `CSS` files in `App_Plugin/Suggestions` folder as well. Some examples of registering the editor is found in the `Suggestions.cs` along with the files from `App_Plugin` from the [Creating a property Editor article](https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-property-editor#setting-up-a-property-editor-with-csharp)
+
+For a functional example, you will need to register the editor and create the `HTML`, `JS`, and `CSS` files in the `App_Plugins/Suggestions` folder. You can find some examples of registering the editor in the `Suggestions.cs` file and within the files in the `App_Plugins` folder. For more information, see the [Creating a Property Editor article](https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-property-editor#setting-up-a-property-editor-with-csharp).
+
 {% endhint %}
 
 ## Root elements
@@ -94,7 +100,7 @@ The manifest can contain seven root collections, none of them are mandatory:
 
 ### Telemetry elements
 
-From version 9.2 some additional root elements was added, the purpose of these are to control and facilitate telemetry about the package, none of these are mandatory. The properties are:
+From version 9.2, some additional root elements were added. Their purpose is to control and facilitate telemetry for the package but none of these are mandatory. The properties are:
 
 * `name` - Allows you to specify a friendly name for your package that will be used for telemetry, if no name is specified the name of the folder will be used instead
 * `version` - The version of your package, if this is not specified there will be no version specific information for your package
@@ -316,7 +322,7 @@ To associate the hosted JSON schema file to all package.manifest files you will 
 To associate the hosted JSON schema file to all package.manifest files you will need to perform the following inside of Visual Studio Code editor.
 
 * File -> Preferences -> Settings. The **Settings** window opens.
-*   In the **User** or **Workspace** tab, go to **Extensions** -> **JSON** -> **Schemas**.
+*   In the **User** tab, go to **Extensions** -> **JSON** -> **Schemas**.
 
     <figure><img src="../../../../10/umbraco-cms/extending/property-editors/images/JSON-schema.png" alt=""><figcaption></figcaption></figure>
 * Select **Edit in settings.json** from the **Schemas** section.

--- a/13/umbraco-cms/extending/property-editors/package-manifest.md
+++ b/13/umbraco-cms/extending/property-editors/package-manifest.md
@@ -8,17 +8,17 @@ This is a sample manifest, it is always stored in a folder in `/App_Plugins/{You
 
 ```json
 {
-    "name": "Sir Trevor",
+    "name": "Suggestions",
     "version": "1.0.0 beta",
     "allowPackageTelemetry": true,
     "bundleOptions": "Default",
-    "packageView": "/App_Plugins/SirTrevor/SirTrevor-config.html",
+    "packageView": "/App_Plugins/Suggestions/suggestion-config.html",
     "propertyEditors": [
         {
-            "alias": "Sir.Trevor",
-            "name": "Sir Trevor",
+            "alias": "Suggestions",
+            "name": "Suggestions",
             "editor": {
-                "view": "/App_Plugins/SirTrevor/SirTrevor.html",
+                "view": "/App_Plugins/Suggestions/suggestion.html",
                 "hideLabel": true,
                 "valueType": "JSON",
                 "supportsReadOnly": true
@@ -26,44 +26,54 @@ This is a sample manifest, it is always stored in a folder in `/App_Plugins/{You
         }
     ],
     "javascript": [
-        "/App_Plugins/SirTrevor/SirTrevor.controller.js"
+        "/App_Plugins/Suggestions/suggestion.controller.js"
     ]
 }
 ```
 
 ## Sample Manifest with Csharp
 
-You can also register your files by implementing a `IManifestFilter` instead of creating a `package.manifest`. Create a `ManifestFilter.cs` file and implement the `IManifestFilter` interface.
+You can also register your files by implementing a `IManifestFilter` instead of creating a `package.manifest`. Create a `ManifestFilter.cs` file and implement the `IManifestFilter` interface. Then define the composer using the `IComposer` interface.
 
 ```csharp
-public class ManifestFilter : IManifestFilter
+namespace MyProject
 {
-    public void Filter(List<PackageManifest> manifests)
-    {
-        manifests.Add(new PackageManifest
-        {
-            PackageName = "Sir Trevor",
-            Scripts = new[]
-            {
-                "/App_Plugins/SirTrevor/SirTrevor.controller.js"
-            }, 
-            Version = "1.0.0"
-        });
-    }
+	public class ManifestComposer : IComposer
+	{
+		//composer
+		public void Compose(IUmbracoBuilder builder)
+		{
+			builder.ManifestFilters().Append<ManifestFilter>();
+		}
+	}
+	public class ManifestFilter : IManifestFilter
+	{
+		private readonly IDataValueEditorFactory _dataValueEditorFactory;
+
+		public ManifestFilter(IDataValueEditorFactory dataValueEditorFactory)
+		{
+			_dataValueEditorFactory = dataValueEditorFactory;
+		}
+
+		public void Filter(List<PackageManifest> manifests)
+		{
+			manifests.Add(new PackageManifest
+			{
+				PackageName = "Suggestions",
+				Scripts = new[]
+				{
+					"/App_Plugins/Suggestions/suggestion.controller.js"
+				},				
+				Version = "1.0.0"
+			});
+		}
+	}
 }
 ```
 
-Then add the `ManifestFilter.cs` to the `CollectionBuilder`.
-
-```csharp
-public class ManifestComposer : IComposer
-{
-    public void Compose(IUmbracoBuilder builder)
-    {
-        builder.ManifestFilters().Append<ManifestFilter>();
-    }
-}
-```
+{% hint style="info" %}
+    For a functional example, you will need to register the editor and create the `HTML`, `JS` and `CSS` files in `App_Plugin/Suggestions` folder as well. Some examples of registering the editor is found in the `Suggestions.cs` along with the files from `App_Plugin` from the [Creating a property Editor article](https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-property-editor#setting-up-a-property-editor-with-csharp)
+{% endhint %}
 
 ## Root elements
 
@@ -84,7 +94,7 @@ The manifest can contain seven root collections, none of them are mandatory:
 
 ### Telemetry elements
 
-In version 9.2 some additional root elements was added, the purpose of these are to control and facilitate telemetry about the package, none of these are mandatory. The properties are:
+From version 9.2 some additional root elements was added, the purpose of these are to control and facilitate telemetry about the package, none of these are mandatory. The properties are:
 
 * `name` - Allows you to specify a friendly name for your package that will be used for telemetry, if no name is specified the name of the folder will be used instead
 * `version` - The version of your package, if this is not specified there will be no version specific information for your package
@@ -111,7 +121,7 @@ The basic values on any editor are `alias`, `name` and `editor`. These three **m
     "alias": "my.editor.alias",
     "name": "My friendly editor name",
     "editor": {
-        "view": "/App_Plugins/SirTrevor/view.html"
+        "view": "/App_Plugins/MyEditorName/view.html"
     },
     "prevalues": {
         "fields": []
@@ -135,7 +145,7 @@ The basic values on any editor are `alias`, `name` and `editor`. These three **m
 
 ```json
 "editor": {
-    "view": "/App_Plugins/SirTrevor/view.html",
+    "view": "/App_Plugins/MyEditorName/view.html",
     "hideLabel": true,
     "valueType": "TEXT",
     "validation": {},
@@ -246,8 +256,8 @@ The parameter editors array follows the same format as the property editors desc
 ```json
 {
   "javascript": [
-    "/App_Plugins/SirTrevor/SirTrevor.controller.js",
-    "/App_Plugins/SirTrevor/service.js"
+    "/App_Plugins/MyEditorName/MyEditorName.controller.js",
+    "/App_Plugins/MyEditorName/MyEditorName.js"
   ]
 }
 ```
@@ -259,8 +269,8 @@ The parameter editors array follows the same format as the property editors desc
 ```json
 {
   "css": [
-    "/App_Plugins/SirTrevor/SirTrevor.css",
-    "/App_Plugins/SirTrevor/hibba.css"
+    "/App_Plugins/MyEditorName/MyEditorName.css",
+    "/App_Plugins/MyEditorName/hibba.css"
   ]
 }
 ```

--- a/13/umbraco-cms/tutorials/creating-a-property-editor/README.md
+++ b/13/umbraco-cms/tutorials/creating-a-property-editor/README.md
@@ -4,11 +4,7 @@ description: A guide to creating a property editor in Umbraco
 
 # Creating a Property Editor
 
-{% hint style="warning" %}
-This tutorial has last been last tested on v8 and therefore might not work as intended for v10 and above.
-{% endhint %}
-
-This guide explains how to set up a property editor, hook it into Umbraco's Data Types, AngularJS' modules, and its injector, and finally how we can test our property editor.
+This guide explains how to set up a property editor, hook it into Umbraco's Data Types, AngularJS modules, and its injector, and finally how we can test our property editor.
 
 The steps we will go through in part 1 are:
 
@@ -27,11 +23,15 @@ This tutorial covers how to use AngularJS with Umbraco, so it does not cover Ang
 
 ## The End Result
 
-By the end of this tutorial, we will have a suggestion data type running inside of Umbraco, registered as a Data Type in the backoffice, and assigned to a Document Type. The data type can create and suggest values.
+By the end of this tutorial, we will have a "suggestions" data type running inside of Umbraco, registered as a Data Type in the backoffice, and assigned to a Document Type. The data type can create and suggest values.
 
 ## Setting up a plugin
 
 To begin with, let's create a new folder inside `/App_Plugins` folder. We will call it `Suggestions`.
+
+{% hint style="warning" %}
+If you do not have an `/App_Plugins` folded, you can create it at the root of your project.
+{% endhint %}
 
 Next, we will create a Package Manifest file to describe what the plugin does. This manifest will tell Umbraco about our new Property Editor and allow us to inject any needed files into the application.
 
@@ -56,7 +56,7 @@ Inside the `package.manifest` file, we will add the following JSON to describe t
             "group": "Common",
             /*the HTML file we will load for the editor*/
             "editor": {
-                "view": "~/App_Plugins/Suggestions/suggestion.html",
+                "view": "/App_Plugins/Suggestions/suggestion.html",
                 /*Optional: Add 'read-only' support. Available from Umbraco 10.2+*/
                 "supportsReadOnly": true
             }
@@ -64,27 +64,27 @@ Inside the `package.manifest` file, we will add the following JSON to describe t
     ],
      // array of files we want to inject into the application on app_start
     "css": [
-        "~/App_Plugins/Suggestions/suggestion.css"
+        "/App_Plugins/Suggestions/suggestion.css"
     ],
     "javascript": [
-        "~/App_Plugins/Suggestions/suggestion.controller.js"
+        "/App_Plugins/Suggestions/suggestion.controller.js"
     ]
 }
 ```
 
 ## Setting up a Property Editor with Csharp
 
-You can also create a property editor with C# instead of defining it in a `package.manifest`. Create a `Suggestion.cs` file in `/App_Code/` to register the editor this way.
+You can also create a property editor with C# instead of defining it in a `package.manifest`. Create a `Suggestion.cs` file at the root of your project to register the editor this way.
 
 ```csharp
-using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.PropertyEditors;
 
-namespace Umbraco.Cms.Core.PropertyEditors;
+namespace YourProjectName;
 
 [DataEditor(
     alias: "Suggestions editor",
     name: "Suggestions",
-    view: "~/App_Plugins/Suggestions/suggestion.html",
+    view: "/App_Plugins/Suggestions/suggestion.html",
     Group = "Common",
     Icon = "icon-list")]
 public class Suggestions : DataEditor
@@ -96,23 +96,23 @@ public class Suggestions : DataEditor
 }
 ```
 
-You will still need to add all of the files you added above but, because your `C#` code is adding the Property Editor, the `package.manifest` file can be simplified like this:
+As the above `C#` code is adding the Property Editor, the `package.manifest` file can be simplified like this:
 
 ```json
 {
     // array of files we want to inject into the application on app_start
     "css": [
-        "~/App_Plugins/Suggestions/suggestion.css"
+        "/App_Plugins/Suggestions/suggestion.css"
     ],
     "javascript": [
-        "~/App_Plugins/Suggestions/suggestion.controller.js"
+        "/App_Plugins/Suggestions/suggestion.controller.js"
     ]
 }
 ```
 
 ## Writing basic HTML and JavaScript
 
-Now, we will add 3 files to the /App\_Plugins/Suggestions/ folder:
+Now, we will add 3 files to the `/App_Plugins/Suggestions/` folder:
 
 * `suggestion.html`
 * `suggestion.controller.js`
@@ -164,7 +164,7 @@ Now our basic parts of the editor are done, namely:
 
 ## Registering the Data Type in Umbraco
 
-We will now restart our application. In the Document Type, let's add our newly added property editor "Suggestions" and save it.
+We will now restart our application. In the Document Type, add a new property called  "Suggestion" and add to it the newly created property editor "Suggestions" and save it.
 
 ![Suggestion Property Editor](../../../../10/umbraco-cms/tutorials/creating-a-property-editor/images/suggestion-property-editor.png)
 
@@ -202,7 +202,7 @@ angular.module("umbraco")
 Visit the [Property Editors page](../../extending/property-editors/) for more details about extending this service.
 {% endhint %}
 
-and add that id to the button in the HTML:
+Then update the HTML file with the following, where we add the id to the button:
 
 ```html
 <div class="suggestion" ng-controller="SuggestionPluginController">

--- a/13/umbraco-cms/tutorials/creating-a-property-editor/README.md
+++ b/13/umbraco-cms/tutorials/creating-a-property-editor/README.md
@@ -4,7 +4,7 @@ description: A guide to creating a property editor in Umbraco
 
 # Creating a Property Editor
 
-This guide explains how to set up a property editor, hook it into Umbraco's Data Types, AngularJS modules, and its injector, and finally how we can test our property editor.
+This tutorial guides you through creating a property editor, integrating it with Umbraco's Data Types, AngularJS modules and its injector. Finally, it explains how we can test our property editor.
 
 The steps we will go through in part 1 are:
 
@@ -23,14 +23,14 @@ This tutorial covers how to use AngularJS with Umbraco, so it does not cover Ang
 
 ## The End Result
 
-By the end of this tutorial, we will have a "suggestions" data type running inside of Umbraco, registered as a Data Type in the backoffice, and assigned to a Document Type. The data type can create and suggest values.
+We will have a "Suggestions" Data Type in Umbraco. It is registered as a Data Type in the backoffice, and assigned to a Document Type. The Data Type can create and suggest values.
 
 ## Setting up a plugin
 
 To begin with, let's create a new folder inside `/App_Plugins` folder. We will call it `Suggestions`.
 
 {% hint style="warning" %}
-If you do not have an `/App_Plugins` folded, you can create it at the root of your project.
+If you do not have an `/App_Plugins` folder, you can create it at the root of your project.
 {% endhint %}
 
 Next, we will create a Package Manifest file to describe what the plugin does. This manifest will tell Umbraco about our new Property Editor and allow us to inject any needed files into the application.
@@ -199,7 +199,7 @@ angular.module("umbraco")
 ```
 
 {% hint style="info" %}
-Visit the [Property Editors page](../../extending/property-editors/) for more details about extending this service.
+Visit the [Property Editors page](../../extending/property-editors/README.md) for more details about extending this service.
 {% endhint %}
 
 Then update the HTML file with the following, where we add the id to the button:
@@ -218,4 +218,4 @@ Now, clear the cache, reload the document, and see the Suggestions Data Type run
 
 When we save or publish, the value of the Data Type is automatically synced to the current content object and sent to the server, all through the power of Angular and the `ng-model` attribute.
 
-Learn more about extending this service by visiting the [Property Editors page](../../extending/property-editors/).
+Learn more about extending this service by visiting the [Property Editors page](../../extending/property-editors/README.md).

--- a/13/umbraco-cms/tutorials/creating-a-property-editor/part-2.md
+++ b/13/umbraco-cms/tutorials/creating-a-property-editor/part-2.md
@@ -19,29 +19,29 @@ To add configuration options to our Suggestion Data Type, open the `package.mani
 ```json
 ...
 "editor": {
-                "view": "~/App_Plugins/Suggestions/suggestion.html"
-            }, // Remember a comma separator here at the end of the editor block!
- "prevalues": {
-                "fields": [
-                    {
-                        "label": "Enabled?",
-                        "description": "Provides Suggestions",
-                        "key": "isEnabled",
-                        "view": "boolean"
-                    },
-                    {
-                        "label": "Default value",
-                        "description": "Provide a default value for the property editor",
-                        "key": "defaultValue",
-                        "view": "textarea"
-                    }
-                ]
-            }
+    "view": "/App_Plugins/Suggestions/suggestion.html"
+}, // Remember a comma separator here at the end of the editor block!
+"prevalues": {
+    "fields": [
+        {
+            "label": "Enabled?",
+            "description": "Provides Suggestions",
+            "key": "isEnabled",
+            "view": "boolean"
+            },
+        {
+            "label": "Default value",
+            "description": "Provide a default value for the property editor",
+            "key": "defaultValue",
+            "view": "textarea"
+        }
+    ]
+}
 ```
 
 So what did we add? We added a prevalue editor, with a `fields` collection. This collection contains information about the UI we will render on the Data Type configuration for this editor.
 
-The label "Enabled?" uses the "boolean" view. This will allow us to turn the suggestions on/off and will provide the user with a toggle button. The name "boolean" comes from the convention that all preview editors are stored in `/umbraco/views/prevalueeditors/` and then found via `boolean.html`.
+The label "Enabled?" uses the "boolean" view. This will allow us to turn the suggestions on/off and will provide the user with a toggle button. The name "boolean" comes from the convention of all preview editors.
 
 Same with the "Default value" label, it will provide the user with a textarea. The user can input a default value for the property editor that should be displayed when the property editor is blank.
 
@@ -49,7 +49,7 @@ To hide the property editor label, add the `hideLabel` parameter in the `editor`
 
 ```json
  "editor": {
-        "view": "~/App_Plugins/Suggestions/suggestion.html",
+        "view": "/App_Plugins/Suggestions/suggestion.html",
         //Turn the label on or off by using true or false, respectively.
         "hideLabel": true,
         /*Optional: Add 'read-only' support. Available from Umbraco 10.2+*/
@@ -74,7 +74,7 @@ Your `package.manifest` file should now look something like this:
       "group": "Common",
       /*the HTML file we will load for the editor*/
       "editor": {
-        "view": "~/App_Plugins/Suggestions/suggestion.html",
+        "view": "/App_Plugins/Suggestions/suggestion.html",
         //Turn the label on or off by using true or false, respectively.
         "hideLabel": true,
         /*Optional: Add 'read-only' support. Available from Umbraco 10.2+*/
@@ -100,22 +100,24 @@ Your `package.manifest` file should now look something like this:
   ],
   // array of files we want to inject into the application on app_start
   "css": [
-    "~/App_Plugins/Suggestions/suggestion.css"
+    "/App_Plugins/Suggestions/suggestion.css"
   ],
   "javascript": [
-    "~/App_Plugins/Suggestions/suggestion.controller.js"
+    "/App_Plugins/Suggestions/suggestion.controller.js"
   ]
 }
 ```
 
 ## Csharp
 
-It is also possible to add configuration if you have chosen to create a property editor using C#. Create two new files in the `/App_Code/` folder and update the existing `Suggestion.cs` file to add configuration to the property editor.
+It is also possible to add configuration if you have chosen to create a property editor using C#. Create two new files at the root of your project and update the existing `Suggestion.cs` file to add configuration to the property editor.
 
 First create a `SuggestionConfiguration.cs` file with three configuration options: `Enabled?`, `Default Value`, and `Hide Label?`:
 
 ```csharp
-namespace Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PropertyEditors;
+
+namespace YourProjectName;
 
 public class SuggestionConfiguration
 {
@@ -124,25 +126,27 @@ public class SuggestionConfiguration
 
     [ConfigurationField("defaultValue", "Default Value", "textarea", Description = "Provide a default value for the property")]
     public string? DefaultValue { get; set; }
-
+    
     [ConfigurationField("hideLabel", "Hide Label?", "boolean", Description = "Hide the property label.")]
     public bool HideLabel { get; set; }
 }
+
 ```
 
 Then create a `SuggestionConfigurationEditor.cs` file:
 
 ```csharp
 using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.PropertyEditors;
 
-namespace Umbraco.Cms.Core.PropertyEditors;
-
+namespace MyProject;
 public class SuggestionConfigurationEditor : ConfigurationEditor<SuggestionConfiguration>
-{
-    public SuggestionConfigurationEditor(IIOHelper ioHelper) : base(ioHelper)
     {
+        [Obsolete]
+        public SuggestionConfigurationEditor(IIOHelper ioHelper) : base(ioHelper)
+        {
+        }
     }
-}
 ```
 
 Finally, edit the `Suggestion.cs` file from step one until it looks like the example below:
@@ -150,12 +154,12 @@ Finally, edit the `Suggestion.cs` file from step one until it looks like the exa
 ```csharp
 using Umbraco.Cms.Core.IO;
 
-namespace Umbraco.Cms.Core.PropertyEditors;
+namespace YourProjectName;
 
 [DataEditor(
     alias: "Suggestions editor",
     name: "Suggestions Editor",
-    view: "~/App_Plugins/Suggestions/suggestion.html",
+    view: "/App_Plugins/Suggestions/suggestion.html",
     Group = "Common",
     Icon = "icon-list")]
 public class Suggestions : DataEditor
@@ -171,73 +175,76 @@ public class Suggestions : DataEditor
     protected override IConfigurationEditor CreateConfigurationEditor() => new SuggestionConfigurationEditor(_ioHelper);
 
 }
+
 ```
 
-Save the file, rebuild the application, and have a look at the Suggestions Data Type. You should see that you have three configuration options.
+Save the file, rebuild the application and have a look at the Suggestions Data Type. You should see that you have one configuration option.
 
-![An example of how the configuration will look](../../../../10/umbraco-cms/tutorials/creating-a-property-editor/images/suggestion-editor-config\_1.png)
+![An example of how the configuration will look](images/suggestion-editor-config\_1.png)
 
 ## Using the configuration
 
 The next step is to gain access to our new configuration options. For this, open the `suggestion.controller.js` file.
 
-1.  Let's add the `isEnabled` functionality. Before the closing tag, we will add a `getState` method:
+1. Let's add the `isEnabled` functionality. Before the closing tag, we will add a `getState` method:
 
-    ```javascript
-        // The controller assigns the behavior to scope as defined by the getState method, which is invoked when the user toggles the enable button in the data type settings.
-        $scope.getState = function () {
+```javascript
+// The controller assigns the behavior to scope as defined by the getState method, which is invoked when the user toggles the enable button in the data type settings.
+$scope.getState = function () {
             
-            //If the data type is enabled in the Settings the 'Give me Suggestions!' button is enabled
-             if (Boolean(Number($scope.model.config.isEnabled))) {
-                return false;
-            }
-            return true;
+//If the data type is enabled in the Settings the 'Give me Suggestions!' button is enabled
+    if (Boolean(Number($scope.model.config.isEnabled))) {
+            return false;
         }
-    ```
-2.  Next, we'll add the `defaultValue` functionality. When the `$scope.model.value` is empty or null, we want to use the default value. To do that, we add the following to the start of the controller:
+    return true;
+}
+```
 
-    ```js
-    if($scope.model.value === null || $scope.model.value === ""){
-        $scope.model.value = $scope.model.config.defaultValue;
-    }
-    ```
+2. Next, we'll add the `defaultValue` functionality. When the `$scope.model.value` is empty or null, we want to use the default value. To do that, we add the following to the start of the controller:
 
-    See what's new? The `$scope.model.config` object. Also, because of this configuration, we now have access to `$scope.model.config.defaultValue` which contains the configuration value for that key.
+```js
+if($scope.model.value === null || $scope.model.value === ""){
+    $scope.model.value = $scope.model.config.defaultValue;
+}
+```
 
-    Your `suggestion.controller.js` file should now look like:
+See what's new? The `$scope.model.config` object. Also, because of this configuration, we now have access to `$scope.model.config.defaultValue` which contains the configuration value for that key.
 
-    ```javascript
-    angular.module("umbraco")
-        .controller("SuggestionPluginController",
-            // Scope object is the main object which is used to pass information from the controller to the view.
-            function ($scope) {
-                if ($scope.model.value === null || $scope.model.value === "") {
-                    $scope.model.value = $scope.model.config.defaultValue;
+Your `suggestion.controller.js` file should now look like:
+
+```javascript
+angular.module("umbraco")
+    .controller("SuggestionPluginController",
+        // Scope object is the main object which is used to pass information from the controller to the view.
+        function ($scope) {
+            if ($scope.model.value === null || $scope.model.value === "") {
+                $scope.model.value = $scope.model.config.defaultValue;
+            }
+            // SuggestionPluginController assigns the suggestions list to the aSuggestions property of the scope
+            $scope.aSuggestions = ["You should take a break", "I suggest that you visit the Eiffel Tower", "How about starting a book club today or this week?", "Are you hungry?"];
+
+            // The controller assigns the behavior to scope as defined by the getSuggestion method, which is invoked when the user clicks on the 'Give me Suggestions!' button.
+            $scope.getSuggestion = function () {
+
+                // The getSuggestion method reads a random value from an array and provides a Suggestion. 
+                $scope.model.value = $scope.aSuggestions[$scope.aSuggestions.length * Math.random() | 0];
+            }
+        
+            // The controller assigns the behavior to scope as defined by the getState method, which is invoked when the user toggles the enable button in the data type settings.
+
+            $scope.getState = function () {
+
+                //If the data type is enabled in the Settings the 'Give me Suggestions!' button is enabled
+                if (Boolean(Number($scope.model.config.isEnabled))) {
+                    return false;
                 }
-                // SuggestionPluginController assigns the suggestions list to the aSuggestions property of the scope
-                $scope.aSuggestions = ["You should take a break", "I suggest that you visit the Eiffel Tower", "How about starting a book club today or this week?", "Are you hungry?"];
+                return true;
+            }
 
-                // The controller assigns the behavior to scope as defined by the getSuggestion method, which is invoked when the user clicks on the 'Give me Suggestions!' button.
-                $scope.getSuggestion = function () {
+});
+```
 
-                    // The getSuggestion method reads a random value from an array and provides a Suggestion. 
-                    $scope.model.value = $scope.aSuggestions[$scope.aSuggestions.length * Math.random() | 0];
-
-                }
-            
-                // The controller assigns the behavior to scope as defined by the getState method, which is invoked when the user toggles the enable button in the data type settings.
-                $scope.getState = function () {
-
-                    //If the data type is enabled in the Settings the 'Give me Suggestions!' button is enabled
-                     if (Boolean(Number($scope.model.config.isEnabled))) {
-                        return false;
-                    }
-                    return true;
-                }
-
-            });
-    ```
-3.  Finally, we'll add the `hideLabel` functionality. For this, we'll open the `Suggestion.cs` file and override the GetValueEditor method with configuration as a parameter.
+3. Finally, we'll add the `hideLabel` functionality. For this, we'll open the `Suggestion.cs` file and override the GetValueEditor method with configuration as a parameter.
 
     ```cs
     public override IDataValueEditor GetValueEditor(object? configuration)
@@ -260,15 +267,16 @@ The next step is to gain access to our new configuration options. For this, open
     ```cs
     using Umbraco.Cms.Core.IO;
     using Umbraco.Cms.Core.Models;
+    using Umbraco.Cms.Core.PropertyEditors;
 
-    namespace Umbraco.Cms.Core.PropertyEditors;
+    namespace YourProjectName;
 
     [DataEditor(
-        alias: "Suggestions editor",
-        name: "Suggestions Editor",
-        view: "~/App_Plugins/Suggestions/suggestion.html",
-        Group = "Common",
-        Icon = "icon-list")]
+	alias: "Suggestions editor",
+	name: "Suggestions Editor",
+	view: "/App_Plugins/Suggestions/suggestion.html",
+	Group = "Common",
+	Icon = "icon-list")]
     public class Suggestions : DataEditor
     {
         private readonly IIOHelper _ioHelper;
@@ -299,6 +307,6 @@ The next step is to gain access to our new configuration options. For this, open
 
 Save the files and rebuild the application. To access the configuration options, enable/disable the `Enabled?` and `Hide Label?` options. Additionally, you can set a default value in the `Default Value` field and see the Suggestions Data Type at play.
 
-![An example of setting the configuration](../../../../10/umbraco-cms/tutorials/creating-a-property-editor/images/suggestion-editor-config\_2.png)
+![An example of setting the configuration](images/suggestion-editor-config\_2.png)
 
-![Backoffice view](../../../../10/umbraco-cms/tutorials/creating-a-property-editor/images/suggestion-editor-backoffice\_1.png)
+![Backoffice view](images/suggestion-editor-backoffice\_1.png)

--- a/13/umbraco-cms/tutorials/creating-a-property-editor/part-3.md
+++ b/13/umbraco-cms/tutorials/creating-a-property-editor/part-3.md
@@ -114,15 +114,15 @@ angular.module("umbraco")
 ```json
 {
  "javascript": [
-        "~/App_Plugins/Suggestions/suggestion.controller.js",
-        "~/App_Plugins/Suggestions/notification.controller.js"
+        "/App_Plugins/Suggestions/suggestion.controller.js",
+        "/App_Plugins/Suggestions/notification.controller.js"
     ]
 }
 ```
 
 ## Creating custom Notification View and Controller
 
-We will add 2 files to the /App\_Plugins/Suggestions/ folder:
+We will add 2 files to the `/App_Plugins/Suggestions/` folder:
 
 * `notification.html`
 * `notification.controller.js`

--- a/13/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/13/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -1,3 +1,8 @@
+---
+
+needsV9Update: "true"
+---
+
 # Adding server-side data to a property editor
 
 ## Overview
@@ -33,26 +38,20 @@ INSERT INTO people(name,town,country) VALUES('Aimee Sampson','Hawera','Antigua a
 
 Next we need to define an `ApiController` to expose a server-side route which our application will use to fetch the data.
 
-For this, we will create a file at: `/App_Code/PersonApiController.cs`. It must be in `App_Code` since we want our app to compile it on start. Alternatively, you can add it to a normal .NET project and compile it into a DLL as usual.
+For this, you can create a new class at the root of the project called `PersonApiController.cs`
 
 In the `PersonApiController.cs` file, add:
 
 ```csharp
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
+    using Umbraco.Cms.Web.BackOffice.Controllers;
+    using Umbraco.Cms.Core.Web.Mvc;
 
-using Umbraco.Cms.Web.BackOffice.Controllers;
-using Umbraco.Cms.Web.Common.Attributes;
-
-namespace My.Controllers;
-
-[Umbraco.Web.Mvc.PluginController("My")]
-public class PersonApiController : UmbracoAuthorizedJsonController
-{
-    // we will add a method here later
-}
+    namespace YourProjectName;
+    [PluginControllerMetadata("My")]
+    public class PersonApiController : UmbracoAuthorizedJsonController
+    {
+        // we will add a method here later
+    }
 ```
 
 This is a very basic API controller which inherits from `UmbracoAuthorizedJsonController` this specific class will only return JSON data and only to requests which are authorized to access the backoffice.


### PR DESCRIPTION
## Description

_What did you add/update/change?_
Update package manifest and property editor docs as they were outdated from v8:
- https://docs.umbraco.com/umbraco-cms/extending/property-editors/package-manifest 
- https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-property-editor - also tested until step 2. There might be some code that is obsolete in step 3 and 4 but with v14 where angular is not used anymore these tutorial might need to be revisited and re-tested
## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [x] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
CMS 10, 12, 13

## Deadline (if relevant)

_When should the content be published?_
anytime