### PR TITLE
Removed reference to an empty article from SUMMARY.md

### DIFF
--- a/10/umbraco-cms/SUMMARY.md
+++ b/10/umbraco-cms/SUMMARY.md
@@ -248,7 +248,6 @@
     * [Understand and Extend](reference/templating/modelsbuilder/understand-and-extend.md)
     * [Using Interfaces](reference/templating/modelsbuilder/using-interfaces.md)
     * [Tips and Tricks](reference/templating/modelsbuilder/coolthingswithmodels.md)
-    * [Install the full version](reference/templating/modelsbuilder/install-models-builder.md)
   * [Working with MVC](reference/templating/mvc/README.md)
     * [Working with MVC Views in Umbraco](reference/templating/mvc/views.md)
     * [View/Razor Examples](reference/templating/mvc/examples.md)

--- a/10/umbraco-cms/reference/templating/modelsbuilder/README.md
+++ b/10/umbraco-cms/reference/templating/modelsbuilder/README.md
@@ -13,4 +13,4 @@ The Models builder is a tool that can generate a complete set of strongly-typed 
 * [Builder Modes](builder-modes.md)
 * [Understand and Extend Models](understand-and-extend.md)
 * [Using Interfaces](using-interfaces.md)
-* [Cool things to do with models](coolthingswithmodels.md)
+* [Tips and Tricks](coolthingswithmodels.md)

--- a/12/umbraco-cms/SUMMARY.md
+++ b/12/umbraco-cms/SUMMARY.md
@@ -248,7 +248,6 @@
     * [Understand and Extend](reference/templating/modelsbuilder/understand-and-extend.md)
     * [Using Interfaces](reference/templating/modelsbuilder/using-interfaces.md)
     * [Tips and Tricks](reference/templating/modelsbuilder/coolthingswithmodels.md)
-    * [Install the full version](reference/templating/modelsbuilder/install-models-builder.md)
   * [Working with MVC](reference/templating/mvc/README.md)
     * [Working with MVC Views in Umbraco](reference/templating/mvc/views.md)
     * [View/Razor Examples](reference/templating/mvc/examples.md)

--- a/12/umbraco-cms/reference/templating/modelsbuilder/README.md
+++ b/12/umbraco-cms/reference/templating/modelsbuilder/README.md
@@ -12,4 +12,4 @@ The Models builder is a tool that can generate a complete set of strongly-typed 
 * [Builder Modes](builder-modes.md)
 * [Understand and Extend Models](understand-and-extend.md)
 * [Using Interfaces](using-interfaces.md)
-* [Cool things to do with models](coolthingswithmodels.md)
+* [Tips and Tricks](coolthingswithmodels.md)

--- a/13/umbraco-cms/SUMMARY.md
+++ b/13/umbraco-cms/SUMMARY.md
@@ -250,7 +250,6 @@
     * [Understand and Extend](reference/templating/modelsbuilder/understand-and-extend.md)
     * [Using Interfaces](reference/templating/modelsbuilder/using-interfaces.md)
     * [Tips and Tricks](reference/templating/modelsbuilder/coolthingswithmodels.md)
-    * [Install the full version](reference/templating/modelsbuilder/install-the-full-version.md)
   * [Working with MVC](reference/templating/mvc/README.md)
     * [Working with MVC Views in Umbraco](reference/templating/mvc/views.md)
     * [View/Razor Examples](reference/templating/mvc/examples.md)

--- a/13/umbraco-cms/reference/templating/modelsbuilder/README.md
+++ b/13/umbraco-cms/reference/templating/modelsbuilder/README.md
@@ -12,4 +12,4 @@ The Models builder is a tool that can generate a complete set of strongly-typed 
 * [Builder Modes](builder-modes.md)
 * [Understand and Extend Models](understand-and-extend.md)
 * [Using Interfaces](using-interfaces.md)
-* [Cool things to do with models](coolthingswithmodels.md)
+* [Tips and Tricks](coolthingswithmodels.md)

--- a/13/umbraco-cms/reference/templating/modelsbuilder/install-the-full-version.md
+++ b/13/umbraco-cms/reference/templating/modelsbuilder/install-the-full-version.md
@@ -1,2 +1,0 @@
-# Install the full version
-

--- a/14/umbraco-cms/SUMMARY.md
+++ b/14/umbraco-cms/SUMMARY.md
@@ -274,7 +274,6 @@
     * [Understand and Extend](reference/templating/modelsbuilder/understand-and-extend.md)
     * [Using Interfaces](reference/templating/modelsbuilder/using-interfaces.md)
     * [Tips and Tricks](reference/templating/modelsbuilder/coolthingswithmodels.md)
-    * [Install the full version](reference/templating/modelsbuilder/install-the-full-version.md)
   * [Working with MVC](reference/templating/mvc/README.md)
     * [Working with MVC Views in Umbraco](reference/templating/mvc/views.md)
     * [View/Razor Examples](reference/templating/mvc/examples.md)

--- a/14/umbraco-cms/reference/templating/modelsbuilder/README.md
+++ b/14/umbraco-cms/reference/templating/modelsbuilder/README.md
@@ -12,4 +12,4 @@ The Models builder is a tool that can generate a complete set of strongly-typed 
 * [Builder Modes](builder-modes.md)
 * [Understand and Extend Models](understand-and-extend.md)
 * [Using Interfaces](using-interfaces.md)
-* [Cool things to do with models](coolthingswithmodels.md)
+* [Tips and Tricks](coolthingswithmodels.md)

--- a/14/umbraco-cms/reference/templating/modelsbuilder/install-the-full-version.md
+++ b/14/umbraco-cms/reference/templating/modelsbuilder/install-the-full-version.md
@@ -1,2 +1,0 @@
-# Install the full version
-


### PR DESCRIPTION
## Description

- Removed reference to an empty article from SUMMARY.md
- Deleted the empty article from v13 and v14. v10 and v12 do not contain the article.
- Changed the link title to match the article title and side nav title.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
CMS v10, v12, v13, v14

## Deadline (if relevant)

Anytime
