### PR TITLE
Remove "Greeting" section from the Login article

### DIFF
--- a/14/umbraco-cms/fundamentals/backoffice/login.md
+++ b/14/umbraco-cms/fundamentals/backoffice/login.md
@@ -6,7 +6,7 @@ description: >-
 
 # Login
 
-To access the backoffice, you will need to login. You can do this by adding `/umbraco` at the end of your website URL, for example http://mywebsite.com/umbraco.
+To access the backoffice, you will need to login. You can do this by adding `/umbraco` at the end of your website URL, for example `http://mywebsite.com/umbraco`.
 
 You will be presented with a login form similar to this:
 
@@ -15,31 +15,6 @@ You will be presented with a login form similar to this:
 The **login** screen contains a **Greeting**, **Email**, **Password** field and optionally a **Forgotten password** link
 
 Below, you will find instructions on how to customize the login screen.
-
-## Greeting
-
-The login screen features a greeting which you can personalize by overriding the existing language translation keys. To do this, create a 'user' translation file for the default language of your Umbraco site, (usually en-US) to override the greetings. For en-US, you'd create a file called: `en_us.user.xml` in the directory `~/config/lang/`. Then take the relevant keys (listed below) and add them to your `~/config/lang/en_us.user.xml` file, and update the greetings as necessary.
-
-**Note:** the `config` directory needs to be in the root of your project (_not_ the `wwwroot`).
-
-```xml
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<language culture="en-US">
-	<area alias="login">
-		<key alias="greeting0">Happy super Sunday</key>
-		<key alias="greeting1">Happy manic Monday</key>
-		<key alias="greeting2">Happy tubular Tuesday</key>
-		<key alias="greeting3">Happy wonderful Wednesday</key>
-		<key alias="greeting4">Happy thunderous Thursday</key>
-		<key alias="greeting5">Happy funky Friday</key>
-		<key alias="greeting6">Happy Caturday</key>
-	</area>
-</language>
-```
-
-* Before the changes takes place you will need to restart the site.
-
-You can customize other text on the login screen as well. First, grab the default values and keys from the [en\_us.xml](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/EmbeddedResources/Lang/en\_us.xml) in the Umbraco CMS Github repository. Thereafter copy the ones you want to translate into `~/config/lang/en_us.user.xml` file.
 
 ## Password reset
 

--- a/14/umbraco-cms/fundamentals/backoffice/login.md
+++ b/14/umbraco-cms/fundamentals/backoffice/login.md
@@ -12,7 +12,7 @@ You will be presented with a login form similar to this:
 
 ![Login screen](../../../../13/umbraco-cms/fundamentals/backoffice/images/login-backoffice-login.png)
 
-The **login** screen contains a **Greeting**, **Email**, **Password** field and optionally a **Forgotten password** link
+The **login** screen contains a short greeting, a **login form** and an optional **Forgotten password** link.
 
 Below, you will find instructions on how to customize the login screen.
 


### PR DESCRIPTION
## Description

The greeting message on the Login screen is no longer a thing since Umbraco 14.
This PR removes the docs on it.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

14
