### PR TITLE
Added release notes for Forms 13.2.4 and 14.1.4

### DIFF
--- a/13/umbraco-forms/release-notes.md
+++ b/13/umbraco-forms/release-notes.md
@@ -17,6 +17,10 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 13 including all changes for this version.
 
+#### [**13.2.4**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.4) **(September 26th 2024)**
+
+* Fixed regression in 13.2.2 that caused validation to fire on the wrong form when multiple forms are hosted on a single page [#1297](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1297).
+
 #### [**13.2.3**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.3) **(September 19th 2024)**
 
 * Fixed regression in 13.2.0 that prevented a form submission from saving if a workflow approved the entry [#1293](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1293).

--- a/13/umbraco-forms/release-notes.md
+++ b/13/umbraco-forms/release-notes.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Get an overview of the things changed and fixed in each version of Umbraco Forms.
+  Get an overview of the changes and fixes in each version of Umbraco Forms.
 ---
 
 # Release Notes

--- a/14/umbraco-forms/release-notes.md
+++ b/14/umbraco-forms/release-notes.md
@@ -21,7 +21,7 @@ This section contains the release notes for Umbraco Forms 14 including all chang
 #### [**14.1.4**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.4) **(September 26th 2024)**
 
 * Fixed regression in 14.1.2 that caused validation to fire on the wrong form when multiple forms are hosted on a single page [#1297](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1297).
-* Fixed issue with line breaks in form submissions breaking the entries view  [#1296](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1296).
+* Fixed issue with line breaks in form submissions breaking the entries view [#1296](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1296).
 
 #### [**14.1.3**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.3) **(September 19th 2024)**
 

--- a/14/umbraco-forms/release-notes.md
+++ b/14/umbraco-forms/release-notes.md
@@ -18,6 +18,11 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 14 including all changes for this version.
 
+#### [**14.1.4**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.4) **(September 26th 2024)**
+
+* Fixed regression in 14.1.2 that caused validation to fire on the wrong form when multiple forms are hosted on a single page [#1297](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1297).
+* Fixed issue with line breaks in form submissions breaking the entries view  [#1296](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1296).
+
 #### [**14.1.3**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.3) **(September 19th 2024)**
 
 * Fixed regression in 13.2.0 that prevented a form submission from saving if a workflow approved the entry [#1293](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1293).


### PR DESCRIPTION
## Description

Added release notes for Forms 13.2.4 and 14.1.4

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [X] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Forms 13.2.4 and 14.1.4

## Deadline (if relevant)

Can go live at any time, but ideally before or on Thursday morning.
