### PR TITLE
Corrected query string before culture parameter

### DIFF
--- a/12/umbraco-forms/developer/ajaxforms.md
+++ b/12/umbraco-forms/developer/ajaxforms.md
@@ -43,7 +43,7 @@ The Open API specification is available from: `/umbraco/swagger/forms/swagger.js
 To request the definition of a form, the following request can be made:
 
 ```none
-GET /umbraco/forms/api/v1/definitions/{id}?contentId={contentId}&culture={culture}
+GET /umbraco/forms/api/v1/definitions/{id}?contentId={contentId}?culture={culture}
 ```
 
 The GET request requires the Guid identifying the form.


### PR DESCRIPTION
Corrected query string before culture parameter

## Description

Corrected query string before culture parameter. Changed from "&" to "?"

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
