### PR TITLE
add september heartcore release notes. update redirect api with new endpoint

### DIFF
--- a/umbraco-heartcore/.gitbook.yaml
+++ b/umbraco-heartcore/.gitbook.yaml
@@ -4,3 +4,4 @@ root: ./
     readme: README.md
     summary: SUMMARY.md
 
+api-documentation/redirect: api-documentation/content-delivery/redirect.md

--- a/umbraco-heartcore/.gitbook.yaml
+++ b/umbraco-heartcore/.gitbook.yaml
@@ -4,4 +4,5 @@ root: ./
     readme: README.md
     summary: SUMMARY.md
 
-api-documentation/redirect: api-documentation/content-delivery/redirect.md
+redirects:
+    api-documentation/redirect: api-documentation/content-delivery/redirect.md

--- a/umbraco-heartcore/SUMMARY.md
+++ b/umbraco-heartcore/SUMMARY.md
@@ -24,10 +24,10 @@
 
 * [API Documentation](api-documentation/README.md)
   * [Rate Limits](api-documentation/rate-limits.md)
-* [Redirect API](api-documentation/redirect.md)
 * [Content Delivery](api-documentation/content-delivery/README.md)
   * [Content](api-documentation/content-delivery/content.md)
   * [Media](api-documentation/content-delivery/media.md)
+  * [Redirect API](api-documentation/content-delivery/redirect.md)
 * [Content Management](api-documentation/content-management/README.md)
   * [Umbraco Forms](api-documentation/content-management/forms.md)
   * [Languages](api-documentation/content-management/language.md)
@@ -68,3 +68,5 @@
 
 * [February 2024](release-notes/2024-02-releasenotes.md)
 * [April 2024](release-notes/2024-04-releasenotes.md)
+* [August 2024](release-notes/2024-08-releasenotes.md)
+* [September 2024](release-notes/2024-09-releasenotes.md)

--- a/umbraco-heartcore/api-documentation/README.md
+++ b/umbraco-heartcore/api-documentation/README.md
@@ -12,8 +12,6 @@ This page contains documentation for the available API endpoints for Umbraco Hea
 
 [The Content Management API](content-management/README.md) can be used to Create, Read, Update and Delete Content, Media, Languages, Relations, Members, and the associated types using Umbraco Backoffice user credentials or API Keys. The API is available on `https://api.umbraco.io`.
 
-[The Redirect API](redirect.md) can be used to query redirects setup in the Umbraco backoffice when moving or renaming content. Use it to create Redirect maps for your website, app, etc. The API is available on `https://cdn.umbraco.io/redirect`.
-
 The Preview API is the read-only Content and Media that you would retrieve to show the draft content in your apps, websites, or other platforms. The API is available on `https://preview.umbraco.io`. The Preview API is always protected and requires an `Api-Key`. The endpoints are the same as the Content Delivery API.
 
 ## REST API Standard

--- a/umbraco-heartcore/api-documentation/content-delivery/redirect.md
+++ b/umbraco-heartcore/api-documentation/content-delivery/redirect.md
@@ -2,10 +2,6 @@
 
 This is the read-only API for delivering redirects, caused by moving or renaming content in the Umbraco backoffice, to any app, website, device, or platform.
 
-{% hint style="info" %}
-The redirect API is only available if your project is using the **Content Delivery Platform**. You can verify this in the Umbraco backoffice, settings section in the headless overview panel.
-{% endhint %}
-
 ## Cultures
 
 To request redirects in a specific language, a culture parameter can be specified. When no culture is specified it's treated as invariant and the default language will be returned.
@@ -55,7 +51,7 @@ If an error occurs, you will receive a HTTP status code along with an API error 
 
 ## Get all redirects
 
-Gets all redirect URLs.
+Get all redirect URLs.
 
 The key is the URL of the content and the values are the URLs redirecting to the content.
 
@@ -111,17 +107,11 @@ The maximum page size is 1000.
 
 ## Get content by redirect URL
 
-Gets destination URL and redirect URLs for a given path.
+Get the destination URL and redirect URLs for a given path.
 
-**URL**: `/redirect/redirecturl`
+**URL**: `/redirect/redirecturl?url={url}`
 
 **Method**: `GET`
-
-**Query Strings**
-
-```
-?url={string}
-```
 
 ### Success Response
 

--- a/umbraco-heartcore/api-documentation/redirect.md
+++ b/umbraco-heartcore/api-documentation/redirect.md
@@ -109,7 +109,7 @@ The maximum page size is 1000.
 ```
 
 
-## Get content by redirect url
+## Get content by redirect URL
 
 Gets destination URL and redirect URLs for a given path.
 

--- a/umbraco-heartcore/api-documentation/redirect.md
+++ b/umbraco-heartcore/api-documentation/redirect.md
@@ -107,3 +107,34 @@ The maximum page size is 1000.
     }
 }
 ```
+
+
+## Get content by redirect url
+
+Gets destination URL and redirect URLs for a given path.
+
+**URL**: `/redirect/redirecturl`
+
+**Method**: `GET`
+
+**Query Strings**
+
+```
+?url={string}
+```
+
+### Success Response
+
+**Code**: 200
+
+**Content Example**:
+
+```json
+{
+    "url": "/home",
+    "redirectUrls": [
+        "/home-redirect-example-1",
+        "/home-redirect-example-2"
+    ]
+}
+```

--- a/umbraco-heartcore/release-notes/2024-02-releasenotes.md
+++ b/umbraco-heartcore/release-notes/2024-02-releasenotes.md
@@ -1,5 +1,5 @@
 # February 2024
-The following features are available to new sites created on or after February 12th. They will be rolled out to existing sites in the second quarter of 2024.
+The following changes have been released to all Heartcore sites.
 
 ## Block Grid Editor
 The Block Grid Editor from core Umbraco is now available in Heartcore. A modern alternative to the Grid Editor, this type is particularly useful for allowing content authors to build page-like structures.

--- a/umbraco-heartcore/release-notes/2024-04-releasenotes.md
+++ b/umbraco-heartcore/release-notes/2024-04-releasenotes.md
@@ -1,5 +1,5 @@
 # April 2024
-The following changes have been released to Heartcore sites created on or after February 12th. They will be rolled out to previously existing sites in the second quarter of 2024.
+The following changes have been released to all Heartcore sites.
 
 ## Grid Disabled By Default
 With the grid property editor [becoming deprecated](https://umbraco.com/blog/umbraco-heartcore-update-october-2023/), it has been decided to hide related functionality in the backoffice for sites that are not using it yet. The modern alternative to Grid Editor is the Block Grid Editor. The migration between Grid and Block Grid won't be fully automated, so this decision was made to encourage use of the most future-proof Data Type.

--- a/umbraco-heartcore/release-notes/2024-08-releasenotes.md
+++ b/umbraco-heartcore/release-notes/2024-08-releasenotes.md
@@ -1,0 +1,14 @@
+# August 2024
+The following changes have been released to all Heartcore sites.
+
+## Webhook Enhancements
+With the core CMS having added webhook support, we have adapted the same function in Heartcore to use the same user interface. You'll now get the same consistent editing experience in both core Umbraco and Heartcore, but also some new features!
+* You may now select multiple event types (for example, publish / unpublish) or content types for a webhook. No more needing to create dozens of hooks to achieve what can now be done with only one!
+* You may now specify custom HTTP headers to send to your endpoint whenever the webhook fires.
+
+Aside from the interface, all other aspects of webhooks in Heartcore are unchanged. Webhooks are still fired from the delivery platform with the same IP address range, retry policy, and payload that you're used to.
+
+For more information about webhook functionality, both new and old, check out the [updated page here](../getting-started/webhooks.md).
+
+## Improved Firewall
+We can't talk too much about this one, but we recently rolled out additional firewall rules for all Heartcore services. While we have made an effort to tune these, there is always a small possibility of false positives. If you believe your legitimate traffic is affected, please raise a support ticket through the portal.`

--- a/umbraco-heartcore/release-notes/2024-08-releasenotes.md
+++ b/umbraco-heartcore/release-notes/2024-08-releasenotes.md
@@ -11,4 +11,4 @@ Aside from the interface, all other aspects of webhooks in Heartcore are unchang
 For more information about webhook functionality, both new and old, check out the [updated Webhooks article](../getting-started/webhooks.md).
 
 ## Improved Firewall
-A recent roll-out as added additional firewall rules for all Heartcore services. While efforts have been made to tune these, there is always a small possibility of false positives. If you believe your legitimate traffic is affected, please raise a support ticket through the portal.
+A recent roll-out has added additional firewall rules for all Heartcore services. While efforts have been made to tune these, there is always a small possibility of false positives. If you believe your legitimate traffic is affected, please raise a support ticket through the portal.

--- a/umbraco-heartcore/release-notes/2024-08-releasenotes.md
+++ b/umbraco-heartcore/release-notes/2024-08-releasenotes.md
@@ -2,13 +2,13 @@
 The following changes have been released to all Heartcore sites.
 
 ## Webhook Enhancements
-With the core CMS having added webhook support, we have adapted the same function in Heartcore to use the same user interface. You'll now get the same consistent editing experience in both core Umbraco and Heartcore, but also some new features!
-* You may now select multiple event types (for example, publish / unpublish) or content types for a webhook. No more needing to create dozens of hooks to achieve what can now be done with only one!
+With the core CMS adding webhook support, the same functionality has been adapted into Heartcore to use the same user interface. You will now get the same consistent editing experience in both Umbraco CMS and Umbraco Heartcore, and it also comes with new features.
+* You may now select multiple event types (for example, publish / unpublish) or content types for a webhook. No more needing to create dozens of hooks to achieve what can now be done with only one.
 * You may now specify custom HTTP headers to send to your endpoint whenever the webhook fires.
 
-Aside from the interface, all other aspects of webhooks in Heartcore are unchanged. Webhooks are still fired from the delivery platform with the same IP address range, retry policy, and payload that you're used to.
+Aside from the interface, all other aspects of webhooks in Heartcore are unchanged. Webhooks are still fired from the delivery platform with the same IP address range, retry policy, and payload that you are used to.
 
-For more information about webhook functionality, both new and old, check out the [updated page here](../getting-started/webhooks.md).
+For more information about webhook functionality, both new and old, check out the [updated Webhooks article](../getting-started/webhooks.md).
 
 ## Improved Firewall
-We can't talk too much about this one, but we recently rolled out additional firewall rules for all Heartcore services. While we have made an effort to tune these, there is always a small possibility of false positives. If you believe your legitimate traffic is affected, please raise a support ticket through the portal.`
+A recent roll-out as added additional firewall rules for all Heartcore services. While efforts have been made to tune these, there is always a small possibility of false positives. If you believe your legitimate traffic is affected, please raise a support ticket through the portal.

--- a/umbraco-heartcore/release-notes/2024-09-releasenotes.md
+++ b/umbraco-heartcore/release-notes/2024-09-releasenotes.md
@@ -2,6 +2,6 @@
 The following changes have been released to all Heartcore sites.
 
 ## New Redirect Endpoint
-For a long time, the only way to get redirect information from Heartcore was a single endpoint on the Delivery API. This endpoint returned paginated redirect information for _all_ content items in the tree. If you needed to find the canonical URL for a given path, then this endpoint was your only option. You would need to find your path in the returned items - especially challenging if it wasn't on the first page of results!
+For a long time, the only way to get redirect information from Heartcore was a single endpoint on the Delivery API. This endpoint returned paginated redirect information for _all_ content items in the tree. If you needed to find the canonical URL for a given path, then this endpoint was your only option. You would need to find your path in the returned items - especially challenging if it was not on the first page of results!
 
-In order to save you the trouble, a brand new endpoint has been added to the Delivery API. It allows you to fetch the canonical URL (and any other redirects) for a given path. For more information, check out the [updated page here](../api-documentation/content-delivery/redirect.md#get-content-by-redirect-url).
+In order to save you the trouble, a brand new endpoint has been added to the Delivery API. It allows you to fetch the canonical URL (and any other redirects) for a given path. For more information, check out the [updated Redirect article](../api-documentation/content-delivery/redirect.md#get-content-by-redirect-url).

--- a/umbraco-heartcore/release-notes/2024-09-releasenotes.md
+++ b/umbraco-heartcore/release-notes/2024-09-releasenotes.md
@@ -3,7 +3,7 @@ The following changes have been released to all Heartcore sites.
 
 ## Webhook Enhancements
 With the core CMS having added webhook support, we have adapted the same function in Heartcore to use the same user interface. Not only does this mean you get the same consistent editing experience in both core Umbraco and Heartcore, but this also means we added support for some new features!
-* You may now select multiple event types (e.g. publish / unpublish) or content types for a webhook. No more needing to create dozens of hooks to achieve what can now be done with just one!
+* You may now select multiple event types (for example, publish / unpublish) or content types for a webhook. No more needing to create dozens of hooks to achieve what can now be done with only one!
 * You may now specify custom HTTP headers to send to your endpoint whenever the webhook fires.
 
 Aside from the interface, all other aspects of webhooks in Heartcore are unchanged. Webhooks are still fired from the delivery platform with the same IP address range, retry policy, and payload that you're used to.
@@ -15,5 +15,5 @@ For a long time, the only way to get redirect information from Heartcore was a s
 
 In order to save you the trouble, a brand new endpoint has been added to the Delivery API. It allows you to fetch the canonical URL (and any other redirects) for a given path. For more information, check out the [updated page here](../api-documentation/redirect.md#get-content-by-redirect-url).
 
-## Improved WAF
+## Improved Firewall
 We can't talk too much about this one, but we recently rolled out additional firewall rules for all Heartcore services. While we have made an effort to tune these, there is always a small possibility of false positives. If you believe your legitimate traffic is affected, please raise a support ticket through the portal.

--- a/umbraco-heartcore/release-notes/2024-09-releasenotes.md
+++ b/umbraco-heartcore/release-notes/2024-09-releasenotes.md
@@ -2,7 +2,7 @@
 The following changes have been released to all Heartcore sites.
 
 ## Webhook Enhancements
-With the core CMS having added webhook support, we have adapted the same function in Heartcore to use the same user interface. Not only does this mean you get the same consistent editing experience in both core Umbraco and Heartcore, but this also means we added support for some new features!
+With the core CMS having added webhook support, we have adapted the same function in Heartcore to use the same user interface. You'll now get the same consistent editing experience in both core Umbraco and Heartcore, but also some new features!
 * You may now select multiple event types (for example, publish / unpublish) or content types for a webhook. No more needing to create dozens of hooks to achieve what can now be done with only one!
 * You may now specify custom HTTP headers to send to your endpoint whenever the webhook fires.
 
@@ -11,9 +11,9 @@ Aside from the interface, all other aspects of webhooks in Heartcore are unchang
 For more information about webhook functionality, both new and old, check out the [updated page here](../getting-started/webhooks.md).
 
 ## New Redirect Endpoint
-For a long time, the only way to get redirect information from Heartcore was a single endpoint on the Delivery API. This endpoint returned paginated redirect information for _all_ content items in the tree. If you needed to find the canonical URL for a given path, then this endpoint was your only option. You would need to search for a matching path in the list of all items - a particular challenge if it wasn't on the first page of results!
+For a long time, the only way to get redirect information from Heartcore was a single endpoint on the Delivery API. This endpoint returned paginated redirect information for _all_ content items in the tree. If you needed to find the canonical URL for a given path, then this endpoint was your only option. You would need to find a matching path in the list of all items - especially challenging if it wasn't on the first page of results!
 
 In order to save you the trouble, a brand new endpoint has been added to the Delivery API. It allows you to fetch the canonical URL (and any other redirects) for a given path. For more information, check out the [updated page here](../api-documentation/redirect.md#get-content-by-redirect-url).
 
 ## Improved Firewall
-We can't talk too much about this one, but we recently rolled out additional firewall rules for all Heartcore services. While we have made an effort to tune these, there is always a small possibility of false positives. If you believe your legitimate traffic is affected, please raise a support ticket through the portal.
+We can't talk too much about this one, but we recently rolled out additional firewall rules for all Heartcore services. While we have made an effort to tune these, there is always a small possibility of false positives. If you believe your legitimate traffic is affected, please raise a support ticket through the portal.`

--- a/umbraco-heartcore/release-notes/2024-09-releasenotes.md
+++ b/umbraco-heartcore/release-notes/2024-09-releasenotes.md
@@ -1,0 +1,19 @@
+# September 2024
+The following changes have been released to all Heartcore sites.
+
+## Webhook Enhancements
+With the core CMS having added webhook support, we have adapted the same function in Heartcore to use the same user interface. Not only does this mean you get the same consistent editing experience in both core Umbraco and Heartcore, but this also means we added support for some new features!
+* You may now select multiple event types (e.g. publish / unpublish) or content types for a webhook. No more needing to create dozens of hooks to achieve what can now be done with just one!
+* You may now specify custom HTTP headers to send to your endpoint whenever the webhook fires.
+
+Aside from the interface, all other aspects of webhooks in Heartcore are unchanged. Webhooks are still fired from the delivery platform with the same IP address range, retry policy, and payload that you're used to.
+
+For more information about webhook functionality, both new and old, check out the [updated page here](../getting-started/webhooks.md).
+
+## New Redirect Endpoint
+For a long time, the only way to get redirect information from Heartcore was a single endpoint on the Delivery API. This endpoint returned paginated redirect information for _all_ content items in the tree. If you needed to find the canonical URL for a given path, then this endpoint was your only option. You would need to search for a matching path in the list of all items - a particular challenge if it wasn't on the first page of results!
+
+In order to save you the trouble, a brand new endpoint has been added to the Delivery API. It allows you to fetch the canonical URL (and any other redirects) for a given path. For more information, check out the [updated page here](../api-documentation/redirect.md#get-content-by-redirect-url).
+
+## Improved WAF
+We can't talk too much about this one, but we recently rolled out additional firewall rules for all Heartcore services. While we have made an effort to tune these, there is always a small possibility of false positives. If you believe your legitimate traffic is affected, please raise a support ticket through the portal.

--- a/umbraco-heartcore/release-notes/2024-09-releasenotes.md
+++ b/umbraco-heartcore/release-notes/2024-09-releasenotes.md
@@ -1,19 +1,7 @@
 # September 2024
 The following changes have been released to all Heartcore sites.
 
-## Webhook Enhancements
-With the core CMS having added webhook support, we have adapted the same function in Heartcore to use the same user interface. You'll now get the same consistent editing experience in both core Umbraco and Heartcore, but also some new features!
-* You may now select multiple event types (for example, publish / unpublish) or content types for a webhook. No more needing to create dozens of hooks to achieve what can now be done with only one!
-* You may now specify custom HTTP headers to send to your endpoint whenever the webhook fires.
-
-Aside from the interface, all other aspects of webhooks in Heartcore are unchanged. Webhooks are still fired from the delivery platform with the same IP address range, retry policy, and payload that you're used to.
-
-For more information about webhook functionality, both new and old, check out the [updated page here](../getting-started/webhooks.md).
-
 ## New Redirect Endpoint
 For a long time, the only way to get redirect information from Heartcore was a single endpoint on the Delivery API. This endpoint returned paginated redirect information for _all_ content items in the tree. If you needed to find the canonical URL for a given path, then this endpoint was your only option. You would need to find a matching path in the list of all items - especially challenging if it wasn't on the first page of results!
 
-In order to save you the trouble, a brand new endpoint has been added to the Delivery API. It allows you to fetch the canonical URL (and any other redirects) for a given path. For more information, check out the [updated page here](../api-documentation/redirect.md#get-content-by-redirect-url).
-
-## Improved Firewall
-We can't talk too much about this one, but we recently rolled out additional firewall rules for all Heartcore services. While we have made an effort to tune these, there is always a small possibility of false positives. If you believe your legitimate traffic is affected, please raise a support ticket through the portal.`
+In order to save you the trouble, a brand new endpoint has been added to the Delivery API. It allows you to fetch the canonical URL (and any other redirects) for a given path. For more information, check out the [updated page here](../api-documentation/content-delivery/redirect.md#get-content-by-redirect-url).

--- a/umbraco-heartcore/release-notes/2024-09-releasenotes.md
+++ b/umbraco-heartcore/release-notes/2024-09-releasenotes.md
@@ -2,6 +2,6 @@
 The following changes have been released to all Heartcore sites.
 
 ## New Redirect Endpoint
-For a long time, the only way to get redirect information from Heartcore was a single endpoint on the Delivery API. This endpoint returned paginated redirect information for _all_ content items in the tree. If you needed to find the canonical URL for a given path, then this endpoint was your only option. You would need to find a matching path in the list of all items - especially challenging if it wasn't on the first page of results!
+For a long time, the only way to get redirect information from Heartcore was a single endpoint on the Delivery API. This endpoint returned paginated redirect information for _all_ content items in the tree. If you needed to find the canonical URL for a given path, then this endpoint was your only option. You would need to find your path in the returned items - especially challenging if it wasn't on the first page of results!
 
 In order to save you the trouble, a brand new endpoint has been added to the Delivery API. It allows you to fetch the canonical URL (and any other redirects) for a given path. For more information, check out the [updated page here](../api-documentation/content-delivery/redirect.md#get-content-by-redirect-url).


### PR DESCRIPTION
## Description

Heartcore release notes & updated API docs for September.

Also moved the redirect API to underneath the content delivery API - It's not really a seperate API on its own and the docs should reflect that.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [x] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Heartcore

## Deadline (if relevant)

_When should the content be published?_

N/A
