### PR TITLE
Corrected typo - Swagger is enabled in non-production environments.

### DIFF
--- a/13/umbraco-cms/reference/api-versioning-and-openapi.md
+++ b/13/umbraco-cms/reference/api-versioning-and-openapi.md
@@ -4,7 +4,7 @@ description: How to use API versioning and OpenAPI (Swagger) for your own APIs.
 
 # API versioning and OpenAPI (Swagger)
 
-Umbraco ships with Swagger to document the Content Delivery API. Swagger and the Swagger UI is available at `{yourdomain}/umbraco/swagger`. For security reasons, both are disabled in non-production environments.
+Umbraco ships with Swagger to document the Content Delivery API. Swagger and the Swagger UI is available at `{yourdomain}/umbraco/swagger`. For security reasons, both are disabled in production environments.
 
 Due to the way OpenAPI works within ASP.NET Core, we have to apply some configurations in a global scope. If your Umbraco site used Swagger previous to Umbraco 12, these global configurations may interfere with your setup.
 


### PR DESCRIPTION
This previously said "both are disabled in non-production environments" (a double negative, meaning that they're only enabled in production). Corrected this to say that swagger is disabled in production.

## Description

Corrected a typo that incorrectly said swagger is only enabled in production.

## Type of suggestion

* [X] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

CMS 13

## Deadline (if relevant)

N/A