### PR TITLE
Update integrating-services-with-a-property-editor.md

### DIFF
--- a/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-context-with-a-property-editor.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-context-with-a-property-editor.md
@@ -15,27 +15,21 @@ The steps we will go through in this part are:
 
 ## Setting up the contexts
 
-1. Insert the following imports into the `suggestions-input.element.ts` file.
+1. Replace the imports in the `suggestions-property-editor-ui.element.ts` file.
 
-{% code title="suggestions-input.element.ts" %}
+{% code title="suggestions-property-editor-ui.element.ts" %}
 ```typescript
-import {
-    UmbModalContext,
-    UMB_MODAL_CONTEXT,
-    UMB_CONFIRM_MODAL,
-} from "@umbraco-cms/backoffice/modal";
-import {
-    UMB_NOTIFICATION_CONTEXT,
-    UmbNotificationContext,
-    UmbNotificationDefaultData,
-} from "@umbraco-cms/backoffice/notification";
+import { LitElement, css, html, customElement, property, state} from "@umbraco-cms/backoffice/external/lit";
+import { UUIInputEvent, UUIFormControlMixin} from "@umbraco-cms/backoffice/external/uui";
+import { UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL} from "@umbraco-cms/backoffice/modal";
+import { UMB_NOTIFICATION_CONTEXT, UmbNotificationContext, UmbNotificationDefaultData} from "@umbraco-cms/backoffice/notification";
 import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";
 ```
 {% endcode %}
 
 2. Update the class to extend from UmbElementMixin. This allows us to consume the contexts that we need:
 
-{% code title="suggestions-input.element.ts" %}
+{% code title="suggestions-property-editor-ui.element.ts" %}
 ```typescript
 export default class UmbMySuggestionsInputElement extends UmbElementMixin(UUIFormControlMixin(LitElement, '')) {
 ```
@@ -43,23 +37,34 @@ export default class UmbMySuggestionsInputElement extends UmbElementMixin(UUIFor
 
 3. Create the constructor where we can consume the contexts:
 
-{% code title="suggestions-input.element.ts" %}
+{% code title="suggestions-property-editor-ui.element.ts" %}
 ```typescript
-private _modalContext?: UmbModalContext;
-private _notificationContext?: UmbNotificationContext;
+_modalManagerContext?: typeof UMB_MODAL_MANAGER_CONTEXT.TYPE;
+_notificationContext?: UmbNotificationContext;
 
 constructor() {
-  super();
-  this.consumeContext(UMB_MODAL_CONTEXT, (instance) => {
-    this._modalContext = instance;
-  });
+    super();
+    this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
+        this._modalManagerContext = instance;
+    });
 
-  this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
-    this._notificationContext = instance;
+    this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
+        this._notificationContext = instance;
     });
 }
 ```
 {% endcode %}
+
+4. Add inherited class getFormElement
+
+{% code title="suggestions-property-editor-ui.element.ts" %}
+```typescript
+protected getFormElement(): HTMLElement | undefined {
+    throw new Error("Method not implemented.");
+}
+```
+{% endcode %}
+
 
 ## Using the modal and notification API
 
@@ -69,19 +74,19 @@ First, check if the length of our input is smaller or equal to our maxLength con
 
 Here we can use the NotificationContext's peek method. It has two parameters `UmbNotificationColor` and an`UmbNotificationDefaultData` object.
 
-1. Add the `#onTextTrim()`code in the `suggestions-input.element.ts`
+1. Add the `#onTextTrim()`code in the `suggestions-property-editor-ui.element.ts`
 
-{% code title="suggestions-input.element.ts" %}
+{% code title="suggestions-property-editor-ui.element.ts" %}
 ```typescript
 #onTextTrim() {
   if (!this.maxLength) return;
-  if (!this.value || (this.value as string).length <= this.maxLength) {
-    const data: UmbNotificationDefaultData = {
-      message: `Nothing to trim!`,
-    };
-    this._notificationContext?.peek('danger', { data });
-    return;
-  }
+    if (!this.value || (this.value as string).length <= this.maxLength) {
+        const data: UmbNotificationDefaultData = {
+            message: `Nothing to trim!`,
+        };
+        this._notificationContext?.peek("danger", { data });
+        return;
+    }
 }
 ```
 {% endcode %}
@@ -92,27 +97,31 @@ Let's add some more logic. If the length is more than the maxLength configuratio
 
 2. Add the `open` method to the `#onTextTrim()`
 
-{% code title="suggestions-input.element.ts" %}
+{% code title="suggestions-property-editor-ui.element.ts" %}
 ```typescript
 #onTextTrim() {
   ...
 
-  const trimmed = (this.value as string).substring(0, this.maxLength);
-  const modalHandler = this._modalContext?.open(UMB_CONFIRM_MODAL, {
-    headline: `Trim text`,
-    content: `Do you want to trim the text to "${trimmed}"?`,
-    color: 'danger',
-    confirmLabel: 'Trim',
-  });
-  modalHandler?.onSubmit().then(() => {
-    this.value = trimmed;
-    this.#dispatchChangeEvent();
-    const data: UmbNotificationDefaultData = {
-      headline: `Text trimmed`,
-      message: `You trimmed the text!`,
-    };
-    this._notificationContext?.peek('positive', { data });
-  }, null);
+    const trimmed = (this.value as string).substring(0, this.maxLength);
+    const modalHandler = this._modalManagerContext?.open(this, UMB_CONFIRM_MODAL,
+        {
+            data: {
+                headline: `Trim text`,
+                content: `Do you want to trim the text to "${trimmed}"?`,
+                color: "danger",
+                confirmLabel: "Trim",
+            }
+        }
+    );
+    modalHandler?.onSubmit().then(() => {
+        this.value = trimmed;
+        this.#dispatchChangeEvent();
+        const data: UmbNotificationDefaultData = {
+            headline: `Text trimmed`,
+            message: `You trimmed the text!`,
+        };
+        this._notificationContext?.peek("positive", { data });
+    }, null);
 }
 ```
 {% endcode %}
@@ -121,15 +130,15 @@ Let's add some more logic. If the length is more than the maxLength configuratio
 
 <summary>See the entire file: suggestions-property-editor-ui.element.ts</summary>
 
-{% code title="suggestions-input.element.ts" %}
+{% code title="suggestions-property-editor-ui.element.ts" %}
 ```typescript
 import { LitElement, css, html, customElement, property, state} from "@umbraco-cms/backoffice/external/lit";
 import { UUIInputEvent, UUIFormControlMixin} from "@umbraco-cms/backoffice/external/uui";
-import { UmbModalContext, UMB_MODAL_CONTEXT, UMB_CONFIRM_MODAL} from "@umbraco-cms/backoffice/modal";
+import { UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL} from "@umbraco-cms/backoffice/modal";
 import { UMB_NOTIFICATION_CONTEXT, UmbNotificationContext, UmbNotificationDefaultData} from "@umbraco-cms/backoffice/notification";
 import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";
 
-@customElement("my-suggestions-input")
+@customElement('my-suggestions-property-editor-ui')
 export default class UmbMySuggestionsInputElement extends UmbElementMixin(UUIFormControlMixin(LitElement, '')) {
     @property({ type: Boolean })
     disabled = false;
@@ -140,13 +149,13 @@ export default class UmbMySuggestionsInputElement extends UmbElementMixin(UUIFor
     @property({ type: Number })
     maxLength?: number;
 
-    private _modalContext?: UmbModalContext;
-    private _notificationContext?: UmbNotificationContext;
+    _modalManagerContext?: typeof UMB_MODAL_MANAGER_CONTEXT.TYPE;
+    _notificationContext?: UmbNotificationContext;
 
     constructor() {
         super();
-        this.consumeContext(UMB_MODAL_CONTEXT, (instance) => {
-            this._modalContext = instance;
+        this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
+            this._modalManagerContext = instance;
         });
 
         this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
@@ -162,8 +171,8 @@ export default class UmbMySuggestionsInputElement extends UmbElementMixin(UUIFor
         "Are you hungry?",
     ];
 
-    protected getFormElement() {
-        return undefined;
+    protected getFormElement(): HTMLElement | undefined {
+        throw new Error("Method not implemented.");
     }
 
     #onInput(e: UUIInputEvent) {
@@ -185,12 +194,16 @@ export default class UmbMySuggestionsInputElement extends UmbElementMixin(UUIFor
             return;
         }
         const trimmed = (this.value as string).substring(0, this.maxLength);
-        const modalHandler = this._modalContext?.open(UMB_CONFIRM_MODAL, {
-            headline: `Trim text`,
-            content: `Do you want to trim the text to "${trimmed}"?`,
-            color: "danger",
-            confirmLabel: "Trim",
-        });
+        const modalHandler = this._modalManagerContext?.open(this, UMB_CONFIRM_MODAL,
+            {
+                data: {
+                    headline: `Trim text`,
+                    content: `Do you want to trim the text to "${trimmed}"?`,
+                    color: "danger",
+                    confirmLabel: "Trim",
+                }
+            }
+        );
         modalHandler?.onSubmit().then(() => {
             this.value = trimmed;
             this.#dispatchChangeEvent();
@@ -258,8 +271,6 @@ export default class UmbMySuggestionsInputElement extends UmbElementMixin(UUIFor
         `,
     ];
 }
-
-export default UmbMySuggestionsInputElement;
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-services-with-a-property-editor.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/integrating-services-with-a-property-editor.md
@@ -153,22 +153,26 @@ import {
 #onTextTrim() {
   ...
 
-  const trimmed = (this.value as string).substring(0, this._maxChars);
-  const modalHandler = this.#modalManagerContext?.open(UMB_CONFIRM_MODAL, {
-    headline: `Trim text`,
-    content: `Do you want to trim the text to "${trimmed}"?`,
-    color: 'danger',
-    confirmLabel: 'Trim',
-  });
-  modalHandler?.onSubmit().then(() => {
-    this.value = trimmed;
-    this.#dispatchEvent();
-    const data: UmbNotificationDefaultData = {
-      headline: `Text trimmed`,
-      message: `You trimmed the text!`,
-    };
-    this.#notificationContext?.peek('positive', { data });
-  }, null);
+    const trimmed = (this.value as string).substring(0, this._maxChars);
+    const modalHandler = this.#modalManagerContext?.open(this, 
+        UMB_CONFIRM_MODAL, {
+        data: {
+                headline: `Trim text`,
+                content: `Do you want to trim the text to "${trimmed}"?`,
+                color: "danger",
+                confirmLabel: "Trim",
+            }
+        }            
+    );
+    modalHandler?.onSubmit().then(() => {
+        this.value = trimmed;
+        this.#dispatchChangeEvent();
+        const data: UmbNotificationDefaultData = {
+            headline: `Text trimmed`,
+            message: `You trimmed the text!`,
+        };
+        this.#notificationContext?.peek("positive", { data });
+    }, null);
 }
 ```
 {% endcode %}
@@ -186,7 +190,7 @@ We have now created a working Property editor. Below you can see the full exampl
 {% code title="suggestions-property-editor-ui.element.ts" %}
 ```typescript
 import { LitElement, css, html, customElement, property, state, ifDefined } from "@umbraco-cms/backoffice/external/lit";
-import { type UmbPropertyEditorExtensionElement } from "@umbraco-cms/backoffice/extension-registry";
+import { type UmbPropertyEditorUiElement } from "@umbraco-cms/backoffice/extension-registry";
 import { type UmbPropertyEditorConfigCollection, UmbPropertyValueChangeEvent } from "@umbraco-cms/backoffice/property-editor";
 import { UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL} from "@umbraco-cms/backoffice/modal";
 import { UMB_NOTIFICATION_CONTEXT, UmbNotificationDefaultData} from "@umbraco-cms/backoffice/notification";
@@ -195,7 +199,7 @@ import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";
 @customElement('my-suggestions-property-editor-ui')
 export default class MySuggestionsPropertyEditorUIElement
     extends UmbElementMixin(LitElement)
-    implements UmbPropertyEditorExtensionElement
+    implements UmbPropertyEditorUiElement
 {
     @property({ type: String })
     public value = "";
@@ -255,19 +259,20 @@ export default class MySuggestionsPropertyEditorUIElement
             const data: UmbNotificationDefaultData = {
                 message: `Nothing to trim!`,
             };
-            this._notificationContext?.peek("danger", { data });
+            this.#notificationContext?.peek("danger", { data });
             return;
         }
 
         const trimmed = (this.value as string).substring(0, this._maxChars);
-        const modalHandler = this._modalManagerContext?.open(
-            UMB_CONFIRM_MODAL,
-            {
-                headline: `Trim text`,
-                content: `Do you want to trim the text to "${trimmed}"?`,
-                color: "danger",
-                confirmLabel: "Trim",
-            }
+        const modalHandler = this.#modalManagerContext?.open(this, 
+            UMB_CONFIRM_MODAL, {
+            data: {
+                    headline: `Trim text`,
+                    content: `Do you want to trim the text to "${trimmed}"?`,
+                    color: "danger",
+                    confirmLabel: "Trim",
+                }
+            }            
         );
         modalHandler?.onSubmit().then(() => {
             this.value = trimmed;
@@ -276,7 +281,7 @@ export default class MySuggestionsPropertyEditorUIElement
                 headline: `Text trimmed`,
                 message: `You trimmed the text!`,
             };
-            this._notificationContext?.peek("positive", { data });
+            this.#notificationContext?.peek("positive", { data });
         }, null);
     }
 


### PR DESCRIPTION
## Description

- Replace UmbPropertyEditorExtensionElement with UmbPropertyEditorUiElement in the extension-registry import. 
- Update import modal context and modal open logic to use the UmbModalTokenDefaults in modal-token.d.ts as the args.
- Replace usages of _notificationContext  with #notifcationContext. This should probably be aligned between part 3 and part 4 of this tutorial as part 3 uses _notificationContext syntax and part 4 uses #notificationContext. 

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

v14.0.0-rc2

## Deadline (if relevant)

_When should the content be published?_
