### PR TITLE
Updating the wording

### DIFF
--- a/14/umbraco-forms/developer/configuration/README.md
+++ b/14/umbraco-forms/developer/configuration/README.md
@@ -405,7 +405,7 @@ If you are rendering your forms dependency scripts using the `async` attribute, 
 
 Forms will by default track relations between forms and the content pages they are used on. This allows editors to see where forms are being used in their Umbraco website.
 
-If you would like to disable this feature, you can set the value of this setting to `false`.
+If you would like to enable this feature, you can set the value of this setting to `true`.
 
 ## TrackRenderedFormsStorageMethod
 


### PR DESCRIPTION
It's not intuitive to say to disable this feature, then set it to false, when it by default is set to false.

If they want to enable "DisableRelationTracking" they should set this to true

## Description

_What did you add/update/change?_

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
