### PR TITLE
Adding redirects for articles removed/renamed with Umbraco 14

### DIFF
--- a/14/umbraco-cms/.gitbook.yaml
+++ b/14/umbraco-cms/.gitbook.yaml
@@ -74,3 +74,16 @@ redirects:
     fundamentals/design/partial-view-macro-files: reference/templating/macros.md
     reference/templating/macros/managing-macros: reference/templating/macros.md
     reference/templating/macros/partial-view-macros: reference/templating/macros.md
+    fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/nested-content: fundamentals/backoffice/property-editors/README.md
+    fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout/build-your-own-editor: fundamentals/backoffice/property-editors/README.md
+    fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout/grid-editors: fundamentals/backoffice/property-editors/README.md
+    fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout: fundamentals/backoffice/property-editors/README.md
+    fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout/add-value-programmatically: fundamentals/backoffice/property-editors/README.md
+    fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout/grid-editors/configuring-the-grid-layout-datatype: fundamentals/backoffice/property-editors/README.md
+    fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout/grid-editors/settings-and-styles: fundamentals/backoffice/property-editors/README.md
+    fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout/grid-editors/build-your-own-editor: fundamentals/backoffice/property-editors/README.md
+    fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout/grid-editors/render-grid-in-template: fundamentals/backoffice/property-editors/README.md
+    fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout/grid-editors/grid-layout-best-practices: fundamentals/backoffice/property-editors/README.md
+    fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout/grid-editors/what-are-grid-layouts: fundamentals/backoffice/property-editors/README.md
+    fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/media-picker: fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/media-picker-3.md
+

--- a/14/umbraco-cms/.gitbook.yaml
+++ b/14/umbraco-cms/.gitbook.yaml
@@ -69,4 +69,8 @@ redirects:
     extending/backoffice-ui-api-documentation: extending/ui-documentation.md
     reference/configuration/richtexteditorsettings: fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/configuration.md
     extending/section-trees/trees/tree-actions: extending/section-trees/trees/entity-actions
-
+    extending/macro-parameter-editors: reference/templating/macros.md
+    extending/health-check/guides/macroerrors: reference/templating/macros.md
+    fundamentals/design/partial-view-macro-files: reference/templating/macros.md
+    reference/templating/macros/managing-macros: reference/templating/macros.md
+    reference/templating/macros/partial-view-macros: reference/templating/macros.md

--- a/14/umbraco-cms/.gitbook.yaml
+++ b/14/umbraco-cms/.gitbook.yaml
@@ -86,4 +86,10 @@ redirects:
     fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout/grid-editors/grid-layout-best-practices: fundamentals/backoffice/property-editors/README.md
     fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/grid-layout/grid-editors/what-are-grid-layouts: fundamentals/backoffice/property-editors/README.md
     fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/media-picker: fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/media-picker-3.md
-
+    reference/notifications/contentypeservice-notifications: reference/notifications/README.md
+    reference/notifications/datatypeservice-notifications: reference/notifications/README.md
+    reference/notifications/fileservice-notifications: reference/notifications/README.md
+    reference/notifications/localizationservice-notifications: reference/notifications/README.md
+    reference/notifications/mediatypeservice-notifications: reference/notifications/README.md
+    reference/notifications/membertypeservice-notifications: reference/notifications/README.md
+    reference/notifications/relationservice-notifications: reference/notifications/README.md

--- a/14/umbraco-cms/.gitbook.yaml
+++ b/14/umbraco-cms/.gitbook.yaml
@@ -96,3 +96,5 @@ redirects:
     tutorials/editors-manual/working-with-content/rich-text-editor: tutorials/editors-manual/working-with-content.md
     fundamentals/backoffice/content-templates: fundamentals/backoffice/document-blueprints.md
     reference/configuration/runtimeminificationsettings: reference/configuration/README.md
+    reference/routing/umbraco-api-controllers/authorization: reference/routing/umbraco-api-controllers/README.md
+    reference/routing/umbraco-api-controllers/routing: reference/routing/umbraco-api-controllers/README.md

--- a/14/umbraco-cms/.gitbook.yaml
+++ b/14/umbraco-cms/.gitbook.yaml
@@ -50,3 +50,12 @@ redirects:
     reference/management/services/retrieving-content-types: reference/management/using-services/contenttypeservice.md
     reference/management/services/retrieving-languages: reference/management/using-services/localizationservice.md
     reference/management/services/managing-users: reference/management/using-services/userservice.md
+    reference/angular: extending/ui-documentation.md
+    reference/angular/directives: extending/ui-documentation.md
+    reference/angular/directives/umbproperty: extending/ui-documentation.md
+    reference/angular/directives/umbloadindicator: extending/ui-documentation.md
+    reference/angular/directives/umblayoutselector: extending/ui-documentation.md
+    reference/angular/services: extending/ui-documentation.md
+    reference/angular/services/editorservice: extending/ui-documentation.md
+    reference/angular/services/eventsservice: extending/ui-documentation.md
+    reference/angular/services/eventsservice/changetitle: extending/ui-documentation.md

--- a/14/umbraco-cms/.gitbook.yaml
+++ b/14/umbraco-cms/.gitbook.yaml
@@ -63,7 +63,7 @@ redirects:
     reference/angular/services/editorservice: extending/ui-documentation.md
     reference/angular/services/eventsservice: extending/ui-documentation.md
     reference/angular/services/eventsservice/changetitle: extending/ui-documentation.md
-    extending/content-apps: fundamentals/backoffice/document-blueprints.md
+    extending/content-apps: extending/workspaces/workspace-editor-views.md
     extending-backoffice/localization: extending/language-files/ui-localization.md
     extending/ui-library: extending/ui-documentation.md
     extending/backoffice-ui-api-documentation: extending/ui-documentation.md
@@ -93,3 +93,6 @@ redirects:
     reference/notifications/mediatypeservice-notifications: reference/notifications/README.md
     reference/notifications/membertypeservice-notifications: reference/notifications/README.md
     reference/notifications/relationservice-notifications: reference/notifications/README.md
+    tutorials/editors-manual/working-with-content/rich-text-editor: tutorials/editors-manual/working-with-content.md
+    fundamentals/backoffice/content-templates: fundamentals/backoffice/document-blueprints.md
+    reference/configuration/runtimeminificationsettings: reference/configuration/README.md

--- a/14/umbraco-cms/.gitbook.yaml
+++ b/14/umbraco-cms/.gitbook.yaml
@@ -46,10 +46,14 @@ redirects:
     reference/management/services/consentservice: reference/management/using-services/consentservice.md
     reference/management/services/mediaservice: reference/management/using-services/mediaservice.md
     reference/management/services/relationservice: reference/management/using-services/relationservice.md
+    reference/management/services/contentservice/create-content-programmatically: reference/management/using-services/contentservice.md
     reference/management/services/create-content-programmatically: reference/management/using-services/contentservice.md
+    reference/management/services/contenttypeservice/retrieving-content-types: reference/management/using-services/contenttypeservice.md
     reference/management/services/retrieving-content-types: reference/management/using-services/contenttypeservice.md
+    reference/management/services/localizationservice/retrieving-languages: reference/management/using-services/localizationservice.md
     reference/management/services/retrieving-languages: reference/management/using-services/localizationservice.md
     reference/management/services/managing-users: reference/management/using-services/userservice.md
+    reference/management/services/userservice/create-a-new-user: reference/management/using-services/userservice.md
     reference/angular: extending/ui-documentation.md
     reference/angular/directives: extending/ui-documentation.md
     reference/angular/directives/umbproperty: extending/ui-documentation.md
@@ -59,3 +63,10 @@ redirects:
     reference/angular/services/editorservice: extending/ui-documentation.md
     reference/angular/services/eventsservice: extending/ui-documentation.md
     reference/angular/services/eventsservice/changetitle: extending/ui-documentation.md
+    extending/content-apps: fundamentals/backoffice/document-blueprints.md
+    extending-backoffice/localization: extending/language-files/ui-localization.md
+    extending/ui-library: extending/ui-documentation.md
+    extending/backoffice-ui-api-documentation: extending/ui-documentation.md
+    reference/configuration/richtexteditorsettings: fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/configuration.md
+    extending/section-trees/trees/tree-actions: extending/section-trees/trees/entity-actions
+

--- a/14/umbraco-cms/extending/ui-documentation.md
+++ b/14/umbraco-cms/extending/ui-documentation.md
@@ -8,6 +8,12 @@ description: Find out more about Umbraco UI Library, UI API and Storybook.
 
 With the UI Library, you get a collection of visual building blocks that consists of pieces to build any UI in Umbraco. Each component is a building block updating its display according to the data passed to it.
 
+{% hint style="info" %}
+**Are you looking for the AngularJS documentation?**
+
+With Umbraco 14 the Umbraco backoffice has been rebuilt using Vite, Lit and Typescript. This means that AngularJS is no longer being used in Umbraco CMS, hence the removal of the corresponding documentation.
+{% endhint %}
+
 With the UI API, you get a set of collections related to modules export, interfaces, and hierarchy. This includes code examples and much more that you can use to extend the backoffice.
 
 <table data-card-size="large" data-view="cards" data-full-width="false"><thead><tr><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th><th data-hidden data-card-cover data-type="files"></th></tr></thead><tbody><tr><td><a href="https://apidocs.umbraco.com/v14/ui/"><strong>Backoffice UI Library</strong></a></td><td>See, test, and get a feel for the familiar backoffice components built using the new UI components.</td><td><a href="https://apidocs.umbraco.com/v14/ui/">https://apidocs.umbraco.com/v14/ui/</a></td><td><a href="../.gitbook/assets/Documentations Icons_Umbraco_CMS_Fundamentals_Backoffice (1) (2).png">Documentations Icons_Umbraco_CMS_Fundamentals_Backoffice (1) (2).png</a></td></tr><tr><td><a href="https://apidocs.umbraco.com/v14/ui-api/index.html"><strong>Backoffice UI API</strong></a></td><td>See what all of the modules export, interfaces, hierarchy, code examples, and much more.</td><td><a href="https://apidocs.umbraco.com/v14/ui-api/index.html">https://apidocs.umbraco.com/v14/ui-api/index.html</a></td><td><a href="../.gitbook/assets/Documentations Icons_Umbraco_CMS_Tutorials_the_Starter_Kit (1).png">Documentations Icons_Umbraco_CMS_Tutorials_the_Starter_Kit (1).png</a></td></tr></tbody></table>

--- a/14/umbraco-cms/fundamentals/backoffice/property-editors/README.md
+++ b/14/umbraco-cms/fundamentals/backoffice/property-editors/README.md
@@ -8,6 +8,17 @@ description: >-
 
 A Property Editor is the editor that a Data Type references. A Data Type is defined by a user in the Umbraco backoffice and references a Property Editor. In Umbraco a Property Editor is defined in a JSON manifest file and associated JavaScript files.
 
+{% hint style="info" %}
+**Are you looking for the Grid Layout or Nested Content?**
+
+The following Property Editors have been removed with the release of Umbraco 14:
+
+* Grid Layout
+* Nested content
+
+We recommend using the [Block Editor](built-in-umbraco-property-editors/block-editor/README.md) or the [Rich Text Editor Blocks](built-in-umbraco-property-editors/rich-text-editor/rte-blocks.md) instead.
+{% endhint %}
+
 When creating a Data Type, specify the property editor for the Data Type to use by selecting from the "Property editor" list (as shown below).
 
 ![Data Type Definition](/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/images/Media-picker-dataType.png)

--- a/14/umbraco-cms/reference/configuration/README.md
+++ b/14/umbraco-cms/reference/configuration/README.md
@@ -8,6 +8,14 @@ Umbraco uses the .NET built-in configuration pattern. This means that the config
 
 For more in depth information on the configuration pattern see Microsofts [Configuration in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-6.0) article.
 
+{% hint style="info" %}
+**Are you looking for the RuntimeMinificationSettings?**
+
+Smidge, which held the RuntimeMinificationSettings configuration, was removed with the release of Umbraco 14.
+
+You can install the Smidge package separately if needed. Learn more and see how to get started in [the official Smidge documentation](https://github.com/Shazwazza/Smidge).
+{% endhint %}
+
 ## Managing Configuration
 
 You might not always want to have the configuration stored in the `appsettings.json` file, for instance, you might not want to have the admin password in the file if using the unattended feature. You might also want to use a specific set of configurations when developing your solution. To achieve this, the `IConfiguration` pattern can be used for this.

--- a/14/umbraco-cms/reference/configuration/README.md
+++ b/14/umbraco-cms/reference/configuration/README.md
@@ -4,7 +4,7 @@ description: Information on configuring Umbraco
 
 # Configuration
 
-In Umbraco 9+, we have moved away from the previous configuration using `.config` files, to instead using the .NET built-in configuration pattern. This means that there is no longer separate files for different configuration, the configuration is now primarily done using `IConfiguration` with diffent sources. E.g. The `appsettings.json` file.
+Umbraco uses the .NET built-in configuration pattern. This means that the configuration is handled in the `appsettings.json` file and primarily done using `IConfiguration` with diffent sources.
 
 For more in depth information on the configuration pattern see Microsofts [Configuration in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-6.0) article.
 

--- a/14/umbraco-cms/reference/routing/umbraco-api-controllers/README.md
+++ b/14/umbraco-cms/reference/routing/umbraco-api-controllers/README.md
@@ -6,6 +6,12 @@ description: A guide to implementing APIs in Umbraco projects
 
 This article describes how to work with API Controllers in Umbraco to create REST services.
 
+{% hint style="warning" %}
+In Umbraco 13 and below, the recommended approach was to base API controllers on the `UmbracoApiController` class. However, `UmbracoApiController` is obsolete in Umbraco 14 and will be removed in Umbraco 15.
+
+Read the article [Porting old Umbraco APIs](porting-old-umbraco-apis.md) for more details.
+{% endhint %}
+
 ## What is an API?
 
 The Microsoft ASP.NET Core API documentation is a great place to familiarize yourself with API concepts. It can be found on the [official ASP.NET Core site](https://dotnet.microsoft.com/en-us/apps/aspnet/apis).
@@ -29,12 +35,6 @@ public class ProductsController : Controller
 }
 ```
 {% endcode %}
-
-{% hint style="warning" %}
-In Umbraco 13 and below, the recommended approach was to base API controllers on the `UmbracoApiController` class. However, `UmbracoApiController` is obsolete in Umbraco 14 and will be removed in Umbraco 15.
-
-Read the article [Porting old Umbraco APIs](porting-old-umbraco-apis.md) for more details.
-{% endhint %}
 
 ## Adding member protection to public APIs
 

--- a/14/umbraco-cms/reference/templating/macros.md
+++ b/14/umbraco-cms/reference/templating/macros.md
@@ -1,0 +1,9 @@
+# Macros and Partial View Macros
+
+{% hint style="warning" %}
+**Are you looking for documentation about Macros and/or Partial View Macros?
+
+Macros and Partial View Macros have been removed with the release of Umbraco 14.
+
+We recommend using using [Partial Views](../../fundamentals/design/partial-views.md) or [Blocks in the Rich Text Editor](../../fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/rte-blocks.md) as a replacement.
+{% endhint %}

--- a/14/umbraco-cms/reference/templating/macros.md
+++ b/14/umbraco-cms/reference/templating/macros.md
@@ -6,4 +6,6 @@
 Macros and Partial View Macros have been removed with the release of Umbraco 14.
 
 We recommend using using [Partial Views](../../fundamentals/design/partial-views.md) or [Blocks in the Rich Text Editor](../../fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/rte-blocks.md) as a replacement.
+
+Learn more about the decision for remove Macros in the official announcement: [Breaking change: Macros will be removed in Umbraco 14](https://github.com/umbraco/Announcements/issues/14).
 {% endhint %}


### PR DESCRIPTION
## Description

- I've added redirects for all the deleted and renamed articles
- I've added notes to landing pages where some of the redirects lead
- Removed the mention of v9 from the Configuration landing page
- Added back the Macros article to inform users about the removed of the feature

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Umbraco CMS
