### PR TITLE
Fix template snippets which for some reason contained zero width spaces

### DIFF
--- a/10/umbraco-commerce/key-concepts/ui-config-files.md
+++ b/10/umbraco-commerce/key-concepts/ui-config-files.md
@@ -48,7 +48,7 @@ The following properties are supported:
 | `label`       | A label to display as the table column header                                                                |
 | `align`       | Sets the alignment of the column. Can be `left` (default), `center` or `right`                               |
 | `placeholder` | The placeholder value to display if there is now Order property value                                        |
-| `template`    | An angular template to use for rendering the property value. Defaults to `{​{ properties['alias'].value }​}` |
+| `template`    | An angular template to use for rendering the property value. Defaults to `{{ properties['alias'].value }}` |
 
 Properties configured to display in the list view will appear in order, after the cart name column.
 
@@ -117,7 +117,7 @@ The Order Line config block configures which Order Line properties should be vie
 | `alias`                  | The alias of the Order Line property                                                                                               |
 | `label`                  | A friendly label to display for this property in the editor interface                                                              |
 | `description`            | A friendly description to display for this property in the editor interface                                                        |
-| `template`               | An angular template to use for rendering the property value. Defaults to `{​{ properties['alias'].value }​}`                         |
+| `template`               | An angular template to use for rendering the property value. Defaults to `{{ properties['alias'].value }}`                         |
 | `isReadOnly`             | Sets the property as read only and so doesn't provide a means of editing the value in the editor interface (Default: `false`)      |
 | `showInOrderLineSummary` | Sets whether to display this property in the Order Lines summary next to the `SKU` in the Order editor interface (Default: `true`) |
 | `view`                   | Sets the name or path of a Property Editor to use when editing this property                                                       |
@@ -285,7 +285,7 @@ The Additional Info config block configures any other Cart/Order properties you 
 | `alias`       | The alias of the Order property                                                                                               |
 | `label`       | A friendly label to display for this property in the editor interface                                                         |
 | `description` | A friendly description to display for this property in the editor interface                                                   |
-| `template`    | An angular template to use for rendering the property value. Defaults to `{​{ properties['alias'].value }​}`                    |
+| `template`    | An angular template to use for rendering the property value. Defaults to `{{ properties['alias'].value }}`                    |
 | `isReadOnly`  | Sets the property as read only and so doesn't provide a means of editing the value in the editor interface (Default: `false`) |
 | `view`        | Sets the name or path of a Property Editor to use when editing this property                                                  |
 | `config`      | Defines a JSON config for the Property Editor if required                                                                     |

--- a/12/umbraco-commerce/key-concepts/ui-config-files.md
+++ b/12/umbraco-commerce/key-concepts/ui-config-files.md
@@ -48,7 +48,7 @@ The following properties are supported:
 | `label`       | A label to display as the table column header                                                                |
 | `align`       | Sets the alignment of the column. Can be `left` (default), `center` or `right`                               |
 | `placeholder` | The placeholder value to display if there is now Order property value                                        |
-| `template`    | An angular template to use for rendering the property value. Defaults to `{​{ properties['alias'].value }​}` |
+| `template`    | An angular template to use for rendering the property value. Defaults to `{{ properties['alias'].value }}` |
 
 Properties configured to display in the list view will appear in order, after the cart name column.
 
@@ -117,7 +117,7 @@ The Order Line config block configures which Order Line properties should be vie
 | `alias`                  | The alias of the Order Line property                                                                                               |
 | `label`                  | A friendly label to display for this property in the editor interface                                                              |
 | `description`            | A friendly description to display for this property in the editor interface                                                        |
-| `template`               | An angular template to use for rendering the property value. Defaults to `{​{ properties['alias'].value }​}`                         |
+| `template`               | An angular template to use for rendering the property value. Defaults to `{{ properties['alias'].value }}`                         |
 | `isReadOnly`             | Sets the property as read only and so doesn't provide a means of editing the value in the editor interface (Default: `false`)      |
 | `showInOrderLineSummary` | Sets whether to display this property in the Order Lines summary next to the `SKU` in the Order editor interface (Default: `true`) |
 | `view`                   | Sets the name or path of a Property Editor to use when editing this property                                                       |
@@ -285,7 +285,7 @@ The Additional Info config block configures any other Cart/Order properties you 
 | `alias`       | The alias of the Order property                                                                                               |
 | `label`       | A friendly label to display for this property in the editor interface                                                         |
 | `description` | A friendly description to display for this property in the editor interface                                                   |
-| `template`    | An angular template to use for rendering the property value. Defaults to `{​{ properties['alias'].value }​}`                    |
+| `template`    | An angular template to use for rendering the property value. Defaults to `{{ properties['alias'].value }}`                    |
 | `isReadOnly`  | Sets the property as read only and so doesn't provide a means of editing the value in the editor interface (Default: `false`) |
 | `view`        | Sets the name or path of a Property Editor to use when editing this property                                                  |
 | `config`      | Defines a JSON config for the Property Editor if required                                                                     |

--- a/13/umbraco-commerce/key-concepts/ui-config-files.md
+++ b/13/umbraco-commerce/key-concepts/ui-config-files.md
@@ -48,7 +48,7 @@ The following properties are supported:
 | `label`       | A label to display as the table column header                                                                |
 | `align`       | Sets the alignment of the column. Can be `left` (default), `center` or `right`                               |
 | `placeholder` | The placeholder value to display if there is now Order property value                                        |
-| `template`    | An angular template to use for rendering the property value. Defaults to `{​{ properties['alias'].value }​}` |
+| `template`    | An angular template to use for rendering the property value. Defaults to `{{ properties['alias'].value }}` |
 
 Properties configured to display in the list view will appear in order, after the cart name column.
 
@@ -117,7 +117,7 @@ The Order Line config block configures which Order Line properties should be vie
 | `alias`                  | The alias of the Order Line property                                                                                               |
 | `label`                  | A friendly label to display for this property in the editor interface                                                              |
 | `description`            | A friendly description to display for this property in the editor interface                                                        |
-| `template`               | An angular template to use for rendering the property value. Defaults to `{​{ properties['alias'].value }​}`                         |                                                        |
+| `template`               | An angular template to use for rendering the property value. Defaults to `{{ properties['alias'].value }}`                         |                                                        |
 | `isReadOnly`             | Sets the property as read only and so doesn't provide a means of editing the value in the editor interface (Default: `false`)      |
 | `showInOrderLineSummary` | Sets whether to display this property in the Order Lines summary next to the `SKU` in the Order editor interface (Default: `true`) |
 | `view`                   | Sets the name or path of a Property Editor to use when editing this property                                                       |
@@ -285,7 +285,7 @@ The Additional Info config block configures any other Cart/Order properties you 
 | `alias`       | The alias of the Order property                                                                                               |
 | `label`       | A friendly label to display for this property in the editor interface                                                         |
 | `description` | A friendly description to display for this property in the editor interface                                                   |
-| `template`    | An angular template to use for rendering the property value. Defaults to `{​{ properties['alias'].value }​}`                    | 
+| `template`    | An angular template to use for rendering the property value. Defaults to `{{ properties['alias'].value }}`                    | 
 | `isReadOnly`  | Sets the property as read only and so doesn't provide a means of editing the value in the editor interface (Default: `false`) |
 | `view`        | Sets the name or path of a Property Editor to use when editing this property                                                  |
 | `config`      | Defines a JSON config for the Property Editor if required                                                                     |


### PR DESCRIPTION
## Description

Fixes an issue in the UI Config docs for Umbraco Commerce. The template code snippets for some reason contained zero width spaces between the `{{` and `}}` characters which meant anyone copying these snippets wouldn't work and wouldn't be totally obvious why.

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Umbraco Commerce 10, 12, 13

## Deadline (if relevant)

ASAP
