### PR TITLE
Fix legacy ProviderName in sqlite examples

### DIFF
--- a/14/umbraco-cms/fundamentals/setup/install/unattended-install.md
+++ b/14/umbraco-cms/fundamentals/setup/install/unattended-install.md
@@ -48,7 +48,7 @@ It is recommended that you make use of the values shown below for the `Cache`, `
 {
   "ConnectionStrings": {
     "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Private;Foreign Keys=True;Pooling=True",
-    "umbracoDbDSN_ProviderName": "Microsoft.Data.SQLite"
+    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
   }
 }
 ```

--- a/14/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
+++ b/14/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
@@ -203,6 +203,28 @@ Additionally, on the backend side, there is an additional helper available to do
 
 More details and code examples can be found in the [External Login Providers](../../../../reference/security/external-login-providers.md) article.\\
 
+
+* **Deprecated SQLite provider name removed**
+
+In previous versions of Umbraco the `umbracoDbDSN_ProviderName` (and `umbracoCommerceDbDSN_ProviderName`) value could be `Microsoft.Data.SQLite` or `Microsoft.Data.Sqlite` with the former being deprecated in Umbraco 12.
+
+The deprecated version has been removed and will require the value to be updated to `Microsoft.Data.Sqlite` for installations using a SQLite database.
+
+```typescript
+{
+    ...
+    "ConnectionStrings": {
+        "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Private;Foreign Keys=True;Pooling=True",
+        "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite",
+        "umbracoCommerceDbDSN": "Data Source=|DataDirectory|/Umbraco.Commerce.sqlite.db;Mode=ReadWrite;Foreign Keys=True;Pooling=True;Cache=Private",
+        "umbracoCommerceDbDSN_ProviderName": "Microsoft.Data.Sqlite"
+    },
+    ...
+}
+
+```
+
+
 **In-depth and further breaking changes for Umbraco 14 can be found on the** [**CMS GitHub**](https://github.com/umbraco/Umbraco-CMS/pulls?q=is%3Apr+base%3Av14%2Fdev+label%3Acategory%2Fbreaking) **repository and on** [**Our Website**](https://our.umbraco.com/download/releases/1400)**.**
 
 </details>

--- a/14/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
+++ b/14/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
@@ -203,14 +203,13 @@ Additionally, on the backend side, there is an additional helper available to do
 
 More details and code examples can be found in the [External Login Providers](../../../../reference/security/external-login-providers.md) article.\\
 
-
 * **Deprecated SQLite provider name removed**
 
 In previous versions of Umbraco the `umbracoDbDSN_ProviderName` (and `umbracoCommerceDbDSN_ProviderName`) value could be `Microsoft.Data.SQLite` or `Microsoft.Data.Sqlite` with the former being deprecated in Umbraco 12.
 
-The deprecated version has been removed and will require the value to be updated to `Microsoft.Data.Sqlite` for installations using a SQLite database.
+The deprecated version, `Microsoft.Data.SQlite`, has been removed and will require the value to be updated to `Microsoft.Data.Sqlite` for installations using an SQLite database.
 
-```typescript
+```json
 {
     ...
     "ConnectionStrings": {
@@ -223,7 +222,6 @@ The deprecated version has been removed and will require the value to be updated
 }
 
 ```
-
 
 **In-depth and further breaking changes for Umbraco 14 can be found on the** [**CMS GitHub**](https://github.com/umbraco/Umbraco-CMS/pulls?q=is%3Apr+base%3Av14%2Fdev+label%3Acategory%2Fbreaking) **repository and on** [**Our Website**](https://our.umbraco.com/download/releases/1400)**.**
 

--- a/14/umbraco-cms/reference/configuration/connectionstringssettings.md
+++ b/14/umbraco-cms/reference/configuration/connectionstringssettings.md
@@ -12,7 +12,7 @@ An connection strings config can look like this:
 {
   "ConnectionStrings": {
     "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Private;Foreign Keys=True;Pooling=True",
-    "umbracoDbDSN_ProviderName": "Microsoft.Data.SQLite"
+    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
   }
 }
 ```

--- a/14/umbraco-commerce/how-to-guides/configure-sqlite-support.md
+++ b/14/umbraco-commerce/how-to-guides/configure-sqlite-support.md
@@ -35,9 +35,9 @@ After configuring Umbraco CMS with SQLite, Umbraco Commerce will automatically u
     ...
     "ConnectionStrings": {
         "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Private;Foreign Keys=True;Pooling=True",
-        "umbracoDbDSN_ProviderName": "Microsoft.Data.SQLite",
+        "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite",
         "umbracoCommerceDbDSN": "Data Source=|DataDirectory|/Umbraco.Commerce.sqlite.db;Mode=ReadWrite;Foreign Keys=True;Pooling=True;Cache=Private",
-        "umbracoCommerceDbDSN_ProviderName": "Microsoft.Data.SQLite"
+        "umbracoCommerceDbDSN_ProviderName": "Microsoft.Data.Sqlite"
     },
     ...
 }


### PR DESCRIPTION
## Description

While upgrading an Umbraco site using Sqlite from v13 to v14 I kept getting the following error: `System.ArgumentException: The specified invariant name 'Microsoft.Data.SQLite' wasn't found in the list of registered .NET Data Providers.`

I was using the exact values from the docs for `umbracoDbDSN_ProviderName` which made this error very confusing. 

After some source diving and looking at the git history, I found umbraco/Umbraco-CMS#15999 which removed support for the format mentioned in the docs. 

This PR updates the examples for version 14 to use the correct format. It may make sense to update the docs for versions 12 and 13 as well as it seems this format has been deprecated for a while.

It also may be worth updating the Breaking Changes section of the [Version Specific Upgrades page](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/upgrading/version-specific). 

I'm happy to add those suggested changes to this PR if the maintainers would prefer that.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
Umbraco.Cms 14


## Deadline (if relevant)

No Deadline
