### PR TITLE
Release notes for Deploy 4.10.0, 10.4.0, 12.2.0 and 13.1.0

### DIFF
--- a/10/umbraco-deploy/release-notes.md
+++ b/10/umbraco-deploy/release-notes.md
@@ -17,6 +17,15 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 4 and 10 including all changes for these versions. For each major version, you can find the details about each release.
 
+#### [10.4.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.4.0) (March 19th 2024)
+
+* All items from 10.4.0-rc1
+* Fixed issue with transfer of date values within Nested Content, Block List or Block Grid properties [#209](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/209)
+* Fixed issue where templates could incorrectly cause schema mismatch errors when running in production mode [#187](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/187)
+
+
+
+
 #### [10.4.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.4.0) (March 5th 2024)
 
 * Add `IArtifactTypeResolver` to allow custom type resolving when deserializing to `IArtifact` (used by Deploy Contrib, see PR [#60](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/61))

--- a/10/umbraco-deploy/release-notes.md
+++ b/10/umbraco-deploy/release-notes.md
@@ -21,7 +21,7 @@ This section contains the release notes for Umbraco Deploy 4 and 10 including al
 
 * All items from 10.4.0-rc1
 * Fixed issue with transfer of date values within Nested Content, Block List or Block Grid properties [#209](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/209)
-* Fixed issue where templates could incorrectly cause schema mismatch errors when running in production mode [#187](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/187)
+* Back-ported fix where templates could incorrectly cause schema mismatch errors when running in production mode. Although runtime modes aren't available in Umbraco 8, we ensure that the template `.uda` files are correctly processed by always setting the template path. [#187](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/187)
 * Fixed issue where importing invalid variant property data would cause a not supported variation exception [#8](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/8)
 * Fixed deserialization issue causing problems with the compare content feature [#212](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/212)
 

--- a/10/umbraco-deploy/release-notes.md
+++ b/10/umbraco-deploy/release-notes.md
@@ -450,6 +450,10 @@ This section contains the release notes for Umbraco Deploy 4 and 10 including al
 
 ## Deploy Contrib
 
+#### [10.2.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-10.2.0 (March 19th 2024)
+
+* All items from 10.2.0-rc1
+
 #### [10.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-10.2.0-rc1) (March 5th 2024)
 
 * Add legacy migrators and type resolver to allow importing from Umbraco 7 in [#61](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/61)

--- a/10/umbraco-deploy/release-notes.md
+++ b/10/umbraco-deploy/release-notes.md
@@ -22,9 +22,8 @@ This section contains the release notes for Umbraco Deploy 4 and 10 including al
 * All items from 10.4.0-rc1
 * Fixed issue with transfer of date values within Nested Content, Block List or Block Grid properties [#209](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/209)
 * Fixed issue where templates could incorrectly cause schema mismatch errors when running in production mode [#187](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/187)
-
-
-
+* Fixed issue where importing invalid variant property data would cause a not supported variation exception [#8](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/8)
+* Fixed deserialization issue causing problems with the compare content feature [#212](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/212)
 
 #### [10.4.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.4.0) (March 5th 2024)
 
@@ -194,6 +193,14 @@ This section contains the release notes for Umbraco Deploy 4 and 10 including al
 
 <details>
 <summary>Version 4</summary>
+
+#### [4.10.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.10.0) (March 19th 2024)
+
+* All items from 4.10.0-rc1
+* Fixed issue with transfer of date values within Nested Content, Block List or Block Grid properties [#209](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/209)
+* Fixed issue where templates could incorrectly cause schema mismatch errors when running in production mode [#187](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/187)
+* Fixed issue where importing invalid variant property data would cause a not supported variation exception [#8](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/8)
+* Fixed deserialization issue causing problems with the compare content feature [#212](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/212)
 
 #### [4.10.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F4.10.0) (March 5th 2024)
 

--- a/12/umbraco-deploy/release-notes.md
+++ b/12/umbraco-deploy/release-notes.md
@@ -122,6 +122,10 @@ This section contains the release notes for Umbraco Deploy 12 including all chan
 
 ## Deploy Contrib
 
+#### [12.1.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-12.1.0 (March 19th 2024)
+
+* All items from 10.2.0-rc1
+
 #### [12.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-12.1.0-rc1) (March 5th 2024)
 
 * Add legacy migrators and type resolver to allow importing from Umbraco 7 in [#61](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/61)

--- a/12/umbraco-deploy/release-notes.md
+++ b/12/umbraco-deploy/release-notes.md
@@ -17,6 +17,15 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 12 including all changes for this version.
 
+#### [12.2.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.2.0) (March 19th 2024)
+
+* All items from 12.2.0-rc1
+* Fixed issue with transfer of date values within Nested Content, Block List or Block Grid properties [#209](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/209)
+* Fixed issue where templates could incorrectly cause schema mismatch errors when running in production mode [#187](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/187)
+* Fixed issue where importing invalid variant property data would cause a not supported variation exception [#8](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/8)
+* Fixed deserialization issue causing problems with the compare content feature [#212](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/212)
+* Added migrator to support changes in Form field prevalues when importing from older Umbraco versions
+
 #### [12.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F12.2.0) (March 5th 2024)
 
 * Add `IArtifactTypeResolver` to allow custom type resolving when deserializing to `IArtifact` (used by Deploy Contrib, see PR [#60](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/61))

--- a/13/umbraco-deploy/getting-started/deploy-settings.md
+++ b/13/umbraco-deploy/getting-started/deploy-settings.md
@@ -68,6 +68,14 @@ For illustration purposes, the following structure represents the full set of op
             "NumberOfSignaturesToUseAllRelationCache": 100,
             "ContinueOnMediaFilePathTooLongException": false,
             "SuppressCacheRefresherNotifications": false,
+            "Suspensions": {
+              "DiskRead": "All",
+              "PartialRestore": "All",
+              "Restore": "All",
+              "Deploy": "All",
+              "Import": "All",
+              "Export": "All"
+            },
             "HideConfigurationDetails": false,
             "HideVersionDetails": false
         }
@@ -371,6 +379,29 @@ When a Deploy operation completes, cache refresher notifications are fired. Thes
 In production this setting shouldn't be changed from it's default value of `false`, to ensure these additional data stores are kept up to date.
 
 If attempting a one-off, large transfer operation, before a site is live, you could set this value to `true`. That would omit the firing and handling of these notifications and remove their performance overhead. Following which you would need to ensure to rebuild the cache and search index manually via the backoffice _Settings_ dashboards.
+
+### Suspensions
+
+Various Deploy operations suspend scheduled publishing, Examine indexing, document cache and signature database update events by default. You can amend this behavior for all supported or specific operations using these settings.
+
+Each setting within this section represents a Deploy operation. For each, the suspensions that are carried out can be amended with one or more of following values:
+
+-  `DiskRead` - `None, ScheduledPublishing, Examine, DocumentCache, All`,
+-  `PartialRestore` - `None, ScheduledPublishing, Examine, DocumentCache, All`,
+-  `Restore` - `None, ScheduledPublishing, Examine, DocumentCache, Signatures|All`,
+-  `Deploy` - `None, ScheduledPublishing, All`,
+-  `Import` - `None, ScheduledPublishing, Examine, DocumentCache, All`,
+-  `Export` - `None, ScheduledPublishing, All`
+
+The default value for all suspension settings is `All`.
+
+So for example if you wanted to remove Examine indexing suspension and resumption during partial restore operations, you could set the following:
+
+```json
+  "Suspensions": {
+    "PartialRestore": "ScheduledPublishing, DocumentCache"
+  }
+```
 
 ### HideConfigurationDetails
 

--- a/13/umbraco-deploy/getting-started/deploy-settings.md
+++ b/13/umbraco-deploy/getting-started/deploy-settings.md
@@ -388,7 +388,7 @@ Each setting within this section represents a Deploy operation. For each, the su
 
 -  `DiskRead` - `None, ScheduledPublishing, Examine, DocumentCache, All`,
 -  `PartialRestore` - `None, ScheduledPublishing, Examine, DocumentCache, All`,
--  `Restore` - `None, ScheduledPublishing, Examine, DocumentCache, Signatures|All`,
+-  `Restore` - `None, ScheduledPublishing, Examine, DocumentCache, Signatures, All`,
 -  `Deploy` - `None, ScheduledPublishing, All`,
 -  `Import` - `None, ScheduledPublishing, Examine, DocumentCache, All`,
 -  `Export` - `None, ScheduledPublishing, All`
@@ -401,6 +401,12 @@ So for example if you wanted to remove Examine indexing suspension and resumptio
   "Suspensions": {
     "PartialRestore": "ScheduledPublishing, DocumentCache"
   }
+```
+
+It's also possible to set the values for all operations by setting `Suspensions` to a value instead of an object, for example:
+
+```json
+  "Suspensions": "ScheduledPublishing, DocumentCache, Signatures"
 ```
 
 ### HideConfigurationDetails

--- a/13/umbraco-deploy/getting-started/deploy-settings.md
+++ b/13/umbraco-deploy/getting-started/deploy-settings.md
@@ -382,7 +382,7 @@ If attempting a one-off, large transfer operation, before a site is live, you co
 
 ### Suspensions
 
-Various Deploy operations suspend scheduled publishing, Examine indexing, document cache and signature database update events by default. You can amend this behavior for all supported or specific operations using these settings.
+Deploy operations suspend scheduled publishing, Examine indexing, document cache and/or signature database update events by default. You can amend this behavior for all supported or specific operations using these settings.
 
 Each setting within this section represents a Deploy operation. For each, the suspensions that are carried out can be amended with one or more of following values:
 

--- a/13/umbraco-deploy/getting-started/deploy-settings.md
+++ b/13/umbraco-deploy/getting-started/deploy-settings.md
@@ -409,6 +409,29 @@ It's also possible to set the values for all operations by setting `Suspensions`
   "Suspensions": "ScheduledPublishing, DocumentCache, Signatures"
 ```
 
+If you prefer configuration in code, operators overloads on the settings class make this process straightforward, as shown in the following example:
+
+```csharp
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Deploy.Core.Configuration.DeployConfiguration;
+
+internal class DeploySuspensionComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+        => builder.Services.Configure<DeploySettings>(options =>
+        {
+            // No suspensions during import
+            options.Suspensions.Import = SuspensionOptions.None;
+
+            // No Examine suspensions on all operations (using bitwise negation operator)
+            options.Suspensions &= ~SuspensionOptions.Examine;
+
+            // Add scheduled publishing suspension to all operations
+            options.Suspensions |= SuspensionOptions.ScheduledPublishing;
+        });
+}
+```
+
 ### HideConfigurationDetails
 
 If set to `true` the configuration details shown on the setting's dashboard will be hidden.

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -24,7 +24,6 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 * Fixed issue where templates could incorrectly cause schema mismatch errors when running in production mode [#187](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/187)
 * Fixed issue where importing invalid variant property data would cause a not supported variation exception [#8](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/8)
 * Fixed deserialization issue causing problems with the compare content feature [#212](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/212)
-* Added migrator to support changes in Form field prevalues when importing from older Umbraco versions
 * Add configuration to allow control over suspension and resumption of Examine and document cache events during Deploy operation [#211](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/211)
 
 #### [13.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.0) (March 5th 2024)
@@ -93,6 +92,10 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
   * Update Richtext value connector to handle references in blocks.
 
 ## Deploy Contrib
+
+#### [13.1.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.1.0 (March 19th 2024)
+
+* All items from 10.2.0-rc1
 
 #### [13.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.1.0-rc1) (March 5th 2024)
 

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -17,6 +17,16 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 13 including all changes for this version.
 
+#### [13.1.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.0) (March 19th 2024)
+
+* All items from 13.1.0-rc1
+* Fixed issue with transfer of date values within Nested Content, Block List or Block Grid properties [#209](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/209)
+* Fixed issue where templates could incorrectly cause schema mismatch errors when running in production mode [#187](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/187)
+* Fixed issue where importing invalid variant property data would cause a not supported variation exception [#8](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/8)
+* Fixed deserialization issue causing problems with the compare content feature [#212](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/212)
+* Added migrator to support changes in Form field prevalues when importing from older Umbraco versions
+* Add configuration to allow control over suspension and resumption of Examine and document cache events during Deploy operation [#211](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/211)
+
 #### [13.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.0) (March 5th 2024)
 
 * Add `IArtifactTypeResolver` to allow custom type resolving when deserializing to `IArtifact` (used by Deploy Contrib, see PR [#60](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/61))

--- a/13/umbraco-forms/release-notes.md
+++ b/13/umbraco-forms/release-notes.md
@@ -70,6 +70,12 @@ And there are a couple of further additions to improve the performance and acces
   * See full details of breaking changes under the [version specific upgrade guide](upgrading/version-specific.md#version-13).
 * Ran registered server-side file validators on file uploads.
 
+## Umbraco.Forms.Deploy
+
+#### [13.0.1] (March 19th 2024)
+
+* Added migrator to support changes in Form field prevalues when importing from older Umbraco versions
+
 ## Legacy release notes
 
 You can find the release notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/release-notes.md) and [Umbraco Forms Package page](https://our.umbraco.com/packages/developer-tools/umbraco-forms/).


### PR DESCRIPTION
## Description

Added release notes for Deploy 4.10.0, 10.4.0, 12.2.0 and 13.1.0

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [X] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Deploy 4.10.0, 10.4.0, 12.2.0 and 13.1.0

## Deadline (if relevant)

Ideally on Tuesday 19th March if possible please.  If not, as soon as is feasible afterwards.
