### PR TITLE
Fixes the delivery API details documented for Forms 14

### DIFF
--- a/14/umbraco-forms/.gitbook/assets/umbraco_forms_swagger.json
+++ b/14/umbraco-forms/.gitbook/assets/umbraco_forms_swagger.json
@@ -6,7 +6,7 @@
     "version": "Latest"
   },
   "paths": {
-    "/umbraco/forms/api/v1/definitions/{id}": {
+    "/umbraco/forms/delivery/api/v1/definitions/{id}": {
       "get": {
         "tags": [
           "Forms"
@@ -73,7 +73,7 @@
         }
       }
     },
-    "/umbraco/forms/api/v1/entries/{id}": {
+    "/umbraco/forms/delivery/api/v1/entries/{id}": {
       "post": {
         "tags": [
           "Forms"


### PR DESCRIPTION
## Description

Fixes the delivery API details documented for Forms 14

At least I think so.  I can't tell locally unfortunately but hopefully you can see this resolves the problems with rendering the Forms delivery API details at https://docs.umbraco.com/umbraco-forms/developer/ajaxforms

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [X] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Forms 14

## Deadline (if relevant)

Can go live any time.
