### PR TITLE
Sectionview: fixed existing example + added extra examples

### DIFF
--- a/14/umbraco-cms/customizing/section-trees/sections/section-view.md
+++ b/14/umbraco-cms/customizing/section-trees/sections/section-view.md
@@ -12,17 +12,100 @@ This page is a work in progress and may undergo further revisions, updates, or a
 
 <figure><img src="../../../.gitbook/assets/section-views.svg" alt=""><figcaption><p>Section View</p></figcaption></figure>
 
-**Manifest**
+## Creating a custom Section View
+
+### Manifest
+
+**Using Json**
+
+We can create the manifest using json in the `umbraco-package.json`.
 
 ```json
 {
 	"type": "sectionView",
 	"alias": "My.SectionView",
 	"name": "My Section View",
+	"element": "./my-section.element.js",
 	"meta": {
-		"sections": ["My.Section"],
 		"label": "My View",
-		"pathname": "/my-view"
-	}
+		"icon": "icon-add",
+		"pathname": "my-view"
+	},
+	"conditions": [
+		{
+			"alias": "Umb.Condition.SectionAlias",
+			"match": "My.Section",
+		}
+	]
 }
+```
+
+**Using TypeScript**
+
+The manifest can also be written in TypeScript.
+
+```typescript
+import { ManifestSectionView } from "@umbraco-cms/backoffice/extension-registry";
+
+const sectionViews: Array<ManifestSectionView> = [
+    {
+        type: "sectionView",
+        alias: "My.SectionView",
+        name: "My Section View",
+        element: () => import('./my-section.element.ts'),
+        meta: {
+            label: "My View",
+            icon: "icon-add"
+			pathname: "my-view",
+        },
+        conditions: [
+            {
+                alias: 'Umb.Condition.SectionAlias',
+				match: 'My.Section',
+            }
+        ]
+    }
+]
+```
+
+### Lit Element
+
+Creating the Section View Element using a Lit Element.
+
+
+**my-section.element.ts:**
+```typescript
+import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
+import { css, html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
+
+@customElement('my-sectionview-element')
+export class MySectionViewElement extends UmbLitElement {
+
+    render() {
+        return html`
+            <uui-box headline="Sectionview Title goes here">
+                Sectionview content goes here
+            </uui-box>
+        `
+    }
+
+    static override styles = [
+        css`
+			:host {
+				display: block;
+                padding: 20px;
+			}
+		`,
+    ];
+
+}
+
+export default MySectionViewElement;
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'my-sectionview-element': MySectionViewElement;
+    }
+}
+
 ```

--- a/14/umbraco-cms/customizing/section-trees/sections/section-view.md
+++ b/14/umbraco-cms/customizing/section-trees/sections/section-view.md
@@ -14,9 +14,15 @@ This page is a work in progress and may undergo further revisions, updates, or a
 
 ## Creating a custom Section View
 
+In this section, you can learn how to register and create a custom Section View for the Umbraco backoffice.
+
 ### Manifest
 
-**Using Json**
+The manifest file can be created using either JSON or Typescript. Both methods are shown below.
+
+{% tabs %}
+
+{% tab title="Json" %} 
 
 We can create the manifest using json in the `umbraco-package.json`.
 
@@ -40,7 +46,10 @@ We can create the manifest using json in the `umbraco-package.json`.
 }
 ```
 
-**Using TypeScript**
+{% endtab %}
+
+{% tab title="Typescript" %} 
+
 
 The manifest can also be written in TypeScript.
 
@@ -69,6 +78,10 @@ const sectionViews: Array<ManifestSectionView> = [
     }
 ]
 ```
+
+ {% endtab %}
+
+{% endtabs %}
 
 
 ### Lit Element

--- a/14/umbraco-cms/customizing/section-trees/sections/section-view.md
+++ b/14/umbraco-cms/customizing/section-trees/sections/section-view.md
@@ -55,7 +55,7 @@ const sectionViews: Array<ManifestSectionView> = [
         element: () => import('./my-section.element.ts'),
         meta: {
             label: "My View",
-            icon: "icon-add"
+            icon: "icon-add",
 			pathname: "my-view",
         },
         conditions: [

--- a/14/umbraco-cms/customizing/section-trees/sections/section-view.md
+++ b/14/umbraco-cms/customizing/section-trees/sections/section-view.md
@@ -68,6 +68,53 @@ const sectionViews: Array<ManifestSectionView> = [
 ]
 ```
 
+For this typescript example we used a entrypoint extension to load the assets.js file.
+
+We also setup our vite build to output the assets.js file in the `app_plugins/Our.Umbraco.Example` folder.
+
+The `umbraco-package.json` then would look like this:
+
+```JSON
+{
+    "$schema": "../umbraco-package-schema.json",
+    "name": "Our.Umbraco.Example",
+    "id": "Our.Umbraco.Example",
+    "version": "0.1.0",
+    "allowTelemetry": true,
+    "extensions": [
+        {
+            "name": "Our.Umbraco.Example.entrypoint",
+            "alias": "Our.Umbraco.Example.EntryPoint",
+            "type": "entryPoint",
+            "js": "/app_plugins/Our.Umbraco.Example/assets.js"
+        }
+    ]
+}
+```
+
+Then we just have to register all the manifests on `onInit` using `extensionRegistry.registerMany()` in our entry file.
+
+So then our `index.ts` file would look like this:
+
+```typescript
+//Import all the manifests here
+
+const manifests: Array<ManifestTypes> = [
+    ...dashboardManifests,
+	...menuManifests,
+	// Manifests for section views
+    ...sectionManifests,
+	//...
+];
+
+export const onInit: UmbEntryPointOnInit = (_host, extensionRegistry) => {
+    
+    // register them here. 
+    extensionRegistry.registerMany(manifests);
+};
+
+```
+
 ### Lit Element
 
 Creating the Section View Element using a Lit Element.

--- a/14/umbraco-cms/customizing/section-trees/sections/section-view.md
+++ b/14/umbraco-cms/customizing/section-trees/sections/section-view.md
@@ -44,6 +44,8 @@ We can create the manifest using json in the `umbraco-package.json`.
 
 The manifest can also be written in TypeScript.
 
+For this typescript example we used a [Backoffice Entry Point](../../extending-overview/extension-types/backoffice-entry-point) extension to register the manifests.
+
 ```typescript
 import { ManifestSectionView } from "@umbraco-cms/backoffice/extension-registry";
 
@@ -68,52 +70,6 @@ const sectionViews: Array<ManifestSectionView> = [
 ]
 ```
 
-For this typescript example we used a entrypoint extension to load the assets.js file.
-
-We also setup our vite build to output the assets.js file in the `app_plugins/Our.Umbraco.Example` folder.
-
-The `umbraco-package.json` then would look like this:
-
-```JSON
-{
-    "$schema": "../umbraco-package-schema.json",
-    "name": "Our.Umbraco.Example",
-    "id": "Our.Umbraco.Example",
-    "version": "0.1.0",
-    "allowTelemetry": true,
-    "extensions": [
-        {
-            "name": "Our.Umbraco.Example.entrypoint",
-            "alias": "Our.Umbraco.Example.EntryPoint",
-            "type": "entryPoint",
-            "js": "/app_plugins/Our.Umbraco.Example/assets.js"
-        }
-    ]
-}
-```
-
-Then we just have to register all the manifests on `onInit` using `extensionRegistry.registerMany()` in our entry file.
-
-So then our `index.ts` file would look like this:
-
-```typescript
-//Import all the manifests here
-
-const manifests: Array<ManifestTypes> = [
-    ...dashboardManifests,
-	...menuManifests,
-	// Manifests for section views
-    ...sectionManifests,
-	//...
-];
-
-export const onInit: UmbEntryPointOnInit = (_host, extensionRegistry) => {
-    
-    // register them here. 
-    extensionRegistry.registerMany(manifests);
-};
-
-```
 
 ### Lit Element
 

--- a/15/umbraco-cms/customizing/section-trees/sections/section-view.md
+++ b/15/umbraco-cms/customizing/section-trees/sections/section-view.md
@@ -12,17 +12,100 @@ This page is a work in progress and may undergo further revisions, updates, or a
 
 <figure><img src="../../../.gitbook/assets/section-views.svg" alt=""><figcaption><p>Section View</p></figcaption></figure>
 
-**Manifest**
+## Creating a custom Section View
+
+### Manifest
+
+**Using Json**
+
+We can create the manifest using json in the `umbraco-package.json`.
 
 ```json
 {
 	"type": "sectionView",
 	"alias": "My.SectionView",
 	"name": "My Section View",
+	"element": "./my-section.element.js",
 	"meta": {
-		"sections": ["My.Section"],
 		"label": "My View",
-		"pathname": "/my-view"
-	}
+		"icon": "icon-add",
+		"pathname": "my-view"
+	},
+	"conditions": [
+		{
+			"alias": "Umb.Condition.SectionAlias",
+			"match": "My.Section",
+		}
+	]
 }
+```
+
+**Using TypeScript**
+
+The manifest can also be written in TypeScript.
+
+```typescript
+import { ManifestSectionView } from "@umbraco-cms/backoffice/extension-registry";
+
+const sectionViews: Array<ManifestSectionView> = [
+    {
+        type: "sectionView",
+        alias: "My.SectionView",
+        name: "My Section View",
+        element: () => import('./my-section.element.ts'),
+        meta: {
+            label: "My View",
+            icon: "icon-add"
+			pathname: "my-view",
+        },
+        conditions: [
+            {
+                alias: 'Umb.Condition.SectionAlias',
+				match: 'My.Section',
+            }
+        ]
+    }
+]
+```
+
+### Lit Element
+
+Creating the Section View Element using a Lit Element.
+
+
+**my-section.element.ts:**
+```typescript
+import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
+import { css, html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
+
+@customElement('my-sectionview-element')
+export class MySectionViewElement extends UmbLitElement {
+
+    render() {
+        return html`
+            <uui-box headline="Sectionview Title goes here">
+                Sectionview content goes here
+            </uui-box>
+        `
+    }
+
+    static override styles = [
+        css`
+			:host {
+				display: block;
+                padding: 20px;
+			}
+		`,
+    ];
+
+}
+
+export default MySectionViewElement;
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'my-sectionview-element': MySectionViewElement;
+    }
+}
+
 ```


### PR DESCRIPTION
## Description

I updated the already existing example which wasn't up to date with the current version of the ManifestSectionView.

I also added a typescript example of how to define the manifest + added a lit component example as reference to the linked element in the manifest.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [x] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
V14, v15

