### PR TITLE
Update import-with-migrations.md

### DIFF
--- a/13/umbraco-deploy/deployment-workflow/import-with-migrations.md
+++ b/13/umbraco-deploy/deployment-workflow/import-with-migrations.md
@@ -242,7 +242,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Deploy.Infrastructure.Migrators;
 
 public class ReplaceNestedContentDataTypeArtifactMigrator : ReplaceDataTypeArtifactMigratorBase<NestedContentConfiguration, BlockListConfiguration>
 {


### PR DESCRIPTION
## Description

_What did you add/update/change?_
For an Umbraco Cloud 13 project
If one includes the package of Umbraco.Deploy.Infrastructure Version="13.2.0"
Then it seems like the usage of:
`using Umbraco.Deploy.Infrastructure.Artifacts;` 
should be replaced with
`using Umbraco.Deploy.Infrastructure.Migrators;`

## Type of suggestion

* [ ] Typo/grammar fix
* [x ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
