### PR TITLE
Updated broken link in Running Umbraco on Linux/macOS article

### DIFF
--- a/10/umbraco-cms/fundamentals/setup/install/running-umbraco-on-linux-macos.md
+++ b/10/umbraco-cms/fundamentals/setup/install/running-umbraco-on-linux-macos.md
@@ -27,4 +27,4 @@ To create new projects using Visual Studio, you can use the [Install using Visua
 
 Once you create a new project it will use SQLite by default.
 
-If you want to use an SQL server database, you will need to [set up Docker](https://creativewebspecialist.co.uk/2021/09/07/how-to-run-netcore-umbraco-cms-on-a-macbook/).
+If you want to use an SQL server database, you will need to [set up Docker](https://skrift.io/issues/umbraco-and-docker-part-1-getting-familiar-with-containers/).

--- a/12/umbraco-cms/fundamentals/setup/install/running-umbraco-on-linux-macos.md
+++ b/12/umbraco-cms/fundamentals/setup/install/running-umbraco-on-linux-macos.md
@@ -27,4 +27,4 @@ To create new projects using Visual Studio, you can use the [Install using Visua
 
 Once you create a new project it will use SQLite by default on Linux/macOS.
 
-If you want to use an SQL server database, you will need to [set up Docker](https://creativewebspecialist.co.uk/2021/09/07/how-to-run-netcore-umbraco-cms-on-a-macbook/).
+If you want to use an SQL server database, you will need to [set up Docker](https://skrift.io/issues/umbraco-and-docker-part-1-getting-familiar-with-containers/).

--- a/13/umbraco-cms/fundamentals/setup/install/running-umbraco-on-linux-macos.md
+++ b/13/umbraco-cms/fundamentals/setup/install/running-umbraco-on-linux-macos.md
@@ -27,4 +27,4 @@ To create new projects using Visual Studio, you can use the [Install using Visua
 
 Once you create a new project it will use SQLite by default on Linux/macOS.
 
-If you want to use an SQL server database, you will need to [set up Docker](https://creativewebspecialist.co.uk/2021/09/07/how-to-run-netcore-umbraco-cms-on-a-macbook/).
+If you want to use an SQL server database, you will need to [set up Docker](https://skrift.io/issues/umbraco-and-docker-part-1-getting-familiar-with-containers/).

--- a/14/umbraco-cms/fundamentals/setup/install/running-umbraco-on-linux-macos.md
+++ b/14/umbraco-cms/fundamentals/setup/install/running-umbraco-on-linux-macos.md
@@ -27,4 +27,4 @@ To create new projects using Visual Studio, you can use the [Install using Visua
 
 Once you create a new project it will use SQLite by default on Linux/macOS.
 
-If you want to use an SQL server database, you will need to [set up Docker](https://creativewebspecialist.co.uk/2021/09/07/how-to-run-netcore-umbraco-cms-on-a-macbook/).
+If you want to use an SQL server database, you will need to [set up Docker](https://skrift.io/issues/umbraco-and-docker-part-1-getting-familiar-with-containers/).


### PR DESCRIPTION
## Description
Updated broken link in Running Umbraco on Linux/macOS article
_What did you add/update/change?_
The link to the tutorial for setting it up with docker was not working anymore.

Instead, I have replaced the article with a new one about setting up Umbraco with docker.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
10
12
13
14


## Deadline (if relevant)
ASAP

_When should the content be published?_
ASAP
