### PR TITLE
Update the Backoffice page to use the screenshot of the new login screen

### DIFF
--- a/13/umbraco-cms/fundamentals/backoffice/README.md
+++ b/13/umbraco-cms/fundamentals/backoffice/README.md
@@ -12,7 +12,7 @@ In this article you can learn more about the common terms and concepts that are 
 
 When you go to the backoffice for the first time, you're presented with the login screen.
 
-![Login screen](../../../../10/umbraco-cms/fundamentals/backoffice/images/backoffice-login.png)
+![Login screen](images/login-backoffice-login.png)
 
 [Read more about the login screen](login.md).
 


### PR DESCRIPTION
## Description
Updated `/umbraco-cms/fundamentals/backoffice` to use the screenshot of the new login screen, rather than the screenshot of the old one, it now uses the same screenshot as found on the `/umbraco-cms/fundamentals/backoffice/login` page.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
Umbraco CMS v13
