### PR TITLE
Add release notes for Deploy 13.2.0, 14.1.0, 14.1.1 and Deploy Contrib 4.4.0, 10.3.0, 12.2.0, 13.2.0 and 14.1.0

### DIFF
--- a/10/umbraco-deploy/release-notes.md
+++ b/10/umbraco-deploy/release-notes.md
@@ -450,6 +450,10 @@ This section contains the release notes for Umbraco Deploy 4 and 10 including al
 
 ## Deploy Contrib
 
+#### [10.3.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-10.3.0) (August 15th 2024)
+
+* All items from 10.3.0-rc1
+
 #### [10.3.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-10.3.0-rc1) (July 19th 2024)
 
 * Skip empty pre-values [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
@@ -486,6 +490,10 @@ This section contains the release notes for Umbraco Deploy 4 and 10 including al
 
 <details>
 <summary>Version 4</summary>
+
+#### [4.4.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-4.4.0) (August 15th 2024)
+
+* All items from 4.4.0-rc1
 
 #### [4.4.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-4.4.0-rc1) (July 19th 2024)
 

--- a/12/umbraco-deploy/release-notes.md
+++ b/12/umbraco-deploy/release-notes.md
@@ -122,6 +122,10 @@ This section contains the release notes for Umbraco Deploy 12 including all chan
 
 ## Deploy Contrib
 
+#### [12.2.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-12.2.0) (August 15th 2024)
+
+* All items from 12.2.0-rc1
+
 #### [12.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-12.2.0-rc1) (July 19th 2024)
 
 * Skip empty pre-values [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
@@ -129,7 +133,7 @@ This section contains the release notes for Umbraco Deploy 12 including all chan
 
 #### [12.1.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-12.1.0) (March 19th 2024)
 
-* All items from 10.2.0-rc1
+* All items from 12.1.0-rc1
 
 #### [12.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-12.1.0-rc1) (March 5th 2024)
 

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -17,6 +17,14 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 13 including all changes for this version.
 
+#### [13.2.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.0) (August 15th 2024)
+
+* All items from 13.2.0-rc1
+* Fixed `Could not create Udi node: {Id} and entity type {EntityType}` exception when exporting tree nodes without children
+* Fixed deploy signatures not getting cleared when members are deleted [#230]( https://github.com/umbraco/Umbraco.Deploy.Issues/issues/230)
+* Allow members to be deployed when selected as items in a multi-node tree picker [#231](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/231)
+* Apply `ExcludedEntityTypes` configuration to disk operations [#232](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/232)
+
 #### [13.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.0) (July 19th 2024)
 
 * Add migrators to support legacy Grid layout to Block Grid migration
@@ -103,6 +111,10 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
   * Update Richtext value connector to handle references in blocks.
 
 ## Deploy Contrib
+
+#### [13.2.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.2.0) (August 15th 2024)
+
+* All items from 13.2.0-rc1
 
 #### [13.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.2.0-rc1) (July 19th 2024)
 

--- a/14/umbraco-deploy/release-notes.md
+++ b/14/umbraco-deploy/release-notes.md
@@ -18,6 +18,22 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 13 including all changes for this version.
 
+#### [14.1.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.1) (August 20th 2024)
+
+* Support getting artifacts from exploded/expanded `NamedUdiRange` with different entity types
+* Fixed typo in `DefaultLegacyDataTypeConfigurationArtifactMigrator` when migrating Color Picker items in v8 format
+
+#### [14.1.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.0) (August 15th 2024)
+
+* All items from 14.1.0-rc1
+* Fixed `Could not create Udi node: {Id} and entity type {EntityType}` exception when exporting tree nodes without children
+* Fixed deploy signatures not getting cleared when members are deleted [#230]( https://github.com/umbraco/Umbraco.Deploy.Issues/issues/230)
+* Allow members to be deployed when selected as items in a multi-node tree picker [#231](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/231)
+* Apply `ExcludedEntityTypes` configuration to disk operations [#232](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/232)
+* Fixed issues with partial restore from an external tree that contains more than one entity
+* Fixed formatting of trial expiry days and added missing translations [#229](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/229)
+* Fixed `Could not get physical path for "umb://template-file/".` exception when deploying/exporting template without physical file on disk
+
 #### [14.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.0) (July 19th 2024)
 
 * Add migrators to support legacy Grid layout to Block Grid migration
@@ -52,6 +68,10 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
   * See full details of breaking changes under the [Version-specific Upgrade Guide](upgrades/version-specific.md).
 
 ## Deploy Contrib
+
+#### [14.1.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-14.1.0) (August 15th 2024)
+
+* All items from 14.1.0-rc1
 
 #### [14.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-14.1.0-rc1) (July 19th 2024)
 


### PR DESCRIPTION
## Description

Added release notes for Deploy 13.2.0, 14.1.0, 14.1.1 and Deploy Contrib 4.4.0, 10.3.0, 12.2.0, 13.2.0 and 14.1.0.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

- Deploy 13.2.0, 14.1.0, 14.1.1.
- Deploy Contrib 4.4.0, 10.3.0, 12.2.0, 13.2.0 and 14.1.0.

## Deadline (if relevant)

These releases are already out, so this can be merged immediately.
