### PR TITLE
fix grammar mistake

### DIFF
--- a/13/umbraco-cms/reference/routing/custom-controllers.md
+++ b/13/umbraco-cms/reference/routing/custom-controllers.md
@@ -21,7 +21,8 @@ For example:
 * To implement any custom/granular security
 * To return alternative templates depending on some custom business logic
 
-This replacement of the default controller can either be made 'globally' for all requests (see last example) or by _'hijacking'_ requests for types of pages based on their specific Document Type following this controller naming convention: `[DocumentTypeAlias]Controller`.
+This replacement of the default controller can either be made 'globally' for all requests (see last example) or
+by _'hijacking'_ requests for types of pages based on their specific Document Type following this controller naming convention: `[DocumentTypeAlias]Controller`.
 
 ## Creating a custom controller
 

--- a/13/umbraco-cms/reference/routing/custom-controllers.md
+++ b/13/umbraco-cms/reference/routing/custom-controllers.md
@@ -21,7 +21,7 @@ For example:
 * To implement any custom/granular security
 * To return alternative templates depending on some custom business logic
 
-This replacement of the default controller can either be made 'globally' for all requests (see last example) or by _'hijacking'_ requests for types of pages based on their specific Document Type following a this controller naming convention: `[DocumentTypeAlias]Controller`.
+This replacement of the default controller can either be made 'globally' for all requests (see last example) or by _'hijacking'_ requests for types of pages based on their specific Document Type following this controller naming convention: `[DocumentTypeAlias]Controller`.
 
 ## Creating a custom controller
 

--- a/13/umbraco-cms/reference/routing/custom-controllers.md
+++ b/13/umbraco-cms/reference/routing/custom-controllers.md
@@ -21,8 +21,8 @@ For example:
 * To implement any custom/granular security
 * To return alternative templates depending on some custom business logic
 
-This replacement of the default controller can either be made 'globally' for all requests (see last example) or
-by _'hijacking'_ requests for types of pages based on their specific Document Type following this controller naming convention: `[DocumentTypeAlias]Controller`.
+This replacement of the default controller can either be made 'globally' for all requests (see last example) 
+It can be also by _'hijacking'_ requests for types of pages based on their specific Document Type following this controller naming convention: `[DocumentTypeAlias]Controller`.
 
 ## Creating a custom controller
 

--- a/13/umbraco-cms/reference/routing/custom-controllers.md
+++ b/13/umbraco-cms/reference/routing/custom-controllers.md
@@ -21,8 +21,7 @@ For example:
 * To implement any custom/granular security
 * To return alternative templates depending on some custom business logic
 
-This replacement of the default controller can either be made 'globally' for all requests (see last example) 
-It can be also by _'hijacking'_ requests for types of pages based on their specific Document Type following this controller naming convention: `[DocumentTypeAlias]Controller`.
+This replacement of the default controller can either be made 'globally' for all requests (see last example). It can be also by _'hijacking'_ requests for types of pages based on their specific Document Type following this controller naming convention: `[DocumentTypeAlias]Controller`.
 
 ## Creating a custom controller
 

--- a/13/umbraco-cms/reference/routing/custom-controllers.md
+++ b/13/umbraco-cms/reference/routing/custom-controllers.md
@@ -21,7 +21,7 @@ For example:
 * To implement any custom/granular security
 * To return alternative templates depending on some custom business logic
 
-This replacement of the default controller can either be made 'globally' for all requests (see last example). It can be also by _'hijacking'_ requests for types of pages based on their specific Document Type following this controller naming convention: `[DocumentTypeAlias]Controller`.
+This replacement of the default controller can either be made 'globally' for all requests (see last example). It can also be by _'hijacking'_ requests for types of pages based on their specific Document Type following this controller naming convention: `[DocumentTypeAlias]Controller`.
 
 ## Creating a custom controller
 


### PR DESCRIPTION
## Description

Fixed grammar mistake by removing an extra 'a'.

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Umbraco CMS v13