### PR TITLE
Added details of VersionDependencyMode option in package owner data for Umbraco Marketplace

### DIFF
--- a/marketplace-and-integrations/marketplace/listing-your-package.md
+++ b/marketplace-and-integrations/marketplace/listing-your-package.md
@@ -184,7 +184,7 @@ Some packages though have no user interface component, and will likely work in U
 
 - Release a new version with a minimum dependency on Umbraco 14, or a maximum exclusive dependency on Umbraco 15.
 - Set this option in the `umbraco-marketplace.json` file to `SemVer`
-    - Via this setting you are indicating that we should take what is defined in NuGet as strictly correct. And as such we'll import the unlimited maximum and report you package as working on the latest major version of Umbraco.
+    - Via this setting you are indicating that we should take what is defined in NuGet as strictly correct. And as such, we'll import the unlimited maximum and report the package as working on any major version of Umbraco according to the semantic version range.
 
 ### Related Packages
 

--- a/marketplace-and-integrations/marketplace/listing-your-package.md
+++ b/marketplace-and-integrations/marketplace/listing-your-package.md
@@ -89,6 +89,7 @@ The [schema for the JSON file is available](https://marketplace.umbraco.com/umbr
       ],
       "Tags": [],
       "Title": "",
+      "VersionDependencyMode": "",
       "VersionSpecificPackageIds": [
         {
           "UmbracoMajorVersion": 8,
@@ -126,6 +127,7 @@ The [schema for the JSON file is available](https://marketplace.umbraco.com/umbr
 | **Screenshots**                                  | Object array     | A collection of screenshots for displaying on the package details page. Each element should consist of a URL to the image file and a short caption.                                                                                                                                                                                                                                                                                 |
 | **Tags**                                         | String array     | One or more package owner-defined tags for the package. Multiple word tags are supported, e.g. "property editor".                                                                                                                                                                                                                                                                                                                   |
 | **Title**                                        | String value     | The package title. If omitted, if a title is defined in the NuGet package details this will be used. Otherwise, the package ID itself is displayed.                                                                                                                                                                                                                                                                                 |
+| **VersionDependencyMode**                        | String value     | The version dependency mode for the package.                                                                                                                                                                                                                                                                                                                                                                                                                |
 | **VersionSpecificPackageIds**                    | Object array     | If a developer has created their package for older Umbraco versions under a different package ID, they can be listed here. Each element should contain an integer value for the Umbraco major version and the associated NuGet package ID.                                                                                                                                                                                          |
 | **Video URL**                                    | String value     | A URL to a video for embedding.                                                                                                                                                                                                                                                                                                                                                                                                     |
 
@@ -160,6 +162,29 @@ When defining the Package Type for your package, use one of the following values
 * Integration
 
 An "Integration" provides a connection between Umbraco and a third-party service that a customer has an account with. All other add-ons are considered as a "Package", which is also the default when nothing is specified for this value.
+
+### Version Dependency Mode
+
+When defining the Version Dependency Mode for your package, use one of the following values:
+
+* Default
+* SemVer
+
+Your Umbraco package will either have a direct or an indirect dependency on Umbraco, which will be reported via NuGet. We use this, across all versions of your package, to determine the minimum and maximum supported versions of Umbraco.
+
+In most cases, we take what we retrieve from NuGet and present that unaltered on the Marketplace.
+
+There is currently one exception though. Many packages are listed with a minimum version of Umbraco as a dependency, but no maximum. Strictly this means the package claims to support not just the minimum selected, but any subsequent major versions of Umbraco too. For major releases with minimal breaking changes, such as Umbraco 9 through 13, this is likely correct. So there is no problem in reporting this compatibility on the website.
+
+With the introduction of Umbraco 14 though, and the significant breaking change of the new backoffice, this is no longer likely to be true. We assume if a package has a minimum version or 13 or less, and an unlimited maximum, that it won't support Umbraco 14. And that's what we'll show on the Marketplace.
+
+For any package that makes backoffice customization, this is almost certainly correct.
+
+Some packages though have no user interface component, and will likely work in Umbraco 14 without modification. If that's the case for you, there are two options:
+
+- Release a new version with a minimum dependency on Umbraco 14, or a maximum exclusive dependency on Umbraco 15.
+- Set this option in the `umbraco-marketplace.json` file to `SemVer`
+    - Via this setting you are indicating that we should take what is defined in NuGet as strictly correct. And as such we'll import the unlimited maximum and report you package as working on the latest major version of Umbraco.
 
 ### Related Packages
 

--- a/marketplace-and-integrations/marketplace/listing-your-package.md
+++ b/marketplace-and-integrations/marketplace/listing-your-package.md
@@ -174,7 +174,7 @@ Your Umbraco package will either have a direct or an indirect dependency on Umbr
 
 In most cases, we take what we retrieve from NuGet and present that unaltered on the Marketplace.
 
-There is currently one exception though. Many packages are listed with a minimum version of Umbraco as a dependency, but no maximum. Strictly this means the package claims to support not just the minimum selected, but any subsequent major versions of Umbraco too. For major releases with minimal breaking changes, such as Umbraco 9 through 13, this is likely correct. So there is no problem in reporting this compatibility on the website.
+There is currently one exception though. Many packages are listed with a minimum version of Umbraco as a dependency, but no maximum. Strictly this means the package claims to support not only the minimum selected, but any subsequent major versions of Umbraco too. For major releases with minimal breaking changes, such as Umbraco 9 through 13, this is likely correct. So there is no problem in reporting this compatibility on the website.
 
 With the introduction of Umbraco 14 though, and the significant breaking change of the new backoffice, this is no longer likely to be true. We assume if a package has a minimum version or 13 or less, and an unlimited maximum, that it won't support Umbraco 14. And that's what we'll show on the Marketplace.
 


### PR DESCRIPTION
## Description

Added details of a new `VersionDependencyMode` option in package owner data for Umbraco Marketplace.

Relates to this PR: https://github.com/umbraco/Umbraco.Marketplace/pull/172

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [X] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Umbraco Marketplace

## Deadline (if relevant)

Can go live any time from next week.
