### PR TITLE
Fix bad formatting

### DIFF
--- a/13/umbraco-cms/reference/security/external-login-providers.md
+++ b/13/umbraco-cms/reference/security/external-login-providers.md
@@ -274,13 +274,6 @@ You can use the [Umbraco Icon Picker](../../fundamentals/data/defining-content/R
 
 {% code title="ProviderMembersExternalLoginProviderOptions.cs" lineNumbers="true" %}
 ```csharp
-
-{% endtab %}
-
-{% tab title="Member Authentication" %}
-
-{% code title="ProviderMembersExternalLoginProviderOptions.cs" lineNumbers="true" %}
-```csharp
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Web.Common.Security;


### PR DESCRIPTION
## Description

_What did you add/update/change?_

Looks like maybe a bad merge left duplicate tags in there?

Currently looks like this on the page:
https://docs.umbraco.com/umbraco-cms/reference/security/external-login-providers#auto-linking-on-member-authentication
![image](https://github.com/umbraco/UmbracoDocs/assets/79840720/2cfc3a95-2d29-4333-ad2d-157f770ac3b1)

This PR should remove the additional tags.


## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [x] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
