### PR TITLE
Corrected typo in "Setting the Navigation Menu"

### DIFF
--- a/14/umbraco-cms/tutorials/creating-a-basic-website/setting-the-navigation-menu.md
+++ b/14/umbraco-cms/tutorials/creating-a-basic-website/setting-the-navigation-menu.md
@@ -38,7 +38,7 @@ You now have the following snippet in your **Master** Template:
 
 This snippet will now need to be merged with the navigation above it.
 
-The `<ul>` tag needs to be wrapped inside the `<class>` and `<nav>` tags, and the classes need to be added to the correct tags as well.
+The `<ul>` tag needs to be wrapped inside the `<div class="container">` and `<nav>` tags, and the classes need to be added to the correct tags as well.
 
 The final result will look like this:
 


### PR DESCRIPTION
Corrected typo in [Setting the Navigation Menu](https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-basic-website/setting-the-navigation-menu). Fixes #6158.

## Description

Original:
"The \<ul> tag needs to be wrapped inside the \<class> and \<nav> tags"

Fix:
"The \<ul> tag needs to be wrapped inside the \<div class="container"> and \<nav> tags"

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
