### PR TITLE
Remove invalid backtick in code blocks in extension-api-for-querying.md [Umbraco 12, 13,14 Docs]

### DIFF
--- a/12/umbraco-cms/reference/content-delivery-api/extension-api-for-querying.md
+++ b/12/umbraco-cms/reference/content-delivery-api/extension-api-for-querying.md
@@ -90,7 +90,7 @@ public class AuthorSelector : ISelectorHandler, IContentIndexHandler
             {
                 FieldName = FieldName,
                 FieldType = FieldType.StringRaw,
-                VariesByCulture = false`
+                VariesByCulture = false
             }
         };
 }

--- a/13/umbraco-cms/reference/content-delivery-api/extension-api-for-querying.md
+++ b/13/umbraco-cms/reference/content-delivery-api/extension-api-for-querying.md
@@ -90,7 +90,7 @@ public class AuthorSelector : ISelectorHandler, IContentIndexHandler
             {
                 FieldName = FieldName,
                 FieldType = FieldType.StringRaw,
-                VariesByCulture = false`
+                VariesByCulture = false
             }
         };
 }

--- a/14/umbraco-cms/reference/content-delivery-api/extension-api-for-querying.md
+++ b/14/umbraco-cms/reference/content-delivery-api/extension-api-for-querying.md
@@ -90,7 +90,7 @@ public class AuthorSelector : ISelectorHandler, IContentIndexHandler
             {
                 FieldName = FieldName,
                 FieldType = FieldType.StringRaw,
-                VariesByCulture = false`
+                VariesByCulture = false
             }
         };
 }


### PR DESCRIPTION
## Description

_What did you add/update/change?_
Remove invalid backtick in code blocks in extension-api-for-querying.md

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [x] Other

## Product & version (if relevant)
Umbraco Docs [ 12 , 13 , 14] - extension-api-for-querying.md 

