### PR TITLE
Link to section on same page

### DIFF
--- a/12/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api.md
+++ b/12/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api.md
@@ -367,7 +367,7 @@ The Delivery API Swagger document can be configured to support member authentica
 
 Before we can do that, we need two things in place:
 
-1. We have to implement a login page [as described above](./#logging-in-members).
+1. We have to implement a login page [as described above](#logging-in-members).
 2. We must add `https://{server-host}/umbraco/swagger/oauth2-redirect.html` to the configured `LoginRedirectUrls`.
 
 With these in place, we can enable member authentication in Swagger for the Delivery API by adding the following to `Startup.cs`:


### PR DESCRIPTION
## Description

Current "We have to implement a login page `[as described above]`" part links to a level up https://docs.umbraco.com/umbraco-cms/v/12.latest/reference/content-delivery-api#logging-in-members instead of same page https://docs.umbraco.com/umbraco-cms/v/12.latest/reference/content-delivery-api/protected-content-in-the-delivery-api#logging-in-members

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
