### PR TITLE
Update testing-stripe-webhooks-locally.md

### DIFF
--- a/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
+++ b/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
@@ -25,7 +25,7 @@ Go to the [stripe documentation](https://stripe.com/docs/stripe-cli#install) and
 Go to the [stripe documentation](https://stripe.com/docs/stripe-cli#login-account) and log in to the CLI.
 ### Step 3: Forward the stripe events to your local environment
 
-Whilst running the site locally, make a note of your local store domain, e.g. `https:localhost:44321`. Using the Stripe CLI, to can configure Stripe to forward any events to that url. 
+While running the site locally, make a note of your local store domain. For example: `https:localhost:44321`. Using the Stripe CLI, you can configure Stripe to forward any events to that URL. 
 
 To do so, run the following from the command line.
 

--- a/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
+++ b/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
@@ -23,7 +23,7 @@ Below you can find two options to create temporary tunnels through your network:
 Go to the [stripe documentation](https://stripe.com/docs/stripe-cli#install) and install the stripe CLI.
 ### Step 2: Log in to the Stripe CLI
 Go to the [stripe documentation](https://stripe.com/docs/stripe-cli#login-account) and log in to the CLI.
-### Step 2: Forward the stripe events to your local environment.
+### Step 3: Forward the stripe events to your local environment
 
 Whilst running the site locally, make a note of your local store domain, e.g. `https:localhost:44321`. Using the Stripe CLI, to can configure Stripe to forward any events to that url. 
 

--- a/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
+++ b/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
@@ -40,7 +40,7 @@ e.g.
 stripe listen --forward-to https:localhost:44321/umbraco/commerce/payment/callback/stripe-checkout/7fb00000-0000-0000-0000-000019094a7a/
 ```
 
-### Step 3: Test the site
+### Step 4: Test the site
 
 With the Stripe CLI running, you can now test the site using your local dev domain. You will see any configured stripe events configured for the webhook displayed in the console window, and can debug them using Visual Studio.
 

--- a/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
+++ b/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
@@ -10,7 +10,7 @@ description: >-
 The Stripe payment provider uses webhooks to finalize payments. Due to this, it can be tricky to test payments locally as Mollie must have a public-facing URL to be able to notify you.
 
 You could expose your website through your network's firewall or use tools that to create temporary tunnels through your network.
-
+You could expose your website through your network's firewall or use tools to create temporary tunnels through your network.
 The following guide will use [ngrok](https://ngrok.com/) to create temporary tunnels through your network.
 
 ## Using Stripe CLI

--- a/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
+++ b/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
@@ -20,7 +20,7 @@ Below you can find two options to create temporary tunnels through your network:
 ## Using Stripe CLI
 ### Step 1: Install the Stripe CLI
 
-Head over to [stripe.com/docs/stripe-cli](https://stripe.com/docs/stripe-cli) and follow steps 1 and 2 to install the CLI and to log in.
+Go to the [stripe documentation](https://stripe.com/docs/stripe-cli#install) and install the stripe CLI.
 
 ### Step 2: Forward the stripe events to your local environment.
 

--- a/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
+++ b/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
@@ -42,7 +42,7 @@ stripe listen --forward-to https:localhost:44321/umbraco/commerce/payment/callba
 
 ### Step 4: Test the site
 
-With the Stripe CLI running, you can now test the site using your local dev domain. You will see any configured stripe events configured for the webhook displayed in the console window, and can debug them using Visual Studio.
+With the Stripe CLI running, you can now test the site using your local dev domain. You will see any configured stripe events configured for the webhook displayed in the console window and can debug them using Visual Studio.
 
 ## Using ngrok
 ### Step 1: Install ngrok

--- a/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
+++ b/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
@@ -9,7 +9,6 @@ description: >-
 
 The Stripe payment provider uses webhooks to finalize payments. Due to this, it can be tricky to test payments locally as Mollie must have a public-facing URL to be able to notify you.
 
-You could expose your website through your network's firewall or use tools that to create temporary tunnels through your network.
 You could expose your website through your network's firewall or use tools to create temporary tunnels through your network.
 Below you can find two options to create temporary tunnels through your network:
 
@@ -18,14 +17,18 @@ Below you can find two options to create temporary tunnels through your network:
 
 
 ## Using Stripe CLI
+
 ### Step 1: Install the Stripe CLI
 
 Go to the [stripe documentation](https://stripe.com/docs/stripe-cli#install) and install the stripe CLI.
+
 ### Step 2: Log in to the Stripe CLI
+
 Go to the [stripe documentation](https://stripe.com/docs/stripe-cli#login-account) and log in to the CLI.
+
 ### Step 3: Forward the stripe events to your local environment
 
-While running the site locally, make a note of your local store domain. For example: `https:localhost:44321`. Using the Stripe CLI, you can configure Stripe to forward any events to that URL. 
+While running the site locally, make a note of your local store domain. For example: `https:localhost:44321`. Using the Stripe CLI, you can configure Stripe to forward any events to that URL.
 
 To do so, run the following from the command line.
 
@@ -35,7 +38,7 @@ stripe listen --forward-to {local_store_domain}/umbraco/commerce/payment/callbac
 
 The `{payment_method_id}` is configured as part of the Stripe [webhook configuration](../configuring-stripe.md#step-3-webhook) step.
 
-e.g. 
+e.g.
 ```
 stripe listen --forward-to https:localhost:44321/umbraco/commerce/payment/callback/stripe-checkout/7fb00000-0000-0000-0000-000019094a7a/
 ```

--- a/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
+++ b/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
@@ -13,12 +13,39 @@ You could expose your website through your network's firewall or use tools that 
 
 The following guide will use [ngrok](https://ngrok.com/) to create temporary tunnels through your network.
 
-## Step 1: Install ngrok
+## Using Stripe CLI
+### Step 1: Install the Stripe CLI and Login into the CLI
+
+Head over to [stripe.com/docs/stripe-cli](https://stripe.com/docs/stripe-cli) and follow steps 1 and 2 to install the CLI and to log in.
+
+### Step 2: Forward the stripe events to your local environment.
+
+Whilst running the site locally, make a note of your local store domain, e.g. `https:localhost:44321`. Using the Stripe CLI, to can configure Stripe to forward any events to that url. 
+
+To do so, run the following from the command line.
+
+```
+stripe listen --forward-to {local_store_domain}/umbraco/commerce/payment/callback/stripe-checkout/{payment_method_id}/
+```
+
+The `{payment_method_id}` is configured as part of the Stripe [webhook configuration](../configuring-stripe.md#step-3-webhook) step.
+
+e.g. 
+```
+stripe listen --forward-to https:localhost:44321/umbraco/commerce/payment/callback/stripe-checkout/7fb00000-0000-0000-0000-000019094a7a/
+```
+
+### Step 3: Test the site
+
+With the Stripe CLI running, you can now test the site using your local dev domain. You will see any configured stripe events configured for the webhook displayed in the console window, and can debug them using Visual Studio.
+
+## Using ngrok
+### Step 1: Install ngrok
 
 1. Head on over to [ngrok.com](https://ngrok.com/).
 2. Download and install the tool on your system.
 
-## Step 2: Launch ngrok
+### Step 2: Launch ngrok
 
 You can either launch ngrok from the command line or use the steps below to create a batch file to be run at any time.
 
@@ -26,7 +53,7 @@ You can either launch ngrok from the command line or use the steps below to crea
 2. Type the following:
 
 ```
-C:\PROGRA~1\ngrok\ngrok.exe http -host-header=rewrite localhost:61191
+C:\PROGRA~1\ngrok\ngrok.exe http --host-header=rewrite localhost:61191
 ```
 
 3. Swap the local domain/port number at the end according to the configuration of your site.
@@ -40,7 +67,7 @@ You can run the batch file at any time to launch ngrok and create a publicly acc
 When you launch ngrok for the first time, it will ask you to sign in. Enter the credentials you used to sign up. It will remember them from now on.
 {% endhint %}
 
-## Step 3: Test the site
+### Step 3: Test the site
 
 With ngrok running you can now test the site using the URLs displayed in the console window. Use these URLs (preferably the secure `https` one) for your Stripe [webhook configuration](../configuring-stripe.md#step-3-webhook) and you should now be able to test your Stripe webhooks locally.
 

--- a/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
+++ b/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
@@ -28,7 +28,7 @@ Go to the [stripe documentation](https://stripe.com/docs/stripe-cli#login-accoun
 
 ### Step 3: Forward the stripe events to your local environment
 
-While running the site locally, make a note of your local store domain. For example: `https:localhost:44321`. Using the Stripe CLI, you can configure Stripe to forward any events to that URL.
+While running the site locally, make a note of your local store domain. For example: `https://localhost:44321`. Using the Stripe CLI, you can configure Stripe to forward any events to that URL.
 
 To do so, run the following from the command line.
 

--- a/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
+++ b/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
@@ -40,7 +40,7 @@ The `{payment_method_id}` is configured as part of the Stripe [webhook configura
 
 e.g.
 ```
-stripe listen --forward-to https:localhost:44321/umbraco/commerce/payment/callback/stripe-checkout/7fb00000-0000-0000-0000-000019094a7a/
+stripe listen --forward-to https://localhost:44321/umbraco/commerce/payment/callback/stripe-checkout/7fb00000-0000-0000-0000-000019094a7a/
 ```
 ### Step 4: Configure your Stripe test webhook signing secret
 

--- a/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
+++ b/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
@@ -18,7 +18,7 @@ Below you can find two options to create temporary tunnels through your network:
 
 
 ## Using Stripe CLI
-### Step 1: Install the Stripe CLI and Login into the CLI
+### Step 1: Install the Stripe CLI
 
 Head over to [stripe.com/docs/stripe-cli](https://stripe.com/docs/stripe-cli) and follow steps 1 and 2 to install the CLI and to log in.
 

--- a/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
+++ b/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
@@ -47,7 +47,7 @@ With the Stripe CLI running, you can now test the site using your local dev doma
 ## Using ngrok
 ### Step 1: Install ngrok
 
-1. Head on over to [ngrok.com](https://ngrok.com/).
+1. Go to the [ngrok website](https://ngrok.com/).
 2. Download and install the tool on your system.
 
 ### Step 2: Launch ngrok

--- a/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
+++ b/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
@@ -21,7 +21,8 @@ Below you can find two options to create temporary tunnels through your network:
 ### Step 1: Install the Stripe CLI
 
 Go to the [stripe documentation](https://stripe.com/docs/stripe-cli#install) and install the stripe CLI.
-
+### Step 2: Log in to the Stripe CLI
+Go to the [stripe documentation](https://stripe.com/docs/stripe-cli#login-account) and log in to the CLI.
 ### Step 2: Forward the stripe events to your local environment.
 
 Whilst running the site locally, make a note of your local store domain, e.g. `https:localhost:44321`. Using the Stripe CLI, to can configure Stripe to forward any events to that url. 

--- a/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
+++ b/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
@@ -11,7 +11,11 @@ The Stripe payment provider uses webhooks to finalize payments. Due to this, it 
 
 You could expose your website through your network's firewall or use tools that to create temporary tunnels through your network.
 You could expose your website through your network's firewall or use tools to create temporary tunnels through your network.
-The following guide will use [ngrok](https://ngrok.com/) to create temporary tunnels through your network.
+Below you can find two options to create temporary tunnels through your network:
+
+- [Using Stripe CLI](using-stripe-cli)
+- [Using ngrok](using-ngrok)
+
 
 ## Using Stripe CLI
 ### Step 1: Install the Stripe CLI and Login into the CLI

--- a/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
+++ b/commerce-add-ons/payment-providers/stripe/how-to-guides/testing-stripe-webhooks-locally.md
@@ -42,8 +42,11 @@ e.g.
 ```
 stripe listen --forward-to https:localhost:44321/umbraco/commerce/payment/callback/stripe-checkout/7fb00000-0000-0000-0000-000019094a7a/
 ```
+### Step 4: Configure your Stripe test webhook signing secret
 
-### Step 4: Test the site
+When you start listening to Stripe events, the command line will give you a webhook signing secret. This should be used to set the `Test Webhook Signing Secret` setting, shown in the Umbraco [configure payment provider settings](../configuring-umbraco.md##step-2-configure-payment-provider-settings) step.
+
+### Step 5: Test the site
 
 With the Stripe CLI running, you can now test the site using your local dev domain. You will see any configured stripe events configured for the webhook displayed in the console window and can debug them using Visual Studio.
 


### PR DESCRIPTION
## Description

This PR adds an additional way to test the Stipe Payment Provider locally, using the Stripe CLI. I found when using the ngrok approach, i would get errors due to the Umbraco Commerce Checkout package redirecting to the default domain, rather than the ngrok domain. 

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [x] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
Umbraco Commerce - Stripe Payment Provider