### PR TITLE
Update webhook events

### DIFF
--- a/13/umbraco-cms/reference/webhooks/README.md
+++ b/13/umbraco-cms/reference/webhooks/README.md
@@ -120,6 +120,7 @@ builder.WebhookEvents().Clear().AddCms(false);
 ```
 
 ## Replace Webhook Events
+
 Sometimes it is desirable to modify one of the standard Umbraco webhooks, for example, to change the Payload. This can be done by adding a custom implementation, as shown in the code example below:
 
 ```csharp

--- a/13/umbraco-cms/reference/webhooks/README.md
+++ b/13/umbraco-cms/reference/webhooks/README.md
@@ -28,7 +28,7 @@ Events are when a given action happens, by default there are 5 events you can ch
 - Media Saved - This event happens whenever a media item is saved.
 
 ## Content type
-If you have selected a Content or Media event, you can specify if you only want your webhook to fire with a given Document or Media type.
+If you have selected a Content or Media event, you can specify your preferences. You can choose to trigger your webhook only for a given Document or Media type.
 
 For example, if you have selected `Content Published` event. You can then specify that you only want the webhook to fire, when the content is of a given content type.
 

--- a/14/umbraco-cms/reference/webhooks/README.md
+++ b/14/umbraco-cms/reference/webhooks/README.md
@@ -1,5 +1,5 @@
 ﻿---
-description: Umbraco webhooks enable seamless integration and real-time updates by notifying external services about content changes and events within the Umbraco CMS.
+description: Umbraco webhooks enable seamless integration and real-time updates by notifying external services about content changes and events within the Umbraco CMS
 ---
 
 # Webhooks
@@ -128,6 +128,57 @@ This is a list of all the current events that are available through Umbraco. If 
 
 ```csharp
 builder.WebhookEvents().Clear().AddCms(false);
+```
+
+## Replace Webhook Events
+
+Sometimes it is desirable to modify one of the standard Umbraco webhooks, for example, to change the Payload. This can be done by adding a custom implementation, as shown in the code example below:
+
+```csharp
+[WebhookEvent("Content Published", Constants.WebhookEvents.Types.Content)]
+public class MyCustomContentPublishedWebhookEvent : WebhookEventContentBase<ContentPublishedNotification, IContent>
+{
+    private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
+    private readonly IApiContentBuilder _apiContentBuilder;
+
+
+    public MyCustomContentPublishedWebhookEvent(IWebhookFiringService webhookFiringService, IWebhookService webhookService, IOptionsMonitor<WebhookSettings> webhookSettings, IServerRoleAccessor serverRoleAccessor, IPublishedSnapshotAccessor publishedSnapshotAccessor, IApiContentBuilder apiContentBuilder) : base(webhookFiringService, webhookService, webhookSettings, serverRoleAccessor)
+    {
+        _publishedSnapshotAccessor = publishedSnapshotAccessor;
+        _apiContentBuilder = apiContentBuilder;
+    }
+
+    public override string Alias => "Umbraco.ContentPublish";
+    protected override IEnumerable<IContent> GetEntitiesFromNotification(ContentPublishedNotification notification) => notification.PublishedEntities;
+
+    protected override object? ConvertEntityToRequestPayload(IContent entity)
+    {
+        if (_publishedSnapshotAccessor.TryGetPublishedSnapshot(out IPublishedSnapshot? publishedSnapshot) is false || publishedSnapshot!.Content is null)
+        {
+            return null;
+        }
+
+        IPublishedContent? publishedContent = publishedSnapshot.Content.GetById(entity.Key);
+
+        return new
+        {
+            MyData = "Your data",
+            PublishedContent = publishedContent is null ? null : _apiContentBuilder.Build(publishedContent)
+        };
+    }
+}
+```
+
+Add the following line in a Composer to replace the standard Umbraco implementation with your custom implementation:
+
+```csharp
+public class MyComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.WebhookEvents().Replace<ContentPublishedWebhookEvent, MyCustomContentPublishedWebhookEvent>();
+    }
+}
 ```
 
 ### Webhook Settings


### PR DESCRIPTION
## Description

Update webhook events:

* [x] Write shorter sentence 
* [x] Explain how to replace a default webhook with own implementation
 
For now, I have only updated the v13 version because I know you are working on all the v14 documentation. Of course, I am willing to update this as well, but could you please let me know when this is possible or allowed?

## Type of suggestion

* [x] New content
* [x] Styleguide

## Product & version (if relevant)
Umbraco v13 