### PR TITLE
Fixed dead links for migration documentation Tinymce

### DIFF
--- a/13/umbraco-cms/reference/configuration/richtexteditorsettings.md
+++ b/13/umbraco-cms/reference/configuration/richtexteditorsettings.md
@@ -13,8 +13,8 @@ In Umbraco 11 the TinyMCE version supported has been upgraded from version 4 to 
 
 If your site is upgraded from an older version, follow the migration guides below to upgrade the TinyMCE version as well.
 
-* [Migrate from version 4 to version 5](https://www.tiny.cloud/docs/migration-from-4x/)
-* [Migrate from version 5 to version 6](https://www.tiny.cloud/docs/tinymce/latest/migration-from-5x/)
+* [Migrate from version 4 to version 5](https://www.tiny.cloud/docs/tinymce/5/migration-from-4x/)
+* [Migrate from version 5 to version 6](https://www.tiny.cloud/docs/tinymce/6/migration-from-5x/)
 {% endhint %}
 
 A config with all the values can be seen underneath. Since there are a lot of defaults configured, some of these have been omitted for the sake of readability. Anywhere something has been omitted it is shown with `{...}`.


### PR DESCRIPTION
## Description

* Fixed the link to the migration documentation version 4 to 5
* Fixed the link to the migration documentation version 5 to 6

_What did you add/update/change?_

Migration links of TinyMce

## Type of suggestion
* [ ] Updated outdated content
