### PR TITLE
Added skipStepIfVisible to v13 Tours

### DIFF
--- a/10/umbraco-cms/extending/backoffice-tours.md
+++ b/10/umbraco-cms/extending/backoffice-tours.md
@@ -122,6 +122,7 @@ Example tour step object:
         "event": "click",
         "view": null,
         "eventElement": "[data-element='global-user'] .umb-avatar",
+        "skipStepIfVisible": ".css-element-selector",
         "customProperties": null
       }
     ]
@@ -183,6 +184,11 @@ Below is an explanation of each of the properties on the tour step object.
     The image below shows the entire tree highlighted, but requires the user to click on a specific tree element.
 
     ![Step eventElement highlighted](images/step-event-element-v8.png)
+*   **skipStepIfVisible**
+
+    A CSS selector for an element that, if it is visible, will skip this tour step.
+
+    This is useful for excluding a navigational step if the user is already there. Or skipping a step that would toggle an eventElement to the wrong state.
 *   **customProperties**
 
     A JSON object that is passed to the scope of a custom step view, so you can use this data in your view with `$scope.model.currentStep.customProperties`.

--- a/12/umbraco-cms/extending/backoffice-tours.md
+++ b/12/umbraco-cms/extending/backoffice-tours.md
@@ -121,6 +121,7 @@ Example tour step object:
         "event": "click",
         "view": null,
         "eventElement": "[data-element='global-user'] .umb-avatar",
+        "skipStepIfVisible": ".css-element-selector",
         "customProperties": null
       }
     ]
@@ -182,6 +183,11 @@ Below is an explanation of each of the properties on the tour step object.
     The image below shows the entire tree highlighted, but requires the user to click on a specific tree element.
 
     ![Step eventElement highlighted](../../../10/umbraco-cms/extending/images/step-event-element-v8.png)
+*   **skipStepIfVisible**
+
+    A CSS selector for an element that, if it is visible, will skip this tour step.
+
+    This is useful for excluding a navigational step if the user is already there. Or skipping a step that would toggle an eventElement to the wrong state.
 *   **customProperties**
 
     A JSON object that is passed to the scope of a custom step view, so you can use this data in your view with `$scope.model.currentStep.customProperties`.

--- a/13/umbraco-cms/extending/backoffice-tours.md
+++ b/13/umbraco-cms/extending/backoffice-tours.md
@@ -187,7 +187,7 @@ Below is an explanation of each of the properties on the tour step object.
 
     A CSS selector for an element that, if it is visible, will skip this tour step.
 
-    As an example, it is useful for excluding navigational step if the user is already there, or skipping a step that would toggle an eventElement to the wrong state.
+    This is useful for excluding a navigational step if the user is already there. Or skipping a step that would toggle an eventElement to the wrong state.
 *   **customProperties**
 
     A JSON object that is passed to the scope of a custom step view, so you can use this data in your view with `$scope.model.currentStep.customProperties`.

--- a/13/umbraco-cms/extending/backoffice-tours.md
+++ b/13/umbraco-cms/extending/backoffice-tours.md
@@ -121,6 +121,7 @@ Example tour step object:
         "event": "click",
         "view": null,
         "eventElement": "[data-element='global-user'] .umb-avatar",
+        "skipStepIfVisible": ".css-element-selector",
         "customProperties": null
       }
     ]
@@ -182,6 +183,11 @@ Below is an explanation of each of the properties on the tour step object.
     The image below shows the entire tree highlighted, but requires the user to click on a specific tree element.
 
     ![Step eventElement highlighted](../../../10/umbraco-cms/extending/images/step-event-element-v8.png)
+*   **skipStepIfVisible**
+
+    A CSS selector for an element that, if it is visible, will skip this tour step.
+
+    As an example, it is useful for excluding navigational step if the user is already there, or skipping a step that would toggle an eventElement to the wrong state.
 *   **customProperties**
 
     A JSON object that is passed to the scope of a custom step view, so you can use this data in your view with `$scope.model.currentStep.customProperties`.

--- a/14/umbraco-cms/extending-cms/backoffice-tours.md
+++ b/14/umbraco-cms/extending-cms/backoffice-tours.md
@@ -125,6 +125,7 @@ Example tour step object:
         "event": "click",
         "view": null,
         "eventElement": "[data-element='global-user'] .umb-avatar",
+        "skipStepIfVisible": ".css-element-selector",
         "customProperties": null
       }
     ]
@@ -186,6 +187,11 @@ Below is an explanation of each of the properties on the tour step object.
     The image below shows the entire tree highlighted, but requires the user to click on a specific tree element.
 
     ![Step eventElement highlighted](../../../10/umbraco-cms/extending/images/step-event-element-v8.png)
+* **skipStepIfVisible**
+
+    A CSS selector for an element that, if it is visible, will skip this tour step.
+
+    This is useful for excluding a navigational step if the user is already there. Or skipping a step that would toggle an eventElement to the wrong state.
 * **customProperties**
 
     A JSON object that is passed to the scope of a custom step view, so you can use this data in your view with `$scope.model.currentStep.customProperties`.


### PR DESCRIPTION
Step Object was missing a functional property: skipStepIfVisible. Added for v13 documentation.

## Description

Added an undocumented property for the backoffice tours in v13. Not sure what all versions the property is relevant to but this was a start at least ^^

Related to [issue #6038](https://github.com/umbraco/UmbracoDocs/issues/6038#issue-2257591188)

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
v13 (could be related to more this is just the only one I confirmed 100%)


## Deadline (if relevant)

N/A
