### PR TITLE
Use UmbPropertyValueChangeEvent over magic string

### DIFF
--- a/14/umbraco-cms/extending-backoffice/extension-types/property-editors/property-editor-ui.md
+++ b/14/umbraco-cms/extending-backoffice/extension-types/property-editors/property-editor-ui.md
@@ -83,6 +83,7 @@ interface UmbPropertyEditorUIElement {}
 ```ts
 import { LitElement, html, css, customElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
+import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 
 @customElement('my-text-box')
 export default class UmbPropertyEditorUITextBoxElement extends UmbElementMixin(LitElement) {
@@ -95,7 +96,7 @@ export default class UmbPropertyEditorUITextBoxElement extends UmbElementMixin(L
 
 	private onInput(e: InputEvent) {
 		this.value = (e.target as HTMLInputElement).value;
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	render() {

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/README.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/README.md
@@ -215,7 +215,7 @@ It's starting to look good! Next, let's look into setting up the event logic.
 
 Let's start with the input field. When we type something in the input field, we want the property editor's value to change to the input field's current value.
 
-We then have to dispatch an `property-value-change` event:
+We then have to dispatch an `property-value-change` event, this can be done using ´new CustomEvent('property-value-change')` or you can leverage the core class `new UmbPropertyValueChangeEvent()` (recommended):
 
 {% code title="suggestions-property-editor-ui.element.ts" %}
 ```typescript
@@ -225,7 +225,7 @@ We then have to dispatch an `property-value-change` event:
   }
 
   #dispatchChangeEvent() {
-    this.dispatchEvent(new CustomEvent('property-value-change'));
+    this.dispatchEvent(new UmbPropertyValueChangeEvent());
   }
 
   render() {

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/README.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/README.md
@@ -216,8 +216,8 @@ It's starting to look good! Next, let's look into setting up the event logic.
 Let's start with the input field. When we type something in the input field, we want the property editor's value to change to the input field's current value.
 
 We then have to dispatch an `property-value-change` event which can be done in two ways:
-- using ´new CustomEvent('property-value-change')` or 
-- using `new UmbPropertyValueChangeEvent()` which is recommended as you can leverage the core class 
+- Using ´new CustomEvent('property-value-change')` or 
+- Using `new UmbPropertyValueChangeEvent()` which is recommended as you can leverage the core class 
 
 {% code title="suggestions-property-editor-ui.element.ts" %}
 ```typescript

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/README.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/README.md
@@ -216,8 +216,17 @@ It's starting to look good! Next, let's look into setting up the event logic.
 Let's start with the input field. When we type something in the input field, we want the property editor's value to change to the input field's current value.
 
 We then have to dispatch an `property-value-change` event which can be done in two ways:
-- Using ´new CustomEvent('property-value-change')` or 
+- Using `new CustomEvent('property-value-change')` or 
 - Using `new UmbPropertyValueChangeEvent()` which is recommended as you can leverage the core class 
+
+1. Add the import so the event can be used:
+{% code title="suggestions-property-editor-ui.element.ts" %}
+
+import { UmbPropertyValueChangeEvent } from "@umbraco-cms/backoffice/property-editor";
+
+{% endcode %}
+
+2. Add the event to the property editor:
 
 {% code title="suggestions-property-editor-ui.element.ts" %}
 ```typescript

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/README.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/README.md
@@ -215,7 +215,9 @@ It's starting to look good! Next, let's look into setting up the event logic.
 
 Let's start with the input field. When we type something in the input field, we want the property editor's value to change to the input field's current value.
 
-We then have to dispatch an `property-value-change` event, this can be done using ´new CustomEvent('property-value-change')` or you can leverage the core class `new UmbPropertyValueChangeEvent()` (recommended):
+We then have to dispatch an `property-value-change` event which can be done in two ways:
+- using ´new CustomEvent('property-value-change')` or 
+- using `new UmbPropertyValueChangeEvent()` which is recommended as you can leverage the core class 
 
 {% code title="suggestions-property-editor-ui.element.ts" %}
 ```typescript

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/README.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/README.md
@@ -316,6 +316,7 @@ import { LitElement, html, css, customElement, property, state } from "@umbraco-
 ```typescript
 import { LitElement, css, html, customElement, property, state } from "@umbraco-cms/backoffice/external/lit";
 import { UmbPropertyEditorExtensionElement } from "@umbraco-cms/backoffice/extension-registry";
+import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 
 @customElement('my-suggestions-property-editor-ui')
 export class MySuggestionsPropertyEditorUIElement
@@ -345,7 +346,7 @@ export class MySuggestionsPropertyEditorUIElement
     }
 
     #dispatchChangeEvent() {
-        this.dispatchEvent(new CustomEvent("property-value-change"));
+        this.dispatchEvent(new UmbPropertyValueChangeEvent());
     }
 
     render() {

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/adding-configuration-to-a-property-editor.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/adding-configuration-to-a-property-editor.md
@@ -248,6 +248,7 @@ import { ifDefined } from "@umbraco-cms/backoffice/external/lit";
 import { LitElement, css, html, customElement, property, state, ifDefined } from "@umbraco-cms/backoffice/external/lit";
 import { type UmbPropertyEditorExtensionElement } from "@umbraco-cms/backoffice/extension-registry";
 import { type UmbPropertyEditorConfigCollection } from "@umbraco-cms/backoffice/components";
+import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 
 @customElement('my-suggestions-property-editor-ui')
 export class MySuggestionsPropertyEditorUIElement
@@ -293,7 +294,7 @@ export class MySuggestionsPropertyEditorUIElement
     }
 
     #dispatchChangeEvent() {
-        this.dispatchEvent(new CustomEvent("property-value-change"));
+        this.dispatchEvent(new UmbPropertyValueChangeEvent());
     }
 
     render() {

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-services-with-a-property-editor.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-services-with-a-property-editor.md
@@ -187,7 +187,7 @@ We have now created a working Property editor. Below you can see the full exampl
 ```typescript
 import { LitElement, css, html, customElement, property, state, ifDefined } from "@umbraco-cms/backoffice/external/lit";
 import { type UmbPropertyEditorExtensionElement } from "@umbraco-cms/backoffice/extension-registry";
-import { type UmbPropertyEditorConfigCollection } from "@umbraco-cms/backoffice/property-editor";
+import { type UmbPropertyEditorConfigCollection, UmbPropertyValueChangeEvent } from "@umbraco-cms/backoffice/property-editor";
 import { UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL} from "@umbraco-cms/backoffice/modal";
 import { UMB_NOTIFICATION_CONTEXT, UmbNotificationDefaultData} from "@umbraco-cms/backoffice/notification";
 import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";
@@ -281,7 +281,7 @@ export class MySuggestionsPropertyEditorUIElement
     }
 
     #dispatchChangeEvent() {
-        this.dispatchEvent(new CustomEvent("property-value-change"));
+        this.dispatchEvent(new UmbPropertyValueChangeEvent());
     }
 
     render() {


### PR DESCRIPTION
Updated guide to use the new UmbPropertyValueChangeEvent-class over magic string.

## Description

_What did you add/update/change?_

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
