### PR TITLE
adding warning note on v13 about removal of UmbracoApiController

### DIFF
--- a/13/umbraco-cms/extending/database.md
+++ b/13/umbraco-cms/extending/database.md
@@ -283,3 +283,7 @@ public class BlogCommentsApiController : UmbracoApiController
     }
 }
 ```
+
+{% hint style="warning" %}
+The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}

--- a/13/umbraco-cms/extending/section-trees/trees/README.md
+++ b/13/umbraco-cms/extending/section-trees/trees/README.md
@@ -59,6 +59,10 @@ The first node in the tree is referred to as the **Root Node**. You can customis
 
 ### Implementing the Tree
 
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
+
 ```csharp
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/block-grid-editor.md
+++ b/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/block-grid-editor.md
@@ -243,6 +243,7 @@ These Partial Views must be placed in the same folder as before, (`Views/Partial
 The following is an example of a Partial View for a Block Type of type `MyElementTypeAliasOfContent`.
 
 {% code title="MyElementTypeAliasOfContent.cshtml" %}
+
 ```csharp
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Cms.Core.Models.Blocks.BlockGridItem>;
 
@@ -252,11 +253,13 @@ The following is an example of a Partial View for a Block Type of type `MyElemen
 @* Render the block areas *@
 @await Html.GetBlockGridItemAreasHtmlAsync(Model)
 ```
+
 {% endcode %}
 
 If you are using ModelsBuilder, you can make the property rendering strongly typed by letting your view accept a model of type `BlockGridItem<T>`. For example:
 
 {% code title="MyElementTypeAliasOfContent.cshtml" %}
+
 ```csharp
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Cms.Core.Models.Blocks.BlockGridItem<ContentModels.MyElementTypeAliasOfContent>>;
 @using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
@@ -267,6 +270,7 @@ If you are using ModelsBuilder, you can make the property rendering strongly typ
 @* Render the block areas *@
 @await Html.GetBlockGridItemAreasHtmlAsync(Model)
 ```
+
 {% endcode %}
 
 #### Stylesheet
@@ -296,6 +300,7 @@ The built-in value converter for the Block Grid property editor lets you use the
 The following example mimics the built-in rendering mechanism for rendering Blocks using Partial Views:
 
 {% code title="View.cshtml" %}
+
 ```csharp
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @using Umbraco.Cms.Core.Models.Blocks
@@ -314,11 +319,13 @@ The following example mimics the built-in rendering mechanism for rendering Bloc
     }
 }
 ```
+
 {% endcode %}
 
 If you do not want to use Partial Views, you can access the block item data directly within your rendering:
 
 {% code title="View.cshtml" %}
+
 ```csharp
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @using Umbraco.Cms.Core.Models.Blocks
@@ -348,6 +355,7 @@ If you do not want to use Partial Views, you can access the block item data dire
     }
 }
 ```
+
 {% endcode %}
 
 ## Write a Custom Layout Stylesheet
@@ -457,15 +465,19 @@ Building Custom Views for Block representations in Backoffice is based on the sa
 ## Creating a Block Grid programmatically
 
 In this example, we will be creating content programmatically for a "spot" Blocks in a Block Grid.
+
 1. On a document type add a property called **blockGrid**.
-2. Then add as editor **Block Grid**. 
+2. Then add as editor **Block Grid**.
 3. In the Block Grid add a new block and click to **Create new Element Type**
 4. Name this element type **spotElement** with the following properties:
+
 - a property called **title** with the editor of **Textstring**
-- a property called **text** with the editor of **Textstring**
-5. Then on the **Settings model** click to add a new Setting. 
+* a property called **text** with the editor of **Textstring**
+
+5. Then on the **Settings model** click to add a new Setting.
 6. Then click to **Create new Element Type**.
 7. Name this element type **spotSettings** with the following properties:
+
 - a property called **featured** with the editor of **True/false**.
 
 ![Block Grid - Block Configuration](../../../images/BlockEditorConfigurationProgramatically.png)
@@ -536,6 +548,7 @@ All `contentData` and `layoutData` entries need their own unique `Udi` as well a
 8. First and foremost, we need models to transform the raw data into Block Grid compatible JSON. Create a class called **Model.cs** containing the following:
 
 {% code title="Models.cs" lineNumbers="true" %}
+
 ```csharp
 using Newtonsoft.Json;
 using Umbraco.Cms.Core;
@@ -620,11 +633,13 @@ public class BlockGridElementData
     public Dictionary<string, object> Data { get; }
 }
 ```
+
 {% endcode %}
 
 9. By injecting [ContentService](../../../../../reference/management/services/contentservice/) and [ContentTypeService](../../../../../reference/management/services/contenttypeservice/) into an API controller, we can transform the raw data into Block Grid JSON. It can then be saved to the target content item. Create a class called **BlockGridTestController.cs** containing the following:
 
 {% code title="BlockGridTestController.cs" lineNumbers="true" %}
+
 ```csharp
 using Microsoft.AspNetCore.Mvc;
 using My.Site.Models;
@@ -715,7 +730,12 @@ public class BlockGridTestController : UmbracoApiController
     }
 }
 ```
+
 {% endcode %}
+
+{% hint style="warning" %}
+The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
 
 For the above code `IContent? content = _contentService.GetById(1203);` change the id with your content node that is using the Block Grid.
 

--- a/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/image-cropper.md
+++ b/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/image-cropper.md
@@ -187,6 +187,10 @@ public class CreateImageCropperValuesController : UmbracoApiController
 }
 ```
 
+{% hint style="warning" %}
+The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
+
 If you use Models Builder to generate source code (modes `SourceCodeAuto` or `SourceCodeManual`), you can use `nameof([generated property name])` to access the desired property without using a magic string:
 
 ```csharp

--- a/13/umbraco-cms/fundamentals/code/debugging/logging.md
+++ b/13/umbraco-cms/fundamentals/code/debugging/logging.md
@@ -10,7 +10,7 @@ The default location of this file is written to `umbraco/Logs` and contains the 
 
 ## Video overview
 
-{% embed url="https://youtu.be/PDqIRVygAQ4" %}
+{% embed url="<https://youtu.be/PDqIRVygAQ4>" %}
 Watch this video to get an overview of how to view and manage logs and logfiles for your Umbraco CMS website.
 {% endembed %}
 
@@ -55,6 +55,10 @@ To learn more about structured logging and message templates you can read more a
 Umbraco writes log messages, but you are also able to use the Umbraco logger to write the log file as needed, so you can get further insights and details about your implementation.
 
 Here is an example of using the logger to write an Information message to the log which will contain one property of **Name** which will output the name variable that is passed into the method
+
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
 
 ```csharp
 using Microsoft.AspNetCore.Mvc;

--- a/13/umbraco-cms/implementation/controllers.md
+++ b/13/umbraco-cms/implementation/controllers.md
@@ -37,6 +37,10 @@ All implementations of Umbraco API Controllers inherit from the base class: `Umb
 
 For details on using Umbraco API Controllers, see the [Umbraco API Controllers](../reference/routing/umbraco-api-controllers/) article.
 
+{% hint style="warning" %}
+UmbracoApiController is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
+
 ## Umbraco Authorized Controllers and Attributes
 
 An Umbraco Authorized Controller is used when the controller requires member or user authentication (authN) and/or authorization (authZ). If either the `authN` or `authZ` fail, the controller will return a `401 - unauthorized response`.
@@ -45,14 +49,15 @@ An Umbraco Authorized Controller is used when the controller requires member or 
 
 The Umbraco Authorized controllers and attributes for Backoffice Users are:
 
-*   **MVC**
+* **MVC**
     There is no specific controller available to inherit from. We recommend inheriting from the basic `Umbraco.Cms.Web.Common.Controllers.UmbracoController` and applying the following attributes to your method:
-    - `[Authorize(Policy = AuthorizationPolicies.BackOfficeAccess)]`: Uses .NET authorization using the BackOfficeAccess policy. We recommend adding extra custom authorization policies for your endpoints.
-    - `[DisableBrowserCache]`: Tells the browser to not cache the result.
+  * `[Authorize(Policy = AuthorizationPolicies.BackOfficeAccess)]`: Uses .NET authorization using the BackOfficeAccess policy. We recommend adding extra custom authorization policies for your endpoints.
+  * `[DisableBrowserCache]`: Tells the browser to not cache the result.
 
     Remember to [add a route](../reference/routing/authorized.md#defining-a-route) for your controller.
 
-    #### Example custom authorized backoffice MVC Controller
+#### Example custom authorized backoffice MVC Controller
+
     ```csharp
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
@@ -73,8 +78,8 @@ The Umbraco Authorized controllers and attributes for Backoffice Users are:
         }
     }
     ```
-    
-*   **WebAPI**
+
+* **WebAPI**
 
     A base class implementation for authorized auto-routed Umbraco API controllers is inherited from: `Umbraco.Cms.Web.BackOffice.Controllers.UmbracoAuthorizedApiController`. This controller inherits from `Umbraco.Cms.Web.Common.Controllers.UmbracoApiController` it is auto-routed. This controller is also attributed with `Umbraco.Cms.Web.Common.Attributes.IsBackOfficeAttribute` to ensure that it is routed correctly to be authenticated for the backoffice.
 

--- a/13/umbraco-cms/implementation/unit-testing.md
+++ b/13/umbraco-cms/implementation/unit-testing.md
@@ -163,6 +163,10 @@ public class PageSurfaceControllerTests
 
 See [Reference documentation on UmbracoApiControllers](../reference/routing/umbraco-api-controllers/README.md#locally-declared-controller).
 
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
+
 ```csharp
 public class ProductsController : UmbracoApiController
 {

--- a/13/umbraco-cms/reference/cache/examples/tags.md
+++ b/13/umbraco-cms/reference/cache/examples/tags.md
@@ -149,6 +149,10 @@ public class TagsController : UmbracoApiController
 }
 ```
 
+{% hint style="warning" %}
+The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
+
 `/umbraco/api/tags/getblogtags`:
 
 ![Result](images/response.png)

--- a/13/umbraco-cms/reference/common-pitfalls.md
+++ b/13/umbraco-cms/reference/common-pitfalls.md
@@ -74,6 +74,10 @@ public class BadApiController : UmbracoApiController
 }
 ```
 
+{% hint style="warning" %}
+The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
+
 This practice can cause memory leaks along with inconsistent data results when using this `_umbracoHelper` instance.
 
 **Why?**
@@ -108,11 +112,11 @@ You create a menu on your Home page like:
 
 ```csharp
 <ul>
-	<li><a href="@Model.Root().Url()">@Model.Root().Name</a></li>
-	@foreach (var node in Model.Root().DescendantsOrSelf().Where(x => x.Level == 2))
-	{
-		<li><a href="@node.Url()">@node.Name</a></li>
-	}
+ <li><a href="@Model.Root().Url()">@Model.Root().Name</a></li>
+ @foreach (var node in Model.Root().DescendantsOrSelf().Where(x => x.Level == 2))
+ {
+  <li><a href="@node.Url()">@node.Name</a></li>
+ }
 </ul>
 ```
 
@@ -124,11 +128,11 @@ This can be re-written as:
 
 ```csharp
 <ul>
-	<li><a href="@Model.Root().Url()">@Model.Root().Name</a></li>
-	@foreach (var node in Model.Root().Children)
-	{
-		<li><a href="@node.Url()">@node.Name</a></li>
-	}
+ <li><a href="@Model.Root().Url()">@Model.Root().Name</a></li>
+ @foreach (var node in Model.Root().Children)
+ {
+  <li><a href="@node.Url()">@node.Name</a></li>
+ }
 </ul>
 ```
 
@@ -142,11 +146,11 @@ Here's a common pitfall that is seen. Let's continue the menu example, in this e
 
 ```csharp
 <ul>
-	<li><a href="@Model.Root().Url()">@Model.Root().Name</a></li>
-	@foreach (var node in Model.Root().Children)
-	{
-		<li><a href="@node.Url()">@node.Name</a></li>
-	}
+ <li><a href="@Model.Root().Url()">@Model.Root().Name</a></li>
+ @foreach (var node in Model.Root().Children)
+ {
+  <li><a href="@node.Url()">@node.Name</a></li>
+ }
 </ul>
 ```
 
@@ -154,14 +158,14 @@ The syntax `@Model.Root()` is shorthand for doing this: `Model.AncestorOrSelf(1)
 
 ```csharp
 @{
-	var root = Model.Root();
+ var root = Model.Root();
 }
 <ul>
-	<li><a href="@root.Url()">@root.Name</a></li>
-	@foreach (var node in root.Children)
-	{
-		<li><a href="@node.Url()">@node.Name</a></li>
-	}
+ <li><a href="@root.Url()">@root.Name</a></li>
+ @foreach (var node in root.Children)
+ {
+  <li><a href="@node.Url()">@node.Name</a></li>
+ }
 </ul>
 ```
 
@@ -178,11 +182,11 @@ Your views should rely only on the read-only data services such as `UmbracoHelpe
 @inject IContentService _contentService
 
 @{
-	// Services access in your views :(
-	var dontDoThis = _contentService.GetById(1234);
-	
-	// Content cache access in your views
-	var doThis = Umbraco.Content(1234);
+ // Services access in your views :(
+ var dontDoThis = _contentService.GetById(1234);
+ 
+ // Content cache access in your views
+ var doThis = Umbraco.Content(1234);
 }
 ```
 
@@ -284,17 +288,17 @@ You then run the following code to show to show the favorites
 ```csharp
 @var recipeNode = Umbraco.TypedContent(3251);
 @{
-	var recipeNode = Umbraco.Content(1234);
+ var recipeNode = Umbraco.Content(1234);
 }
 
 <ul>
-	@foreach (var recipe in recipeNode.Children
-		.Select(x => new RecipeModel(x, _publishedValueFallback))
-		.OrderByDescending(x => x.Votes)
-		.Take(10))
-	{
-		<li><a href="@recipe.Url()">@recipe.Name</a></li>
-	}	
+ @foreach (var recipe in recipeNode.Children
+  .Select(x => new RecipeModel(x, _publishedValueFallback))
+  .OrderByDescending(x => x.Votes)
+  .Take(10))
+ {
+  <li><a href="@recipe.Url()">@recipe.Name</a></li>
+ } 
 </ul>
 ```
 
@@ -345,16 +349,16 @@ This is still not great though. There really isn't much reason to create a `Reci
 
 ```csharp
 @{
-	var recipeNode = Umbraco.Content(1234);
+ var recipeNode = Umbraco.Content(1234);
 }
 
 <ul>
-	@foreach (var recipe in recipeNode.Children
-		.OrderByDescending(x => x.Value<int>("votes"))
-		.Take(10))
-	{
-		<li><a href="@recipe.Url()">@recipe.Name</a></li>
-	}
+ @foreach (var recipe in recipeNode.Children
+  .OrderByDescending(x => x.Value<int>("votes"))
+  .Take(10))
+ {
+  <li><a href="@recipe.Url()">@recipe.Name</a></li>
+ }
 </ul>
 ```
 

--- a/13/umbraco-cms/reference/management/services/relationservice.md
+++ b/13/umbraco-cms/reference/management/services/relationservice.md
@@ -403,6 +403,10 @@ public class RelationsController : UmbracoApiController
 }
 ```
 
+{% hint style="warning" %}
+The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
+
 Notice the `x => new Relation()`? We need to make sure what we are returning can be serialized. Therefore the `Relation` class is:
 
 ```csharp

--- a/13/umbraco-cms/reference/mapping.md
+++ b/13/umbraco-cms/reference/mapping.md
@@ -12,7 +12,7 @@ UmbracoMapper was originally introduced to solve some issues in the Umbraco core
 
 ## Accessing the IUmbracoMapper
 
-The IUmbracoMapper is registered with Dependency Injection (DI). It can therefore be injected into constructors of controllers, custom classes etc, wherever DI is used. 
+The IUmbracoMapper is registered with Dependency Injection (DI). It can therefore be injected into constructors of controllers, custom classes etc, wherever DI is used.
 
 ## Mapping
 
@@ -186,6 +186,10 @@ And the comment can be repeated if the list of excluded properties is long:
 The analyzer follows the standard analyzer development patterns, and building the code in Release mode produces the appropriate NuGet package.
 
 ## Full example
+
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
 
 Below you will find a full example showing you how to map a collection of type Product to a collection of type ProductDto.
 

--- a/13/umbraco-cms/reference/querying/itagquery.md
+++ b/13/umbraco-cms/reference/querying/itagquery.md
@@ -18,6 +18,10 @@ After this you can use `_tagQuery` to access the `ITagQuery`.
 
 If you're using it in controllers, you can inject it into the constructor like so:
 
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
+
 ```csharp
 using System.Collections.Generic;
 using System.Linq;
@@ -30,17 +34,17 @@ namespace UmbracoHelperDocs.Controllers;
 [Route("tags/[action]")]
 public class TagApiController : UmbracoApiController
 {
-	private readonly ITagQuery _tagQuery;
+ private readonly ITagQuery _tagQuery;
 
-	public TagApiController(ITagQuery tagQuery)
-	{
-		_tagQuery = tagQuery;
-	}
+ public TagApiController(ITagQuery tagQuery)
+ {
+  _tagQuery = tagQuery;
+ }
 
-	public ActionResult<IEnumerable<string>> GetMediaTags()
-	{
-		return _tagQuery.GetAllMediaTags().Select(tag => tag.Text).ToList();
-	}
+ public ActionResult<IEnumerable<string>> GetMediaTags()
+ {
+  return _tagQuery.GetAllMediaTags().Select(tag => tag.Text).ToList();
+ }
 }
 ```
 
@@ -58,8 +62,8 @@ Get a collection of tags used by content items on the site, you can optionally p
 
 ```csharp
 @{
-	var allContentTags = _tagQuery.GetAllContentTags();
-	var newsContentTags = _tagQuery.GetAllContentTags("news");
+ var allContentTags = _tagQuery.GetAllContentTags();
+ var newsContentTags = _tagQuery.GetAllContentTags("news");
 }
 ```
 
@@ -69,8 +73,8 @@ Get a collection of tags used by media items on the site, you can optionally pas
 
 ```csharp
 @{
-	var allMediaTags = _tagQuery.GetAllMediaTags();
-	var newsMediaTags = _tagQuery.GetAllMediaTags("news");
+ var allMediaTags = _tagQuery.GetAllMediaTags();
+ var newsMediaTags = _tagQuery.GetAllMediaTags("news");
 }
 ```
 
@@ -80,8 +84,8 @@ Get a collection of tags used by members on the site, you can optionally pass in
 
 ```csharp
 @{
-	var allMemberTags = _tagQuery.GetAllMemberTags();
-	var newsMemberTags = _tagQuery.GetAllMemberTags("news");
+ var allMemberTags = _tagQuery.GetAllMemberTags();
+ var newsMemberTags = _tagQuery.GetAllMemberTags("news");
 }
 ```
 
@@ -91,8 +95,8 @@ Get a collection of tags used on the site, you can optionally pass in a group na
 
 ```csharp
 @{
-	var allTags = _tagQuery.GetAllTags();
-	var allNewsTags = _tagQuery.GetAllTags("news");
+ var allTags = _tagQuery.GetAllTags();
+ var allNewsTags = _tagQuery.GetAllTags("news");
 }
 ```
 
@@ -102,7 +106,7 @@ Get a collection of IPublishedContent by tag, and you can optionally filter by t
 
 ```csharp
 @{
-	var taggedContent = _tagQuery.GetContentByTag("News");
+ var taggedContent = _tagQuery.GetContentByTag("News");
 }
 ```
 
@@ -112,7 +116,7 @@ Get a collection of IPublishedContent by tag group
 
 ```csharp
 @{
-	var taggedContent = _tagQuery.GetContentByTagGroup("BlogTags");
+ var taggedContent = _tagQuery.GetContentByTagGroup("BlogTags");
 }
 ```
 
@@ -122,7 +126,7 @@ Get a collection of Media by tag, and you can optionally filter by tag group as 
 
 ```csharp
 @{
-	var taggedMedia = _tagQuery.GetMediaByTag("BlogTag");
+ var taggedMedia = _tagQuery.GetMediaByTag("BlogTag");
 }
 ```
 
@@ -132,7 +136,7 @@ Get a collection of Media by tag group
 
 ```csharp
 @{
-	var mediaByTagGroup = _tagQuery.GetMediaByTagGroup("BlogTags");
+ var mediaByTagGroup = _tagQuery.GetMediaByTagGroup("BlogTags");
 }
 ```
 
@@ -142,7 +146,7 @@ Get a collection of tags by entity id (queries content, media and members), and 
 
 ```csharp
 @{
-	var tagsForEntity = _tagQuery.GetTagsForEntity(1234);
+ var tagsForEntity = _tagQuery.GetTagsForEntity(1234);
 }
 ```
 
@@ -152,6 +156,6 @@ Get a collection of tags assigned to a property of an entity (queries content, m
 
 ```csharp
 @{
-	var propertyTags = _tagQuery.GetTagsForProperty(1234, "propertyTypeAlias");
+ var propertyTags = _tagQuery.GetTagsForProperty(1234, "propertyTypeAlias");
 }
 ```

--- a/13/umbraco-cms/reference/querying/umbraco-context.md
+++ b/13/umbraco-cms/reference/querying/umbraco-context.md
@@ -18,7 +18,7 @@ If you need an `UmbracoContext` in your own controllers, you need to inject an `
 
 The following is an example of how to get access to the `UmbracoContext` in a controller:
 
-```
+``` csharp
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -66,5 +66,9 @@ public class PeopleController : UmbracoApiController
     }
 }
 ```
+
+{% hint style="warning" %}
+The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
 
 UmbracoContext is registered with a scoped lifetime. See the [Microsoft documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-5.0#lifetime-and-registration-options) for more information. A service scope is created for each request, which means you can resolve an instance directly in a controller.

--- a/13/umbraco-cms/reference/routing/umbraco-api-controllers/README.md
+++ b/13/umbraco-cms/reference/routing/umbraco-api-controllers/README.md
@@ -25,6 +25,10 @@ We have created a base API controller for developers to inherit from. This will 
 
 The class to inherit from is: `Umbraco.Cms.Web.Common.Controllers.UmbracoApiController`
 
+{% hint style="warning" %}
+UmbracoApiController is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
+
 ## Creating a Web API controller
 
 There are 2 types of Umbraco API controllers:

--- a/13/umbraco-cms/reference/routing/umbraco-api-controllers/authorization.md
+++ b/13/umbraco-cms/reference/routing/umbraco-api-controllers/authorization.md
@@ -22,6 +22,10 @@ This attribute will ensure that a valid backoffice user is logged in. It is impo
 
 **Example:**
 
+{% hint style="warning" %}
+The examples below uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
+
 This will only allow a logged in backoffice user to access the `GetProduct`action:
 
 ```csharp

--- a/13/umbraco-cms/reference/routing/umbraco-api-controllers/routing.md
+++ b/13/umbraco-cms/reference/routing/umbraco-api-controllers/routing.md
@@ -8,6 +8,10 @@ _This section will describe how Umbraco Api controllers are routed and how to re
 
 ## Routing
 
+{% hint style="warning" %}
+UmbracoApiController is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
+
 Like Surface Controllers in Umbraco, when you inherit from the base class `Umbraco.Cms.Web.Common.Controllers.UmbracoApiController` we will auto-route this controller so you don't have to worry about routing at all.
 
 All locally declared Umbraco api controllers will be routed under the URL path of:

--- a/13/umbraco-cms/reference/using-ioc.md
+++ b/13/umbraco-cms/reference/using-ioc.md
@@ -104,6 +104,7 @@ It is not required to have an interface for your dependency:
 ```csharp
 services.AddSingleton<Foobar>();
 ```
+
 {% endhint %}
 
 Now you can call your `AddCustomServices` in either the `Program.cs` file, or your composer like so:
@@ -188,6 +189,10 @@ public class FooController : UmbracoApiController
 }
 ```
 
+{% hint style="warning" %}
+The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}
+
 If you place a breakpoint on `var bar = _foobar.Foo()`, open `/Umbraco/Api/foo/foo` in your browser and inspect the variable, you'll see that the value is `bar`, which is what you'd expect since all the `Foobar.Foo()` method does it to return `Bar` as a string:
 
 ```csharp
@@ -214,7 +219,7 @@ You might need to use services within your templates or views, fortunately, you 
 @inject IFooBar _fooBar
 
 @{
-	Layout = null;
+ Layout = null;
 }
 
 <h1>@_fooBar.Foo()</h1>

--- a/13/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
+++ b/13/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
@@ -144,6 +144,7 @@ builder.Services.AddUmbracoDbContext<CustomDbContext>((serviceProvider, options)
         options.UseUmbracoDatabaseProvider(serviceProvider);
     });
 ```
+
 {% endhint %}
 
 2. Open your terminal and navigate to your project folder.
@@ -162,6 +163,7 @@ If you use another class library in your project to store models and DBContext c
 ```bash
 dotnet ef migrations add initialCreate -s ../Project.Web/ --context BlogContext
 ```
+
 {% endhint %}
 
 In this example, we have named the migration `InitialCreate`. However, you can choose the name you like.
@@ -293,6 +295,8 @@ public class BlogCommentsController : UmbracoApiController
         scope.Complete();
     }
 }
-
-
 ```
+
+{% hint style="warning" %}
+The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+{% endhint %}

--- a/14/umbraco-cms/reference/management/services/create-a-new-user.md
+++ b/14/umbraco-cms/reference/management/services/create-a-new-user.md
@@ -6,7 +6,7 @@ description: This will show you how to add a user to a user group using the User
 
 ## Services property
 
-If you wish to use the UserService in a class that inherits from one of the Umbraco base classes. For example: `SurfaceController`, `UmbracoApiController`, or `UmbracoAuthorizedApiController`). You can access the service through a local `Services` property:
+If you wish to use the UserService in a class that inherits from one of the Umbraco base classes. For example: `SurfaceController`, `UmbracoManagementApiControllerBase`, or `UmbracoAuthorizedApiController`). You can access the service through a local `Services` property:
 
 ```csharp
 IUserService userService = Services.UserService;

--- a/14/umbraco-cms/reference/querying/imembermanager.md
+++ b/14/umbraco-cms/reference/querying/imembermanager.md
@@ -23,7 +23,7 @@ _memberManager.IsLoggedIn()
 
 ### Dependency Injection
 
-If you wish to use the `IMemberManager` in a class that inherits from one of the Umbraco base classes (eg. `SurfaceController`, `UmbracoApiController`, or `UmbracoAuthorizedApiController`), you can use Dependency Injection. For instance, if you have registered your own class in Umbraco's dependency injection, you can specify the `IMemberManager` interface in your constructor:
+If you wish to use the `IMemberManager` in a class that inherits from one of the Umbraco base classes (eg. `SurfaceController`, `UmbracoManagementApiControllerBase`, or `UmbracoAuthorizedApiController`), you can use Dependency Injection. For instance, if you have registered your own class in Umbraco's dependency injection, you can specify the `IMemberManager` interface in your constructor:
 
 ```csharp
 public class MemberAuthenticationSurfaceController : SurfaceController


### PR DESCRIPTION
## Description

_What did you add/update/change?_
UmbracoApiController is removed in v14 and replaced with UmbracoManagementApiControllerBase as per CMS PR https://github.com/umbraco/Umbraco-CMS/pull/15863 so I have added a warning note about this on v13 docs.

CMS team has it on their backlog to help update the articles with examples where UmbracoApiController  to be replaced with UmbracoManagementApiControllerBase 👍 