### PR TITLE
Ensure SQLite connection strings are consistent across docs

### DIFF
--- a/10/umbraco-commerce/how-to-guides/configure-sqlite-support.md
+++ b/10/umbraco-commerce/how-to-guides/configure-sqlite-support.md
@@ -34,9 +34,9 @@ After configuring Umbraco CMS with SQLite, Umbraco Commerce will automatically u
 {
     ...
     "ConnectionStrings": {
-        "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
+        "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Private;Foreign Keys=True;Pooling=True",
         "umbracoDbDSN_ProviderName": "Microsoft.Data.SQLite",
-        "umbracoCommerceDbDSN": "Data Source=|DataDirectory|/Umbraco.Commerce.sqlite.db;Mode=ReadWrite;Foreign Keys=True;Pooling=True;Cache=Shared",
+        "umbracoCommerceDbDSN": "Data Source=|DataDirectory|/Umbraco.Commerce.sqlite.db;Mode=ReadWrite;Foreign Keys=True;Pooling=True;Cache=Private",
         "umbracoCommerceDbDSN_ProviderName": "Microsoft.Data.SQLite"
     },
     ...

--- a/12/umbraco-cms/fundamentals/setup/install/unattended-install.md
+++ b/12/umbraco-cms/fundamentals/setup/install/unattended-install.md
@@ -47,7 +47,7 @@ It is recommended that you make use of the values shown below for the `Cache`, `
 ```json
 {
   "ConnectionStrings": {
-    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
+    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Private;Foreign Keys=True;Pooling=True",
     "umbracoDbDSN_ProviderName": "Microsoft.Data.SQLite"
   }
 }

--- a/12/umbraco-commerce/how-to-guides/configure-sqlite-support.md
+++ b/12/umbraco-commerce/how-to-guides/configure-sqlite-support.md
@@ -34,9 +34,9 @@ When you have set up Umbraco CMS to use SQLite, the above is all you need to do 
 {
     ...
     "ConnectionStrings": {
-        "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
+        "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Private;Foreign Keys=True;Pooling=True",
         "umbracoDbDSN_ProviderName": "Microsoft.Data.SQLite",
-        "umbracoCommerceDbDSN": "Data Source=|DataDirectory|/Umbraco.Commerce.sqlite.db;Mode=ReadWrite;Foreign Keys=True;Pooling=True;Cache=Shared",
+        "umbracoCommerceDbDSN": "Data Source=|DataDirectory|/Umbraco.Commerce.sqlite.db;Mode=ReadWrite;Foreign Keys=True;Pooling=True;Cache=Private",
         "umbracoCommerceDbDSN_ProviderName": "Microsoft.Data.SQLite"
     },
     ...

--- a/13/umbraco-cms/fundamentals/setup/install/unattended-install.md
+++ b/13/umbraco-cms/fundamentals/setup/install/unattended-install.md
@@ -47,7 +47,7 @@ It is recommended that you make use of the values shown below for the `Cache`, `
 ```json
 {
   "ConnectionStrings": {
-    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
+    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Private;Foreign Keys=True;Pooling=True",
     "umbracoDbDSN_ProviderName": "Microsoft.Data.SQLite"
   }
 }

--- a/13/umbraco-commerce/how-to-guides/configure-sqlite-support.md
+++ b/13/umbraco-commerce/how-to-guides/configure-sqlite-support.md
@@ -34,9 +34,9 @@ After configuring Umbraco CMS with SQLite, Umbraco Commerce will automatically u
 {
     ...
     "ConnectionStrings": {
-        "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
+        "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Private;Foreign Keys=True;Pooling=True",
         "umbracoDbDSN_ProviderName": "Microsoft.Data.SQLite",
-        "umbracoCommerceDbDSN": "Data Source=|DataDirectory|/Umbraco.Commerce.sqlite.db;Mode=ReadWrite;Foreign Keys=True;Pooling=True;Cache=Shared",
+        "umbracoCommerceDbDSN": "Data Source=|DataDirectory|/Umbraco.Commerce.sqlite.db;Mode=ReadWrite;Foreign Keys=True;Pooling=True;Cache=Private",
         "umbracoCommerceDbDSN_ProviderName": "Microsoft.Data.SQLite"
     },
     ...

--- a/14/umbraco-cms/fundamentals/setup/install/unattended-install.md
+++ b/14/umbraco-cms/fundamentals/setup/install/unattended-install.md
@@ -47,7 +47,7 @@ It is recommended that you make use of the values shown below for the `Cache`, `
 ```json
 {
   "ConnectionStrings": {
-    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
+    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Private;Foreign Keys=True;Pooling=True",
     "umbracoDbDSN_ProviderName": "Microsoft.Data.SQLite"
   }
 }

--- a/14/umbraco-commerce/how-to-guides/configure-sqlite-support.md
+++ b/14/umbraco-commerce/how-to-guides/configure-sqlite-support.md
@@ -34,9 +34,9 @@ After configuring Umbraco CMS with SQLite, Umbraco Commerce will automatically u
 {
     ...
     "ConnectionStrings": {
-        "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
+        "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Private;Foreign Keys=True;Pooling=True",
         "umbracoDbDSN_ProviderName": "Microsoft.Data.SQLite",
-        "umbracoCommerceDbDSN": "Data Source=|DataDirectory|/Umbraco.Commerce.sqlite.db;Mode=ReadWrite;Foreign Keys=True;Pooling=True;Cache=Shared",
+        "umbracoCommerceDbDSN": "Data Source=|DataDirectory|/Umbraco.Commerce.sqlite.db;Mode=ReadWrite;Foreign Keys=True;Pooling=True;Cache=Private",
         "umbracoCommerceDbDSN_ProviderName": "Microsoft.Data.SQLite"
     },
     ...


### PR DESCRIPTION
## Description

As per #4649, the preferred cache mode is Private. However, most examples across the docs still recommend Shared. This fixes that.

## Type of suggestion

* [ ] Typo/grammar fix
* [X] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other
