### PR TITLE
V13 - Cache refreshers: Added practical examples

### DIFF
--- a/13/umbraco-cms/reference/cache/README.md
+++ b/13/umbraco-cms/reference/cache/README.md
@@ -166,7 +166,6 @@ internal sealed class FavouriteThingsCacheRefresher(AppCaches appCaches,
 You can then invoke them on the injected `DistributedCache` object.
 
 ```c#
-using Serilog;
 using Umbraco.Cms.Core.Cache;
 
 namespace Our.Umbraco.FavouriteThings.Sync.NotificationHandlers;


### PR DESCRIPTION
## Description

The existing documentation on adding Cache Refreshing for load balancing was unclear to me. After figuring out how to implement it, I thought it would be helpful to update the documentation.

This PR improves the documentation by including practical examples of how to implement basic CacheRefreshers. With these examples I hope to help other developers better understand and apply the CacheRefreshers concept in their projects. 😃 

Additionally, I have added an example to the existing section about invoking CacheRefresher notifications.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [x] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
Umbraco CMS - V13 
