### PR TITLE
Typo in example on label-property-configuration.md

### DIFF
--- a/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/label-property-configuration.md
+++ b/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/label-property-configuration.md
@@ -6,7 +6,7 @@ Previous versions of Umbraco used AngularJS expressions and filters for advanced
 With the removal of AngularJS in Umbraco 14, this has been replaced using native web components. Advanced label rendering is done using [Umbraco Flavored Markdown](../../../../../reference/umbraco-flavored-markdown.md).
 {% endhint %}
 
-When configuring a Block, the label property allows you to define a label for the appearance of the Block in the editor. The label can use Umbraco Flavored Markdown (UFM) syntax to display values of properties. Example: `My Block {= myPropertyAlias }` will be shown as: `My Block FooBar`.
+When configuring a Block, the label property allows you to define a label for the appearance of the Block in the editor. The label can use Umbraco Flavored Markdown (UFM) syntax to display values of properties. Example: `My Block {=myPropertyAlias}` will be shown as: `My Block FooBar`.
 
 ## Special variables
 


### PR DESCRIPTION
The labels only work without the spaces. so it should be {=myPropertyAlias} and not {= myPropertyAlias }

## Description

_What did you add/update/change?_
removed spaces from the example label.

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

14.1

## Deadline (if relevant)

_When should the content be published?_
 at any time