### PR TITLE
Updated URL typo error in configuration.md

### DIFF
--- a/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/configuration.md
+++ b/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/configuration.md
@@ -72,7 +72,7 @@ The RTE can also accept advanced configuration through the `appSettings.json` fi
 
 * [Commands](https://www.tiny.cloud/docs/tinymce/latest/editor-command-identifiers/)
 * [Plugins](https://www.tiny.cloud/docs/tinymce/latest/plugins/)
-* [CustomConfig](hhttps://www.tiny.cloud/docs/tinymce/latest/editor-important-options/)
+* [CustomConfig](https://www.tiny.cloud/docs/tinymce/latest/editor-important-options/)
 * [ValidElements](https://www.tiny.cloud/docs/tinymce/latest/content-filtering/#valid_elements)
 * [InvalidElements](https://www.tiny.cloud/docs/tinymce/latest/content-filtering/#invalid_elements)
 


### PR DESCRIPTION
## Description
CustomConfig link in rich text editor configuration has invalid link. 

_What did you add/update/change?_
Updated hhttps to https protocol in the link

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
