### PR TITLE
Release notes and documentation updates for Forms 10.5.7, 13.2.2 and 14.1.2

### DIFF
--- a/10/umbraco-forms/release-notes.md
+++ b/10/umbraco-forms/release-notes.md
@@ -21,6 +21,10 @@ This section contains the release notes for Umbraco Forms 8 and 10 including all
 
 <summary>Version 10</summary>
 
+[**10.5.7**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.5.7) **(September 12th 2024)**
+
+* Added server-side validation of configured maximum length for short and long answer fields.
+
 [**10.5.6**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F10.5.6) **(July 9th 2024)**
 
 * Fixed issue with save button UI, when save is canceled via a notification [#1219](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1219).

--- a/13/umbraco-forms/developer/configuration/README.md
+++ b/13/umbraco-forms/developer/configuration/README.md
@@ -114,7 +114,8 @@ For illustration purposes, the following structure represents the full set of op
         "SiteKey": "",
         "PrivateKey": "",
         "Domain": "Google",
-        "VerificationUrl": "https://www.google.com/recaptcha/api/siteverify"
+        "VerificationUrl": "https://www.google.com/recaptcha/api/siteverify",
+        "ShowFieldValidation": false
       },
       "RichText": {
         "DataTypeId": "ca90c950-0aff-4e72-b976-a30b1ac57dad"
@@ -510,6 +511,14 @@ Valid options are `Google` (the default) or `Recaptcha`. You may want to use the
 By default, the server-side validation of the reCAPTCHA response is sent to Google's servers at `https://www.google.com/recaptcha/api/siteverify`.
 
 Some customers with a locked-down production environment cannot configure the firewall to allow these requests and instead use a proxy server. They can use this setting to configure the URL to their proxy server, which will relay the request to and response from Google.
+
+#### ShowFieldValidation
+
+By default the validation message returned from a failed reCAPTCHA 3 request will be displayed only in the form level validation summary.
+
+To render also at a field level, set this value to `true`.
+
+We expect to make the default value for this option `true` in Umbraco Forms 15.
 
 ### Rich text field type configuration
 

--- a/13/umbraco-forms/developer/themes.md
+++ b/13/umbraco-forms/developer/themes.md
@@ -23,7 +23,7 @@ You can obtain the latest versions of the default theme for each Forms major ver
 * [Forms 10 Default Theme](https://umbra.co/umbraco-forms-default-theme) (for 10.5.5 and above)
 * [Forms 11 Default Theme](https://umbra.co/umbraco-forms-default-theme-11) (for 11.1.0 and above)
 * [Forms 12 Default Theme](https://umbra.co/umbraco-forms-default-theme-12) (for 12.2.4 and above)
-* [Forms 13 Default Theme](https://umbra.co/umbraco-forms-default-theme-13) (for 13.2.0 and above)
+* [Forms 13 Default Theme](https://umbra.co/umbraco-forms-default-theme-13) (for 13.2.2 and above)
 
 If you are using a lower minor version of Forms than those listed, you should download an older version of the default theme.
 

--- a/13/umbraco-forms/release-notes.md
+++ b/13/umbraco-forms/release-notes.md
@@ -17,6 +17,18 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 13 including all changes for this version.
 
+#### [**13.2.2**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.2) **(September 12th 2024)**
+
+* Used localized label for submit workflow summary heading [#1273](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1273).
+* Removed autocomplete on field previews [#1271](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1273).
+* Added configurable field level rendering of reCAPTCHA 3 validation result [#1277](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1277).
+* Fixed validate and submit script to handle additional markup around submit buttons [#1280](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1280).
+* Fixed incorrect concatenation of field CSS classes [#1284](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1284).
+* Added server-side validation of configured maximum length for short and long answer fields.
+* Restored provision of field values in HTTP headers in Post as XML workflow.
+* Fixed issue with recording of form submissions in custom Examine indexes [#1282](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1282).
+* Added ability to retrieve "slim" workflow entities from services [#1283](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1283).
+
 #### [**13.2.1**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.1) **(August 6th 2024)**
 
 * Fixed issue with entries export for Windows installations without access to a component necessary for auto-fit of Excel columns [#1259](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1259).

--- a/14/umbraco-forms/developer/configuration/README.md
+++ b/14/umbraco-forms/developer/configuration/README.md
@@ -114,7 +114,8 @@ For illustration purposes, the following structure represents the full set of op
         "SiteKey": "",
         "PrivateKey": "",
         "Domain": "Google",
-        "VerificationUrl": "https://www.google.com/recaptcha/api/siteverify"
+        "VerificationUrl": "https://www.google.com/recaptcha/api/siteverify",
+        "ShowFieldValidation": false
       },
       "RichText": {
         "DataTypeId": "ca90c950-0aff-4e72-b976-a30b1ac57dad"
@@ -507,6 +508,14 @@ Valid options are `Google` (the default) or `Recaptcha`. You may want to use the
 By default, the server-side validation of the reCAPTCHA response is sent to Google's servers at `https://www.google.com/recaptcha/api/siteverify`.
 
 Some customers with a locked-down production environment cannot configure the firewall to allow these requests and instead use a proxy server. They can use this setting to configure the URL to their proxy server, which will relay the request to and response from Google.
+
+#### ShowFieldValidation
+
+By default the validation message returned from a failed reCAPTCHA 3 request will be displayed only in the form level validation summary.
+
+To render also at a field level, set this value to `true`.
+
+We expect to make the default value for this option `true` in Umbraco Forms 15.
 
 ### Rich text field type configuration
 

--- a/14/umbraco-forms/developer/themes.md
+++ b/14/umbraco-forms/developer/themes.md
@@ -23,8 +23,8 @@ You can obtain the latest versions of the default theme for each Forms major ver
 * [Forms 10 Default Theme](https://umbra.co/umbraco-forms-default-theme) (for 10.5.5 and above)
 * [Forms 11 Default Theme](https://umbra.co/umbraco-forms-default-theme-11) (for 11.1.0 and above)
 * [Forms 12 Default Theme](https://umbra.co/umbraco-forms-default-theme-12) (for 12.2.4 and above)
-* [Forms 13 Default Theme](https://umbra.co/umbraco-forms-default-theme-13) (for 13.2.0 and above)
-* [Forms 14 Default Theme](https://umbra.co/umbraco-forms-default-theme-14) (for 14.1.0 and above)
+* [Forms 13 Default Theme](https://umbra.co/umbraco-forms-default-theme-13) (for 13.2.2 and above)
+* [Forms 14 Default Theme](https://umbra.co/umbraco-forms-default-theme-14) (for 14.1.2 and above)
 
 If you are using a lower minor version of Forms than those listed, you should download an older version of the default theme.
 

--- a/14/umbraco-forms/release-notes.md
+++ b/14/umbraco-forms/release-notes.md
@@ -26,7 +26,7 @@ This section contains the release notes for Umbraco Forms 14 including all chang
 * Restored provision of field values in HTTP headers in Post as XML workflow.
 * Fixed issue with recording of form submissions in custom Examine indexes [#1282](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1282).
 * Added ability to retrieve "slim" workflow entities from services [#1283](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1283).
-* Fixed various backoffice user interface issues [#1291](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1291), [#1290](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1290), [#1288](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1288), [#1287](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1287), [#1286](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1286), [#1278](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1278) and [#1275](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1275).
+* Fixed the following backoffice user interface issues [#1291](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1291), [#1290](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1290), [#1288](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1288), [#1287](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1287), [#1286](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1286), [#1278](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1278) and [#1275](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1275).
 
 #### [**14.1.1**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.1) **(August 6th 2024)**
 

--- a/14/umbraco-forms/release-notes.md
+++ b/14/umbraco-forms/release-notes.md
@@ -17,6 +17,17 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 14 including all changes for this version.
 
+#### [**14.1.2**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.2) **(September 12th 2024)**
+
+* Added configurable field level rendering of reCAPTCHA 3 validation result [#1277](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1277).
+* Fixed validate and submit script to handle additional markup around submit buttons [#1280](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1280).
+* Fixed incorrect concatenation of field CSS classes [#1284](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1284).
+* Added server-side validation of configured maximum length for short and long answer fields.
+* Restored provision of field values in HTTP headers in Post as XML workflow.
+* Fixed issue with recording of form submissions in custom Examine indexes [#1282](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1282).
+* Added ability to retrieve "slim" workflow entities from services [#1283](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1283).
+* Fixed various backoffice user interface issues [#1291](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1291), [#1290](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1290), [#1288](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1288), [#1287](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1287), [#1286](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1286), [#1278](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1278) and [#1275](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1275).
+
 #### [**14.1.1**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.1) **(August 6th 2024)**
 
 * Fixed issues with entries export for Windows installations without access to a component necessary for auto-fit of Excel columns [#1259](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1259).


### PR DESCRIPTION
## Description

Added release notes and documentation updates for Forms 10.5.7, 13.2.2 and 14.1.2

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [X] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Forms 10.5.7, 13.2.2 and 14.1.2

## Deadline (if relevant)

Can be reviewed and published at any time, ideally by the morning of Thursday 12th September.  Thanks.
