### PR TITLE
Added details of how to license commercial products in an environment without an outgoing Internet connection.

### DIFF
--- a/10/umbraco-commerce/installation/licensing-model.md
+++ b/10/umbraco-commerce/installation/licensing-model.md
@@ -112,3 +112,50 @@ services.Configure<WebRoutingSettings>(o => o.UmbracoApplicationUrl = "<your app
 
 In practice, you will probably want to make this a bit more sophisticated. You can read the value from another configuration key, removing the need to hard-code it and have it set as appropriate in different environments. You can also move this code into a composer or an extension method if you prefer not to clutter up the `Startup.ConfigureServices` method.
 
+### Validating a license without an outgoing Internet connection
+
+Some Umbraco installations will have a highly locked down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
+
+On start-up, and periodically whilst Umbraco is running, the license component used by Umbraco Commerce will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
+
+If it's possible to do so, the firewall rules should be adjusted to allow this request.
+
+If such a change is not feasible, there is another approach you can use.
+
+You will need to have a server, or serverless function, that is running and can make a request to the online license validation service. That needs to run on a daily schedule, making a request and relaying it onto the restricted Umbraco environment.
+
+To set this up, firstly ensure you have a reference to `Umbraco.Licenses` version 10.1 or higher. If the version of Commerce you are using depends on an earlier version, you can add a direct package reference for `Umbraco.Licenses`.
+
+Then configure a random string as an authorization key in configuration. This is used as protection to ensure only valid requests are handled. You can also disable the normal regular license checks - as there is no point in these running if they will be blocked:
+
+```json
+  "Umbraco": {
+    "Licenses": {
+      "Umbraco.Commerce": "<your license key>"
+    },
+    "LicensesOptions": {
+      "EnableScheduledValidation": false,
+      "ValidatedLicenseRelayAuthKey": "<your authorization key>"
+    }
+```
+
+Your Internet enabled server should make a request of the following form to the online license validation service:
+
+```
+POST https://license-validation.umbraco.com/api/ValidateLicense
+{
+    "ProductId": "Umbraco.Commerce",
+    "LicenseKey": "<your license key>",
+    "Domain": "<your licensed domain>"
+}
+```
+
+The response should be relayed exactly via an HTTP request to your restricted Umbraco environment:
+
+```
+POST http://<your umbraco environment>/umbraco/licenses/validatedLicense/relay?productId=<product id>&licenseKey=<license key>
+```
+
+A header with a key of `X-AUTH-KEY` and value of the authorization key you have configured should be provided.
+
+This will trigger the same processes that occur when the normal scheduled validation completes ensuring your product is considered licensed.

--- a/10/umbraco-ui-builder/installation/licensing-model.md
+++ b/10/umbraco-ui-builder/installation/licensing-model.md
@@ -70,3 +70,51 @@ Once you have received your license code it needs to be installed on your site.
 ### Verify the license installation
 
 You can verify that your license is successfully installed by logging into your project's backoffice and navigating to the settings section. Here you will see a license dashboard which should display the status of your license.
+
+### Validating a license without an outgoing Internet connection
+
+Some Umbraco installations will have a highly locked down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
+
+On start-up, and periodically whilst Umbraco is running, the license component used by Umbraco UIBuilder will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
+
+If it's possible to do so, the firewall rules should be adjusted to allow this request.
+
+If such a change is not feasible, there is another approach you can use.
+
+You will need to have a server, or serverless function, that is running and can make a request to the online license validation service. That needs to run on a daily schedule, making a request and relaying it onto the restricted Umbraco environment.
+
+To set this up, firstly ensure you have a reference to `Umbraco.Licenses` version 10.1 or higher. If the version of UIBuilder you are using depends on an earlier version, you can add a direct package reference for `Umbraco.Licenses`.
+
+Then configure a random string as an authorization key in configuration. This is used as protection to ensure only valid requests are handled. You can also disable the normal regular license checks - as there is no point in these running if they will be blocked:
+
+```json
+  "Umbraco": {
+    "Licenses": {
+      "Umbraco.UIBulder": "<your license key>"
+    },
+    "LicensesOptions": {
+      "EnableScheduledValidation": false,
+      "ValidatedLicenseRelayAuthKey": "<your authorization key>"
+    }
+```
+
+Your Internet enabled server should make a request of the following form to the online license validation service:
+
+```
+POST https://license-validation.umbraco.com/api/ValidateLicense
+{
+    "ProductId": "Umbraco.UIBulder",
+    "LicenseKey": "<your license key>",
+    "Domain": "<your licensed domain>"
+}
+```
+
+The response should be relayed exactly via an HTTP request to your restricted Umbraco environment:
+
+```
+POST http://<your umbraco environment>/umbraco/licenses/validatedLicense/relay?productId=<product id>&licenseKey=<license key>
+```
+
+A header with a key of `X-AUTH-KEY` and value of the authorization key you have configured should be provided.
+
+This will trigger the same processes that occur when the normal scheduled validation completes ensuring your product is considered licensed.

--- a/10/umbraco-workflow/installation/licensing.md
+++ b/10/umbraco-workflow/installation/licensing.md
@@ -85,3 +85,51 @@ To impersonate the full license on a local site, set `EnableTestLicense` to `tru
 {% hint style="info" %}
 The test license is restricted to sites running in a development environment with a debugger attached. Hit F5 in Visual Studio, in Debug mode to enable the test license.
 {% endhint %}
+
+### Validating a license without an outgoing Internet connection
+
+Some Umbraco installations will have a highly locked down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
+
+On start-up, and periodically whilst Umbraco is running, the license component used by Umbraco Workflow will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
+
+If it's possible to do so, the firewall rules should be adjusted to allow this request.
+
+If such a change is not feasible, there is another approach you can use.
+
+You will need to have a server, or serverless function, that is running and can make a request to the online license validation service. That needs to run on a daily schedule, making a request and relaying it onto the restricted Umbraco environment.
+
+To set this up, firstly ensure you have a reference to `Umbraco.Licenses` version 10.1 or higher. If the version of Workflow you are using depends on an earlier version, you can add a direct package reference for `Umbraco.Licenses`.
+
+Then configure a random string as an authorization key in configuration. This is used as protection to ensure only valid requests are handled. You can also disable the normal regular license checks - as there is no point in these running if they will be blocked:
+
+```json
+  "Umbraco": {
+    "Licenses": {
+      "Umbraco.Workflow": "<your license key>"
+    },
+    "LicensesOptions": {
+      "EnableScheduledValidation": false,
+      "ValidatedLicenseRelayAuthKey": "<your authorization key>"
+    }
+```
+
+Your Internet enabled server should make a request of the following form to the online license validation service:
+
+```
+POST https://license-validation.umbraco.com/api/ValidateLicense
+{
+    "ProductId": "Umbraco.Workflow",
+    "LicenseKey": "<your license key>",
+    "Domain": "<your licensed domain>"
+}
+```
+
+The response should be relayed exactly via an HTTP request to your restricted Umbraco environment:
+
+```
+POST http://<your umbraco environment>/umbraco/licenses/validatedLicense/relay?productId=<product id>&licenseKey=<license key>
+```
+
+A header with a key of `X-AUTH-KEY` and value of the authorization key you have configured should be provided.
+
+This will trigger the same processes that occur when the normal scheduled validation completes ensuring your product is considered licensed.

--- a/12/umbraco-commerce/installation/licensing-model.md
+++ b/12/umbraco-commerce/installation/licensing-model.md
@@ -112,4 +112,50 @@ services.Configure<WebRoutingSettings>(o => o.UmbracoApplicationUrl = "<your app
 
 In practice, you will probably want to make this a bit more sophisticated. You can read the value from another configuration key, removing the need to hard-code it and have it set as appropriate in different environments. You can also move this code into a composer or an extension method if you prefer not to clutter up the `Startup.ConfigureServices` method.
 
+### Validating a license without an outgoing Internet connection
 
+Some Umbraco installations will have a highly locked down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
+
+On start-up, and periodically whilst Umbraco is running, the license component used by Umbraco Commerce will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
+
+If it's possible to do so, the firewall rules should be adjusted to allow this request.
+
+If such a change is not feasible, there is another approach you can use.
+
+You will need to have a server, or serverless function, that is running and can make a request to the online license validation service. That needs to run on a daily schedule, making a request and relaying it onto the restricted Umbraco environment.
+
+To set this up, firstly ensure you have a reference to `Umbraco.Licenses` version 12.1 or higher. If the version of Commerce you are using depends on an earlier version, you can add a direct package reference for `Umbraco.Licenses`.
+
+Then configure a random string as an authorization key in configuration. This is used as protection to ensure only valid requests are handled. You can also disable the normal regular license checks - as there is no point in these running if they will be blocked:
+
+```json
+  "Umbraco": {
+    "Licenses": {
+      "Umbraco.Commerce": "<your license key>"
+    },
+    "LicensesOptions": {
+      "EnableScheduledValidation": false,
+      "ValidatedLicenseRelayAuthKey": "<your authorization key>"
+    }
+```
+
+Your Internet enabled server should make a request of the following form to the online license validation service:
+
+```
+POST https://license-validation.umbraco.com/api/ValidateLicense
+{
+    "ProductId": "Umbraco.Commerce",
+    "LicenseKey": "<your license key>",
+    "Domain": "<your licensed domain>"
+}
+```
+
+The response should be relayed exactly via an HTTP request to your restricted Umbraco environment:
+
+```
+POST http://<your umbraco environment>/umbraco/licenses/validatedLicense/relay?productId=<product id>&licenseKey=<license key>
+```
+
+A header with a key of `X-AUTH-KEY` and value of the authorization key you have configured should be provided.
+
+This will trigger the same processes that occur when the normal scheduled validation completes ensuring your product is considered licensed.

--- a/12/umbraco-ui-builder/installation/licensing-model.md
+++ b/12/umbraco-ui-builder/installation/licensing-model.md
@@ -70,3 +70,51 @@ Once you have received your license code it needs to be installed on your site.
 ### Verify the license installation
 
 You can verify that your license is successfully installed by logging into your project's backoffice and navigating to the settings section. Here you will see a license dashboard which should display the status of your license.
+
+### Validating a license without an outgoing Internet connection
+
+Some Umbraco installations will have a highly locked down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
+
+On start-up, and periodically whilst Umbraco is running, the license component used by Umbraco UIBuilder will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
+
+If it's possible to do so, the firewall rules should be adjusted to allow this request.
+
+If such a change is not feasible, there is another approach you can use.
+
+You will need to have a server, or serverless function, that is running and can make a request to the online license validation service. That needs to run on a daily schedule, making a request and relaying it onto the restricted Umbraco environment.
+
+To set this up, firstly ensure you have a reference to `Umbraco.Licenses` version 12.1 or higher. If the version of UIBuilder you are using depends on an earlier version, you can add a direct package reference for `Umbraco.Licenses`.
+
+Then configure a random string as an authorization key in configuration. This is used as protection to ensure only valid requests are handled. You can also disable the normal regular license checks - as there is no point in these running if they will be blocked:
+
+```json
+  "Umbraco": {
+    "Licenses": {
+      "Umbraco.UIBulder": "<your license key>"
+    },
+    "LicensesOptions": {
+      "EnableScheduledValidation": false,
+      "ValidatedLicenseRelayAuthKey": "<your authorization key>"
+    }
+```
+
+Your Internet enabled server should make a request of the following form to the online license validation service:
+
+```
+POST https://license-validation.umbraco.com/api/ValidateLicense
+{
+    "ProductId": "Umbraco.UIBulder",
+    "LicenseKey": "<your license key>",
+    "Domain": "<your licensed domain>"
+}
+```
+
+The response should be relayed exactly via an HTTP request to your restricted Umbraco environment:
+
+```
+POST http://<your umbraco environment>/umbraco/licenses/validatedLicense/relay?productId=<product id>&licenseKey=<license key>
+```
+
+A header with a key of `X-AUTH-KEY` and value of the authorization key you have configured should be provided.
+
+This will trigger the same processes that occur when the normal scheduled validation completes ensuring your product is considered licensed.

--- a/12/umbraco-workflow/installation/licensing.md
+++ b/12/umbraco-workflow/installation/licensing.md
@@ -85,3 +85,51 @@ To impersonate the full license on a local site, set `EnableTestLicense` to `tru
 {% hint style="info" %}
 The test license is restricted to sites running in a development environment with a debugger attached. Hit F5 in Visual Studio, in Debug mode to enable the test license.
 {% endhint %}
+
+### Validating a license without an outgoing Internet connection
+
+Some Umbraco installations will have a highly locked down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
+
+On start-up, and periodically whilst Umbraco is running, the license component used by Umbraco Workflow will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
+
+If it's possible to do so, the firewall rules should be adjusted to allow this request.
+
+If such a change is not feasible, there is another approach you can use.
+
+You will need to have a server, or serverless function, that is running and can make a request to the online license validation service. That needs to run on a daily schedule, making a request and relaying it onto the restricted Umbraco environment.
+
+To set this up, firstly ensure you have a reference to `Umbraco.Licenses` version 12.1 or higher. If the version of Workflow you are using depends on an earlier version, you can add a direct package reference for `Umbraco.Licenses`.
+
+Then configure a random string as an authorization key in configuration. This is used as protection to ensure only valid requests are handled. You can also disable the normal regular license checks - as there is no point in these running if they will be blocked:
+
+```json
+  "Umbraco": {
+    "Licenses": {
+      "Umbraco.Workflow": "<your license key>"
+    },
+    "LicensesOptions": {
+      "EnableScheduledValidation": false,
+      "ValidatedLicenseRelayAuthKey": "<your authorization key>"
+    }
+```
+
+Your Internet enabled server should make a request of the following form to the online license validation service:
+
+```
+POST https://license-validation.umbraco.com/api/ValidateLicense
+{
+    "ProductId": "Umbraco.Workflow",
+    "LicenseKey": "<your license key>",
+    "Domain": "<your licensed domain>"
+}
+```
+
+The response should be relayed exactly via an HTTP request to your restricted Umbraco environment:
+
+```
+POST http://<your umbraco environment>/umbraco/licenses/validatedLicense/relay?productId=<product id>&licenseKey=<license key>
+```
+
+A header with a key of `X-AUTH-KEY` and value of the authorization key you have configured should be provided.
+
+This will trigger the same processes that occur when the normal scheduled validation completes ensuring your product is considered licensed.

--- a/13/umbraco-commerce/installation/the-licensing-model.md
+++ b/13/umbraco-commerce/installation/the-licensing-model.md
@@ -112,4 +112,50 @@ services.Configure<WebRoutingSettings>(o => o.UmbracoApplicationUrl = "<your app
 
 In practice, you will probably want to make this a bit more sophisticated. You can read the value from another configuration key, removing the need to hard-code it and have it set as appropriate in different environments. You can also move this code into a composer or an extension method if you prefer not to clutter up the `Program.cs` file.
 
+### Validating a license without an outgoing Internet connection
 
+Some Umbraco installations will have a highly locked down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
+
+On start-up, and periodically whilst Umbraco is running, the license component used by Umbraco Commerce will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
+
+If it's possible to do so, the firewall rules should be adjusted to allow this request.
+
+If such a change is not feasible, there is another approach you can use.
+
+You will need to have a server, or serverless function, that is running and can make a request to the online license validation service. That needs to run on a daily schedule, making a request and relaying it onto the restricted Umbraco environment.
+
+To set this up, firstly ensure you have a reference to `Umbraco.Licenses` version 13.1 or higher. If the version of Commerce you are using depends on an earlier version, you can add a direct package reference for `Umbraco.Licenses`.
+
+Then configure a random string as an authorization key in configuration. This is used as protection to ensure only valid requests are handled. You can also disable the normal regular license checks - as there is no point in these running if they will be blocked:
+
+```json
+  "Umbraco": {
+    "Licenses": {
+      "Umbraco.Commerce": "<your license key>"
+    },
+    "LicensesOptions": {
+      "EnableScheduledValidation": false,
+      "ValidatedLicenseRelayAuthKey": "<your authorization key>"
+    }
+```
+
+Your Internet enabled server should make a request of the following form to the online license validation service:
+
+```
+POST https://license-validation.umbraco.com/api/ValidateLicense
+{
+    "ProductId": "Umbraco.Commerce",
+    "LicenseKey": "<your license key>",
+    "Domain": "<your licensed domain>"
+}
+```
+
+The response should be relayed exactly via an HTTP request to your restricted Umbraco environment:
+
+```
+POST http://<your umbraco environment>/umbraco/licenses/validatedLicense/relay?productId=<product id>&licenseKey=<license key>
+```
+
+A header with a key of `X-AUTH-KEY` and value of the authorization key you have configured should be provided.
+
+This will trigger the same processes that occur when the normal scheduled validation completes ensuring your product is considered licensed.

--- a/13/umbraco-deploy/installation/the-licensing-model.md
+++ b/13/umbraco-deploy/installation/the-licensing-model.md
@@ -100,3 +100,51 @@ An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file lik
 ```
 
 See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) documentation for more details about this setting.
+
+### Validating a license without an outgoing Internet connection
+
+Some Umbraco installations will have a highly locked down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
+
+On start-up, and periodically whilst Umbraco is running, the license component used by Umbraco Deploy will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
+
+If it's possible to do so, the firewall rules should be adjusted to allow this request.
+
+If such a change is not feasible, there is another approach you can use.
+
+You will need to have a server, or serverless function, that is running and can make a request to the online license validation service. That needs to run on a daily schedule, making a request and relaying it onto the restricted Umbraco environment.
+
+To set this up, firstly ensure you have a reference to `Umbraco.Licenses` version 13.1 or higher. This will be the case if you are running Umbraco Deploy 13.1 or higher. If you are on an earlier version, you can add a direct package reference for `Umbraco.Licenses`.
+
+Then configure a random string as an authorization key in configuration. This is used as protection to ensure only valid requests are handled. You can also disable the normal regular license checks - as there is no point in these running if they will be blocked:
+
+```json
+  "Umbraco": {
+    "Licenses": {
+      "Umbraco.Deploy.OnPrem": "<your license key>"
+    },
+    "LicensesOptions": {
+      "EnableScheduledValidation": false,
+      "ValidatedLicenseRelayAuthKey": "<your authorization key>"
+    }
+```
+
+Your Internet enabled server should make a request of the following form to the online license validation service:
+
+```
+POST https://license-validation.umbraco.com/api/ValidateLicense
+{
+    "ProductId": "Umbraco.Deploy.OnPrem",
+    "LicenseKey": "<your license key>",
+    "Domain": "<your licensed domain>"
+}
+```
+
+The response should be relayed exactly via an HTTP request to your restricted Umbraco environment:
+
+```
+POST http://<your umbraco environment>/umbraco/licenses/validatedLicense/relay?productId=<product id>&licenseKey=<license key>
+```
+
+A header with a key of `X-AUTH-KEY` and value of the authorization key you have configured should be provided.
+
+This will trigger the same processes that occur when the normal scheduled validation completes ensuring your product is considered licensed.

--- a/13/umbraco-ui-builder/installation/licensing-model.md
+++ b/13/umbraco-ui-builder/installation/licensing-model.md
@@ -70,3 +70,51 @@ Once you have received your license code it needs to be installed on your site.
 ### Verify the license installation
 
 You can verify that your license is successfully installed by logging into your project's backoffice and navigating to the settings section. Here you will see a license dashboard which should display the status of your license.
+
+### Validating a license without an outgoing Internet connection
+
+Some Umbraco installations will have a highly locked down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
+
+On start-up, and periodically whilst Umbraco is running, the license component used by Umbraco UIBuilder will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
+
+If it's possible to do so, the firewall rules should be adjusted to allow this request.
+
+If such a change is not feasible, there is another approach you can use.
+
+You will need to have a server, or serverless function, that is running and can make a request to the online license validation service. That needs to run on a daily schedule, making a request and relaying it onto the restricted Umbraco environment.
+
+To set this up, firstly ensure you have a reference to `Umbraco.Licenses` version 13.1 or higher. If the version of UIBuilder you are using depends on an earlier version, you can add a direct package reference for `Umbraco.Licenses`.
+
+Then configure a random string as an authorization key in configuration. This is used as protection to ensure only valid requests are handled. You can also disable the normal regular license checks - as there is no point in these running if they will be blocked:
+
+```json
+  "Umbraco": {
+    "Licenses": {
+      "Umbraco.UIBuilder": "<your license key>"
+    },
+    "LicensesOptions": {
+      "EnableScheduledValidation": false,
+      "ValidatedLicenseRelayAuthKey": "<your authorization key>"
+    }
+```
+
+Your Internet enabled server should make a request of the following form to the online license validation service:
+
+```
+POST https://license-validation.umbraco.com/api/ValidateLicense
+{
+    "ProductId": "Umbraco.UIBuilder",
+    "LicenseKey": "<your license key>",
+    "Domain": "<your licensed domain>"
+}
+```
+
+The response should be relayed exactly via an HTTP request to your restricted Umbraco environment:
+
+```
+POST http://<your umbraco environment>/umbraco/licenses/validatedLicense/relay?productId=<product id>&licenseKey=<license key>
+```
+
+A header with a key of `X-AUTH-KEY` and value of the authorization key you have configured should be provided.
+
+This will trigger the same processes that occur when the normal scheduled validation completes ensuring your product is considered licensed.

--- a/13/umbraco-workflow/installation/licensing.md
+++ b/13/umbraco-workflow/installation/licensing.md
@@ -85,3 +85,51 @@ To impersonate the full license on a local site, set `EnableTestLicense` to `tru
 {% hint style="info" %}
 The test license is restricted to sites running in a development environment with a debugger attached. Hit F5 in Visual Studio, in Debug mode to enable the test license.
 {% endhint %}
+
+### Validating a license without an outgoing Internet connection
+
+Some Umbraco installations will have a highly locked down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
+
+On start-up, and periodically whilst Umbraco is running, the license component used by Umbraco Workflow will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
+
+If it's possible to do so, the firewall rules should be adjusted to allow this request.
+
+If such a change is not feasible, there is another approach you can use.
+
+You will need to have a server, or serverless function, that is running and can make a request to the online license validation service. That needs to run on a daily schedule, making a request and relaying it onto the restricted Umbraco environment.
+
+To set this up, firstly ensure you have a reference to `Umbraco.Licenses` version 13.1 or higher. If the version of Workflow you are using depends on an earlier version, you can add a direct package reference for `Umbraco.Licenses`.
+
+Then configure a random string as an authorization key in configuration. This is used as protection to ensure only valid requests are handled. You can also disable the normal regular license checks - as there is no point in these running if they will be blocked:
+
+```json
+  "Umbraco": {
+    "Licenses": {
+      "Umbraco.Workflow": "<your license key>"
+    },
+    "LicensesOptions": {
+      "EnableScheduledValidation": false,
+      "ValidatedLicenseRelayAuthKey": "<your authorization key>"
+    }
+```
+
+Your Internet enabled server should make a request of the following form to the online license validation service:
+
+```
+POST https://license-validation.umbraco.com/api/ValidateLicense
+{
+    "ProductId": "Umbraco.Workflow",
+    "LicenseKey": "<your license key>",
+    "Domain": "<your licensed domain>"
+}
+```
+
+The response should be relayed exactly via an HTTP request to your restricted Umbraco environment:
+
+```
+POST http://<your umbraco environment>/umbraco/licenses/validatedLicense/relay?productId=<product id>&licenseKey=<license key>
+```
+
+A header with a key of `X-AUTH-KEY` and value of the authorization key you have configured should be provided.
+
+This will trigger the same processes that occur when the normal scheduled validation completes ensuring your product is considered licensed.


### PR DESCRIPTION
## Description

Added details of how to license commercial products in an environment without an outgoing Internet connection.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [X] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Umbraco.Licenses (used by Deploy, Commerce, Workflow and UIBuilder) 10.1, 12.1 and 13.1

## Deadline (if relevant)

Can be reviewed and published at any time.
