### PR TITLE
Update limit-orderline-quantity.md

### DIFF
--- a/13/umbraco-commerce/how-to-guides/limit-orderline-quantity.md
+++ b/13/umbraco-commerce/how-to-guides/limit-orderline-quantity.md
@@ -30,7 +30,7 @@ public class ProductAddValidationHandler : ValidationEventHandlerBase<ValidateOr
 
         var stock = _productService.GetProductStock(evt.Order.StoreId, productReference);
 
-        if (stock.HasValue && order.Quantity > stock.Value)
+        if (stock.HasValue && evt.Quantity > stock.Value)
             evt.Fail($"Only {stock} quantities can be purchased for {productReference}.");
     }
 }

--- a/13/umbraco-commerce/how-to-guides/limit-orderline-quantity.md
+++ b/13/umbraco-commerce/how-to-guides/limit-orderline-quantity.md
@@ -30,9 +30,7 @@ public class ProductAddValidationHandler : ValidationEventHandlerBase<ValidateOr
 
         var stock = _productService.GetProductStock(evt.Order.StoreId, productReference);
 
-        var totalQuantities = order?.OrderLines.Where(x => x.ProductReference == productReference).Sum(x => x.Quantity) ?? 0;
-
-        if (stock.HasValue && totalQuantities >= stock.Value)
+        if (stock.HasValue && order.Quantity > stock.Value)
             evt.Fail($"Only {stock} quantities can be purchased for {productReference}.");
     }
 }

--- a/13/umbraco-commerce/how-to-guides/limit-orderline-quantity.md
+++ b/13/umbraco-commerce/how-to-guides/limit-orderline-quantity.md
@@ -28,7 +28,7 @@ public class ProductAddValidationHandler : ValidationEventHandlerBase<ValidateOr
         var order = evt.Order;
         var productReference = evt.ProductReference;
 
-        var stock = _productService.GetProductStock(productReference);
+        var stock = _productService.GetProductStock(evt.Order.StoreId, productReference);
 
         var totalQuantities = order?.OrderLines.Where(x => x.ProductReference == productReference).Sum(x => x.Quantity) ?? 0;
 
@@ -58,7 +58,7 @@ public class OrderLineQuantityValidationHandler : ValidationEventHandlerBase<Val
         var orderLine = evt.OrderLine;
         var productReference = orderLine.ProductReference;
 
-        var stock = _productService.GetProductStock(productReference);
+        var stock = _productService.GetProductStock(evt.Order.StoreId, productReference);
 
         if (stock.HasValue && evt.Quantity.To > stock.Value)
             evt.Fail($"Only {stock} quantities can be purchased for {productReference}.");


### PR DESCRIPTION
## Description

`_productService.GetProductStock()` does not have a method accepting a single argument, so updated to use `_productService.GetProductStock(evt.Order.StoreId, productReference)` - include `storeId`.

AddProduct handlers was also checking orderlines for quantity but orderlines are empty, and checking stock value incorrectly.

## Product & version (if relevant)
Umbraco 13.3.0
Umbraco.Commerce 13.1.1