### PR TITLE
Notes on renamed pickers

### DIFF
--- a/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/content-picker.md
+++ b/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/content-picker.md
@@ -10,6 +10,10 @@ The Content Picker allows you to configure the type of content tree to render an
 The Content Picker is what was known as the **Multinode Treepicker** in version 13 and below.
 
 The renaming is purely a client-side UI change, meaning the property editor still uses the `Umbraco.MultiNodeTreePicker` schema alias.
+
+**Are you looking for the original Content Picker?**
+
+The Content Picker from verison 13 and below has been renamed to [Document Picker](./document-picker.md).
 {% endhint %}
 
 ## Node type

--- a/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/content-picker.md
+++ b/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/content-picker.md
@@ -4,10 +4,10 @@
 
 `Returns: IEnumerable<IPublishedContent>`
 
-The Content Picker allows you to configure the type of content tree to render and what part of it should be rendered. For content it allows you to select a dynamic root node based on the current document using the Content Picker.
+The Content Picker enables you to select the type of content tree to display and which specific part of it should be rendered. It also allows you to choose a dynamic root node for the content based on the current document using the Content Picker.
 
 {% hint style="info" %}
-The Content Picker is what was known as the **Multinode Treepicker** in version 13 and below.
+The Content Picker was formerly known as the **Multinode Treepicker** in version 13 and below.
 
 The renaming is purely a client-side UI change, meaning the property editor still uses the `Umbraco.MultiNodeTreePicker` schema alias.
 
@@ -15,7 +15,7 @@ The change was made as the word **Content** in the backoffice acts as an umbrell
 
 **Are you looking for the original Content Picker?**
 
-The Content Picker from verison 13 and below has been renamed to [Document Picker](./document-picker.md).
+The Content Picker from version 13 and below has been renamed to [Document Picker](./document-picker.md).
 {% endhint %}
 
 ## Node type

--- a/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/content-picker.md
+++ b/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/content-picker.md
@@ -11,6 +11,8 @@ The Content Picker is what was known as the **Multinode Treepicker** in version 
 
 The renaming is purely a client-side UI change, meaning the property editor still uses the `Umbraco.MultiNodeTreePicker` schema alias.
 
+The change was made as the word **Content** in the backoffice acts as an umbrella term covering the terms Document, Media, and Member.
+
 **Are you looking for the original Content Picker?**
 
 The Content Picker from verison 13 and below has been renamed to [Document Picker](./document-picker.md).

--- a/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/content-picker.md
+++ b/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/content-picker.md
@@ -7,7 +7,7 @@
 The Content Picker allows you to configure the type of content tree to render and what part of it should be rendered. For content it allows you to select a dynamic root node based on the current document using the Content Picker.
 
 {% hint style="info" %}
-The Content Picker has been renamed from **Multinode Treepicker** (version 13 and below).
+The Content Picker is what was known as the **Multinode Treepicker** in version 13 and below.
 
 The renaming is purely a client-side UI change, meaning the property editor still uses the `Umbraco.MultiNodeTreePicker` schema alias.
 {% endhint %}

--- a/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/content-picker.md
+++ b/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/content-picker.md
@@ -4,11 +4,15 @@
 
 `Returns: IEnumerable<IPublishedContent>`
 
-## Settings
+The Content Picker allows you to configure the type of content tree to render and what part of it should be rendered. For content it allows you to select a dynamic root node based on the current document using the Content Picker.
 
-The Content Picker allows you to configure the type of tree to render and what part of the tree should be rendered. For content it allows you to select a dynamic root node based on the current document using the content picker.
+{% hint style="info" %}
+The Content Picker has been renamed from **Multinode Treepicker** (version 13 and below).
 
-### Node type
+The renaming is purely a client-side UI change, meaning the property editor still uses the `Umbraco.MultiNodeTreePicker` schema alias.
+{% endhint %}
+
+## Node type
 
 Set the type of node, the root node of the tree, or query for the root node.
 
@@ -48,7 +52,7 @@ Each query step takes the output from the last step (or the origin) as input.
 
 ![Content Picker Data Type Definition](../../images/mntp\_node\_type\_dynamic\_root\_overview.png)
 
-#### Adding a custom query step
+### Adding a custom query step
 
 Custom query steps can be used to solve some specific use cases.
 

--- a/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/document-picker.md
+++ b/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/document-picker.md
@@ -4,7 +4,13 @@
 
 `Returns: IPublishedContent`
 
-The document picker opens a panel to pick a specific page from the content structure. The value saved is the selected nodes [UDI](../../../../reference/querying/udi-identifiers.md)
+The Document Picker opens a panel to pick a specific page from the content structure. The value saved is the selected nodes [UDI](../../../../reference/querying/udi-identifiers.md).
+
+{% hint style="info" %}
+The Document Picker has been renamed from **Content Picker** (version 13 and below).
+
+The renaming is purely a client-side UI change, meaning the property editor still uses the `Umbraco.ContentPicker` schema alias.
+{% endhint %}
 
 ## Data Type Definition Example
 

--- a/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/document-picker.md
+++ b/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/document-picker.md
@@ -7,7 +7,7 @@
 The Document Picker opens a panel to pick a specific page from the content structure. The value saved is the selected nodes [UDI](../../../../reference/querying/udi-identifiers.md).
 
 {% hint style="info" %}
-The Document Picker has been renamed from **Content Picker** (version 13 and below).
+The Document Picker is was what known as the **Content Picker** in version 13 and below.
 
 The renaming is purely a client-side UI change, meaning the property editor still uses the `Umbraco.ContentPicker` schema alias.
 {% endhint %}

--- a/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/document-picker.md
+++ b/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/document-picker.md
@@ -10,6 +10,8 @@ The Document Picker opens a panel to pick a specific page from the content struc
 The Document Picker is was what known as the **Content Picker** in version 13 and below.
 
 The renaming is purely a client-side UI change, meaning the property editor still uses the `Umbraco.ContentPicker` schema alias.
+
+The change was made as the word **Content** in the backoffice acts as an umbrella term covering the terms Document, Media, and Member.
 {% endhint %}
 
 ## Data Type Definition Example

--- a/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/document-picker.md
+++ b/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/document-picker.md
@@ -7,7 +7,7 @@
 The Document Picker opens a panel to pick a specific page from the content structure. The value saved is the selected nodes [UDI](../../../../reference/querying/udi-identifiers.md).
 
 {% hint style="info" %}
-The Document Picker is was what known as the **Content Picker** in version 13 and below.
+The Document Picker was formerly known as the **Content Picker** in version 13 and below.
 
 The renaming is purely a client-side UI change, meaning the property editor still uses the `Umbraco.ContentPicker` schema alias.
 


### PR DESCRIPTION
Add notes to the renamed Content Picker and Document Picker to avoid confusion.