### PR TITLE
updated install docs for versions below v14

### DIFF
--- a/10/umbraco-cms/fundamentals/setup/install/README.md
+++ b/10/umbraco-cms/fundamentals/setup/install/README.md
@@ -12,7 +12,7 @@ The fastest way to get the latest version of Umbraco up and running is using the
 2. Install the Umbraco templates:
 
 ```bash
-dotnet new install Umbraco.Templates
+dotnet new install Umbraco.Templates::10.xx
 ```
 
 3. Create a new project:

--- a/12/umbraco-cms/fundamentals/setup/install/README.md
+++ b/12/umbraco-cms/fundamentals/setup/install/README.md
@@ -12,7 +12,7 @@ The fastest way to get the latest version of Umbraco up and running is using the
 2. Install the Umbraco templates:
 
 ```bash
-dotnet new install Umbraco.Templates
+dotnet new install Umbraco.Templates::12.xx
 ```
 
 3. Create a new project:

--- a/13/umbraco-cms/fundamentals/setup/install/README.md
+++ b/13/umbraco-cms/fundamentals/setup/install/README.md
@@ -12,7 +12,7 @@ The fastest way to get the latest version of Umbraco up and running is using the
 2. Install the Umbraco templates:
 
 ```bash
-dotnet new install Umbraco.Templates
+dotnet new install Umbraco.Templates::13.xx
 ```
 
 3. Create a new project:


### PR DESCRIPTION
## Description

The install docs for using the terminal was wrong and would result in installing v14 for versions below.

This PR fixes that.

Fixes #6160

_What did you add/update/change?_

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
10
12
13


## Deadline (if relevant)

_When should the content be published?_
