### PR TITLE
Remove note from Content Delivery API article

### DIFF
--- a/14/umbraco-cms/reference/content-delivery-api/README.md
+++ b/14/umbraco-cms/reference/content-delivery-api/README.md
@@ -10,34 +10,6 @@ The Content Delivery API delivers headless capabilities built directly into Umbr
 
 The Delivery API is an opt-in feature of Umbraco. It must be explicitly enabled through configuration before it can be utilized.
 
-<details>
-
-<summary>Register the Content Delivery API dependencies - <mark style="color:red;"><strong>Only for Version 12 or below</strong></mark></summary>
-
-Umbraco projects started on version 11 or below also need to opt-in through code to use the Content Delivery API. Follow the steps below to see how to opt-in through code:
-
-1. Open your project's `Startup.cs` file and locate the `ConfigureServices` method.
-2. Register the API dependencies by adding `.AddDeliveryApi()`:
-
-```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    services.AddUmbraco(_env, _config)
-        .AddBackOffice()
-        .AddWebsite()
-        // Register all Delivery API dependencies
-        .AddDeliveryApi()
-        .AddComposers()
-        .Build();
-}
-```
-
-From version 13 and above, the Content Delivery API is added by default in `Program.cs`.
-
-The next step is to enable the Content Delivery API in `appsettings.json`. Follow the next section [Enable the Content Delivery API](./#enable-the-content-delivery-api) for this.
-
-</details>
-
 ### Enable the Content Delivery API
 
 1. Open your project's `appsettings.json`.


### PR DESCRIPTION
## Description

The note in the article that mentions Umbraco 12 has been removed.
It remains for version 13, but no longer makes sense for 14.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

