### PR TITLE
Reflect server cache changes for `umbraco-package.json` in docs

### DIFF
--- a/14/umbraco-cms/tutorials/creating-a-custom-dashboard/README.md
+++ b/14/umbraco-cms/tutorials/creating-a-custom-dashboard/README.md
@@ -89,7 +89,7 @@ At each step, you will find a dropdown for `welcome-dashboard.element.ts`, `and 
 For more information about the `umbraco-package.json` file, read the article [Package Manifest](../../extending/property-editors/package-manifest.md). For more information about the dashboard configurations read the [Dashboards](../../extending/dashboards.md) article.
 
 {% hint style="info" %}
-The `umbraco-package.json` files are cached by the server. If you are running your site in development mode, the cache is short-lived (~10 seconds). In case changes to `umbraco-package.json` files are not reflected immediately, try reloading the backoffice a few seconds later.
+The `umbraco-package.json` files are cached by the server. If you are running your site in development mode, the cache is short-lived (~10 seconds). If changes to `umbraco-package.json` files are not reflected immediately, try reloading the backoffice a few seconds later.
 
 When running the site in production mode, the cache is long-lived. You can read more about runtime modes in [this article](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/server-setup/runtime-modes).
 {% endhint %}

--- a/14/umbraco-cms/tutorials/creating-a-custom-dashboard/README.md
+++ b/14/umbraco-cms/tutorials/creating-a-custom-dashboard/README.md
@@ -89,7 +89,9 @@ At each step, you will find a dropdown for `welcome-dashboard.element.ts`, `and 
 For more information about the `umbraco-package.json` file, read the article [Package Manifest](../../extending/property-editors/package-manifest.md). For more information about the dashboard configurations read the [Dashboards](../../extending/dashboards.md) article.
 
 {% hint style="info" %}
-Please be aware that the file`umbraco-package.json` is loaded into memory when Umbraco starts up. If you are changing or adding new configurations you will need to start and stop your application for it to be loaded.
+The `umbraco-package.json` files are cached by the server. If you are running your site in development mode, the cache is short-lived (~10 seconds). In case changes to `umbraco-package.json` files are not reflected immediately, try reloading the backoffice a few seconds later.
+
+When running the site in production mode, the cache is long-lived. You can read more about runtime modes in [this article](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/server-setup/runtime-modes).
 {% endhint %}
 
 ## Creating the Dashboard Web Component

--- a/14/umbraco-cms/tutorials/creating-a-custom-dashboard/README.md
+++ b/14/umbraco-cms/tutorials/creating-a-custom-dashboard/README.md
@@ -91,7 +91,7 @@ For more information about the `umbraco-package.json` file, read the article [Pa
 {% hint style="info" %}
 The `umbraco-package.json` files are cached by the server. If you are running your site in development mode, the cache is short-lived (~10 seconds). If changes to `umbraco-package.json` files are not reflected immediately, try reloading the backoffice a few seconds later.
 
-When running the site in production mode, the cache is long-lived. You can read more about runtime modes in [this article](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/server-setup/runtime-modes).
+When running the site in production mode, the cache is long-lived. You can read more about runtime modes in the [Runtime Modes article](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/server-setup/runtime-modes).
 {% endhint %}
 
 ## Creating the Dashboard Web Component

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/README.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/README.md
@@ -69,7 +69,7 @@ At each step, you will find a dropdown for `suggestions-property-editor-ui.eleme
 {% endcode %}
 
 {% hint style="info" %}
-Make sure to restart the application after you create and update`umbraco-package.json`
+The `umbraco-package.json` files are cached by the server. When creating new `umbraco-package.json` files, it might take a few seconds before those are loaded into the server cache.
 {% endhint %}
 
 {% hint style="info" %}
@@ -121,7 +121,7 @@ Now our basic parts of the editor are done, namely:
 * The package manifest, telling Umbraco what to load
 * The web component for the editor
 
-4. Restart the application.
+4. Reload the backoffice.
 
 ## Registering the Data Type in Umbraco
 

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/adding-configuration-to-a-property-editor.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/adding-configuration-to-a-property-editor.md
@@ -170,7 +170,7 @@ You can use any Property Editor UI to define Configuration fields. The alias of 
 
 </details>
 
-3. Save the files and restart the application. Once it has restarted we can configure our Data Type:
+3. Save the files and reload the backoffice. We can now configure our Data Type:
 
 <figure><img src="images/suggestion-editor-config_3.png" alt=""><figcaption><p>Data Type configuration.</p></figcaption></figure>
 

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/adding-server-side-validation.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/adding-server-side-validation.md
@@ -133,7 +133,7 @@ With the Data Editor in place, update the Property Editor `propertyEditorSchemaA
 }
 ```
 
-Restart Umbraco. Open the "Suggestions" Data Type:
+Reload the backoffice and open the "Suggestions" Data Type:
 
 ![The Data Type with the new Data Editor registered](images/suggestion-editor-config_4.png)
 


### PR DESCRIPTION
## Description

[This PR](https://github.com/umbraco/Umbraco-CMS/pull/16393) changes how the server performs caching on `umbraco-package.json` files. TL;DR: It is no longer necessary to restart the Umbraco site when changing these files 😄 

I have updated the docs to reflect this cache change.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

V14 RC5

## Deadline (if relevant)

After today 😉 RC5 is (hopefully) going out today.
