### PR TITLE
Add warning to Document Type Localization

### DIFF
--- a/14/umbraco-cms/fundamentals/data/defining-content/document-type-localization.md
+++ b/14/umbraco-cms/fundamentals/data/defining-content/document-type-localization.md
@@ -4,6 +4,10 @@ description: Here you will learn how to apply localization for Document Types in
 
 # Document Type Localization
 
+{% hint style="warning" %}
+This article is a work in progress and may undergo further revisions, updates, or amendments. The information contained herein is subject to change without notice.
+{% endhint %}
+
 The Umbraco backoffice is fully localized to match the user's [configured language](../users.md). When defining Document Types, you can apply localization to:
 
 * Document Type names and descriptions.


### PR DESCRIPTION
## Description

Document Type Localization has changed a lot for V14, so the [current article](https://docs.umbraco.com/umbraco-cms/fundamentals/data/defining-content/document-type-localization) is no longer correct. I have added a warning to it 😄 

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

V14

## Deadline (if relevant)

Whenever. Not urgent 😄 