### PR TITLE
Corrected JSON syntax

### DIFF
--- a/14/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
+++ b/14/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
@@ -19,18 +19,18 @@ The following example shows an `umbraco-package.json` that refers to one bundle,
 {% code title="umbraco-package.json" %}
 
 ```json
-{
-		name: 'My Package Name',
-		version: '1.0.0',
-		extensions: [
+    {
+		"name": "My Package Name",
+		"version": "1.0.0",
+		"extensions": [
 			{
-				type: 'bundle',
-				alias: 'My.Package.Bundle',
-				name: 'My Package Bundle',
-				js: '/App_Plugins/my-package/manifests.js',
-			},
-		],
-	},
+				"type": "bundle",
+				"alias": "My.Package.Bundle",
+				"name": "My Package Bundle",
+				"js": "/App_Plugins/my-package/manifests.js"
+			}
+		]
+	}
 ```
 
 {% endcode %}


### PR DESCRIPTION
## Description

Corrected the JSON syntax in the example code for the [bundle](https://docs.umbraco.com/umbraco-cms/customizing/extending-overview/extension-types/bundle) example to follow JSON standards.

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

