### PR TITLE
Removed u.UseInstallerEndpoints();  from the documentation for v14

### DIFF
--- a/14/umbraco-cms/extending/key-vault.md
+++ b/14/umbraco-cms/extending/key-vault.md
@@ -97,7 +97,6 @@ app.UseUmbraco()
     })
     .WithEndpoints(u =>
     {
-        u.UseInstallerEndpoints();
         u.UseBackOfficeEndpoints();
         u.UseWebsiteEndpoints();
     });

--- a/14/umbraco-cms/reference/routing/custom-routes.md
+++ b/14/umbraco-cms/reference/routing/custom-routes.md
@@ -21,7 +21,6 @@ app.UseUmbraco()
     {
         // This is where to put the custom routing
 
-        u.UseInstallerEndpoints();
         u.UseBackOfficeEndpoints();
         u.UseWebsiteEndpoints();
     });
@@ -232,7 +231,6 @@ app.UseUmbraco()
                 "/shop/{action}/{id?}",
                 new {Controller = "Shop", Action = "Index"});
 
-        u.UseInstallerEndpoints();
         u.UseBackOfficeEndpoints();
         u.UseWebsiteEndpoints();
     });
@@ -364,7 +362,6 @@ app.UseUmbraco()
     {
         u.EndpointRouteBuilder.MapControllers();
 
-        u.UseInstallerEndpoints();
         u.UseBackOfficeEndpoints();
         u.UseWebsiteEndpoints();
     });

--- a/14/umbraco-cms/reference/security/ssl-https.md
+++ b/14/umbraco-cms/reference/security/ssl-https.md
@@ -56,7 +56,6 @@ app.UseHttpsRedirection();
         })
         .WithEndpoints(u =>
         {
-            u.UseInstallerEndpoints();
             u.UseBackOfficeEndpoints();
             u.UseWebsiteEndpoints();
         });


### PR DESCRIPTION
## Description
From v14 u.UseInstallerEndpoints(); is not longer used in the program.cs file.

This PR removes the mention of this from the documentation.

Fixes #6151 

_What did you add/update/change?_

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
14


## Deadline (if relevant)
ASAP
_When should the content be published?_
