### PR TITLE
Updated creating a  property editor part 4

### DIFF
--- a/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -179,6 +179,6 @@ There is a good amount of things to keep track of, but each component is tiny an
 
 ## Wrap-up
 
-The important part of the above is the way you create a `ApiController` call to the database for your own data, and finally expose the data to angular as a service using `$http`.
+The important part of the above is the way you create an `ApiController` call to the database for your own data. And finally, expose the data to angular as a service using `$http`.
 
 For simplicity, you could have skipped the service part and called `$http` directly in your controller. However, having your data in services it becomes a reusable resource for your entire application.

--- a/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -79,7 +79,7 @@ public IEnumerable<Person> GetAll()
 }
 ```
 
-Inside the `GetAll()` method, we now write a bit of code, that connects to the database, creates a query, and returns the data, mapped to the `Person` class above:
+Inside the `GetAll()` method, we write a bit of code. The code connects to the database, creates a query, and returns the data, mapped to the `Person` class above:
 
 ```csharp
 private readonly Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider;

--- a/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -87,7 +87,7 @@ Inside the `GetAll()` method, we write a bit of code. The code connects to the d
 private readonly IScopeProvider scopeProvider;
 
 
-public PersonApiController(Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider)
+public PersonApiController(IScopeProvider scopeProvider)
 {
     this.scopeProvider = scopeProvider;
 }

--- a/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -50,7 +50,7 @@ In the `PersonApiController.cs` file, add:
     }
 ```
 
-This is a very basic API controller that inherits from `UmbracoAuthorizedJsonController` this specific class and will only return JSON data and only to requests which are authorized to access the backoffice.
+This is a basic API controller that inherits from `UmbracoAuthorizedJsonController`. This specific class will only return JSON data and only to requests that are authorized to access the backoffice.
 
 ## Setup the GetAll() method
 

--- a/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -40,6 +40,8 @@ In the `PersonApiController.cs` file, add:
 ```csharp
     using Umbraco.Cms.Web.BackOffice.Controllers;
     using Umbraco.Cms.Web.Common.Attributes;
+    using Umbraco.Cms.Infrastructure.Scoping;
+
 
 
     namespace YourProjectName;
@@ -82,7 +84,7 @@ public IEnumerable<Person> GetAll()
 Inside the `GetAll()` method, we write a bit of code. The code connects to the database, creates a query, and returns the data, mapped to the `Person` class above:
 
 ```csharp
-private readonly Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider;
+private readonly IScopeProvider scopeProvider;
 
 
 public PersonApiController(Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider)

--- a/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -1,21 +1,16 @@
----
-
-needsV9Update: "true"
----
-
 # Adding server-side data to a property editor
 
 ## Overview
 
-In this tutorial, we will add a server-side API controller, which will query a custom table in the Umbraco database, and then return the data to an angular controller + view.
+In this tutorial, we will add a server-side API controller, which will query a custom table in the Umbraco database. It will then return the data to an angular controller + view.
 
-The end result will be a person-list, populated from a custom table. When clicked it will store the ID of the selected person.
+The result will be a person-list, populated from a custom table. When clicked it will store the ID of the selected person.
 
 ## Setup the database
 
-First thing we need is some data; below is an SQL Script for creating a `people` table with some random data in it. You could also use [https://generatedata.com](https://generatedata.com) for larger amounts of data:
+The first thing we need is some data; below is an SQL Script for creating a `people` table with some random data in it. You could also use [https://generatedata.com](https://generatedata.com) for larger amounts of data:
 
-```xml
+```sql
 CREATE TABLE people (
     id INTEGER NOT NULL IDENTITY(1, 1),
     name VARCHAR(255) NULL,
@@ -36,7 +31,7 @@ INSERT INTO people(name,town,country) VALUES('Aimee Sampson','Hawera','Antigua a
 
 ## Setup ApiController routes
 
-Next we need to define an `ApiController` to expose a server-side route which our application will use to fetch the data.
+Next, we need to define an `ApiController` to expose a server-side route that our application will use to fetch the data.
 
 For this, you can create a new class at the root of the project called `PersonApiController.cs`
 
@@ -44,17 +39,18 @@ In the `PersonApiController.cs` file, add:
 
 ```csharp
     using Umbraco.Cms.Web.BackOffice.Controllers;
-    using Umbraco.Cms.Core.Web.Mvc;
+    using Umbraco.Cms.Web.Common.Attributes;
+
 
     namespace YourProjectName;
-    [PluginControllerMetadata("My")]
+    [PluginController("My")]
     public class PersonApiController : UmbracoAuthorizedJsonController
     {
         // we will add a method here later
     }
 ```
 
-This is a very basic API controller which inherits from `UmbracoAuthorizedJsonController` this specific class will only return JSON data and only to requests which are authorized to access the backoffice.
+This is a very basic API controller that inherits from `UmbracoAuthorizedJsonController` this specific class and will only return JSON data and only to requests which are authorized to access the backoffice.
 
 ## Setup the GetAll() method
 
@@ -83,12 +79,13 @@ public IEnumerable<Person> GetAll()
 }
 ```
 
-Inside the `GetAll()` method, we now write a bit of code, that connects to the database, creates a query and returns the data, mapped to the `Person` class above:
+Inside the `GetAll()` method, we now write a bit of code, that connects to the database, creates a query, and returns the data, mapped to the `Person` class above:
 
 ```csharp
-private readonly IScopeProvider scopeProvider;
+private readonly Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider;
 
-public PersonApiController(IScopeProvider scopeProvider)
+
+public PersonApiController(Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider)
 {
     this.scopeProvider = scopeProvider;
 }
@@ -106,13 +103,13 @@ public IEnumerable<Person> GetAll()
 }
 ```
 
-We are now done with the server-side of things, with the file saved in App_Code you can now open the URL: `/umbraco/backoffice/My/PersonApi/GetAll`.
+We are now done with the server side of things, with the file saved you can now open the URL: `/umbraco/backoffice/My/PersonApi/GetAll`.
 
 This will return our JSON data.
 
 ## Create a Person Resource
 
-Now that we have the server-side in place, and a URL to call, we will setup a service to retrieve our data. As an Umbraco-specific convention, we call these services a *resource*, so we always have an indication of what services fetch data from the DB.
+Now that we have the server side in place and a URL to call, we will set up a service to retrieve our data. As an Umbraco-specific convention, we call these services a _resource_, so we always indicate what services fetch data from the DB.
 
 Create a new file as `person.resource.js` and add:
 
@@ -139,7 +136,7 @@ The `getAll()` method returns a promise from an `$http.get` call, which handles 
 
 ## Create the view and controller
 
-We will now finally setup a new view and controller, which follows previous tutorials, so you can refer to those for more details:
+We will now finally set up a new view and controller, which follows previous tutorials, so you can refer to those for more details:
 
 ### The view
 
@@ -175,13 +172,13 @@ With this, the entire flow is:
 3. The personResource returns a Promise and asks the my/PersonAPI ApiController
 4. The ApiController queries the database, which returns the data as strongly typed Person objects
 5. The ApiController returns those `Person` objects as JSON to the resource
-6. The resource resolve the Promise
+6. The resource resolves the Promise
 7. The controller populates the view
 
 There is a good amount of things to keep track of, but each component is tiny and flexible.
 
 ## Wrap-up
 
-The important part of the above is the way you create an `ApiController` call to the database for your own data, and finally expose the data to angular as a service using `$http`.
+The important part of the above is the way you create a `ApiController` call to the database for your own data, and finally expose the data to angular as a service using `$http`.
 
-For simplicity, you could also have skipped the service part, and called `$http` directly in your controller, but by having your data in a service, it becomes a reusable resource for your entire application.
+For simplicity, you could also have skipped the service part and called `$http` directly in your controller, but by having your data in services, it becomes a reusable resource for your entire application.

--- a/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/10/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -181,4 +181,4 @@ There is a good amount of things to keep track of, but each component is tiny an
 
 The important part of the above is the way you create a `ApiController` call to the database for your own data, and finally expose the data to angular as a service using `$http`.
 
-For simplicity, you could also have skipped the service part and called `$http` directly in your controller, but by having your data in services, it becomes a reusable resource for your entire application.
+For simplicity, you could have skipped the service part and called `$http` directly in your controller. However, having your data in services it becomes a reusable resource for your entire application.

--- a/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -87,7 +87,7 @@ Inside the `GetAll()` method, we write a bit of code. The code connects to the d
 private readonly IScopeProvider scopeProvider;
 
 
-public PersonApiController(Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider)
+public PersonApiController(IScopeProvider scopeProvider)
 {
     this.scopeProvider = scopeProvider;
 }

--- a/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -182,4 +182,4 @@ There is a good amount of things to keep track of, but each component is tiny an
 
 The important part of the above is the way you create a `ApiController` call to the database for your own data, and finally expose the data to angular as a service using `$http`.
 
-For simplicity, you could also have skipped the service part and called `$http` directly in your controller, but by having your data in services, it becomes a reusable resource for your entire application.
+For simplicity, you could have skipped the service part and called `$http` directly in your controller. However, having your data in services it becomes a reusable resource for your entire application.

--- a/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -51,7 +51,7 @@ In the `PersonApiController.cs` file, add:
     }
 ```
 
-This is a very basic API controller that inherits from `UmbracoAuthorizedJsonController` this specific class and will only return JSON data and only to requests which are authorized to access the backoffice.
+This is a basic API controller that inherits from `UmbracoAuthorizedJsonController`. This specific class will only return JSON data and only to requests that are authorized to access the backoffice.
 
 ## Setup the GetAll() method
 

--- a/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -180,6 +180,6 @@ There is a good amount of things to keep track of, but each component is tiny an
 
 ## Wrap-up
 
-The important part of the above is the way you create a `ApiController` call to the database for your own data, and finally expose the data to angular as a service using `$http`.
+The important part of the above is the way you create an `ApiController` call to the database for your own data. And finally, expose the data to angular as a service using `$http`.
 
 For simplicity, you could have skipped the service part and called `$http` directly in your controller. However, having your data in services it becomes a reusable resource for your entire application.

--- a/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -1,21 +1,17 @@
----
-
-needsV9Update: "true"
----
 
 # Adding server-side data to a property editor
 
 ## Overview
 
-In this tutorial, we will add a server-side API controller, which will query a custom table in the Umbraco database, and then return the data to an angular controller + view.
+In this tutorial, we will add a server-side API controller, which will query a custom table in the Umbraco database. It will then return the data to an angular controller + view.
 
-The end result will be a person-list, populated from a custom table. When clicked it will store the ID of the selected person.
+The result will be a person-list, populated from a custom table. When clicked it will store the ID of the selected person.
 
 ## Setup the database
 
-First thing we need is some data; below is an SQL Script for creating a `people` table with some random data in it. You could also use [https://generatedata.com](https://generatedata.com) for larger amounts of data:
+The first thing we need is some data; below is an SQL Script for creating a `people` table with some random data in it. You could also use [https://generatedata.com](https://generatedata.com) for larger amounts of data:
 
-```xml
+```sql
 CREATE TABLE people (
     id INTEGER NOT NULL IDENTITY(1, 1),
     name VARCHAR(255) NULL,
@@ -36,7 +32,7 @@ INSERT INTO people(name,town,country) VALUES('Aimee Sampson','Hawera','Antigua a
 
 ## Setup ApiController routes
 
-Next we need to define an `ApiController` to expose a server-side route which our application will use to fetch the data.
+Next, we need to define an `ApiController` to expose a server-side route that our application will use to fetch the data.
 
 For this, you can create a new class at the root of the project called `PersonApiController.cs`
 
@@ -44,17 +40,18 @@ In the `PersonApiController.cs` file, add:
 
 ```csharp
     using Umbraco.Cms.Web.BackOffice.Controllers;
-    using Umbraco.Cms.Core.Web.Mvc;
+    using Umbraco.Cms.Web.Common.Attributes;
+
 
     namespace YourProjectName;
-    [PluginControllerMetadata("My")]
+    [PluginController("My")]
     public class PersonApiController : UmbracoAuthorizedJsonController
     {
         // we will add a method here later
     }
 ```
 
-This is a very basic API controller which inherits from `UmbracoAuthorizedJsonController` this specific class will only return JSON data and only to requests which are authorized to access the backoffice.
+This is a very basic API controller that inherits from `UmbracoAuthorizedJsonController` this specific class and will only return JSON data and only to requests which are authorized to access the backoffice.
 
 ## Setup the GetAll() method
 
@@ -83,12 +80,13 @@ public IEnumerable<Person> GetAll()
 }
 ```
 
-Inside the `GetAll()` method, we now write a bit of code, that connects to the database, creates a query and returns the data, mapped to the `Person` class above:
+Inside the `GetAll()` method, we now write a bit of code, that connects to the database, creates a query, and returns the data, mapped to the `Person` class above:
 
 ```csharp
-private readonly IScopeProvider scopeProvider;
+private readonly Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider;
 
-public PersonApiController(IScopeProvider scopeProvider)
+
+public PersonApiController(Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider)
 {
     this.scopeProvider = scopeProvider;
 }
@@ -106,13 +104,13 @@ public IEnumerable<Person> GetAll()
 }
 ```
 
-We are now done with the server-side of things, with the file saved in App_Code you can now open the URL: `/umbraco/backoffice/My/PersonApi/GetAll`.
+We are now done with the server side of things, with the file saved you can now open the URL: `/umbraco/backoffice/My/PersonApi/GetAll`.
 
 This will return our JSON data.
 
 ## Create a Person Resource
 
-Now that we have the server-side in place, and a URL to call, we will setup a service to retrieve our data. As an Umbraco-specific convention, we call these services a *resource*, so we always have an indication of what services fetch data from the DB.
+Now that we have the server side in place and a URL to call, we will set up a service to retrieve our data. As an Umbraco-specific convention, we call these services a _resource_, so we always indicate what services fetch data from the DB.
 
 Create a new file as `person.resource.js` and add:
 
@@ -139,7 +137,7 @@ The `getAll()` method returns a promise from an `$http.get` call, which handles 
 
 ## Create the view and controller
 
-We will now finally setup a new view and controller, which follows previous tutorials, so you can refer to those for more details:
+We will now finally set up a new view and controller, which follows previous tutorials, so you can refer to those for more details:
 
 ### The view
 
@@ -175,13 +173,13 @@ With this, the entire flow is:
 3. The personResource returns a Promise and asks the my/PersonAPI ApiController
 4. The ApiController queries the database, which returns the data as strongly typed Person objects
 5. The ApiController returns those `Person` objects as JSON to the resource
-6. The resource resolve the Promise
+6. The resource resolves the Promise
 7. The controller populates the view
 
 There is a good amount of things to keep track of, but each component is tiny and flexible.
 
 ## Wrap-up
 
-The important part of the above is the way you create an `ApiController` call to the database for your own data, and finally expose the data to angular as a service using `$http`.
+The important part of the above is the way you create a `ApiController` call to the database for your own data, and finally expose the data to angular as a service using `$http`.
 
-For simplicity, you could also have skipped the service part, and called `$http` directly in your controller, but by having your data in a service, it becomes a reusable resource for your entire application.
+For simplicity, you could also have skipped the service part and called `$http` directly in your controller, but by having your data in services, it becomes a reusable resource for your entire application.

--- a/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -80,7 +80,7 @@ public IEnumerable<Person> GetAll()
 }
 ```
 
-Inside the `GetAll()` method, we now write a bit of code, that connects to the database, creates a query, and returns the data, mapped to the `Person` class above:
+Inside the `GetAll()` method, we write a bit of code. The code connects to the database, creates a query, and returns the data, mapped to the `Person` class above:
 
 ```csharp
 private readonly Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider;

--- a/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/12/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -1,4 +1,3 @@
-
 # Adding server-side data to a property editor
 
 ## Overview
@@ -41,6 +40,8 @@ In the `PersonApiController.cs` file, add:
 ```csharp
     using Umbraco.Cms.Web.BackOffice.Controllers;
     using Umbraco.Cms.Web.Common.Attributes;
+    using Umbraco.Cms.Infrastructure.Scoping;
+
 
 
     namespace YourProjectName;
@@ -83,7 +84,7 @@ public IEnumerable<Person> GetAll()
 Inside the `GetAll()` method, we write a bit of code. The code connects to the database, creates a query, and returns the data, mapped to the `Person` class above:
 
 ```csharp
-private readonly Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider;
+private readonly IScopeProvider scopeProvider;
 
 
 public PersonApiController(Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider)

--- a/13/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/13/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -1,12 +1,8 @@
----
-needsV9Update: 'true'
----
-
 # Adding server-side data to a property editor
 
 ## Overview
 
-In this tutorial, we will add a server-side API controller, which will query a custom table in the Umbraco database, and then return the data to an angular controller + view.
+In this tutorial, we will add a server-side API controller, which will query a custom table in the Umbraco database. It will then return the data to an angular controller + view.
 
 The result will be a person-list, populated from a custom table. When clicked it will store the ID of the selected person.
 

--- a/13/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/13/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -87,7 +87,7 @@ Inside the `GetAll()` method, we write a bit of code. The code connects to the d
 private readonly IScopeProvider scopeProvider;
 
 
-public PersonApiController(Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider)
+public PersonApiController(IScopeProvider scopeProvider)
 {
     this.scopeProvider = scopeProvider;
 }

--- a/13/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/13/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -40,6 +40,8 @@ In the `PersonApiController.cs` file, add:
 ```csharp
     using Umbraco.Cms.Web.BackOffice.Controllers;
     using Umbraco.Cms.Web.Common.Attributes;
+    using Umbraco.Cms.Infrastructure.Scoping;
+
 
 
     namespace YourProjectName;
@@ -82,7 +84,7 @@ public IEnumerable<Person> GetAll()
 Inside the `GetAll()` method, we write a bit of code. The code connects to the database, creates a query, and returns the data, mapped to the `Person` class above:
 
 ```csharp
-private readonly Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider;
+private readonly IScopeProvider scopeProvider;
 
 
 public PersonApiController(Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider)

--- a/13/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
+++ b/13/umbraco-cms/tutorials/creating-a-property-editor/part-4.md
@@ -50,7 +50,7 @@ In the `PersonApiController.cs` file, add:
     }
 ```
 
-This is a very basic API controller that inherits from `UmbracoAuthorizedJsonController` this specific class and will only return JSON data and only to requests which are authorized to access the backoffice.
+This is a basic API controller that inherits from `UmbracoAuthorizedJsonController`. This specific class will only return JSON data and only to requests that are authorized to access the backoffice.
 
 ## Setup the GetAll() method
 
@@ -79,7 +79,7 @@ public IEnumerable<Person> GetAll()
 }
 ```
 
-Inside the `GetAll()` method, we now write a bit of code, that connects to the database, creates a query, and returns the data, mapped to the `Person` class above:
+Inside the `GetAll()` method, we write a bit of code. The code connects to the database, creates a query, and returns the data, mapped to the `Person` class above:
 
 ```csharp
 private readonly Umbraco.Cms.Infrastructure.Scoping.IScopeProvider scopeProvider;
@@ -179,6 +179,6 @@ There is a good amount of things to keep track of, but each component is tiny an
 
 ## Wrap-up
 
-The important part of the above is the way you create a `ApiController` call to the database for your own data, and finally expose the data to angular as a service using `$http`.
+The important part of the above is the way you create an `ApiController` call to the database for your own data. And finally, expose the data to angular as a service using `$http`.
 
-For simplicity, you could also have skipped the service part and called `$http` directly in your controller, but by having your data in services, it becomes a reusable resource for your entire application.
+For simplicity, you could have skipped the service part and called `$http` directly in your controller. However, having your data in services it becomes a reusable resource for your entire application.


### PR DESCRIPTION
## Description
We have gotten some feedback from various people, about part 4 of the Creating a Property Editor guide not working and having wrong information.

This PR is created to mitigate that.

_What did you add/update/change?_

Updated the code as it was using `IScopeProvider` which is marked as obsolete, and it is recommended to use `Umbraco.Cms.Infrastructure.Scoping.IScopeProvider` instead.

The example was also using `[PluginControllerMetadata("My")]` which is also wrong and should be `[PluginController("My")]`

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
10
12


## Deadline (if relevant)
N/A

_When should the content be published?_
N/A