### PR TITLE
Change information about using CNAME records pointing to dns.umbraco.io

### DIFF
--- a/umbraco-cloud/set-up/project-settings/manage-hostnames/README.md
+++ b/umbraco-cloud/set-up/project-settings/manage-hostnames/README.md
@@ -30,7 +30,7 @@ Ensure that the hostname you are binding to your Umbraco Cloud environment has a
 
 - **CNAME**: usually used for domains with "`www`" in the URL, recommended to use if possible, as the record is not changed as often as A & AAAA records are. When setting up a CNAME it needs to point to `dns.umbraco.io`.
 
-{% hint style="info" %} Be aware that when using dns.umbraco.io, wildcard asterisks are not supported. Individual CNAME records must be created for each individual subdomain you want to use `dns.umbraco.io`. {% endhint %}
+{% hint style="info" %} Be aware that when using dns.umbraco.io, wildcard asterisks are not supported. Individual CNAME records must be created for each subdomain you want to use `dns.umbraco.io`. {% endhint %}
 
 * CNAME record value:
   * `dns.umbraco.io`


### PR DESCRIPTION
Wildcard asterisks in DNS records, are no longer supported when combined with dns.umbraco.io as that will make SSL certificate generation and renewal fail. 

See support ticket #72019 

This change also clarifies that A & AAAA records has to be used for root domain, as CNAME records are not possible for root domains.