### PR TITLE
Add Deploy 13.2.1 and 14.1.2 release notes

### DIFF
--- a/10/umbraco-deploy/release-notes.md
+++ b/10/umbraco-deploy/release-notes.md
@@ -459,7 +459,7 @@ This section contains the release notes for Umbraco Deploy 4 and 10 including al
 * Skip empty pre-values [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
 * Add DocTypeGridEditor Data Type configuration connector [#65](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/65)
 
-#### [10.2.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-10.2.0 (March 19th 2024)
+#### [10.2.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-10.2.0) (March 19th 2024)
 
 * All items from 10.2.0-rc1
 

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -17,11 +17,17 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 13 including all changes for this version.
 
+#### [13.2.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.1) (September 17th 2024)
+
+* Fix tree export of members by member type
+* Ensure release date of invariant content is correctly transferred [#233](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/233)
+* Parse nested JSON property values from artifact values [#234](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/234)
+
 #### [13.2.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.0) (August 15th 2024)
 
 * All items from 13.2.0-rc1
 * Fixed `Could not create Udi node: {Id} and entity type {EntityType}` exception when exporting tree nodes without children
-* Fixed deploy signatures not getting cleared when members are deleted [#230]( https://github.com/umbraco/Umbraco.Deploy.Issues/issues/230)
+* Fixed deploy signatures not getting cleared when members are deleted [#230](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/230)
 * Allow members to be deployed when selected as items in a multi-node tree picker [#231](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/231)
 * Apply `ExcludedEntityTypes` configuration to disk operations [#232](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/232)
 

--- a/14/umbraco-deploy/release-notes.md
+++ b/14/umbraco-deploy/release-notes.md
@@ -18,6 +18,13 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 13 including all changes for this version.
 
+#### [14.1.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.2) (September 17th 2024)
+
+* Fix document blueprint connector and add support for containers
+* Fix tree export of members by member type
+* Ensure release date of invariant content is correctly transferred [#233](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/233)
+* Parse nested JSON property values from artifact values [#234](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/234)
+
 #### [14.1.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.1) (August 20th 2024)
 
 * Support getting artifacts from exploded/expanded `NamedUdiRange` with different entity types
@@ -27,7 +34,7 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 
 * All items from 14.1.0-rc1
 * Fixed `Could not create Udi node: {Id} and entity type {EntityType}` exception when exporting tree nodes without children
-* Fixed deploy signatures not getting cleared when members are deleted [#230]( https://github.com/umbraco/Umbraco.Deploy.Issues/issues/230)
+* Fixed deploy signatures not getting cleared when members are deleted [#230](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/230)
 * Allow members to be deployed when selected as items in a multi-node tree picker [#231](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/231)
 * Apply `ExcludedEntityTypes` configuration to disk operations [#232](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/232)
 * Fixed issues with partial restore from an external tree that contains more than one entity


### PR DESCRIPTION
## Description

Added release notes for Deploy patch versions 13.2.1 and 14.1.2,

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Deploy 13.2.1 and 14.1.2

## Deadline (if relevant)

The patches are already released, so this can get merged right away!
