### PR TITLE
Update and fix custom condition documentation

### DIFF
--- a/14/umbraco-cms/customizing/extending-overview/extension-types/condition.md
+++ b/14/umbraco-cms/customizing/extending-overview/extension-types/condition.md
@@ -46,41 +46,93 @@ The following conditions are available out of the box, for all extension types t
 You can make your own conditions by creating a class that implements the `UmbExtensionCondition` interface.
 
 ```typescript
-import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import {
- ManifestCondition,
- UmbConditionConfigBase,
- UmbConditionControllerArguments,
- UmbExtensionCondition,
+  ManifestCondition,
+  UmbConditionConfigBase,
+  UmbConditionControllerArguments,
+  UmbExtensionCondition
 } from '@umbraco-cms/backoffice/extension-api';
-import { UMB_SECTION_CONTEXT } from '@umbraco-cms/backoffice/section';
+import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
+import { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
-type MyConditionConfig = UmbConditionConfigBase & {
- match: string;
+export type MyConditionConfig = UmbConditionConfigBase & {
+  match: string;
 };
 
-export class MyExtensionCondition extends UmbControllerBase implements UmbExtensionCondition {
- config: MyConditionConfig;
- permitted = false;
+export class MyExtensionCondition extends UmbConditionBase<MyConditionConfig> implements UmbExtensionCondition {
+  constructor(host: UmbControllerHost, args: UmbConditionControllerArguments<MyConditionConfig>) {
+    super(host, args);
 
- constructor(args: UmbConditionControllerArguments<MyConditionConfig>) {
-  super(args.host);
-  // This condition aproves after 10 seconds
-  setTimeout(() => {
-   this.permitted = strue;
-   args.onChange();
-  }, 10000);
- }
+    // enable extension after 10 seconds
+    setTimeout(() => {
+      this.permitted = true;
+      args.onChange();
+    }, 10000);
+  }
 }
 ```
 
-This has to be registered in the extension registry, like this:
+This has to be registered in the extension registry like so:
 
 ```typescript
 export const manifest: ManifestCondition = {
  type: 'condition',
  name: 'My Condition',
- alias: 'My.Condition.TenSecondDelay',
+ alias: 'My.Condition.CustomName',
  api: MyExtensionCondition,
 };
+```
+
+Now you can make use of this condition in your configuration:
+
+```typescript
+{
+ type: 'workspaceAction',
+ name: 'example-workspace-action',
+ alias: 'My.Example.WorkspaceAction',
+ elementName: 'my-workspace-action-element',
+ conditions: [
+  {
+    alias: 'Umb.Condition.SectionAlias',
+    match: 'My.Example.Workspace'
+  },
+  {
+    alias: 'My.Condition.CustomName'
+  }
+ ]
+}
+```
+
+As can be seen in the code above, we never make use of `match`. We can do this by replacing the timeout with some other check.
+
+```typescript
+// ...
+
+export class MyExtensionCondition extends UmbConditionBase<MyConditionConfig> implements UmbExtensionCondition {
+  constructor(host: UmbControllerHost, args: UmbConditionControllerArguments<MyConditionConfig>) {
+    super(host, args);
+
+    if (args.config.match === 'Yes') {
+      this.permitted = true;
+      args.onChange();
+    }
+  }
+}
+
+// ...
+```
+
+Then our configuration might look like so:
+
+```typescript
+{
+ // ...
+ conditions: [
+  // ...
+  {
+    alias: 'My.Condition.CustomName',
+    match: 'Yes'
+  } as MyConditionConfig
+ ]
+}
 ```


### PR DESCRIPTION
#6361 

## Description
After having tried to create a custom condition for my extension, I ran into several issues following the documentation.

There were minor errors such as `true` being written as `strue`. But there were also some major issues, like things being imported which weren't used, extending the wrong classes and in general unclear ways to do stuff.

I ran into an issue requiring many hours of debugging, reading documentation and trial-and-error, where the custom condition was extending the wrong class, leading to something like `args.host` being `undefined`, resulting in the entire extension never being permitted, never reaching the timeout.

It also wasn't being shown how to make use of `match`, even though a condition config type was created to allow for this.

## Type of suggestion

* [x] Typo/grammar fix
* [x] Updated outdated content
* [x] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
Umbraco 14
