### PR TITLE
fixes broken link in Connection String Settings documentation

### DIFF
--- a/13/umbraco-cms/reference/configuration/connectionstringssettings.md
+++ b/13/umbraco-cms/reference/configuration/connectionstringssettings.md
@@ -33,5 +33,5 @@ If you're using Umbraco 9 [SQL Server Compact database](https://www.connectionst
 {% endhint %}
 
 ## Provider name
-Because Umbraco cannot determine the provider name from the connection string in all cases. Umbraco follows [Microsoft's convention](ttps://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-5.0#connection-string-prefixes-1) for provider names, which involves specifying it as a postfix in the connection string name.
+Because Umbraco cannot determine the provider name from the connection string in all cases. Umbraco follows [Microsoft's convention](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-5.0#connection-string-prefixes-1) for provider names, which involves specifying it as a postfix in the connection string name.
 

--- a/13/umbraco-cms/reference/configuration/connectionstringssettings.md
+++ b/13/umbraco-cms/reference/configuration/connectionstringssettings.md
@@ -33,5 +33,5 @@ If you're using Umbraco 9 [SQL Server Compact database](https://www.connectionst
 {% endhint %}
 
 ## Provider name
-Because Umbraco cannot determine the provider name from the connection string in all cases. Umbraco follows [Microsoft's convention](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-5.0#connection-string-prefixes-1) for provider names, which involves specifying it as a postfix in the connection string name.
+Because Umbraco cannot determine the provider name from the connection string in all cases. Umbraco follows [Microsoft's convention](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-8.0#connection-string-prefixes-1) for provider names, which involves specifying it as a postfix in the connection string name.
 


### PR DESCRIPTION
## Description

This fixes a malformed tag linking to external documentation - ttps:// -> https://
Located on the Connection String Settings part of the documentation site -> https://docs.umbraco.com/umbraco-cms/reference/configuration/connectionstringssettings

## Type of suggestion

* [x] Typo/grammar fix

## Product & version (if relevant)
 N/A


## Deadline (if relevant)

N/A
