### PR TITLE
Fixed broken link

### DIFF
--- a/14/umbraco-cms/reference/routing/umbraco-api-controllers/README.md
+++ b/14/umbraco-cms/reference/routing/umbraco-api-controllers/README.md
@@ -33,7 +33,7 @@ public class ProductsController : Controller
 {% hint style="warning" %}
 In Umbraco 13 and below, the recommended approach was to base API controllers on the `UmbracoApiController` class. However, `UmbracoApiController` is obsolete in Umbraco 14 and will be removed in Umbraco 15.
 
-Read the article [Porting old Umbraco APIs](authorization.md) for more details.
+Read the article [Porting old Umbraco APIs](porting-old-umbraco-apis.md) for more details.
 {% endhint %}
 
 ## Adding member protection to public APIs


### PR DESCRIPTION
## Description

The link in the warning was referencing the wrong article. I've made sure the correct article is referenced.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [x] Other
