### PR TITLE
Update setting-types.md

### DIFF
--- a/12/umbraco-forms/developer/extending/setting-types.md
+++ b/12/umbraco-forms/developer/extending/setting-types.md
@@ -49,6 +49,10 @@ It offers the option of text field entry or the selection of a field from the fo
 
 ## Creating a setting type
 
-To create a custom setting type you will need to create an AngularJS view and controller at the following location: `/App_Plugins/UmbracoForms/backoffice/Common/SettingTypes/mysettingview.html`.
+To create a custom setting type you will need an AngularJS view and controller in the following location: `/App_Plugins/MyPlugin/`.
+
+{% hint style="info" %}
+**Tip:** Your plugin folder path must be outside of the `/App_Plugins/UmbracoForms/` folder if you are going to use a custom Angular controller and Package.manifest.
+{% endhint %}
 
 You then add the name of the view as the `View` property on the `Setting` attribute defined on the type.


### PR DESCRIPTION
update creating a setting type for umbraco 12 docs to reflect what folder structure to use.

## Description

The documentation was pointing to an HTML file in reference for creating a view and controller. This file lived in the Umbraco Forms folder which appeared to not work when a controller was placed inside. Moving the files to their own folder in a different location worked so I updated the docs to reflect this change.

## Type of suggestion

* [ ] Typo/grammar fix
* [ x ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

12

## Deadline (if relevant)

_When should the content be published?_
