### PR TITLE
Updated use of obsolete method

### DIFF
--- a/13/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
+++ b/13/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
@@ -99,6 +99,7 @@ To do this we can use this helpful extension method:
 builder.Services.AddUmbracoDbContext<BlogContext>(options => 
 {
     options.UseSqlServer("{YOUR CONNECTIONSTRING HERE}");
+    //If you are using SQlite, replace UseSqlServer with UseSqlite
 });
 ```
 

--- a/13/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
+++ b/13/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
@@ -116,6 +116,7 @@ builder.CreateUmbracoBuilder()
 builder.Services.AddUmbracoDbContext<BlogContext>(options => 
 {
     options.UseSqlServer("{YOUR CONNECTIONSTRING HERE}");
+    //If you are using SQlite, replace UseSqlServer with UseSqlite
 });
 ```
 

--- a/13/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
+++ b/13/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
@@ -96,7 +96,10 @@ We need to register the `DbContext` to be able to use it in Umbraco.
 To do this we can use this helpful extension method:
 
 ```csharp
-services.AddUmbracoEFCoreContext<BlogContext>("{YOUR CONNECTIONSTRING HERE}", "{YOUR PROVIDER NAME HERE}");
+builder.Services.AddUmbracoDbContext<BlogContext>(options => 
+{
+    options.UseSqlServer("{YOUR CONNECTIONSTRING HERE}");
+});
 ```
 
 Add the method in the `Program.cs` file:
@@ -109,7 +112,10 @@ builder.CreateUmbracoBuilder()
     .AddComposers()
     .Build();
 
-builder.Services.AddUmbracoEFCoreContext<BlogContext>("{YOUR CONNECTIONSTRING HERE}", "{YOUR PROVIDER NAME HERE}");
+builder.Services.AddUmbracoDbContext<BlogContext>(options => 
+{
+    options.UseSqlServer("{YOUR CONNECTIONSTRING HERE}");
+});
 ```
 
 {% hint style="warning" %}


### PR DESCRIPTION
Updated documentation to prevent it recommending the use of an obsolete method.

## Description

Removed reference to `AddUmbracoEFCoreContext` for V13 as this now marked `[Obsolete("Use AddUmbracoDbContext<T>(this IServiceCollection services, Action<DbContextOptionsBuilder>? optionsAction = null) instead.")]` in the latest release but the documentation doesn't reflect.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
V13


## Deadline (if relevant)

N/A
