### PR TITLE
Fix broken links for sections and tree

### DIFF
--- a/14/umbraco-cms/extending-backoffice/extension-types/sections-and-trees/README.md
+++ b/14/umbraco-cms/extending-backoffice/extension-types/sections-and-trees/README.md
@@ -11,7 +11,7 @@ This page is a work in progress. It will be updated as the software evolves.
 <figure><img src="../../../.gitbook/assets/section.svg" alt=""><figcaption><p>Section</p></figcaption></figure>
 
 **Manifest**
-When creating a new section it's recommended to use a [Entry Point](../extension-types/entry-point)-extension in your [Umbraco Package Manifest](../../package-manifest). This is to get better control over all the additional extensions required for the new section.
+When creating a new section it's recommended to use a [Entry Point](../extension-types/entry-point.md)-extension in your [Umbraco Package Manifest](../../package-manifest.md). This is to get better control over all the additional extensions required for the new section.
 
 This is how to define a section in TypeScript:
 


### PR DESCRIPTION
## Description

I think and hope that I fixed some broken links on this page: https://docs.umbraco.com/umbraco-cms/v/14.latest-beta/extending-backoffice/extension-types/sections-and-trees

The lacked the `.md` extension so the links ended up as 404s to Github. 

I'm not 100% sure, looked at other articles, is this correct? Should links point to the markdown files with the `.md` extension at the end?


## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

