### PR TITLE
Add reference to the id field in the example umbraco-package.json file.

### DIFF
--- a/14/umbraco-cms/tutorials/creating-a-property-editor/adding-configuration-to-a-property-editor.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/adding-configuration-to-a-property-editor.md
@@ -105,7 +105,8 @@ You can use any Property Editor UI to define Configuration fields. The alias of 
 ```json
 {
     "$schema": "../../umbraco-package-schema.json",
-    "name": "My.AwesomePackage",
+    "id": "My.AwesomePackage",
+    "name": "My Awesome Package",
     "version": "0.1.0",
     "extensions": [
         {


### PR DESCRIPTION
## Description

Add reference to the id field in the example umbraco-package.json file.  By providing this we are able to better match up a package's install data available from telemetry in order to order it by this metric on the Umbraco Marketplace.

This should in time be documented properly, as really this is just a passing reference to the file as part of a page focussed mostly on other topics.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [X] Other

## Product & version (if relevant)

Umbraco 14

## Deadline (if relevant)

No urgency.
