### PR TITLE
Add JPG & JPEG to the list of acronyms

### DIFF
--- a/.github/styles/UmbracoDocs/Acronyms.yml
+++ b/.github/styles/UmbracoDocs/Acronyms.yml
@@ -84,3 +84,5 @@ exceptions:
     - DHL
     - UUI
     - MDN
+    - JPG
+    - JPEG


### PR DESCRIPTION
## Description

Add JPG & JPEG to the list of acronyms since PNG is also on the list. 

## Type of suggestion

* [x] Styleguide
