### PR TITLE
Specifying that Umbraco includes NPoco

### DIFF
--- a/14/umbraco-cms/extending/database.md
+++ b/14/umbraco-cms/extending/database.md
@@ -4,7 +4,7 @@ description: A guide to creating a custom Database table in Umbraco
 
 # Creating a Custom Database Table
 
-It is possible to add custom database tables to your site to store additional data that should not be stored as normal content nodes.
+UmbracoCMS ships with [NPoco](https://github.com/schotime/NPoco), a lightweight, quasi-ORM that makes it easy to map the results of database queries to plain old CLR objects (POCOs). NPoco makes it possible to add custom database tables to your site to store additional data that should not be stored as normal content nodes.
 
 The end result looks like this:
 

--- a/14/umbraco-cms/extending/database.md
+++ b/14/umbraco-cms/extending/database.md
@@ -4,7 +4,7 @@ description: A guide to creating a custom Database table in Umbraco
 
 # Creating a Custom Database Table
 
-UmbracoCMS ships with [NPoco](https://github.com/schotime/NPoco), a lightweight, quasi-ORM that makes it easy to map the results of database queries to plain old CLR objects (POCOs). NPoco makes it possible to add custom database tables to your site to store additional data that should not be stored as normal content nodes.
+Umbraco ships with [NPoco](https://github.com/schotime/NPoco), which enables mapping the results of database queries to Common Language Runtime (CLR) objects. NPoco allows custom database tables to be added to your site to store additional data that should not be stored as normal content nodes.
 
 The end result looks like this:
 


### PR DESCRIPTION
## Description

I added a line in the introduction to specify and link to NPoco.

This documentation worked really well for me, however I wished that it had specified that we're using NPoco. In earlier Umbraco days, it used to be PetaPoco, of which NPoco is based on. Coming back to Umbraco several years later, I was a bit confused until I figured out that PetaPoco had been swapped out.

I think it's also important to mention NPoco explicitly and link to it, as developers are likely going to need to go to NPoco's own documentation to learn how it works and how to use it. At first glance, I feel like it could be misunderstood that the database access facilities are provided by Umbraco itself, instead of by an outside project/dependency.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ X] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

v14

## Deadline (if relevant)

N/A
