### PR TITLE
Add Deploy 13.2.0-rc1 and 14.1.0-rc1, Deploy Contrib 4.4.0-rc1, 10.3.0-rc1, 12.2.0-rc1, 13.2.0-rc1 and 14.1.0-rc1 release notes

### DIFF
--- a/10/umbraco-deploy/release-notes.md
+++ b/10/umbraco-deploy/release-notes.md
@@ -489,7 +489,7 @@ This section contains the release notes for Umbraco Deploy 4 and 10 including al
 
 #### [4.4.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-4.4.0-rc1) (July 19th 2024)
 
-* Skip empty pre-values in [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
+* Skip empty pre-values [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
 * Add DocTypeGridEditor Data Type configuration connector [#65](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/65)
 
 #### [4.3.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-4.3.0) (March 16th 2024)

--- a/10/umbraco-deploy/release-notes.md
+++ b/10/umbraco-deploy/release-notes.md
@@ -450,6 +450,11 @@ This section contains the release notes for Umbraco Deploy 4 and 10 including al
 
 ## Deploy Contrib
 
+#### [10.3.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-10.3.0-rc1) (July 19th 2024)
+
+* Skip empty pre-values in [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
+* Add DocTypeGridEditor data type configuration connector in [#65](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/65)
+
 #### [10.2.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-10.2.0 (March 19th 2024)
 
 * All items from 10.2.0-rc1
@@ -481,6 +486,15 @@ This section contains the release notes for Umbraco Deploy 4 and 10 including al
 
 <details>
 <summary>Version 4</summary>
+
+#### [4.4.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-4.4.0-rc1) (July 19th 2024)
+
+* Skip empty pre-values in [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
+* Add DocTypeGridEditor data type configuration connector in [#65](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/65)
+
+#### [4.3.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-4.3.0) (March 16th 2024)
+
+* All items from 4.3.0-rc1
 
 #### [4.3.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-4.3.0-rc1) (March 5th 2024)
 

--- a/10/umbraco-deploy/release-notes.md
+++ b/10/umbraco-deploy/release-notes.md
@@ -490,7 +490,7 @@ This section contains the release notes for Umbraco Deploy 4 and 10 including al
 #### [4.4.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-4.4.0-rc1) (July 19th 2024)
 
 * Skip empty pre-values in [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
-* Add DocTypeGridEditor data type configuration connector in [#65](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/65)
+* Add DocTypeGridEditor Data Type configuration connector [#65](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/65)
 
 #### [4.3.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-4.3.0) (March 16th 2024)
 

--- a/10/umbraco-deploy/release-notes.md
+++ b/10/umbraco-deploy/release-notes.md
@@ -452,8 +452,8 @@ This section contains the release notes for Umbraco Deploy 4 and 10 including al
 
 #### [10.3.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-10.3.0-rc1) (July 19th 2024)
 
-* Skip empty pre-values in [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
-* Add DocTypeGridEditor data type configuration connector in [#65](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/65)
+* Skip empty pre-values [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
+* Add DocTypeGridEditor Data Type configuration connector [#65](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/65)
 
 #### [10.2.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-10.2.0 (March 19th 2024)
 

--- a/12/umbraco-deploy/release-notes.md
+++ b/12/umbraco-deploy/release-notes.md
@@ -122,7 +122,12 @@ This section contains the release notes for Umbraco Deploy 12 including all chan
 
 ## Deploy Contrib
 
-#### [12.1.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-12.1.0 (March 19th 2024)
+#### [12.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-12.2.0-rc1) (July 19th 2024)
+
+* Skip empty pre-values in [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
+* Add DocTypeGridEditor data type configuration connector in [#65](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/65)
+
+#### [12.1.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-12.1.0) (March 19th 2024)
 
 * All items from 10.2.0-rc1
 

--- a/12/umbraco-deploy/release-notes.md
+++ b/12/umbraco-deploy/release-notes.md
@@ -125,7 +125,7 @@ This section contains the release notes for Umbraco Deploy 12 including all chan
 #### [12.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-12.2.0-rc1) (July 19th 2024)
 
 * Skip empty pre-values in [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
-* Add DocTypeGridEditor data type configuration connector in [#65](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/65)
+* Add DocTypeGridEditor Data Type configuration connector [#65](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/65)
 
 #### [12.1.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-12.1.0) (March 19th 2024)
 

--- a/12/umbraco-deploy/release-notes.md
+++ b/12/umbraco-deploy/release-notes.md
@@ -124,7 +124,7 @@ This section contains the release notes for Umbraco Deploy 12 including all chan
 
 #### [12.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-12.2.0-rc1) (July 19th 2024)
 
-* Skip empty pre-values in [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
+* Skip empty pre-values [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
 * Add DocTypeGridEditor Data Type configuration connector [#65](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/65)
 
 #### [12.1.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-12.1.0) (March 19th 2024)

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -17,6 +17,10 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 13 including all changes for this version.
 
+#### [13.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.0) (July 19th 2024)
+
+* Add migrators to support legacy Grid layout to Block Grid migration
+
 #### [13.1.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.1) (July 11th 2024)
 
 * Add `[DisableRequestSizeLimit]` attribute to `UploadForImport` endpoint to remove application request size limit (server/infrastructure restrictions may still apply)

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -106,9 +106,9 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 
 #### [13.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.2.0-rc1) (July 19th 2024)
 
-* Skip empty pre-values in [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
-* Add Matryoshka Group Separator artifact migrator in [#67](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/67)
-* Add migrators to support DocTypeGridEditor to Block Grid migration in [#66](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/66)
+* Skip empty pre-values [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
+* Add Matryoshka Group Separator artifact migrator [#67](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/67)
+* Add migrators to support DocTypeGridEditor to Block Grid migration [#66](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/66)
 
 #### [13.1.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.1.0) (March 19th 2024)
 

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -104,7 +104,13 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 
 ## Deploy Contrib
 
-#### [13.1.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.1.0 (March 19th 2024)
+#### [13.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.2.0-rc1) (July 19th 2024)
+
+* Skip empty pre-values in [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
+* Add Matryoshka Group Separator artifact migrator in [#67](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/67)
+* Add migrators to support DocTypeGridEditor to Block Grid migration in [#66](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/66)
+
+#### [13.1.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.1.0) (March 19th 2024)
 
 * All items from 10.2.0-rc1
 

--- a/14/umbraco-deploy/release-notes.md
+++ b/14/umbraco-deploy/release-notes.md
@@ -18,6 +18,14 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 13 including all changes for this version.
 
+#### [14.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.0) (July 19th 2024)
+
+* Add migrators to support legacy Grid layout to Block Grid migration
+* Fix schema mismatch when saving templates in production runtime mode [#228](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/228)
+* Add default migrator to add missing editor UI aliases and update when replacing editor
+* Add default migrator to update data type configuration
+* Support processing document/media type list view keys and add migrator
+
 #### [14.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.2) (July 11th 2024)
 
 * Set trashed state when processing content [#223](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/223)

--- a/14/umbraco-deploy/release-notes.md
+++ b/14/umbraco-deploy/release-notes.md
@@ -53,6 +53,12 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 
 ## Deploy Contrib
 
+#### [14.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-14.1.0-rc1) (July 19th 2024)
+
+* Add Matryoshka Group Separator artifact migrator in [#67](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/67)
+* Add migrators to support DocTypeGridEditor to Block Grid migration in [#66](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/66)
+* Fix and enable remaining legacy artifact migrators in [#68](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/68)
+
 #### [14.0.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-14.0.0) (May 30th 2024)
 
 * Compatibility with Umbraco 14 and Deploy 14.

--- a/14/umbraco-deploy/release-notes.md
+++ b/14/umbraco-deploy/release-notes.md
@@ -23,7 +23,7 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 * Add migrators to support legacy Grid layout to Block Grid migration
 * Fix schema mismatch when saving templates in production runtime mode [#228](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/228)
 * Add default migrator to add missing editor UI aliases and update when replacing editor
-* Add default migrator to update data type configuration
+* Add default migrator to update Data Type configuration
 * Support processing document/media type list view keys and add migrator
 
 #### [14.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.2) (July 11th 2024)

--- a/14/umbraco-deploy/release-notes.md
+++ b/14/umbraco-deploy/release-notes.md
@@ -55,9 +55,9 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 
 #### [14.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-14.1.0-rc1) (July 19th 2024)
 
-* Add Matryoshka Group Separator artifact migrator in [#67](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/67)
-* Add migrators to support DocTypeGridEditor to Block Grid migration in [#66](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/66)
-* Fix and enable remaining legacy artifact migrators in [#68](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/68)
+* Add Matryoshka Group Separator artifact migrator [#67](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/67)
+* Add migrators to support DocTypeGridEditor to Block Grid migration [#66](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/66)
+* Fix and enable remaining legacy artifact migrators [#68](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/68)
 
 #### [14.0.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-14.0.0) (May 30th 2024)
 

--- a/14/umbraco-deploy/release-notes.md
+++ b/14/umbraco-deploy/release-notes.md
@@ -24,7 +24,7 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 * Fix schema mismatch when saving templates in production runtime mode [#228](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/228)
 * Add default migrator to add missing editor UI aliases and update when replacing editor
 * Add default migrator to update Data Type configuration
-* Support processing document/media type list view keys and add migrator
+* Support processing Document/Media Type list view keys and add migrator
 
 #### [14.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.2) (July 11th 2024)
 


### PR DESCRIPTION
## Description

Release notes for the first RC release of Deploy and Deploy Contrib minors.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Deploy 13.2.0-rc1 and 14.1.0-rc1
Deploy Contrib 4.4.0-rc1, 10.3.0-rc1, 12.2.0-rc1, 13.2.0-rc1 and 14.1.0-rc1

## Deadline (if relevant)

Friday July 19th (the releases have already been published to NuGet)
