### PR TITLE
Correct schema name in PropertyEditor example

### DIFF
--- a/14/umbraco-cms/customizing/property-editors/composition/property-editor-ui.md
+++ b/14/umbraco-cms/customizing/property-editors/composition/property-editor-ui.md
@@ -30,11 +30,11 @@ The Property Editor UI is a pure front-end extension. This determines how the da
 }
 ```
 
-If no Property Editor Schema is specified in the manifest, the Property Editor UI cannot be used for Content Types. However, it can still be utilized to manipulate JSON. A case of that could be a Settings property for another Property Editor UI or Schema.
+The Property Editor UI cannot be used for Content Types if no Property Editor Schema is specified in the manifest. However, it can still be utilized to manipulate JSON. A case of that could be a Settings property for another Property Editor UI or Schema.
 
 ### Settings
 
-The Property Editor UI settings are used for configuration that is related to rendering the UI in the backoffice. This is the same for Property Editor Schemas:
+The Property Editor UI settings are used for configuration related to rendering the UI in the backoffice. This is the same for Property Editor Schemas:
 
 {% hint style="info" %}
 The Property Editor UI inherits the Settings of its Property Editor Schema.

--- a/14/umbraco-cms/customizing/property-editors/composition/property-editor-ui.md
+++ b/14/umbraco-cms/customizing/property-editors/composition/property-editor-ui.md
@@ -23,7 +23,7 @@ The Property Editor UI is a pure front-end extension. This determines how the da
  "elementName": "my-text-box",
  "meta": {
   "label": "My Text Box",
-  "propertyEditorSchema": "Umbraco.TextBox",
+  "propertyEditorSchemaAlias": "Umbraco.TextBox",
   "icon": "icon-autofill",
   "group": "common"
  }

--- a/14/umbraco-cms/customizing/property-editors/composition/property-editor-ui.md
+++ b/14/umbraco-cms/customizing/property-editors/composition/property-editor-ui.md
@@ -73,14 +73,14 @@ The Property Editor UI inherits the Settings of its Property Editor Schema.
 
 Inherit the interface, to secure your Element live up to the requirements of this.
 
-```ts
+```typescript
 // TODO: get interface
 interface UmbPropertyEditorUIElement {}
 ```
 
 **Example with LitElement**
 
-```ts
+```typescript
 import { LitElement, html, css, customElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';


### PR DESCRIPTION
In the example it references the incorrect `propertyEditorSchema`, it should be `propertyEditorSchemaAlias`

## Description

In the example for [Property Editor UI](https://docs.umbraco.com/umbraco-cms/customizing/property-editors/composition/property-editor-ui) the property to select the schema is incorrect. It is currently `propertyEditorSchema`, it should be `propertyEditorSchemaAlias`.

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
