### PR TITLE
Remove mentions of Macros to render Umbraco Forms

### DIFF
--- a/13/umbraco-ums/security-and-privacy/gdpr/how-to-become-gdpr-compliant-using-cookiebot.md
+++ b/13/umbraco-ums/security-and-privacy/gdpr/how-to-become-gdpr-compliant-using-cookiebot.md
@@ -1,12 +1,12 @@
-# how To Become GDPR compliant using cookiebot
+# How To Become GDPR Compliant Using Cookiebot
 
-We can integrate with a cookie consent banner service such as CookieBot and [depending on the choice of the user we can enable or disable certain parts of uMarketingSuite](../../../../the-umarketingsuite-broad-overview/the-umarketingsuite-cookie/module-permissions/).
+You can integrate with a cookie consent banner service such as CookieBot and [depending on the users choice you can configure certain parts of uMS](../../../../the-umarketingsuite-broad-overview/the-umarketingsuite-cookie/module-permissions/).
 
 This has been covered in our documentation previously, but this tutorial gives you a full working implementation to use with [CookieBot](https://www.cookiebot.com/) in particular.
 
 ![]()
 
-#### Code Example
+## Code Example
 
 The code example below shows how to create the back-end code to read the CookieBot consent cookie from the end-user, and based on that decides which features of uMarketingSuite it should enable or disable.
 

--- a/14/umbraco-forms/developer/rendering-forms.md
+++ b/14/umbraco-forms/developer/rendering-forms.md
@@ -17,7 +17,9 @@ When selecting a theme, it can be added directly as a string or dynamically by r
 {% tab title="Dynamic" %}
 
 ```csharp
-@await Component.InvokeAsync("RenderForm", new { formId = @Model.Form, theme = @Model.Theme, includeScripts = false })
+@await Component.InvokeAsync("RenderForm", new { formId = @Model.Form, 
+                                                 theme = @Model.Theme,
+                                                 includeScripts = false })
 ```
 
 This example uses a Forms Picker with `form` as alias, and a Theme Picker with `theme` as alias.
@@ -26,8 +28,10 @@ This example uses a Forms Picker with `form` as alias, and a Theme Picker with `
 
 {% tab title="Static" %}
 
-```cshtml
-@await Component.InvokeAsync("RenderForm", new { formId = Guid.Parse("<form guid>"), theme = "default", includeScripts = false })
+```csharp
+@await Component.InvokeAsync("RenderForm", new { formId = Guid.Parse("<form guid>"), 
+                                                 theme = "default", 
+                                                 includeScripts = false })
 ```
 
 This example hard-codes the GUID of a form and the name of the theme.
@@ -49,7 +53,10 @@ The following example shows how the `additionalData` parameter is used:
 
 ```csharp
 var additionalData = new Dictionary<string, string> { { "foo", "bar" }, { "buzz", "baz" } };
-@await Component.InvokeAsync("RenderForm", new { formId = @Model.Form, theme = @Model.Theme, includeScripts = false, additionalData })
+@await Component.InvokeAsync("RenderForm", new { formId = @Model.Form, 
+                                                 theme = @Model.Theme, 
+                                                 includeScripts = false, 
+                                                 additionalData })
 ```
 
 ## Rendering Using a Tag Helper
@@ -68,6 +75,9 @@ Then in your view you can use:
 @if (Model.Form.HasValue)
 {
     var additionalData = new Dictionary<string, string> { { "foo", "bar" }, { "buzz", "baz" } };
-    <umb-forms-render form-id="@Model.FormId.Value" theme="@Model.FormTheme" exclude-scripts="true" additional-data="@additionalData" />
+    <umb-forms-render form-id="@Model.FormId.Value" 
+                      theme="@Model.FormTheme" 
+                      exclude-scripts="true" 
+                      additional-data="@additionalData" />
 }
 ```

--- a/14/umbraco-forms/developer/rendering-forms.md
+++ b/14/umbraco-forms/developer/rendering-forms.md
@@ -51,13 +51,14 @@ Six parameters can be provided:
 
 The following example shows how the `additionalData` parameter is used:
 
+{% code wrap="true" %}
+
 ```csharp
 var additionalData = new Dictionary<string, string> { { "foo", "bar" }, { "buzz", "baz" } };
-@await Component.InvokeAsync("RenderForm", new { formId = @Model.Form, 
-                                                 theme = @Model.Theme, 
-                                                 includeScripts = false, 
-                                                 additionalData })
+@await Component.InvokeAsync("RenderForm", new { formId = @Model.Form, theme = @Model.Theme, includeScripts = false, additionalData })
 ```
+
+{% endcode %}
 
 ## Rendering Using a Tag Helper
 

--- a/14/umbraco-forms/developer/rendering-forms.md
+++ b/14/umbraco-forms/developer/rendering-forms.md
@@ -4,7 +4,7 @@ description: Learn the different ways of rendering a form on your website when u
 
 # Rendering Forms
 
-There are three options available for rendering a form.
+There are two options available for rendering a form.
 
 ## Rendering Using a View Component
 
@@ -47,28 +47,5 @@ Then in your view you can use:
 {
     var additionalData = new Dictionary<string, string> { { "foo", "bar" }, { "buzz", "baz" } };
     <umb-forms-render form-id="@Model.FormId.Value" theme="@Model.FormTheme" exclude-scripts="true" additional-data="@additionalData" />
-}
-```
-
-## Rendering Using a Macro
-
-With a grid or Rich Text Editor, you need to use a macro. This is also available as an option to display a form in your view, where you provide three parameters:
-
-```cshtml
-@await Umbraco.RenderMacroAsync("renderUmbracoForm", new { FormGuid = "<form guid>", FormTheme = "default", ExcludeScripts = "1" })
-```
-
-- `FormGuid` is the GUID of a form.
-- `FormTheme` is the name of a theme. If not provided, the default theme is used.
-- `ExcludeScripts` takes a value of 0 or 1, indicating whether scripts should be excluded from rendering.
-- `RedirectToPageId` is an optional picked content item that, if provided, is redirected to once the form has been submitted. It will be used in preference to post-submission behavior defined on the form itself.
-
-
-Similarly, you can reference a form picker property on your page:
-
-```cshtml
-@if (Model.FormId is Guid formId)
-{
-    @await Umbraco.RenderMacroAsync("renderUmbracoForm", new { FormGuid = formId, FormTheme = Model.FormTheme, ExcludeScripts = "1" })
 }
 ```

--- a/14/umbraco-forms/developer/rendering-forms.md
+++ b/14/umbraco-forms/developer/rendering-forms.md
@@ -8,11 +8,36 @@ There are two options available for rendering a form.
 
 ## Rendering Using a View Component
 
-To display a form in your view, you can make a call to a view component:
+To display a form in your view, you can make a call to a view component. You can use a forms GUID directly or add a form dynamically by referencing a form selected via a Forms Picker.
+
+When selecting a theme, it can be added directly as a string or dynamically by referencing a theme picked via a Theme Picker.
+
+{% tabs %}
+
+{% tab title="Dynamic" %}
+
+```csharp
+var additionalData = new Dictionary<string, string> { { "foo", "bar" }, { "buzz", "baz" } };
+@await Component.InvokeAsync("RenderForm", new { formId = @Model.Form, theme = @Model.Theme, includeScripts = false, additionalData })
+```
+
+This example uses a Forms Picker with `form` as alias, and a Theme Picker with `theme` as alias.
+
+This example also adds magic strings replacements using the `additionalData` parameter.
+
+{% endtab %}
+
+{% tab title="Static" %}
 
 ```cshtml
 @await Component.InvokeAsync("RenderForm", new { formId = Guid.Parse("<form guid>"), theme = "default", includeScripts = false })
 ```
+
+This example hard-codes the GUID of a form and the name of the theme.
+
+{% endtab %}
+
+{% endtabs %}
 
 Six parameters can be provided:
 
@@ -22,13 +47,6 @@ Six parameters can be provided:
 - `recordId` is an optional existing record GUID, used if editing records via the website is [enabled in configuration](../developer/configuration/README.md#alloweditableformsubmissions)
 - `redirectToPageId` is an optional GUID for a content page that, if provided, is redirected to once the form has been submitted. It will be used in preference to post-submission behavior defined on the form itself.
 - `additionalData` is an optional dictionary of string values. When provided it will be used as a source for ["magic string" replacements](./magic-strings.md). The data will be associated with the created record and made available for custom logic or update within workflows.
-
-Usually, rather than hard-coding the form's GUID and other details, you'll use a form, theme or content picker on your page:
-
-```csharp
-var additionalData = new Dictionary<string, string> { { "foo", "bar" }, { "buzz", "baz" } };
-@await Component.InvokeAsync("RenderForm", new { formId = @Model.Form, theme = @Model.Theme, includeScripts = false, additionalData })
-```
 
 ## Rendering Using a Tag Helper
 

--- a/14/umbraco-forms/developer/rendering-forms.md
+++ b/14/umbraco-forms/developer/rendering-forms.md
@@ -17,13 +17,10 @@ When selecting a theme, it can be added directly as a string or dynamically by r
 {% tab title="Dynamic" %}
 
 ```csharp
-var additionalData = new Dictionary<string, string> { { "foo", "bar" }, { "buzz", "baz" } };
-@await Component.InvokeAsync("RenderForm", new { formId = @Model.Form, theme = @Model.Theme, includeScripts = false, additionalData })
+@await Component.InvokeAsync("RenderForm", new { formId = @Model.Form, theme = @Model.Theme, includeScripts = false })
 ```
 
 This example uses a Forms Picker with `form` as alias, and a Theme Picker with `theme` as alias.
-
-This example also adds magic strings replacements using the `additionalData` parameter.
 
 {% endtab %}
 
@@ -47,6 +44,13 @@ Six parameters can be provided:
 - `recordId` is an optional existing record GUID, used if editing records via the website is [enabled in configuration](../developer/configuration/README.md#alloweditableformsubmissions)
 - `redirectToPageId` is an optional GUID for a content page that, if provided, is redirected to once the form has been submitted. It will be used in preference to post-submission behavior defined on the form itself.
 - `additionalData` is an optional dictionary of string values. When provided it will be used as a source for ["magic string" replacements](./magic-strings.md). The data will be associated with the created record and made available for custom logic or update within workflows.
+
+The following example shows how the `additionalData` parameter is used:
+
+```csharp
+var additionalData = new Dictionary<string, string> { { "foo", "bar" }, { "buzz", "baz" } };
+@await Component.InvokeAsync("RenderForm", new { formId = @Model.Form, theme = @Model.Theme, includeScripts = false, additionalData })
+```
 
 ## Rendering Using a Tag Helper
 

--- a/14/umbraco-forms/developer/themes.md
+++ b/14/umbraco-forms/developer/themes.md
@@ -44,17 +44,9 @@ If adding or amending client-side scripts, you need to copy the `Script.cshtml` 
 
 ## Using a Theme
 
-To use a theme with a Form use the "Insert Form" macro where you will be presented with the options of the form you wish to insert along with an option to pick a theme. This displays the list of theme folders found at `Views/Partials/Forms/Themes`.
+When rendering a form in a view file, you can specify which theme to use with the form.
 
-![Choosing and using a theme](../../../10/umbraco-forms/developer/images/select-a-theme.png)
-
-When you are rendering your form directly in your template, you need to specify your theme by filling out the `FormTheme` attribute:
-
-```csharp
-@await Umbraco.RenderMacroAsync("renderUmbracoForm", new {FormGuid="1ec026cb-d4d3-496c-b8e8-90e0758c78d8", FormTheme="MyFormTheme", ExcludeScripts="0"})
-```
-
-If you do not pick and/or set a theme, the `default` theme will be used to render the form.
+Learn more about how to render a form with a theme in the [Rendering Forms](./rendering-forms.md) article.
 
 ## Theme Fallbacks
 


### PR DESCRIPTION
## Description

I've updated the "Render Forms" article by removing the macro section.
I've updated the "Themes article" by linking to the "Rendering Forms" article instead of the example using Macros.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Forms - 14
