### PR TITLE
Add release notes for Deploy 13.1.1 and 14.0.2

### DIFF
--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -20,7 +20,7 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 #### [13.1.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.1) (July 11th 2024)
 
 * Add `[DisableRequestSizeLimit]` attribute to `UploadForImport` endpoint to remove application request size limit (server/infrastructure restrictions may still apply)
-* Determine missing `routePath` based on `$routeParams` to fix Export, Queue for transfer and Partial Restore actions on items with children in a list view
+* Determine missing `routePath` based on `$routeParams` to fix Export, Queue for transfer, and Partial Restore actions on items with children in a list view
 * Set trashed state when processing content (https://github.com/umbraco/Umbraco.Deploy.Issues/issues/223)
 * Improve exception message when parent can't be found when getting artifact (https://github.com/umbraco/Umbraco.Deploy.Issues/issues/216)
 

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -22,7 +22,7 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 * Add `[DisableRequestSizeLimit]` attribute to `UploadForImport` endpoint to remove application request size limit (server/infrastructure restrictions may still apply)
 * Determine missing `routePath` based on `$routeParams` to fix Export, Queue for transfer, and Partial Restore actions on items with children in a list view
 * Set trashed state when processing content [223](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/223)
-* Improve exception message when parent can't be found when getting artifact (https://github.com/umbraco/Umbraco.Deploy.Issues/issues/216)
+* Improve exception message when parent cannot be found when getting artifact [216](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/216)
 
 #### [13.1.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.0) (March 19th 2024)
 

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -21,7 +21,7 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 
 * Add `[DisableRequestSizeLimit]` attribute to `UploadForImport` endpoint to remove application request size limit (server/infrastructure restrictions may still apply)
 * Determine missing `routePath` based on `$routeParams` to fix Export, Queue for transfer, and Partial Restore actions on items with children in a list view
-* Set trashed state when processing content (https://github.com/umbraco/Umbraco.Deploy.Issues/issues/223)
+* Set trashed state when processing content [223](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/223)
 * Improve exception message when parent can't be found when getting artifact (https://github.com/umbraco/Umbraco.Deploy.Issues/issues/216)
 
 #### [13.1.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.0) (March 19th 2024)

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -17,6 +17,13 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 13 including all changes for this version.
 
+#### [13.1.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.1) (July 11th 2024)
+
+* Add `[DisableRequestSizeLimit]` attribute to `UploadForImport` endpoint to remove application request size limit (server/infrastructure restrictions may still apply)
+* Determine missing `routePath` based on `$routeParams` to fix Export, Queue for transfer and Partial Restore actions on items with children in a list view
+* Set trashed state when processing content (https://github.com/umbraco/Umbraco.Deploy.Issues/issues/223)
+* Improve exception message when parent can't be found when getting artifact (https://github.com/umbraco/Umbraco.Deploy.Issues/issues/216)
+
 #### [13.1.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.0) (March 19th 2024)
 
 * All items from 13.1.0-rc1

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -21,8 +21,8 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 
 * Add `[DisableRequestSizeLimit]` attribute to `UploadForImport` endpoint to remove application request size limit (server/infrastructure restrictions may still apply)
 * Determine missing `routePath` based on `$routeParams` to fix Export, Queue for transfer, and Partial Restore actions on items with children in a list view
-* Set trashed state when processing content [223](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/223)
-* Improve exception message when parent cannot be found when getting artifact [216](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/216)
+* Set trashed state when processing content [#223](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/223)
+* Improve exception message when parent cannot be found when getting artifact [#216](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/216)
 
 #### [13.1.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.0) (March 19th 2024)
 

--- a/14/umbraco-deploy/getting-started/deploy-settings.md
+++ b/14/umbraco-deploy/getting-started/deploy-settings.md
@@ -48,6 +48,7 @@ For illustration purposes, the following structure represents the full set of op
             "DiskOperationsTimeout": "0.0:05:00",
             "SourceDeployBatchSize": null,
             "PackageBatchSize": null,
+            "MaxRequestLength": null,
             "UseDatabaseBackedTransferQueue": true,
             "IgnoreBrokenDependenciesBehavior": "Restore",
             "AcceptInvalidCertificates": false,
@@ -179,6 +180,12 @@ If encountering this issue, there are two batch settings that can be applied wit
 
 * `SourceDeployBatchSize` - applies a batch setting for the transfer of multiple selected items to an upstream environment (such as a media folder with many images).
 * `PackageBatchSize` - applies a batch setting to the processing of a Deploy "package", which contains all the items selected for a Deploy operation, plus all the determined dependencies and relations.
+
+### MaxRequestLength
+
+When Deploy transfers files between environments that can't connect to each other (like a local environment that isn't exposed publicly), it falls back from fetching/downloading the files to uploading them. This is done in fixed-sized chunks, so multiple files can be combined in a single request or a large file into multiple requests. This setting can specify the size of these chuncks **(in bytes)**.
+
+If no value is set, Deploy will create 16MB chunks, unless the [CMS `MaxRequestLength` setting](../../umbraco-cms/reference/configuration/runtimesettings.md) is set to a lower value (note that the CMS setting is configured in kilobytes). Setting this to a value higher than the CMS `MaxRequestLength` (multiplied by 1024) will cause a validation error. Similarly, configuring a value that is higher than the [server or infrastructure allows](../../umbraco-cms/reference/configuration/maximumuploadsizesettings.md) will result in file transfers failing.
 
 ### UseDatabaseBackedTransferQueue
 

--- a/14/umbraco-deploy/getting-started/deploy-settings.md
+++ b/14/umbraco-deploy/getting-started/deploy-settings.md
@@ -183,9 +183,9 @@ If encountering this issue, there are two batch settings that can be applied wit
 
 ### MaxRequestLength
 
-When Deploy transfers files between environments that can't connect to each other (like a local environment that isn't exposed publicly), it falls back from fetching/downloading the files to uploading them. This is done in fixed-sized chunks, so multiple files can be combined in a single request or a large file into multiple requests. This setting can specify the size of these chuncks **(in bytes)**.
+When Deploy transfers files between unconnected environments (like a non-public local environment), it falls back from fetching/downloading the files to uploading them. This is done in fixed-sized chunks, so multiple files can be combined in a single request or a large file into multiple requests. This setting can specify the size of these chunks **(in bytes)**.
 
-If no value is set, Deploy will create 16MB chunks, unless the [CMS `MaxRequestLength` setting](../../umbraco-cms/reference/configuration/runtimesettings.md) is set to a lower value (note that the CMS setting is configured in kilobytes). Setting this to a value higher than the CMS `MaxRequestLength` (multiplied by 1024) will cause a validation error. Similarly, configuring a value that is higher than the [server or infrastructure allows](../../umbraco-cms/reference/configuration/maximumuploadsizesettings.md) will result in file transfers failing.
+If no value is set, Deploy will create 16MB chunks, unless the [CMS `MaxRequestLength` setting](../../umbraco-cms/reference/configuration/runtimesettings.md) is lower (CMS setting is configured in kilobytes). Setting a value higher than the CMS `MaxRequestLength` (multiplied by 1024) will cause a validation error. Similarly, configuring a value higher than the [server or infrastructure limits](../../umbraco-cms/reference/configuration/maximumuploadsizesettings.md) will result in file transfers failures.
 
 ### UseDatabaseBackedTransferQueue
 

--- a/14/umbraco-deploy/release-notes.md
+++ b/14/umbraco-deploy/release-notes.md
@@ -20,10 +20,10 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 
 #### [14.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.2) (July 11th 2024)
 
-* Set trashed state when processing content [223](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/223)
-* Improve exception message when parent can't be found when getting artifact [216](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/216)
+* Set trashed state when processing content [#223](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/223)
+* Improve exception message when parent can't be found when getting artifact [#216](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/216)
 * Add `MaxRequestLength` Deploy setting to break file upload into multiple requests
-* Set variant names when creating new content [222](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/222)
+* Set variant names when creating new content [#222](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/222)
 
 #### [14.0.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.1) (June 6th 2024)
 

--- a/14/umbraco-deploy/release-notes.md
+++ b/14/umbraco-deploy/release-notes.md
@@ -20,10 +20,10 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 
 #### [14.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.2) (July 11th 2024)
 
-* Set trashed state when processing content (https://github.com/umbraco/Umbraco.Deploy.Issues/issues/223)
-* Improve exception message when parent can't be found when getting artifact (https://github.com/umbraco/Umbraco.Deploy.Issues/issues/216)
+* Set trashed state when processing content [223](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/223)
+* Improve exception message when parent can't be found when getting artifact [216](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/216)
 * Add `MaxRequestLength` Deploy setting to break file upload into multiple requests
-* Set variant names when creating new content (https://github.com/umbraco/Umbraco.Deploy.Issues/issues/222)
+* Set variant names when creating new content [222](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/222)
 
 #### [14.0.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.1) (June 6th 2024)
 

--- a/14/umbraco-deploy/release-notes.md
+++ b/14/umbraco-deploy/release-notes.md
@@ -18,6 +18,13 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 13 including all changes for this version.
 
+#### [14.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.2) (July 11th 2024)
+
+* Set trashed state when processing content (https://github.com/umbraco/Umbraco.Deploy.Issues/issues/223)
+* Improve exception message when parent can't be found when getting artifact (https://github.com/umbraco/Umbraco.Deploy.Issues/issues/216)
+* Add `MaxRequestLength` Deploy setting to break file upload into multiple requests
+* Set variant names when creating new content (https://github.com/umbraco/Umbraco.Deploy.Issues/issues/222)
+
 #### [14.0.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.1) (June 6th 2024)
 
 * Ensure remote tree uses correct entity type (if multiple entities like folders and items are present in a tree):


### PR DESCRIPTION
## Description

Add release notes for Deploy 13.1.1 and 14.0.2.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [x] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Deploy 13.1.1 and 14.0.2.

## Deadline (if relevant)

Thursday July 11th (the patches are already released to NuGet)
