### PR TITLE
v14 fix: should be "production" not "non-production"

### DIFF
--- a/14/umbraco-cms/reference/management-api/README.md
+++ b/14/umbraco-cms/reference/management-api/README.md
@@ -16,7 +16,7 @@ The Management API is a replacement for the backoffice controllers that lacked R
 
 ### Swagger Documentation
 
-Umbraco ships with Swagger to document the Management API. Swagger and the Swagger UI are based on [Swashbuckle.AspNetCore](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/) and is available at `{yourdomain}/umbraco/swagger`. For security reasons, both are disabled in non-production environments.
+Umbraco ships with Swagger to document the Management API. Swagger and the Swagger UI are based on [Swashbuckle.AspNetCore](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/) and is available at `{yourdomain}/umbraco/swagger`. For security reasons, both are disabled in production environments.
 
 The Swagger documentation allows you to select a definition and go to either Umbraco Management API or Content Delivery API. If you are extending the Management API with your own controllers, you can also create custom documentation for these in Swagger. See [Custom Swagger API](../custom-swagger-api.md) and [Creating a backoffice API](../../tutorials/creating-a-backoffice-api/) articles for details.
 


### PR DESCRIPTION
## Description

Swagger is disabled in production environments. This page incorrectly says it's disabled for **non**-production environments.
You can confirm this from the existing docs page that discusses the security of the [Content Delivery API](https://docs.umbraco.com/umbraco-cms/reference/api-versioning-and-openapi).

## Type of suggestion

* [X] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

v14

## Deadline (if relevant)

ASAP
