### PR TITLE
removing hint about UmbracoApiController  in v13 and adding it to v14

### DIFF
--- a/13/umbraco-cms/extending/database.md
+++ b/13/umbraco-cms/extending/database.md
@@ -283,7 +283,3 @@ public class BlogCommentsApiController : UmbracoApiController
     }
 }
 ```
-
-{% hint style="warning" %}
-The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}

--- a/13/umbraco-cms/extending/section-trees/trees/README.md
+++ b/13/umbraco-cms/extending/section-trees/trees/README.md
@@ -60,7 +60,7 @@ The first node in the tree is referred to as the **Root Node**. You can customis
 ### Implementing the Tree
 
 {% hint style="warning" %}
-The example below uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
+The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
 {% endhint %}
 
 ```csharp

--- a/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/block-grid-editor.md
+++ b/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/block-grid-editor.md
@@ -471,14 +471,15 @@ In this example, we will be creating content programmatically for a "spot" Block
 3. In the Block Grid add a new block and click to **Create new Element Type**
 4. Name this element type **spotElement** with the following properties:
 
-- a property called **title** with the editor of **Textstring**
+* a property called **title** with the editor of **Textstring**
+
 * a property called **text** with the editor of **Textstring**
 
 5. Then on the **Settings model** click to add a new Setting.
 6. Then click to **Create new Element Type**.
 7. Name this element type **spotSettings** with the following properties:
 
-- a property called **featured** with the editor of **True/false**.
+* a property called **featured** with the editor of **True/false**.
 
 ![Block Grid - Block Configuration](../../../images/BlockEditorConfigurationProgramatically.png)
 
@@ -732,10 +733,6 @@ public class BlockGridTestController : UmbracoApiController
 ```
 
 {% endcode %}
-
-{% hint style="warning" %}
-The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}
 
 For the above code `IContent? content = _contentService.GetById(1203);` change the id with your content node that is using the Block Grid.
 

--- a/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/image-cropper.md
+++ b/13/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/image-cropper.md
@@ -187,10 +187,6 @@ public class CreateImageCropperValuesController : UmbracoApiController
 }
 ```
 
-{% hint style="warning" %}
-The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}
-
 If you use Models Builder to generate source code (modes `SourceCodeAuto` or `SourceCodeManual`), you can use `nameof([generated property name])` to access the desired property without using a magic string:
 
 ```csharp

--- a/13/umbraco-cms/fundamentals/code/debugging/logging.md
+++ b/13/umbraco-cms/fundamentals/code/debugging/logging.md
@@ -56,10 +56,6 @@ Umbraco writes log messages, but you are also able to use the Umbraco logger to 
 
 Here is an example of using the logger to write an Information message to the log which will contain one property of **Name** which will output the name variable that is passed into the method
 
-{% hint style="warning" %}
-The example below uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}
-
 ```csharp
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;

--- a/13/umbraco-cms/implementation/controllers.md
+++ b/13/umbraco-cms/implementation/controllers.md
@@ -37,10 +37,6 @@ All implementations of Umbraco API Controllers inherit from the base class: `Umb
 
 For details on using Umbraco API Controllers, see the [Umbraco API Controllers](../reference/routing/umbraco-api-controllers/) article.
 
-{% hint style="warning" %}
-UmbracoApiController is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}
-
 ## Umbraco Authorized Controllers and Attributes
 
 An Umbraco Authorized Controller is used when the controller requires member or user authentication (authN) and/or authorization (authZ). If either the `authN` or `authZ` fail, the controller will return a `401 - unauthorized response`.

--- a/13/umbraco-cms/implementation/unit-testing.md
+++ b/13/umbraco-cms/implementation/unit-testing.md
@@ -163,10 +163,6 @@ public class PageSurfaceControllerTests
 
 See [Reference documentation on UmbracoApiControllers](../reference/routing/umbraco-api-controllers/README.md#locally-declared-controller).
 
-{% hint style="warning" %}
-The example below uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}
-
 ```csharp
 public class ProductsController : UmbracoApiController
 {

--- a/13/umbraco-cms/reference/cache/examples/tags.md
+++ b/13/umbraco-cms/reference/cache/examples/tags.md
@@ -149,10 +149,6 @@ public class TagsController : UmbracoApiController
 }
 ```
 
-{% hint style="warning" %}
-The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}
-
 `/umbraco/api/tags/getblogtags`:
 
 ![Result](images/response.png)

--- a/13/umbraco-cms/reference/common-pitfalls.md
+++ b/13/umbraco-cms/reference/common-pitfalls.md
@@ -74,10 +74,6 @@ public class BadApiController : UmbracoApiController
 }
 ```
 
-{% hint style="warning" %}
-The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}
-
 This practice can cause memory leaks along with inconsistent data results when using this `_umbracoHelper` instance.
 
 **Why?**

--- a/13/umbraco-cms/reference/management/services/relationservice.md
+++ b/13/umbraco-cms/reference/management/services/relationservice.md
@@ -403,10 +403,6 @@ public class RelationsController : UmbracoApiController
 }
 ```
 
-{% hint style="warning" %}
-The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}
-
 Notice the `x => new Relation()`? We need to make sure what we are returning can be serialized. Therefore the `Relation` class is:
 
 ```csharp

--- a/13/umbraco-cms/reference/mapping.md
+++ b/13/umbraco-cms/reference/mapping.md
@@ -187,10 +187,6 @@ The analyzer follows the standard analyzer development patterns, and building th
 
 ## Full example
 
-{% hint style="warning" %}
-The example below uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}
-
 Below you will find a full example showing you how to map a collection of type Product to a collection of type ProductDto.
 
 ```csharp

--- a/13/umbraco-cms/reference/querying/itagquery.md
+++ b/13/umbraco-cms/reference/querying/itagquery.md
@@ -18,10 +18,6 @@ After this you can use `_tagQuery` to access the `ITagQuery`.
 
 If you're using it in controllers, you can inject it into the constructor like so:
 
-{% hint style="warning" %}
-The example below uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}
-
 ```csharp
 using System.Collections.Generic;
 using System.Linq;

--- a/13/umbraco-cms/reference/querying/umbraco-context.md
+++ b/13/umbraco-cms/reference/querying/umbraco-context.md
@@ -67,8 +67,4 @@ public class PeopleController : UmbracoApiController
 }
 ```
 
-{% hint style="warning" %}
-The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}
-
 UmbracoContext is registered with a scoped lifetime. See the [Microsoft documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-5.0#lifetime-and-registration-options) for more information. A service scope is created for each request, which means you can resolve an instance directly in a controller.

--- a/13/umbraco-cms/reference/routing/umbraco-api-controllers/README.md
+++ b/13/umbraco-cms/reference/routing/umbraco-api-controllers/README.md
@@ -25,10 +25,6 @@ We have created a base API controller for developers to inherit from. This will 
 
 The class to inherit from is: `Umbraco.Cms.Web.Common.Controllers.UmbracoApiController`
 
-{% hint style="warning" %}
-UmbracoApiController is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}
-
 ## Creating a Web API controller
 
 There are 2 types of Umbraco API controllers:

--- a/13/umbraco-cms/reference/routing/umbraco-api-controllers/authorization.md
+++ b/13/umbraco-cms/reference/routing/umbraco-api-controllers/authorization.md
@@ -22,10 +22,6 @@ This attribute will ensure that a valid backoffice user is logged in. It is impo
 
 **Example:**
 
-{% hint style="warning" %}
-The examples below uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}
-
 This will only allow a logged in backoffice user to access the `GetProduct`action:
 
 ```csharp

--- a/13/umbraco-cms/reference/routing/umbraco-api-controllers/routing.md
+++ b/13/umbraco-cms/reference/routing/umbraco-api-controllers/routing.md
@@ -8,10 +8,6 @@ _This section will describe how Umbraco Api controllers are routed and how to re
 
 ## Routing
 
-{% hint style="warning" %}
-UmbracoApiController is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}
-
 Like Surface Controllers in Umbraco, when you inherit from the base class `Umbraco.Cms.Web.Common.Controllers.UmbracoApiController` we will auto-route this controller so you don't have to worry about routing at all.
 
 All locally declared Umbraco api controllers will be routed under the URL path of:

--- a/13/umbraco-cms/reference/using-ioc.md
+++ b/13/umbraco-cms/reference/using-ioc.md
@@ -189,10 +189,6 @@ public class FooController : UmbracoApiController
 }
 ```
 
-{% hint style="warning" %}
-The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}
-
 If you place a breakpoint on `var bar = _foobar.Foo()`, open `/Umbraco/Api/foo/foo` in your browser and inspect the variable, you'll see that the value is `bar`, which is what you'd expect since all the `Foobar.Foo()` method does it to return `Bar` as a string:
 
 ```csharp

--- a/13/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
+++ b/13/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
@@ -296,7 +296,3 @@ public class BlogCommentsController : UmbracoApiController
     }
 }
 ```
-
-{% hint style="warning" %}
-The above example uses UmbracoApiController which is removed in Umbraco 14. The replacement for this is UmbracoManagementApiControllerBase.
-{% endhint %}

--- a/14/umbraco-cms/extending-cms/database.md
+++ b/14/umbraco-cms/extending-cms/database.md
@@ -251,6 +251,10 @@ The following example creates an `UmbracoApiController` to be able to fetch and 
 This example does not use the aforementioned `BlogCommentSchema` class but rather a separate (yet duplicate) class that is not part of the example. Also, be aware that things like error handling and data validation have been omitted for brevity.
 {% endhint %}
 
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
+
 ```csharp
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;

--- a/14/umbraco-cms/extending-cms/section-trees/trees/README.md
+++ b/14/umbraco-cms/extending-cms/section-trees/trees/README.md
@@ -59,6 +59,10 @@ The first node in the tree is referred to as the **Root Node**. You can customis
 
 ### Implementing the Tree
 
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
+
 ```csharp
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/block-grid-editor.md
+++ b/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/block-grid-editor.md
@@ -638,6 +638,10 @@ public class BlockGridElementData
 
 9. By injecting [ContentService](../../../../../reference/management/services/README.md#contentservice) and [ContentTypeService](../../../../../reference/management/services/README.md#contenttypeservice) into an API controller, we can transform the raw data into Block Grid JSON. It can then be saved to the target content item. Create a class called **BlockGridTestController.cs** containing the following:
 
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
+
 {% code title="BlockGridTestController.cs" lineNumbers="true" %}
 
 ```csharp

--- a/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/image-cropper.md
+++ b/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/image-cropper.md
@@ -44,7 +44,6 @@ By default, the Image Cropper allows the editor to set a focal point on the uplo
 
 All the preset crops are shown to give the editor a preview of what the image will look like on the frontend.
 
-
 ![Image Cropper Focal Point](/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/images/imageCropper-focalpoint.png)
 
 ### Crop and resize
@@ -116,6 +115,10 @@ Set the `htmlEncode` to false so that the URL is not HTML encoded
 To update a content property value you need the [Content Service](../../../../reference/management/services/README.md#contentservice).
 
 The following sample demonstrates how to add or change the value of an Image Cropper property programmatically. The sample creates an API controller with an action, which must be invoked via a POST request to the URL written above the action.
+
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
 
 ```csharp
 using Microsoft.AspNetCore.Mvc;

--- a/14/umbraco-cms/fundamentals/code/debugging/logging.md
+++ b/14/umbraco-cms/fundamentals/code/debugging/logging.md
@@ -10,7 +10,7 @@ The default location of this file is written to `umbraco/Logs` and contains the 
 
 ## Video overview
 
-{% embed url="https://youtu.be/PDqIRVygAQ4" %}
+{% embed url="<https://youtu.be/PDqIRVygAQ4>" %}
 Watch this video to get an overview of how to view and manage logs and logfiles for your Umbraco CMS website.
 {% endembed %}
 
@@ -55,6 +55,10 @@ To learn more about structured logging and message templates you can read more a
 Umbraco writes log messages, but you are also able to use the Umbraco logger to write the log file as needed, so you can get further insights and details about your implementation.
 
 Here is an example of using the logger to write an Information message to the log which will contain one property of **Name** which will output the name variable that is passed into the method
+
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
 
 ```csharp
 using Microsoft.AspNetCore.Mvc;

--- a/14/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
+++ b/14/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
@@ -38,7 +38,6 @@ Below you can find the list of breaking changes introduced in Umbraco 14 CMS.
 * XPath has been removed. An alternative is using the Dynamic Roots in the Multinode Treepicker and for ContentXPath the alternative is [IContentLastChanceFinder](../../../../tutorials/custom-error-page.md).
 * [package-manifest is now umbraco.package.json](../../../../extending-backoffice/development-flow/package-manifest.md)
 * [Smidge has been removed from default installation](https://github.com/umbraco/Umbraco-CMS/pull/15788) along with RuntimeMinification setting. Smidge can be manually installed if needed and you can read the [Smidge](https://github.com/Shazwazza/Smidge) documentation on how to setup a similar setting to [RuntimeMinification](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-cms/reference/configuration/runtimeminificationsettings.md).
-* `UmbracoApiController` has been removed and replaced with `UmbracoManagementApiControllerBase`
 * New login screen with possibility to change it and make it customizable
 * **Light, Dark or Contract Mode** option has been added in the backoffice. You can choose your preffered mode from your profile information.
 * [UI Library and UI API](broken-reference) external documentations.
@@ -55,18 +54,18 @@ Below you can find the list of breaking changes introduced in Umbraco 14 RC rele
 
 **RC 3**
 
-* [Bellissima (frontend/backoffice) changes ](https://github.com/umbraco/Umbraco.CMS.Backoffice/releases/tag/v14.0.0-rc3)
+* [Bellissima (frontend/backoffice) changes](https://github.com/umbraco/Umbraco.CMS.Backoffice/releases/tag/v14.0.0-rc3)
 * [Backend (CMS) changes](https://github.com/umbraco/Umbraco-CMS/releases/tag/release-14.0.0-rc3)
 
 **RC 2**
 
-* [Bellissima (frontend/backoffice) changes ](https://github.com/umbraco/Umbraco.CMS.Backoffice/releases/tag/v14.0.0-rc2)
+* [Bellissima (frontend/backoffice) changes](https://github.com/umbraco/Umbraco.CMS.Backoffice/releases/tag/v14.0.0-rc2)
 * [Backend (CMS) changes](https://github.com/umbraco/Umbraco-CMS/releases/tag/release-14.0.0-rc2)
 
 **RC 1**\
 First RC release - 17th of April. Breaking changes since Beta 3:
 
-* [Bellissima (frontend/backoffice) changes ](https://github.com/umbraco/Umbraco.CMS.Backoffice/releases/tag/v14.0.0-rc1)
+* [Bellissima (frontend/backoffice) changes](https://github.com/umbraco/Umbraco.CMS.Backoffice/releases/tag/v14.0.0-rc1)
 * [Backend (CMS) changes](https://github.com/umbraco/Umbraco-CMS/releases/tag/release-14.0.0-rc1)
 
 </details>
@@ -79,7 +78,7 @@ Below you can find the list of breaking changes introduced in Umbraco 14 Beta re
 
 **Beta 3**
 
-* [Bellissima (frontend/backoffice) changes ](https://github.com/umbraco/Umbraco.CMS.Backoffice/releases/tag/v14.0.0-beta003)
+* [Bellissima (frontend/backoffice) changes](https://github.com/umbraco/Umbraco.CMS.Backoffice/releases/tag/v14.0.0-beta003)
 * [Backend (CMS) changes](https://github.com/umbraco/Umbraco-CMS/releases/tag/release-14.0.0-beta003)
 
 **Beta 2**
@@ -92,7 +91,7 @@ There are a few breaking changes since **Beta 1**. Most of the changes concern p
 **Beta 1**\
 Official release of Beta, 6th March 2023.
 
-* [Bellissima (frontend/backoffice) changes ](https://github.com/umbraco/Umbraco.CMS.Backoffice/releases/tag/v14.0.0-beta001)
+* [Bellissima (frontend/backoffice) changes](https://github.com/umbraco/Umbraco.CMS.Backoffice/releases/tag/v14.0.0-beta001)
 * [Backend (CMS) changes](https://github.com/umbraco/Umbraco-CMS/releases/tag/release-14.0.0-beta001)
 
 </details>

--- a/14/umbraco-cms/implementation/controllers.md
+++ b/14/umbraco-cms/implementation/controllers.md
@@ -37,6 +37,10 @@ All implementations of Umbraco API Controllers inherit from the base class: `Umb
 
 For details on using Umbraco API Controllers, see the [Umbraco API Controllers](../reference/routing/umbraco-api-controllers/) article.
 
+{% hint style="warning" %}
+UmbracoApiController is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
+
 ## Umbraco Authorized Controllers and Attributes
 
 An Umbraco Authorized Controller is used when the controller requires member or user authentication (authN) and/or authorization (authZ). If either the `authN` or `authZ` fail, the controller will return a `401 - unauthorized response`.
@@ -45,14 +49,15 @@ An Umbraco Authorized Controller is used when the controller requires member or 
 
 The Umbraco Authorized controllers and attributes for Backoffice Users are:
 
-*   **MVC**
+* **MVC**
     There is no specific controller available to inherit from. We recommend inheriting from the basic `Umbraco.Cms.Web.Common.Controllers.UmbracoController` and applying the following attributes to your method:
-    - `[Authorize(Policy = AuthorizationPolicies.BackOfficeAccess)]`: Uses .NET authorization using the BackOfficeAccess policy. We recommend adding extra custom authorization policies for your endpoints.
-    - `[DisableBrowserCache]`: Tells the browser to not cache the result.
+  * `[Authorize(Policy = AuthorizationPolicies.BackOfficeAccess)]`: Uses .NET authorization using the BackOfficeAccess policy. We recommend adding extra custom authorization policies for your endpoints.
+  * `[DisableBrowserCache]`: Tells the browser to not cache the result.
 
     Remember to [add a route](../reference/routing/authorized.md#defining-a-route) for your controller.
 
-    #### Example custom authorized backoffice MVC Controller
+#### Example custom authorized backoffice MVC Controller
+
     ```csharp
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
@@ -73,8 +78,8 @@ The Umbraco Authorized controllers and attributes for Backoffice Users are:
         }
     }
     ```
-    
-*   **WebAPI**
+
+* **WebAPI**
 
     A base class implementation for authorized auto-routed Umbraco API controllers is inherited from: `Umbraco.Cms.Web.BackOffice.Controllers.UmbracoAuthorizedApiController`. This controller inherits from `Umbraco.Cms.Web.Common.Controllers.UmbracoApiController` it is auto-routed. This controller is also attributed with `Umbraco.Cms.Web.Common.Attributes.IsBackOfficeAttribute` to ensure that it is routed correctly to be authenticated for the backoffice.
 

--- a/14/umbraco-cms/implementation/unit-testing.md
+++ b/14/umbraco-cms/implementation/unit-testing.md
@@ -163,6 +163,10 @@ public class PageSurfaceControllerTests
 
 See [Reference documentation on UmbracoApiControllers](../reference/routing/umbraco-api-controllers/README.md#locally-declared-controller).
 
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
+
 ```csharp
 public class ProductsController : UmbracoApiController
 {

--- a/14/umbraco-cms/reference/cache/examples/tags.md
+++ b/14/umbraco-cms/reference/cache/examples/tags.md
@@ -108,6 +108,10 @@ Now you can inject `ICacheTagService` in any constructor in your project - wohoo
 
 Now that we have our service it's time to create an endpoint where we can fetch the (cached) tags.
 
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
+
 ```csharp
 using System;
 using System.Collections.Generic;

--- a/14/umbraco-cms/reference/common-pitfalls.md
+++ b/14/umbraco-cms/reference/common-pitfalls.md
@@ -54,6 +54,10 @@ So next time you are using a singleton pattern or a static, think "Why am I doin
 
 ## Static references to scoped instances (such as `UmbracoHelper`)
 
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
+
 **Example 1:**
 
 ```csharp

--- a/14/umbraco-cms/reference/management/services/create-a-new-user.md
+++ b/14/umbraco-cms/reference/management/services/create-a-new-user.md
@@ -6,7 +6,7 @@ description: This will show you how to add a user to a user group using the User
 
 ## Services property
 
-If you wish to use the UserService in a class that inherits from one of the Umbraco base classes. For example: `SurfaceController`, `UmbracoManagementApiControllerBase`, or `UmbracoAuthorizedApiController`). You can access the service through a local `Services` property:
+If you wish to use the UserService in a class that inherits from one of the Umbraco base classes. For example: `SurfaceController`, `UmbracoApiController`, or `UmbracoAuthorizedApiController`). You can access the service through a local `Services` property:
 
 ```csharp
 IUserService userService = Services.UserService;

--- a/14/umbraco-cms/reference/management/services/relationservice.md
+++ b/14/umbraco-cms/reference/management/services/relationservice.md
@@ -90,6 +90,10 @@ If I know `Save and Publish` my `Products` node I get the following result:
 
 Now let us try and fetch the data from an API.
 
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
+
 ```csharp
 using System;
 using System.Linq;

--- a/14/umbraco-cms/reference/mapping.md
+++ b/14/umbraco-cms/reference/mapping.md
@@ -12,7 +12,7 @@ UmbracoMapper was originally introduced to solve some issues in the Umbraco core
 
 ## Accessing the IUmbracoMapper
 
-The IUmbracoMapper is registered with Dependency Injection (DI). It can therefore be injected into constructors of controllers, custom classes etc, wherever DI is used. 
+The IUmbracoMapper is registered with Dependency Injection (DI). It can therefore be injected into constructors of controllers, custom classes etc, wherever DI is used.
 
 ## Mapping
 
@@ -188,6 +188,10 @@ The analyzer follows the standard analyzer development patterns, and building th
 ## Full example
 
 Below you will find a full example showing you how to map a collection of type Product to a collection of type ProductDto.
+
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
 
 ```csharp
 #region Models

--- a/14/umbraco-cms/reference/querying/imembermanager.md
+++ b/14/umbraco-cms/reference/querying/imembermanager.md
@@ -23,7 +23,7 @@ _memberManager.IsLoggedIn()
 
 ### Dependency Injection
 
-If you wish to use the `IMemberManager` in a class that inherits from one of the Umbraco base classes (eg. `SurfaceController`, `UmbracoManagementApiControllerBase`, or `UmbracoAuthorizedApiController`), you can use Dependency Injection. For instance, if you have registered your own class in Umbraco's dependency injection, you can specify the `IMemberManager` interface in your constructor:
+If you wish to use the `IMemberManager` in a class that inherits from one of the Umbraco base classes (eg. `SurfaceController`, `UmbracoApiController`, or `UmbracoAuthorizedApiController`), you can use Dependency Injection. For instance, if you have registered your own class in Umbraco's dependency injection, you can specify the `IMemberManager` interface in your constructor:
 
 ```csharp
 public class MemberAuthenticationSurfaceController : SurfaceController

--- a/14/umbraco-cms/reference/querying/itagquery.md
+++ b/14/umbraco-cms/reference/querying/itagquery.md
@@ -18,6 +18,10 @@ After this you can use `_tagQuery` to access the `ITagQuery`.
 
 If you're using it in controllers, you can inject it into the constructor like so:
 
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
+
 ```csharp
 using System.Collections.Generic;
 using System.Linq;
@@ -30,17 +34,17 @@ namespace UmbracoHelperDocs.Controllers;
 [Route("tags/[action]")]
 public class TagApiController : UmbracoApiController
 {
-	private readonly ITagQuery _tagQuery;
+ private readonly ITagQuery _tagQuery;
 
-	public TagApiController(ITagQuery tagQuery)
-	{
-		_tagQuery = tagQuery;
-	}
+ public TagApiController(ITagQuery tagQuery)
+ {
+  _tagQuery = tagQuery;
+ }
 
-	public ActionResult<IEnumerable<string>> GetMediaTags()
-	{
-		return _tagQuery.GetAllMediaTags().Select(tag => tag.Text).ToList();
-	}
+ public ActionResult<IEnumerable<string>> GetMediaTags()
+ {
+  return _tagQuery.GetAllMediaTags().Select(tag => tag.Text).ToList();
+ }
 }
 ```
 
@@ -58,8 +62,8 @@ Get a collection of tags used by content items on the site, you can optionally p
 
 ```csharp
 @{
-	var allContentTags = _tagQuery.GetAllContentTags();
-	var newsContentTags = _tagQuery.GetAllContentTags("news");
+ var allContentTags = _tagQuery.GetAllContentTags();
+ var newsContentTags = _tagQuery.GetAllContentTags("news");
 }
 ```
 
@@ -69,8 +73,8 @@ Get a collection of tags used by media items on the site, you can optionally pas
 
 ```csharp
 @{
-	var allMediaTags = _tagQuery.GetAllMediaTags();
-	var newsMediaTags = _tagQuery.GetAllMediaTags("news");
+ var allMediaTags = _tagQuery.GetAllMediaTags();
+ var newsMediaTags = _tagQuery.GetAllMediaTags("news");
 }
 ```
 
@@ -80,8 +84,8 @@ Get a collection of tags used by members on the site, you can optionally pass in
 
 ```csharp
 @{
-	var allMemberTags = _tagQuery.GetAllMemberTags();
-	var newsMemberTags = _tagQuery.GetAllMemberTags("news");
+ var allMemberTags = _tagQuery.GetAllMemberTags();
+ var newsMemberTags = _tagQuery.GetAllMemberTags("news");
 }
 ```
 
@@ -91,8 +95,8 @@ Get a collection of tags used on the site, you can optionally pass in a group na
 
 ```csharp
 @{
-	var allTags = _tagQuery.GetAllTags();
-	var allNewsTags = _tagQuery.GetAllTags("news");
+ var allTags = _tagQuery.GetAllTags();
+ var allNewsTags = _tagQuery.GetAllTags("news");
 }
 ```
 
@@ -102,7 +106,7 @@ Get a collection of IPublishedContent by tag, and you can optionally filter by t
 
 ```csharp
 @{
-	var taggedContent = _tagQuery.GetContentByTag("News");
+ var taggedContent = _tagQuery.GetContentByTag("News");
 }
 ```
 
@@ -112,7 +116,7 @@ Get a collection of IPublishedContent by tag group
 
 ```csharp
 @{
-	var taggedContent = _tagQuery.GetContentByTagGroup("BlogTags");
+ var taggedContent = _tagQuery.GetContentByTagGroup("BlogTags");
 }
 ```
 
@@ -122,7 +126,7 @@ Get a collection of Media by tag, and you can optionally filter by tag group as 
 
 ```csharp
 @{
-	var taggedMedia = _tagQuery.GetMediaByTag("BlogTag");
+ var taggedMedia = _tagQuery.GetMediaByTag("BlogTag");
 }
 ```
 
@@ -132,7 +136,7 @@ Get a collection of Media by tag group
 
 ```csharp
 @{
-	var mediaByTagGroup = _tagQuery.GetMediaByTagGroup("BlogTags");
+ var mediaByTagGroup = _tagQuery.GetMediaByTagGroup("BlogTags");
 }
 ```
 
@@ -142,7 +146,7 @@ Get a collection of tags by entity id (queries content, media and members), and 
 
 ```csharp
 @{
-	var tagsForEntity = _tagQuery.GetTagsForEntity(1234);
+ var tagsForEntity = _tagQuery.GetTagsForEntity(1234);
 }
 ```
 
@@ -152,6 +156,6 @@ Get a collection of tags assigned to a property of an entity (queries content, m
 
 ```csharp
 @{
-	var propertyTags = _tagQuery.GetTagsForProperty(1234, "propertyTypeAlias");
+ var propertyTags = _tagQuery.GetTagsForProperty(1234, "propertyTypeAlias");
 }
 ```

--- a/14/umbraco-cms/reference/querying/umbraco-context.md
+++ b/14/umbraco-cms/reference/querying/umbraco-context.md
@@ -18,6 +18,10 @@ If you need an `UmbracoContext` in your own controllers, you need to inject an `
 
 The following is an example of how to get access to the `UmbracoContext` in a controller:
 
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
+
 ``` csharp
 using System;
 using System.Collections.Generic;

--- a/14/umbraco-cms/reference/routing/umbraco-api-controllers/README.md
+++ b/14/umbraco-cms/reference/routing/umbraco-api-controllers/README.md
@@ -11,6 +11,10 @@ Related links:
 * [Umbraco API routes and Urls](routing.md)
 * [Umbraco API authorization](authorization.md)
 
+{% hint style="warning" %}
+UmbracoApiController is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
+
 ## What is Web API?
 
 The Microsoft Web API reference can be found on the [official ASP.NET Web API website](https://www.asp.net/web-api).

--- a/14/umbraco-cms/reference/routing/umbraco-api-controllers/authorization.md
+++ b/14/umbraco-cms/reference/routing/umbraco-api-controllers/authorization.md
@@ -2,9 +2,13 @@
 description: How to secure your Umbraco Api controllers
 ---
 
-# Umbraco ÀPI - Authorization
+# Umbraco API - Authorization
 
 _This section will describe how to secure your Umbraco Api controllers based on a users membership_
+
+{% hint style="warning" %}
+UmbracoApiController is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
 
 ## Authorizing for the backoffice
 
@@ -124,7 +128,7 @@ public class ProductsController : UmbracoApiController
 
 This will only allow member's belonging to the group VIP to access any actions on the controller:
 
-```
+```csharp
 [UmbracoMemberAuthorize("", "VIP", "")]
 public class ProductsController : UmbracoApiController
 {

--- a/14/umbraco-cms/reference/routing/umbraco-api-controllers/routing.md
+++ b/14/umbraco-cms/reference/routing/umbraco-api-controllers/routing.md
@@ -6,6 +6,10 @@ description: How api controllers are routed and how to retrieve their URLs
 
 _This section will describe how Umbraco Api controllers are routed and how to retrieve their URLs_
 
+{% hint style="warning" %}
+UmbracoApiController is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
+
 ## Routing
 
 Like Surface Controllers in Umbraco, when you inherit from the base class `Umbraco.Cms.Web.Common.Controllers.UmbracoApiController` we will auto-route this controller so you don't have to worry about routing at all.

--- a/14/umbraco-cms/reference/using-ioc.md
+++ b/14/umbraco-cms/reference/using-ioc.md
@@ -104,6 +104,7 @@ It is not required to have an interface for your dependency:
 ```csharp
 services.AddSingleton<Foobar>();
 ```
+
 {% endhint %}
 
 Now you can call your `AddCustomServices` in either the `Program.cs` file, or your composer like so:
@@ -165,6 +166,10 @@ Once you have registered your services, factories, helpers or whatever you need 
 
 If you need to inject your service into a controller, or another service, you'll do so through the class
 
+{% hint style="warning" %}
+The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+{% endhint %}
+
 ```csharp
 using IOCDocs.Services;
 using Umbraco.Cms.Web.Common.Controllers;
@@ -214,7 +219,7 @@ You might need to use services within your templates or views, fortunately, you 
 @inject IFooBar _fooBar
 
 @{
-	Layout = null;
+ Layout = null;
 }
 
 <h1>@_fooBar.Foo()</h1>

--- a/14/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
+++ b/14/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
@@ -243,7 +243,10 @@ To create, read, update, or delete data from your custom database tables, use th
 The example below creates a `UmbracoApiController` to be able to fetch and insert blog comments in a custom database table.
 
 {% hint style="warning" %}
-This example uses the `BlogComment` class, which is a database model. The recommended approach would be to map these over to a ViewModel instead, that way your database & UI layers are not coupled. Be aware that things like error handling and data validation have been omitted for brevity.
+
+* This example uses the `BlogComment` class, which is a database model. The recommended approach would be to map these over to a ViewModel instead, that way your database & UI layers are not coupled. Be aware that things like error handling and data validation have been omitted for brevity.
+* The example uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+
 {% endhint %}
 
 ```csharp


### PR DESCRIPTION
## Description

_What did you add/update/change?_
UmbracoApiController is brought back on v14 as obsolete but removed in v15 according to https://github.com/umbraco/Umbraco-CMS/pull/15863 so I am removing the hints from v13 and adding them to v14 instead. 
## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
cms v14

## Deadline (if relevant)

_When should the content be published?_
anytime