### PR TITLE
Update Modelsbuilder HasValue check

### DIFF
--- a/10/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/email-address.md
+++ b/10/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/email-address.md
@@ -36,10 +36,9 @@ The Email Address Property Editor does not come with any further configuration. 
 ### With Modelsbuilder
 
 ```csharp
-@if (!Model.HasValue(Model.Email))
+@if (!string.IsNullOrWhiteSpace(Model.Email))
 {
-    var emailAddress = Model.Email;
-    <p>@emailAddress</p>
+    <p>@Model.Email</p>
 }
 ```
 

--- a/12/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/email-address.md
+++ b/12/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/email-address.md
@@ -35,7 +35,7 @@ The Email Address Property Editor does not come with any further configuration. 
 ### With Modelsbuilder
 
 ```csharp
-@if (!Model.HasValue(Model.Email))
+@if (!string.IsNullOrWhiteSpace(Model.Email))
 {
     var emailAddress = Model.Email;
     <p>@emailAddress</p>

--- a/12/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/email-address.md
+++ b/12/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/email-address.md
@@ -37,8 +37,7 @@ The Email Address Property Editor does not come with any further configuration. 
 ```csharp
 @if (!string.IsNullOrWhiteSpace(Model.Email))
 {
-    var emailAddress = Model.Email;
-    <p>@emailAddress</p>
+    <p>@Model.Email</p>
 }
 ```
 

--- a/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/email-address.md
+++ b/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/email-address.md
@@ -35,7 +35,7 @@ The Email Address Property Editor does not come with any further configuration. 
 ### With Modelsbuilder
 
 ```csharp
-@if (Model.HasValue((nameof(Model.Email))
+@if (Model.HasValue((nameof(Model.Email))))
 {
     var emailAddress = Model.Email;
     <p>@emailAddress</p>

--- a/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/email-address.md
+++ b/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/email-address.md
@@ -35,7 +35,7 @@ The Email Address Property Editor does not come with any further configuration. 
 ### With Modelsbuilder
 
 ```csharp
-@if (Model.HasValue((nameof(Model.Email))))
+@if (!string.IsNullOrWhiteSpace(Model.Email))
 {
     var emailAddress = Model.Email;
     <p>@emailAddress</p>

--- a/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/email-address.md
+++ b/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/email-address.md
@@ -35,7 +35,7 @@ The Email Address Property Editor does not come with any further configuration. 
 ### With Modelsbuilder
 
 ```csharp
-@if (!Model.HasValue(Model.Email))
+@if (Model.HasValue((nameof(Model.Email))
 {
     var emailAddress = Model.Email;
     <p>@emailAddress</p>

--- a/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/email-address.md
+++ b/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/email-address.md
@@ -37,8 +37,7 @@ The Email Address Property Editor does not come with any further configuration. 
 ```csharp
 @if (!string.IsNullOrWhiteSpace(Model.Email))
 {
-    var emailAddress = Model.Email;
-    <p>@emailAddress</p>
+    <p>@Model.Email</p>
 }
 ```
 


### PR DESCRIPTION
## Description

_What did you add/update/change?_

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [x] Other

## Product & version (if relevant)

v13

## Deadline (if relevant)

whenever

---

The example was sending the 'value' of ModelEmail instead of the alias of the field...

... there is also a counterargument to say that HasValue shouldn't be being used here at all, in either with and without Modelsbuilder...

that instead we should be promoting

```
@if (!string.IsNullOrWhiteSpace(Model.Value<string>("email")))
```
and
```
@if (!string.IsNullOrWhiteSpace(Model.Email))
```

because HasValue isn't necessarily considering PropertyValueConverters...