### PR TITLE
Redirect for renamed Trees/Tree-Actions

### DIFF
--- a/14/umbraco-cms/.gitbook.yaml
+++ b/14/umbraco-cms/.gitbook.yaml
@@ -68,7 +68,7 @@ redirects:
     extending/ui-library: extending/ui-documentation.md
     extending/backoffice-ui-api-documentation: extending/ui-documentation.md
     reference/configuration/richtexteditorsettings: fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/configuration.md
-    extending/section-trees/trees/tree-actions: extending/section-trees/trees/entity-actions
+    extending/section-trees/trees/tree-actions: extending/section-trees/trees/entity-actions.md
     extending/macro-parameter-editors: reference/templating/macros.md
     extending/health-check/guides/macroerrors: reference/templating/macros.md
     fundamentals/design/partial-view-macro-files: reference/templating/macros.md
@@ -98,5 +98,3 @@ redirects:
     reference/configuration/runtimeminificationsettings: reference/configuration/README.md
     reference/routing/umbraco-api-controllers/authorization: reference/routing/umbraco-api-controllers/README.md
     reference/routing/umbraco-api-controllers/routing: reference/routing/umbraco-api-controllers/README.md
-    extending/section-trees/trees/tree-actions: extending/section-trees/trees/entity-actions.md
-    

--- a/14/umbraco-cms/.gitbook.yaml
+++ b/14/umbraco-cms/.gitbook.yaml
@@ -99,3 +99,4 @@ redirects:
     reference/routing/umbraco-api-controllers/authorization: reference/routing/umbraco-api-controllers/README.md
     reference/routing/umbraco-api-controllers/routing: reference/routing/umbraco-api-controllers/README.md
     extending/section-trees/trees/tree-actions: extending/section-trees/trees/entity-actions.md
+    

--- a/14/umbraco-cms/.gitbook.yaml
+++ b/14/umbraco-cms/.gitbook.yaml
@@ -98,3 +98,4 @@ redirects:
     reference/configuration/runtimeminificationsettings: reference/configuration/README.md
     reference/routing/umbraco-api-controllers/authorization: reference/routing/umbraco-api-controllers/README.md
     reference/routing/umbraco-api-controllers/routing: reference/routing/umbraco-api-controllers/README.md
+    extending/section-trees/trees/tree-actions: extending/section-trees/trees/entity-actions.md

--- a/14/umbraco-cms/SUMMARY.md
+++ b/14/umbraco-cms/SUMMARY.md
@@ -188,7 +188,6 @@
   * [Property Actions](extending/property-editors/property-actions.md)
   * [Build a Block Editor](extending/property-editors/build-a-block-editor.md)
   * [Tracking References](extending/property-editors/tracking.md)
-  * [Declaring your property editor](extending/property-editors/declaring-your-property-editor.md)
   * [Content Picker Value Converter Example](extending/property-editors/full-examples-value-converters.md)
 * [Health Check](extending/health-check/README.md)
   * [Health Check Guides](extending/health-check/guides/README.md)

--- a/14/umbraco-cms/extending/property-editors/declaring-your-property-editor.md
+++ b/14/umbraco-cms/extending/property-editors/declaring-your-property-editor.md
@@ -1,2 +1,0 @@
-# Declaring your property editor
-


### PR DESCRIPTION
## Description

Tree Actions were renamed Entity Actions.
I've added a redirect in order to present the user with the correct content.

Also removed the "Declaring your property editor" correctly from the SUMMARY file 💪 

