### PR TITLE
Updated migration IDs for Forms 10+

### DIFF
--- a/14/umbraco-forms/upgrading/version-specific/migration-ids.md
+++ b/14/umbraco-forms/upgrading/version-specific/migration-ids.md
@@ -10,30 +10,21 @@ A unique **migration ID** is generated for each Umbraco Forms upgrade that requi
 This article is a work in progress. Please do not use the information in the article as long as this note is present.
 {% endhint %}
 
-## Version 14
+| Migration ID                         | Introduced In Version | Description                                                                    |
+|--------------------------------------|-----------------------|--------------------------------------------------------------------------------|
+| 7c7bc5ee-4c5b-42dc-9576-5ce6dfbddb8e | 10.0.0                | Installs Umbraco Forms                                                         |
+| 9f7e6fe6-bbd5-4b2b-8820-e9e0e36cc74c | 10.1.0                | Adds Culture column to Records table                                           |
+| 1a8f0d04-9396-40a2-9423-39fc9ae3828f | 10.1.0                | Adds Record Workflow Audit table                                               |
+| 6e692c5d-c670-4c34-af17-28d8dbf0dcd2 | 10.1.0                | Adds ExecutionStage column to Record Workflow Audit table                      |
+| 5d84fee1-388c-4e5f-b98c-1e66947278f1 | 10.1.0                | No operation migration                                                         |
+| 22df962a-ae26-4bdd-b8fd-0513a9c636bf | 10.5.2/12.1.2         | Ensures the presence of an index on the FolderKey column in the Forms table    |
+| c3e657f6-3ae7-4ee9-b442-01702a41de9a | 12.2.0/13.0.0         | Adds relation between content and forms                                        |
+| e0290a40-91c9-4acb-a7ca-d312037078f2 | 12.2.0/13.0.0         | Adds NodeId column to Forms table                                              |
+| 6f0eb771-6690-4b53-870a-f7dbb2785cac | 12.2.0/13.0.0         | Populates the NodeId column in the Forms table                                 |
+| 44949e12-e4ef-42c0-949b-67286b946fe0 | 12.2.0/13.0.0         | No operation migration                                                         |
+| 773ae769-00b7-4429-b7d5-de0fda0b4217 | 12.2.1/13.0.1         | Ensured consistent key is used for the relation type between content and forms |
+| 55d53d2e-f795-42fb-9e77-8edfc6eed4aa | 13.2.0                | Added AdditionalData column to Records table                                   |
+| c74223ed-a554-4a14-a1f0-0477dce01ad6 | 14.0.0                | Updates the form picker property editor UI alias                               |
+| a5ffa9a7-ca77-4a7c-a1e4-f32e25cde758 | 14.1.0                | Added AdditionalData column to Records table                                   |
 
-<table><thead><tr><th width="109">Version</th><th width="292">Name</th><th>Migration ID</th></tr></thead><tbody><tr><td>14.1.0</td><td>AddRecordAdditionalDataColumn</td><td>a5ffa9a7-ca77-4a7c-a1e4-f32e25cde758</td></tr><tr><td>14.0.0</td><td>UpdateDataTypePropertyEditorUiAlias</td><td>c74223ed-a554-4a14-a1f0-0477dce01ad6</td></tr></tbody></table>
 
-## Version 13
-
-<table><thead><tr><th width="107">Version</th><th>Name</th><th>Migration ID</th></tr></thead><tbody><tr><td>13.2.0</td><td>AddRecordAdditionalDataColumn</td><td>55d53d2e-f795-42fb-9e77-8edfc6eed4aa</td></tr><tr><td>13.0.1</td><td></td><td></td></tr><tr><td>13.0.0</td><td></td><td></td></tr></tbody></table>
-
-## Version 12
-
-<table><thead><tr><th width="107">Version</th><th>Name</th><th>Migration ID</th></tr></thead><tbody><tr><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td></tr></tbody></table>
-
-## Version 11
-
-<table><thead><tr><th width="107">Version</th><th>Name</th><th>Migration ID</th></tr></thead><tbody><tr><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td></tr></tbody></table>
-
-## Version 10
-
-<table><thead><tr><th width="107">Version</th><th>Name</th><th>Migration ID</th></tr></thead><tbody><tr><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td></tr></tbody></table>
-
-## Version 9
-
-<table><thead><tr><th width="107">Version</th><th>Name</th><th>Migration ID</th></tr></thead><tbody><tr><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td></tr></tbody></table>
-
-## Version 8
-
-<table><thead><tr><th width="107">Version</th><th>Name</th><th>Migration ID</th></tr></thead><tbody><tr><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td></tr></tbody></table>

--- a/14/umbraco-forms/upgrading/version-specific/migration-ids.md
+++ b/14/umbraco-forms/upgrading/version-specific/migration-ids.md
@@ -6,25 +6,19 @@ hidden: true
 
 A unique **migration ID** is generated for each Umbraco Forms upgrade that requires a migration. The migration IDs are all listed in this article.
 
-{% hint style="danger" %}
-This article is a work in progress. Please do not use the information in the article as long as this note is present.
-{% endhint %}
-
-| Migration ID                         | Introduced In Version | Description                                                                    |
-|--------------------------------------|-----------------------|--------------------------------------------------------------------------------|
-| 7c7bc5ee-4c5b-42dc-9576-5ce6dfbddb8e | 10.0.0                | Installs Umbraco Forms                                                         |
-| 9f7e6fe6-bbd5-4b2b-8820-e9e0e36cc74c | 10.1.0                | Adds Culture column to Records table                                           |
-| 1a8f0d04-9396-40a2-9423-39fc9ae3828f | 10.1.0                | Adds Record Workflow Audit table                                               |
-| 6e692c5d-c670-4c34-af17-28d8dbf0dcd2 | 10.1.0                | Adds ExecutionStage column to Record Workflow Audit table                      |
-| 5d84fee1-388c-4e5f-b98c-1e66947278f1 | 10.1.0                | No operation migration                                                         |
-| 22df962a-ae26-4bdd-b8fd-0513a9c636bf | 10.5.2/12.1.2         | Ensures the presence of an index on the FolderKey column in the Forms table    |
-| c3e657f6-3ae7-4ee9-b442-01702a41de9a | 12.2.0/13.0.0         | Adds relation between content and forms                                        |
-| e0290a40-91c9-4acb-a7ca-d312037078f2 | 12.2.0/13.0.0         | Adds NodeId column to Forms table                                              |
-| 6f0eb771-6690-4b53-870a-f7dbb2785cac | 12.2.0/13.0.0         | Populates the NodeId column in the Forms table                                 |
-| 44949e12-e4ef-42c0-949b-67286b946fe0 | 12.2.0/13.0.0         | No operation migration                                                         |
-| 773ae769-00b7-4429-b7d5-de0fda0b4217 | 12.2.1/13.0.1         | Ensured consistent key is used for the relation type between content and forms |
-| 55d53d2e-f795-42fb-9e77-8edfc6eed4aa | 13.2.0                | Added AdditionalData column to Records table                                   |
-| c74223ed-a554-4a14-a1f0-0477dce01ad6 | 14.0.0                | Updates the form picker property editor UI alias                               |
-| a5ffa9a7-ca77-4a7c-a1e4-f32e25cde758 | 14.1.0                | Added AdditionalData column to Records table                                   |
-
-
+| Migration ID                         | Introduced In Version | Description                                                                        |
+|--------------------------------------|-----------------------|------------------------------------------------------------------------------------|
+| 7c7bc5ee-4c5b-42dc-9576-5ce6dfbddb8e | 10.0.0                | Installs Umbraco Forms.                                                            |
+| 9f7e6fe6-bbd5-4b2b-8820-e9e0e36cc74c | 10.1.0                | Adds Culture column to Records table.                                              |
+| 1a8f0d04-9396-40a2-9423-39fc9ae3828f | 10.1.0                | Adds a Record Workflow Audit table.                                                |
+| 6e692c5d-c670-4c34-af17-28d8dbf0dcd2 | 10.1.0                | Adds an ExecutionStage column to the Record Workflow Audit table.                  |
+| 5d84fee1-388c-4e5f-b98c-1e66947278f1 | 10.1.0                | No operation migration.                                                            |
+| 22df962a-ae26-4bdd-b8fd-0513a9c636bf | 10.5.2/12.1.2         | Ensures the presence of an index on the FolderKey column in the Forms table.       |
+| c3e657f6-3ae7-4ee9-b442-01702a41de9a | 12.2.0/13.0.0         | Adds a relation between content and forms.                                         |
+| e0290a40-91c9-4acb-a7ca-d312037078f2 | 12.2.0/13.0.0         | Adds a NodeId column to Forms table                                                |
+| 6f0eb771-6690-4b53-870a-f7dbb2785cac | 12.2.0/13.0.0         | Populates the NodeId column in the Forms table.                                    |
+| 44949e12-e4ef-42c0-949b-67286b946fe0 | 12.2.0/13.0.0         | No operation migration.                                                            |
+| 773ae769-00b7-4429-b7d5-de0fda0b4217 | 12.2.1/13.0.1         | Ensures the consistent key is used for the relation type between content and forms.|
+| 55d53d2e-f795-42fb-9e77-8edfc6eed4aa | 13.2.0                | Adds an AdditionalData column to the Records table.                                |
+| c74223ed-a554-4a14-a1f0-0477dce01ad6 | 14.0.0                | Updates the form picker property editor UI alias.                                  |
+| a5ffa9a7-ca77-4a7c-a1e4-f32e25cde758 | 14.1.0                | Adds an AdditionalData column to the Records table.                                |


### PR DESCRIPTION
## Description

Updated migration IDs for Forms 10+.

Please note I modified the layout to use markdown rather than HTML (as it's much easier to edit in a text file).  I've included migrations from 10+, which seems reasonable given Forms 8 is out of support.

You will want to tidy up and remove the WIP note if you are happy with it.  And probably copy into the 10 and 13 folders, removing the migrations that are for versions subsequent to the one you copy into.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [X] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Forms 10+

## Deadline (if relevant)

Any time.
