### PR TITLE
Update signalR docs by using the UmbracoPipelineFilter correct

### DIFF
--- a/13/umbraco-cms/implementation/custom-routing/signalR.md
+++ b/13/umbraco-cms/implementation/custom-routing/signalR.md
@@ -107,9 +107,7 @@ public class TestHubComposer : IComposer
         {
             options.AddFilter(new UmbracoPipelineFilter(
                 "test",
-                applicationBuilder => { },
-                applicationBuilder => { },
-                applicationBuilder =>
+                 endpoints: applicationBuilder =>
                 {
                     applicationBuilder.UseEndpoints(e =>
                     {


### PR DESCRIPTION
## Description
The docs said you have you have to put terminating middleware in the postpipeline, that's not correct. It needs to be in the endpoints.

It was found here https://github.com/umbraco/Umbraco-CMS/issues/16114, and have not always been failing before v14, but apparently it fails hard now.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
I would guess this is v10+, but at least v13+


## Deadline (if relevant)

ASAP, as the current docs are wrong.
