### PR TITLE
Added documentation for Entra ID membership auth with a single-tenant…

### DIFF
--- a/12/umbraco-cms/tutorials/add-microsoft-entra-id-authentication.md
+++ b/12/umbraco-cms/tutorials/add-microsoft-entra-id-authentication.md
@@ -22,7 +22,7 @@ It is still possible to use other [External Login Providers](../reference/securi
 
 ## Step 1: Configure Entra ID
 
-Before your applications can interact with Entra ID B2C, they must be registered with a tenant that you manage. For more information, see [Microsoft's Tutorial: Create an Azure Active Directory B2C tenant](https://learn.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant).
+Before your applications can interact with Entra ID, they must be registered with a tenant that you manage. This can be either an Entra ID (Azure AD) tenant, or an Entra ID B2C (Azure AD B2C) tenant. For more information on creating an Azure AD B2C tenant, see [Microsoft's Tutorial: Create an Azure Active Directory B2C tenant](https://learn.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant).
 
 ## Step 2: Install the NuGet package
 
@@ -139,6 +139,10 @@ public static class MemberAuthenticationExtensions
                             //Obtained from the ENTRA ID B2C WEB APP
                             options.ClientSecret = "YOURCLIENTSECRET"; 
 
+                            // If you are using single-tenant app registration (e.g. for an intranet site), you must specify the Token Endpoint and Authorization Endpoint:
+                                //options.TokenEndpoint = $"https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token";
+                                //options.AuthorizationEndpoint = $"https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/authorize";    
+
                             options.SaveTokens = true;
                         });
                 });
@@ -150,7 +154,7 @@ public static class MemberAuthenticationExtensions
 {% endcode %}
 
 {% hint style="info" %}
-Ensure to replace `YOURCLIENTID` and `YOURCLIENTSECRET` in the code with the values from the Entra ID tenant.
+Ensure to replace `YOURCLIENTID` and `YOURCLIENTSECRET` in the code with the values from the Entra ID tenant. If Entra ID is configured to use accounts in the organizational directory only (single tenant registration), you must specify the Token and Authorization endpoint. For more information on the differences between single and multi tenant registration, refer to [Microsoft's identity platform documentation](https://learn.microsoft.com/en-us/entra/identity-platform/howto-modify-supported-accounts).
 {% endhint %}
 
 4. Add the Members authentication configuration to the `ConfigureServices` method in the `Startup.cs` file:

--- a/13/umbraco-cms/tutorials/add-microsoft-entra-id-authentication.md
+++ b/13/umbraco-cms/tutorials/add-microsoft-entra-id-authentication.md
@@ -1,7 +1,6 @@
 ---
 description: >-
-  Learn how to use Microsoft Entra ID (Azure Active Directory) credentials to login to Umbraco as a
-  member.
+  Learn how to use Microsoft Entra ID (Azure Active Directory) credentials to login to Umbraco as a member.
 ---
 
 # Add Microsoft Entra ID (Azure Active Directory) authentication (Members)

--- a/13/umbraco-cms/tutorials/add-microsoft-entra-id-authentication.md
+++ b/13/umbraco-cms/tutorials/add-microsoft-entra-id-authentication.md
@@ -23,7 +23,7 @@ It is still possible to use other [External Login Providers](../reference/securi
 
 ## Step 1: Configure Entra ID
 
-Before your applications can interact with Entra ID B2C, they must be registered with a tenant that you manage. For more information, see [Microsoft's Tutorial: Create an Azure Active Directory B2C tenant](https://learn.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant).
+Before your applications can interact with Entra ID, they must be registered with a tenant that you manage - either an Entra ID (Azure AD) tenant, or an Entra ID B2C (Azure AD B2C) tenant. For more information on creating an Azure AD B2C tenant, see [Microsoft's Tutorial: Create an Azure Active Directory B2C tenant](https://learn.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant).
 
 ## Step 2: Install the NuGet package
 
@@ -143,6 +143,10 @@ public static class MemberAuthenticationExtensions
                                 //Obtained from the ENTRA ID B2C WEB APP
                                 options.ClientSecret = "YOURCLIENTSECRET";
 
+                                // If you are using single-tenant app registration (e.g. for an intranet site), you must specify the Token Endpoint and Authorization Endpoint:
+                                //options.TokenEndpoint = $"https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token";
+                                //options.AuthorizationEndpoint = $"https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/authorize";    
+
                                 options.SaveTokens = true;
                             });
                     });
@@ -156,7 +160,7 @@ public static class MemberAuthenticationExtensions
 {% endcode %}
 
 {% hint style="info" %}
-Ensure to replace `YOURCLIENTID` and `YOURCLIENTSECRET` in the code with the values from the Entra ID tenant.
+Ensure to replace `YOURCLIENTID` and `YOURCLIENTSECRET` in the code with the values from the Entra ID tenant. If Entra ID is configured to use accounts in the organizational directory only (single tenant registration), you must specify the Token and Authorization endpoint. For more information on the differences between single and multi tenant registration, refer to [Microsoft's identity platform documentation](https://learn.microsoft.com/en-us/entra/identity-platform/howto-modify-supported-accounts).
 {% endhint %}
 
 4. Add the Members authentication configuration in the `Program.cs` file:

--- a/13/umbraco-cms/tutorials/add-microsoft-entra-id-authentication.md
+++ b/13/umbraco-cms/tutorials/add-microsoft-entra-id-authentication.md
@@ -23,7 +23,7 @@ It is still possible to use other [External Login Providers](../reference/securi
 
 ## Step 1: Configure Entra ID
 
-Before your applications can interact with Entra ID, they must be registered with a tenant that you manage - either an Entra ID (Azure AD) tenant, or an Entra ID B2C (Azure AD B2C) tenant. For more information on creating an Azure AD B2C tenant, see [Microsoft's Tutorial: Create an Azure Active Directory B2C tenant](https://learn.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant).
+Before your applications can interact with Entra ID, they must be registered with a tenant that you manage. This can be either an Entra ID (Azure AD) tenant, or an Entra ID B2C (Azure AD B2C) tenant. For more information on creating an Azure AD B2C tenant, see [Microsoft's Tutorial: Create an Azure Active Directory B2C tenant](https://learn.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant).
 
 ## Step 2: Install the NuGet package
 

--- a/14/umbraco-cms/tutorials/add-azure-active-directory-authentication.md
+++ b/14/umbraco-cms/tutorials/add-azure-active-directory-authentication.md
@@ -23,7 +23,7 @@ It is still possible to use other [External Login Providers](../reference/securi
 
 ## Step 1: Configure Azure AD
 
-Before your applications can interact with Azure AD B2C, they must be registered with a tenant that you manage. For more information, see [Microsoft's Tutorial: Create an Azure Active Directory B2C tenant](https://learn.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant).
+Before your applications can interact with Entra ID, they must be registered with a tenant that you manage. This can be either an Entra ID (Azure AD) tenant, or an Entra ID B2C (Azure AD B2C) tenant. For more information on creating an Azure AD B2C tenant, see [Microsoft's Tutorial: Create an Azure Active Directory B2C tenant](https://learn.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant).
 
 ## Step 2: Install the NuGet package
 
@@ -143,6 +143,10 @@ public static class MemberAuthenticationExtensions
                                 //Obtained from the AZURE AD B2C WEB APP
                                 options.ClientSecret = "YOURCLIENTSECRET";
 
+                                // If you are using single-tenant app registration (e.g. for an intranet site), you must specify the Token Endpoint and Authorization Endpoint:
+                                //options.TokenEndpoint = $"https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token";
+                                //options.AuthorizationEndpoint = $"https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/authorize";
+
                                 options.SaveTokens = true;
                             });
                     });
@@ -156,7 +160,7 @@ public static class MemberAuthenticationExtensions
 {% endcode %}
 
 {% hint style="info" %}
-Ensure to replace `YOURCLIENTID` and `YOURCLIENTSECRET` in the code with the values from the Azure AD tenant.
+Ensure to replace `YOURCLIENTID` and `YOURCLIENTSECRET` in the code with the values from the Entra ID tenant. If Entra ID is configured to use accounts in the organizational directory only (single tenant registration), you must specify the Token and Authorization endpoint. For more information on the differences between single and multi tenant registration, refer to [Microsoft's identity platform documentation](https://learn.microsoft.com/en-us/entra/identity-platform/howto-modify-supported-accounts).
 {% endhint %}
 
 4. Add the Members authentication configuration in the `Program.cs` file:


### PR DESCRIPTION
… app registration

Added code sample to show authorization endpoint and token endpoint being manually set for single-tenant registration.  Updated hint at end of step 3 to include information on single vs multi-tenant registration.

## Description

I've updated the documentation on Entra ID authentication for members to include information on using a single-tenant app registration. This information was [included in the v10 documentation](https://docs.umbraco.com/umbraco-cms/v/10.latest-lts/tutorials/add-microsoft-entra-id-authentication), but not included in v13. 
There have been a few forum questions asking how to do this, so seems like a use case that people want. 

Hopefully I followed all the contributor guidelines! 😄  


## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [X] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

None