### PR TITLE
docs: fixed typo in storefront docs

### DIFF
--- a/13/umbraco-commerce/reference/storefront-api/README.md
+++ b/13/umbraco-commerce/reference/storefront-api/README.md
@@ -42,7 +42,7 @@ builder.CreateUmbracoBuilder()
 {
     "Umbraco": {
         "Commerce": {
-            "StorefrontAPi": {
+            "StorefrontApi": {
                 "Enabled": true
             }
         }
@@ -60,7 +60,7 @@ In order to work with the Storefront API many of the endpoints require authoriza
 {
     "Umbraco": {
         "Commerce": {
-            "StorefrontAPi": {
+            "StorefrontApi": {
                 "Enabled": true,
                 "ApiKey": "ZUynC149dD2N5efs6HN6dCdXlgOVASs6"
             }


### PR DESCRIPTION
## Description

Fixed a typo in the Storefront documenentation `StorefrontAPi -> StorefrontApi`

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)




