### PR TITLE
Notice about register `IUmbracoCommerceBuilder` extensions using composer

### DIFF
--- a/13/umbraco-commerce/key-concepts/umbraco-commerce-builder.md
+++ b/13/umbraco-commerce/key-concepts/umbraco-commerce-builder.md
@@ -60,3 +60,33 @@ public static class UmbracoCommerceUmbracoBuilderExtensions
 })
 ...
 ```
+
+{% hint style="info" %}
+Notice if using a composer to register `IUmbracoCommerceBuilder` extensions and its dependencies, the composer need to run before `UmbracoCommerceComposer` otherwise it will use default configuration.
+{% endhint %}
+
+```csharp
+public static class StoreBuilderExtensions
+{
+	public static IUmbracoBuilder AddBillundStore(this IUmbracoBuilder umbracoBuilder)
+	{
+		umbracoBuilder.AddUmbracoCommerce(v =>
+		{
+			...
+		});
+
+		return umbracoBuilder;
+	}
+}
+```
+
+```csharp
+[ComposeBefore(typeof(UmbracoCommerceComposer))]
+public class StoreComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.AddMyStore();
+    }
+}
+```

--- a/13/umbraco-commerce/key-concepts/umbraco-commerce-builder.md
+++ b/13/umbraco-commerce/key-concepts/umbraco-commerce-builder.md
@@ -62,7 +62,7 @@ public static class UmbracoCommerceUmbracoBuilderExtensions
 ```
 
 {% hint style="info" %}
-Notice if using a composer to register `IUmbracoCommerceBuilder` extensions and its dependencies, the composer need to run before `UmbracoCommerceComposer` otherwise it will use default configuration.
+If using a composer to register `IUmbracoCommerceBuilder` extensions and their dependencies, the composer needs to run before `UmbracoCommerceComposer` otherwise it will use the default configuration.
 {% endhint %}
 
 ```csharp

--- a/13/umbraco-commerce/key-concepts/umbraco-commerce-builder.md
+++ b/13/umbraco-commerce/key-concepts/umbraco-commerce-builder.md
@@ -68,7 +68,7 @@ Notice if using a composer to register `IUmbracoCommerceBuilder` extensions and 
 ```csharp
 public static class StoreBuilderExtensions
 {
-	public static IUmbracoBuilder AddBillundStore(this IUmbracoBuilder umbracoBuilder)
+	public static IUmbracoBuilder AddMyStore(this IUmbracoBuilder umbracoBuilder)
 	{
 		umbracoBuilder.AddUmbracoCommerce(v =>
 		{


### PR DESCRIPTION
## Description
Related to https://github.com/umbraco/Umbraco.Commerce.Issues/issues/475 
It is important the composer which extends `IUmbracoCommerceBuilder` run before `UmbracoCommerceComposer` to work.

while this work, it seems to fail with `InsertBefore<TTask>()` or `InsertAfter<TTask>()` used in the composer:
https://docs.umbraco.com/umbraco-commerce/key-concepts/pipelines

https://github.com/umbraco/Umbraco.Commerce.Issues/issues/475#issuecomment-2003367330

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [x] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
