### PR TITLE
Deploy Import file size limit on Umbraco Cloud

### DIFF
--- a/13/umbraco-deploy/deployment-workflow/import-export.md
+++ b/13/umbraco-deploy/deployment-workflow/import-export.md
@@ -60,6 +60,7 @@ Similar to when exporting, you can choose to import everything from the archive 
 
 {% hint style="info" %}
 Deploy does not touch the default maximum upload size, but you can [configure this yourself by following the CMS documentation](https://docs.umbraco.com/umbraco-cms/reference/configuration/maximumuploadsizesettings).
+However, on Umbraco Cloud the upload size limit is 500mb.
 {% endhint %}
 
 ![Import dialog step 2](../../../10/umbraco-deploy/deployment-workflow/images//import-dialog-2.png)

--- a/13/umbraco-deploy/deployment-workflow/import-export.md
+++ b/13/umbraco-deploy/deployment-workflow/import-export.md
@@ -60,7 +60,7 @@ Similar to when exporting, you can choose to import everything from the archive 
 
 {% hint style="info" %}
 Deploy does not touch the default maximum upload size, but you can [configure this yourself by following the CMS documentation](https://docs.umbraco.com/umbraco-cms/reference/configuration/maximumuploadsizesettings).
-However, on Umbraco Cloud the upload size limit is 500mb.
+ On Umbraco Cloud, the upload size limit is 500 MB.
 {% endhint %}
 
 ![Import dialog step 2](../../../10/umbraco-deploy/deployment-workflow/images//import-dialog-2.png)


### PR DESCRIPTION
## Description

_What did you add/update/change?_
I added additional info to the current note about Deploy not touching the maximum upload size
Discovered in a recent case using import/export, we encountered a 500mb limit on the file size for importing on Umbraco Cloud.
This is imposed by Cloudflare.

I have only added it on v13 docs, but I suggest getting it added on the other versions.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [x] Other

## Product & version
Deploy 
