### PR TITLE
Update IIS rewrite rule examples

### DIFF
--- a/13/umbraco-cms/reference/routing/iisrewriterules.md
+++ b/13/umbraco-cms/reference/routing/iisrewriterules.md
@@ -1,20 +1,20 @@
 # URL Rewrites in Umbraco
 
-With the release of Umbraco 9 and the change of the underlying web framework that is decoupled from the webserver, the way that you configure rewrites has changed as well.
+Since the release of Umbraco v9 and the change of the underlying web framework that is decoupled from the webserver, the way that you configure rewrites has changed as well.
 
-Instead of the URL Rewriting extension in IIS you can use the [URL Rewriting Middleware in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/url-rewriting?view=aspnetcore-5.0), which needs to be added to your project startup code first.
+Instead of the URL Rewriting extension in IIS you can use the [URL Rewriting Middleware in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/url-rewriting), which needs to be added to your project startup code first.
 
 {% hint style="info" %}
-If you are running Umbraco 9 on IIS you can still add a `web.config` file to configure IIS features such as URL rewrites.
+If you are running Umbraco v9+ on IIS you can still add a `web.config` file to configure IIS features such as URL rewrites.
 {% endhint %}
 
 ## When to use the URL Rewriting Middleware
 
-Make sure to check the official [URL Rewriting Middleware in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/url-rewriting?view=aspnetcore-5.0#when-to-use-url-rewriting-middleware) documentation for more information about when you should or should not use the URL Rewriting Middleware.
+Make sure to check the official [URL Rewriting Middleware in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/url-rewriting#when-to-use-url-rewriting-middleware) documentation for more information about when you should or should not use the URL Rewriting Middleware.
 
 ## Using the URL Rewriting Middleware
 
-To use rewrites with Umbraco 9 you have to register the middleware in your `Program.cs` by using the [`UseRewriter`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.rewritebuilderextensions.userewriter?view=aspnetcore-5.0) extension method and then configure the rewrite options.
+To use rewrites with Umbraco v9+ you have to register the middleware in your `Program.cs` by using the [`UseRewriter`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.rewritebuilderextensions.userewriter) extension method and then configure the rewrite options.
 
 ### Example
 
@@ -37,7 +37,7 @@ To use rewrites with Umbraco 9 you have to register the middleware in your `Prog
 </rewrite>
 ```
 
-* In the `Program.cs` file you can add the URL Rewriting Middleware before the call to `app.UseUmbraco()` and use [`AddIISUrlRewrite`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.rewrite.iisurlrewriteoptionsextensions.addiisurlrewrite?view=aspnetcore-5.0)) to add the rewrite rules from the XML file:
+* In the `Program.cs` file you can add the URL Rewriting Middleware before the call to `app.UseUmbraco()` and use [`AddIISUrlRewrite`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.rewrite.iisurlrewriteoptionsextensions.addiisurlrewrite) to add the rewrite rules from the XML file:
 
 ```csharp
 using Microsoft.AspNetCore.Rewrite;

--- a/umbraco-cloud/set-up/project-settings/manage-hostnames/rewrites-on-cloud.md
+++ b/umbraco-cloud/set-up/project-settings/manage-hostnames/rewrites-on-cloud.md
@@ -32,16 +32,16 @@ Once you've assigned a hostname to your Live environment, you may want to "hide"
 One approach for this is to add a new rewrite rule to the `<system.webServer><rewrite><rules>` section in the `web.config` file. For example, the following rule will redirect all requests for the project mysite.euwest01.umbraco.io URL to the mysite.com URL and respond with a permanent redirect status.
 
 ```xml
-<rule name="Redirects umbraco.io to actual domain" stopProcessing="true">
+<rule name="Redirect umbraco.io to primary hostname" stopProcessing="true">
   <match url=".*" />
   <conditions>
-    <add input="{HTTP_HOST}" pattern="^(.*)?.euwest01.umbraco.io$" />
-    <add input="{HTTP_HOST}" pattern="^(dev|stage)(.*)?.euwest01.umbraco.io$" ignoreCase="true" negate="true" />
-    <add input="{REQUEST_URI}" negate="true" pattern="^/umbraco" />
-    <add input="{REQUEST_URI}" negate="true" pattern="^/DependencyHandler.axd" />
-    <add input="{REQUEST_URI}" negate="true" pattern="^/App_Plugins" />
-    <add input="{REQUEST_URI}" negate="true" pattern="^/sb" /> <!-- Don't redirect Smidge Bundle -->
-    <add input="{REQUEST_URI}" negate="true" pattern="localhost" />
+    <add input="{HTTP_HOST}" pattern="\.umbraco\.io$" />
+    <add input="{HTTP_HOST}" pattern="^(dev-|stage-)(.*)?\.umbraco\.io$" ignoreCase="true" negate="true" />
+    <add input="{REQUEST_URI}" pattern="^/umbraco" ignoreCase="true" negate="true" />
+    <add input="{REQUEST_URI}" pattern="^/App_Plugins" ignoreCase="true" negate="true" />
+    <add input="{REQUEST_URI}" pattern="^/sb" negate="true" /> <!-- Don't redirect Smidge Bundle -->
+    <add input="{HTTP_COOKIE}" pattern="^(.+; )?UMB_UCONTEXT=([^;]*)(;.+)?$" negate="true" /> <!-- Ensure preview can render -->
+		<add input="{HTTP_HOST}" pattern="^localhost(:[0-9]+)?$" negate="true" />
   </conditions>
   <action type="Redirect" url="http://<your actual domain here>.com/{R:0}"
         appendQueryString="true" redirectType="Permanent" />


### PR DESCRIPTION
Following on from discussions on #5662 I have update the rewrite rule example to remove the data centre specific match and add a check on the UMB_UCONTEXT cookie so that backoffice preview works when this rule is in place

