### PR TITLE
Update integrating-context-with-a-property-editor.md

### DIFF
--- a/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-context-with-a-property-editor.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-context-with-a-property-editor.md
@@ -332,7 +332,7 @@ declare global {
 
 ## Wrap up
 
-Over the four previous steps, we have:
+Over the previous steps, we have:
 
 * Created a plugin.
 * Defined an editor.

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-context-with-a-property-editor.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-context-with-a-property-editor.md
@@ -27,14 +27,11 @@ import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";
 
 2. Update the class to extend from UmbElementMixin. This allows us to consume the contexts that we need:
 
-Here we also implement abstract class `getFormElement()` as required by `UUIFormControlMixinInterface`
 
 {% code title="suggestions-property-editor-ui.element.ts" %}
 ```typescript
-export default class UmbMySuggestionsInputElement extends UmbElementMixin(UUIFormControlMixin(LitElement, '')) {
-	protected getFormElement(): HTMLElement | undefined {
-	    throw new Error("Method not implemented.");
-	}
+export default class MySuggestionsPropertyEditorUIElement extends UmbElementMixin((LitElement)) implements UmbPropertyEditorUiElement {
+	
 	...
 }
 ```

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-context-with-a-property-editor.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-context-with-a-property-editor.md
@@ -20,7 +20,6 @@ The steps we will go through in this part are:
 
 {% code title="suggestions-property-editor-ui.element.ts" %}
 ```typescript
-import { UUIInputEvent, UUIFormControlMixin} from "@umbraco-cms/backoffice/external/uui";
 import { UMB_NOTIFICATION_CONTEXT, UmbNotificationContext, UmbNotificationDefaultData} from "@umbraco-cms/backoffice/notification";
 import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";
 ```

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-context-with-a-property-editor.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-context-with-a-property-editor.md
@@ -20,9 +20,8 @@ The steps we will go through in this part are:
 {% code title="suggestions-input.element.ts" %}
 ```typescript
 import {
-    UmbModalContext,
-    UMB_MODAL_CONTEXT,
-    UMB_CONFIRM_MODAL,
+    UMB_MODAL_MANAGER_CONTEXT,
+    UMB_CONFIRM_MODAL
 } from "@umbraco-cms/backoffice/modal";
 import {
     UMB_NOTIFICATION_CONTEXT,
@@ -45,17 +44,17 @@ export default class UmbMySuggestionsInputElement extends UmbElementMixin(UUIFor
 
 {% code title="suggestions-input.element.ts" %}
 ```typescript
-private _modalContext?: UmbModalContext;
-private _notificationContext?: UmbNotificationContext;
+_modalManagerContext?: typeof UMB_MODAL_MANAGER_CONTEXT.TYPE;
+_notificationContext?: UmbNotificationContext;
 
 constructor() {
-  super();
-  this.consumeContext(UMB_MODAL_CONTEXT, (instance) => {
-    this._modalContext = instance;
-  });
+    super();
+    this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
+        this._modalManagerContext = instance;
+    });
 
-  this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
-    this._notificationContext = instance;
+    this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
+        this._notificationContext = instance;
     });
 }
 ```
@@ -98,12 +97,16 @@ Let's add some more logic. If the length is more than the maxLength configuratio
   ...
 
   const trimmed = (this.value as string).substring(0, this.maxLength);
-  const modalHandler = this._modalContext?.open(UMB_CONFIRM_MODAL, {
-    headline: `Trim text`,
-    content: `Do you want to trim the text to "${trimmed}"?`,
-    color: 'danger',
-    confirmLabel: 'Trim',
-  });
+  const modalHandler = this._modalManagerContext?.open(this, UMB_CONFIRM_MODAL,
+      {
+          data: {
+              headline: `Trim text`,
+              content: `Do you want to trim the text to "${trimmed}"?`,
+              color: "danger",
+              confirmLabel: "Trim",
+          }
+      }
+  );
   modalHandler?.onSubmit().then(() => {
     this.value = trimmed;
     this.#dispatchChangeEvent();
@@ -125,7 +128,7 @@ Let's add some more logic. If the length is more than the maxLength configuratio
 ```typescript
 import { LitElement, css, html, customElement, property, state} from "@umbraco-cms/backoffice/external/lit";
 import { UUIInputEvent, UUIFormControlMixin} from "@umbraco-cms/backoffice/external/uui";
-import { UmbModalContext, UMB_MODAL_CONTEXT, UMB_CONFIRM_MODAL} from "@umbraco-cms/backoffice/modal";
+import { UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL} from "@umbraco-cms/backoffice/modal";
 import { UMB_NOTIFICATION_CONTEXT, UmbNotificationContext, UmbNotificationDefaultData} from "@umbraco-cms/backoffice/notification";
 import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";
 
@@ -140,13 +143,13 @@ export default class UmbMySuggestionsInputElement extends UmbElementMixin(UUIFor
     @property({ type: Number })
     maxLength?: number;
 
-    private _modalContext?: UmbModalContext;
-    private _notificationContext?: UmbNotificationContext;
+    _modalManagerContext?: typeof UMB_MODAL_MANAGER_CONTEXT.TYPE;
+    _notificationContext?: UmbNotificationContext;
 
     constructor() {
         super();
-        this.consumeContext(UMB_MODAL_CONTEXT, (instance) => {
-            this._modalContext = instance;
+        this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
+            this._modalManagerContext = instance;
         });
 
         this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
@@ -185,12 +188,16 @@ export default class UmbMySuggestionsInputElement extends UmbElementMixin(UUIFor
             return;
         }
         const trimmed = (this.value as string).substring(0, this.maxLength);
-        const modalHandler = this._modalContext?.open(UMB_CONFIRM_MODAL, {
-            headline: `Trim text`,
-            content: `Do you want to trim the text to "${trimmed}"?`,
-            color: "danger",
-            confirmLabel: "Trim",
-        });
+        const modalHandler = this._modalManagerContext?.open(this, UMB_CONFIRM_MODAL,
+            {
+                data: {
+                    headline: `Trim text`,
+                    content: `Do you want to trim the text to "${trimmed}"?`,
+                    color: "danger",
+                    confirmLabel: "Trim",
+                }
+            }
+        );
         modalHandler?.onSubmit().then(() => {
             this.value = trimmed;
             this.#dispatchChangeEvent();
@@ -258,8 +265,6 @@ export default class UmbMySuggestionsInputElement extends UmbElementMixin(UUIFor
         `,
     ];
 }
-
-export default UmbMySuggestionsInputElement;
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-context-with-a-property-editor.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-context-with-a-property-editor.md
@@ -6,7 +6,7 @@ description: Integrate one of the built-in Umbraco Contexts.
 
 ## Overview
 
-This is the third step in the Property Editor tutorial. In this part, we will integrate built-in Umbraco Contexts. For this sample, we will use the `UmbNotificationContext` for some pop-ups and the `UmbModalManagerContext`. `UmbModalManagerContext` is used to show a dialog when you click the Trim button and the textbox's input length is longer than the maxLength configuration.
+This is the third step in the Property Editor tutorial. In this part, we will integrate built-in Umbraco Contexts. For this sample, we will use the `UmbNotificationContext` for some pop-ups and the `UmbModalManagerContext`. `UmbNotificationContext` is used to show a dialog when you click the Trim button and the textbox's input length is longer than the maxLength configuration.
 
 The steps we will go through in this part are:
 


### PR DESCRIPTION
I was unable to build suggestions-input.element.ts until I made the following changes. 

## Description

- Remove duplicate export default UmbMySuggestionsInputElement; 
- Update import modal context and modal open logic to use the UmbModalTokenDefaults in modal-token.d.ts as the args.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

v14.0.0-rc2

## Deadline (if relevant)

_When should the content be published?_
