### PR TITLE
Add redirect for package manifest file

### DIFF
--- a/14/umbraco-cms/.gitbook.yaml
+++ b/14/umbraco-cms/.gitbook.yaml
@@ -98,3 +98,4 @@ redirects:
     reference/configuration/runtimeminificationsettings: reference/configuration/README.md
     reference/routing/umbraco-api-controllers/authorization: reference/routing/umbraco-api-controllers/README.md
     reference/routing/umbraco-api-controllers/routing: reference/routing/umbraco-api-controllers/README.md
+    extending/property-editors/package-manifest: extending/package-manifest.md


### PR DESCRIPTION
## Description

The package manifest file was recently moved further up in the tree structure.
This was done via GitBook so the rewrite should work, however, I've received reports that this is not the case after all.

This PR adds the redirect manually.
