### PR TITLE
Remove references to images in v12 directory

### DIFF
--- a/10/umbraco-deploy/deployment-workflow/content-transfer.md
+++ b/10/umbraco-deploy/deployment-workflow/content-transfer.md
@@ -33,7 +33,7 @@ You want to transfer the whole site. You start from the `Home` node and choose t
     {% endhint %}
 7.  Click **Queue** to add the content item to the transfer queue.
 
-    ![Queue for transfer window](../../../12/umbraco-deploy/deployment-workflow/images/queue-for-transfer-dialog.png)
+    ![Queue for transfer window](images/queue-for-transfer-dialog.png)
 8. Go to the Deployment dashboard by clicking on the Content section header.
    * You will be able to see which items are currently ready to be transferred - this will include both content and media that you've _queued for transfer_.
 9.  Confirm by clicking **Transfer toDevelopment** and monitor the progress of the transfer.

--- a/13/umbraco-cms/fundamentals/data/defining-content/README.md
+++ b/13/umbraco-cms/fundamentals/data/defining-content/README.md
@@ -28,7 +28,7 @@ A Document Type is created using the Document Type editor in the **Settings** se
 * On the **Document Types** node click the menu icon (•••) to bring up the context menu.&#x20;
 * Here choose **Document Type with Template**. This will create a new Document Type with a template. The Template can be found under **Templates** in the **Settings** section which will be assigned as the default template for the Document Type.
 
-<figure><img src="../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/createDoctype.PNG" alt=""><figcaption></figcaption></figure>
+<figure><img src="../images/v8Screenshots/createDoctype.PNG" alt=""><figcaption></figcaption></figure>
 
 You can also choose to create a **Document Type** without a template and create **Folders** to organize your Document Types. Other options are to create Compositions and Element types, which you can read more about in the [Default Document Types](default-document-types.md) section.
 
@@ -38,7 +38,7 @@ You can also choose to create a **Document Type** without a template and create 
 
 First, we're prompted to give the Document Type a **name**. This first Document Type will be the root node for our content, name it "`Home`".
 
-<figure><img src="../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/homePage.PNG" alt=""><figcaption></figcaption></figure>
+<figure><img src="../images/v8Screenshots/homePage.PNG" alt=""><figcaption></figcaption></figure>
 
 {% hint style="info" %}
 The alias of the Document Type is automatically generated based on the property name. If you want to change the auto-generated alias, click the "**lock**" icon. The alias must be in camel case. For example: _`homePage`_.
@@ -52,7 +52,7 @@ Choosing appropriate icons for your content nodes is a good way to give editors 
 
 To set an icon for the Document Type click the document icon in the top left corner. This will open the icon select dialog. Search for "`Home"`and select the icon. This icon will be used in the content tree.
 
-<figure><img src="../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/docTypeIcon.PNG" alt=""><figcaption></figcaption></figure>
+<figure><img src="../images/v8Screenshots/docTypeIcon.PNG" alt=""><figcaption></figcaption></figure>
 
 ### Setting Permissions
 
@@ -62,7 +62,7 @@ This will allow this Document Type to be created as the first content in the **C
 * Tick the **Allow as root** toggle&#x20;
 * Save the Document Type by clicking **save** in the bottom right corner.&#x20;
 
-<figure><img src="../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/docTypePermissions.PNG" alt=""><figcaption></figcaption></figure>
+<figure><img src="../images/v8Screenshots/docTypePermissions.PNG" alt=""><figcaption></figcaption></figure>
 
 ## 3. Creating the content
 
@@ -73,7 +73,7 @@ Now that we have the Document Type in place, we can create the content.
 * Select the "`Home`" Document Type. We'll name it "`Home`"&#x20;
 * Then click the **Save and Publish** button.
 
-<figure><img src="../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/createHomepage.PNG" alt=""><figcaption></figcaption></figure>
+<figure><img src="../images/v8Screenshots/createHomepage.PNG" alt=""><figcaption></figcaption></figure>
 
 As we haven't created our properties, all we can see on the "`Home`" node is the Properties tab. This tab contains the default properties that are available on all content nodes in Umbraco.
 
@@ -115,7 +115,7 @@ Before we start adding properties to the Document Type we need to create a group
 
 * Click **Add group** and name the group "`Content`".
 
-![Creating groups](../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/createGroup\_new.png)
+![Creating groups](../images/v8Screenshots/createGroup\_new.png)
 
 {% hint style="info" %}
 
@@ -133,7 +133,7 @@ Now that we have created a group we can start adding properties. Let's add a Ric
 * **Choose** which Data Type/property editor to use, and add validation if needed.
 * Give the property a **name.** The name will be shown to the editor to make it relevant and understandable. Notice the alias is automatically generated based on the name. We'll name this "`Body Text`".
 
-![Adding a property](../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/addproperty\_new.png)
+![Adding a property](../images/v8Screenshots/addproperty\_new.png)
 
 #### Property Editors
 
@@ -141,7 +141,7 @@ Now that we have created a group we can start adding properties. Let's add a Ric
 * To make it easier to find what you need use the **search field** to filter by typing "`Rich`". Filtering will display configured properties first (under **Available configurations**) and all available editors under that.
 * Select the **Rich Text editor** under **Create new**. This will let you configure the editor settings - the Rich Text editor for this property.
 
-![Choosing the Rich Text editor](../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/selectEditor\_new.png)
+![Choosing the Rich Text editor](../images/v8Screenshots/selectEditor\_new.png)
 
 {% hint style="info" %}
 
@@ -249,7 +249,7 @@ This is *italic*
 ![Image alt text](https://media.giphy.com/media/bezxCUK2D2TuBCJ7r5/giphy.gif)
 ```
 
-![Makrdown description example](../../../../../12/umbraco-cms/fundamentals/data/images/md-description.gif)
+![Makrdown description example](../images/md-description.gif)
 
 ## 5. Defining child nodes
 
@@ -272,14 +272,14 @@ Before creating a Text Page in **Content** section, allow the Text Page Document
 * Click **Add child**&#x20;
 * **Select** "`Text Page`".
 
-<figure><img src="../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/setPagePermissions.PNG" alt=""><figcaption></figcaption></figure>
+<figure><img src="../images/v8Screenshots/setPagePermissions.PNG" alt=""><figcaption></figcaption></figure>
 
 * Go to the **Content** section&#x20;
 * Click the menu icon (•••) next to the "`Home`" node&#x20;
 * **Select** the "`Text page`" Document Type. We'll name the page "`About us`". \
   We now have a basic content structure.
 
-<figure><img src="../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/createAboutUs.PNG" alt=""><figcaption></figcaption></figure>
+<figure><img src="../images/v8Screenshots/createAboutUs.PNG" alt=""><figcaption></figcaption></figure>
 
 Document Types are flexible and can be used for defining pieces of reusable content or an entire page, to act as a container or repository.
 
@@ -291,7 +291,7 @@ You can also export document types from an already existing project/installation
 * Right-click the **Document type**
 * Select **Export**. When you click on the **Export** button, the Document Type is saved as a \*.udt file.
 
-![Exporting a Document Type](../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/export-document-type.png)
+![Exporting a Document Type](../images/v8Screenshots/export-document-type.png)
 
 To import a Document Type:
 
@@ -301,7 +301,7 @@ To import a Document Type:
 * Click on the **Import** button and browse to the Document Type you exported. The **Name** and **Alias** of the Document Type are displayed.&#x20;
 * Click **Import** to complete the process.
 
-![Importing a Document Type](../../../../../12/umbraco-cms/fundamentals/data/images/import-document-type.png)
+![Importing a Document Type](../images/import-document-type.png)
 
 {% hint style="info" %}
 

--- a/13/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
+++ b/13/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
@@ -2,7 +2,7 @@
 
 On this page, you will find the default Document Types in Umbraco. If you want to use these document types, you can create them in the Settings section.
 
-<figure><img src="../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/createDoctype.PNG" alt=""><figcaption></figcaption></figure>
+<figure><img src="../images/v8Screenshots/createDoctype.PNG" alt=""><figcaption></figcaption></figure>
 
 ## Document type with template
 
@@ -18,12 +18,12 @@ Compositions provide a way to create reusable sets of properties that can be add
 
 When using a mixed setup, you can take advantage of nesting and use compositions by clicking on "**Compositions**..." option.
 
-<figure><img src="../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/createGroup_new.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../images/v8Screenshots/createGroup_new.png" alt=""><figcaption></figcaption></figure>
 
 {% hint style="warning" %}
 
 If you create 2 compositions that contain some common properties it is only possible to pick one of the compositions in a Document Type. If preferred, those compositions that cannot be used can be marked as hidden by checkmarking the `Hide unavailable options`.
-<figure><img src="../../../../../12/umbraco-cms/fundamentals/data/images/Composition-hide-unavailable-options.PNG" alt=""><figcaption></figcaption></figure>
+<figure><img src="../images/Composition-hide-unavailable-options.PNG" alt=""><figcaption></figcaption></figure>
 
 {% endhint %}
 
@@ -33,6 +33,6 @@ An Element Type is a Document Type without a template containing schema configur
 
 Element Types cannot be used to create content that resides in the Content tree. When you create an Element type, it automatically sets the **Is Element Type** flag to **True** on the **Permissions** tab.
 
-<figure><img src="../../../../../12/umbraco-cms/fundamentals/data/images/Element-Type.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../images/Element-Type.png" alt=""><figcaption></figcaption></figure>
 
 Element Types are created using the same workflow as regular Document Types but usually contain fewer properties. You can also create Element Types as part of configuring a Block Grid or Block List Data Type.

--- a/13/umbraco-deploy/deployment-workflow/content-transfer.md
+++ b/13/umbraco-deploy/deployment-workflow/content-transfer.md
@@ -32,12 +32,12 @@ You want to transfer the whole site. You start from the `Home` node and choose t
     {% endhint %}
 7.  Click **Queue** to add the content item to the transfer queue.
 
-    ![Queue for transfer window](../../../12/umbraco-deploy/deployment-workflow/images/queue-for-transfer-dialog.png)
+    ![Queue for transfer window](images/queue-for-transfer-dialog.png)
 8. Go to the Deployment dashboard by clicking on the Content section header.
    * You will be able to see which items are currently ready to be transferred - this will include both content and media that you've _queued for transfer_.
 9.  Confirm by clicking **Transfer toDevelopment** and monitor the progress of the transfer.
 
-    ![Transfer queue](../../../10/umbraco-deploy/deployment-workflow/images/transfer-queue.png)
+    ![Transfer queue](images/transfer-queue.png)
 
 If everything went well, you will see the confirmation screen saying that the transfer has succeeded.
 
@@ -67,6 +67,6 @@ This does not include entries submitted via the forms.
 
 Sometimes a content transfer might not be possible. For example if you add a new property to the HomePage Document type and you don’t have that property in both environments, you’ll get an error with a hint on how to fix this.
 
-![clone dialog](<../../../10/umbraco-deploy/deployment-workflow/images/schema-mismatch (1).png>)
+![clone dialog](<images/schema-mismatch (1).png>)
 
 If you are seeing this type of issue when trying to transfer content, head over to our article about [Schema Mismatch errors](../troubleshooting.md), where you can read about how to resolve the issues.

--- a/13/umbraco-deploy/troubleshooting.md
+++ b/13/umbraco-deploy/troubleshooting.md
@@ -18,7 +18,7 @@ If having resolved schema mismatches you still have reports of errors, it might 
 
 This should not be necessary in normal use, but can occur after upgrades. If you have this situation, you can clear the cached signatures in both the upstream and downstream environments. You do this via the _Clear Cached Signatures_ operation available on the _Settings > Deploy_ dashboard:
 
-![Clear cached signatures](../../12/umbraco-deploy/images/clear-cached-sigs.png)
+![Clear cached signatures](images/clear-cached-sigs.png)
 
 ## Slow responses or timeouts when restoring or transferring
 
@@ -64,7 +64,7 @@ When set, if the number of items determined for the package exceeds the batch si
 
 For transfer or restore operations, it's worth ensuring Deploy's cached signatures are fully populated in both the upstream and downstream environments. This can be done via the _Set Cached Signatures_ operation available on the _Settings > Deploy_ dashboard:
 
-![Set cached signatures](../../12/umbraco-deploy/images/set-cached-sigs.png)
+![Set cached signatures](images/set-cached-sigs.png)
 
 The process make take a few minutes to complete if you have a lot of content or media in your installation. Information is written to the log indicating the signatures calculated for each entity type.
 
@@ -108,6 +108,6 @@ This can lead to situations where Deploy continues to process a file it consider
 
 To resolve this situation, following an upgrade, it is good practice to re-save the `.uda` files in the "left-most" environment. This will usually be the local one, or if not using that, the Development environment. You can do this via the _Export Schema To Data Files_ operation available on the _Settings > Deploy_ dashboard:
 
-![Export schema](../../12/umbraco-deploy/images/export-schema.png)
+![Export schema](images/export-schema.png)
 
 The updated files should be committed to source control and deployed to upstream environments.

--- a/13/umbraco-forms/editor/creating-a-form/conditional-logic.md
+++ b/13/umbraco-forms/editor/creating-a-form/conditional-logic.md
@@ -8,7 +8,7 @@ You can achieve this setting by using **conditional logic** on Fields.
 
 Take a look at the following:
 
-![Example Form](../../../../12/umbraco-forms/editor/creating-a-form/images/ExampleForm.png)
+![Example Form](images/ExampleForm.png)
 
 In this case, it makes sense to **only** show the email or phone field when the corresponding option is selected in the **How should we contact you?** field.
 
@@ -17,10 +17,10 @@ To enable conditions for the **Email** and **Phone** fields, do the following:
 1. Click the `cog` wheel next to the **Email** and **Phone** field. The **Edit question** dialog opens.
 2.  Select **Enable Conditions** in the **Conditions** section.
 
-    <figure><img src="../../../../12/umbraco-forms/editor/creating-a-form/images/EnableConditions-v9.png" alt=""><figcaption></figcaption></figure>
+    <figure><img src="images/EnableConditions-v9.png" alt=""><figcaption></figcaption></figure>
 3.  Enabling the condition field displays more options:
 
-    <figure><img src="../../../../12/umbraco-forms/editor/creating-a-form/images/conditions-v9.png" alt=""><figcaption></figcaption></figure>
+    <figure><img src="images/conditions-v9.png" alt=""><figcaption></figcaption></figure>
 4. Set the appropriate conditions and click **Submit**.
 
 ### Action and Logic Types
@@ -41,17 +41,17 @@ When adding a new condition, you'll need to select the field where you want to e
 
 In this example, we only want to show the **Phone** field if the value of the **How should we contact you** field is `Phone`.
 
-![Setup rule](../../../../12/umbraco-forms/editor/creating-a-form/images/conditions-v9.png)
+![Setup rule](images/conditions-v9.png)
 
 Similarly, you can display the **Email** field, if the value of the **How should we contact you** field is `Email`. You can see the conditions added to each field in the Forms designer:
 
-![See conditions in the Forms designer](../../../../12/umbraco-forms/editor/creating-a-form/images/exampleBackoffice-v9.png)
+![See conditions in the Forms designer](images/exampleBackoffice-v9.png)
 
 ## Result
 
 When both the conditions have been set as shown above, this is how it will look on the frontend:
 
-![Frontend Example](../../../../12/umbraco-forms/editor/creating-a-form/images/exampleFrontend-v9.png)
+![Frontend Example](images/exampleFrontend-v9.png)
 
 In this example, we have only selected **Phone** but it is possible to choose both _Phone_\* and **Email** and display both the fields.
 

--- a/13/umbraco-forms/editor/creating-a-form/form-settings.md
+++ b/13/umbraco-forms/editor/creating-a-form/form-settings.md
@@ -55,7 +55,7 @@ The following Validations are available:
 
 The autocomplete setting for the overall form can be changed from the default of "None" to "On" or "Off". Setting this explicitly will control how the browser offers automatic prompts to the user when completing the form.
 
-<figure><img src="../../../../12/umbraco-forms/editor/creating-a-form/images/FormSettingsAutocomplete.png" alt=""><figcaption><p>Form Settings Autocomplete</p></figcaption></figure>
+<figure><img src="images/FormSettingsAutocomplete.png" alt=""><figcaption><p>Form Settings Autocomplete</p></figcaption></figure>
 
 ### Moderation
 
@@ -69,7 +69,7 @@ By default, a constant set of fields are displayed when form entries are shown i
 
 To customize this, turn off the "Display default fields" option and select the ones you wish to display.
 
-<figure><img src="../../../../10/umbraco-forms/.gitbook/assets/FormSettingsFieldsDisplayed.png" alt=""><figcaption><p>Forms Settings Fields Displayed</p></figcaption></figure>
+<figure><img src="../../../../13/umbraco-forms/.gitbook/assets/FormSettingsFieldsDisplayed.png" alt=""><figcaption><p>Forms Settings Fields Displayed</p></figcaption></figure>
 
 ### Data retentions
 
@@ -77,4 +77,4 @@ To help protect site visitor privacy, rules can be configured in this section fo
 
 A background service that carries out the actual removal of records needs to be [enabled in configuration](../../developer/configuration/#scheduledrecorddeletion). If that is not running, a notification will be displayed.
 
-![Form settings Date Retentions](../../../../10/umbraco-forms/.gitbook/assets/FormSettingsDataRetention.png)
+![Form settings Date Retentions](../../../../13/umbraco-forms/.gitbook/assets/FormSettingsDataRetention.png)

--- a/14/umbraco-cms/fundamentals/data/defining-content/README.md
+++ b/14/umbraco-cms/fundamentals/data/defining-content/README.md
@@ -241,7 +241,7 @@ This is *italic*
 ![Image alt text](https://media.giphy.com/media/bezxCUK2D2TuBCJ7r5/giphy.gif)
 ```
 
-![Makrdown description example](../../../../../12/umbraco-cms/fundamentals/data/images/md-description.gif)
+![Makrdown description example](../../../../../14/umbraco-cms/fundamentals/data/images/md-description.gif)
 
 ## 5. Defining child nodes
 
@@ -270,7 +270,7 @@ Before creating a Text Page in **Content** section, allow the Text Page Document
 * Click the menu icon (•••) next to the "`Home`" node
 * **Select** the "`Text page`" Document Type. We'll name the page "`About us`". We now have a basic content structure.
 
-<figure><img src="../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/createAboutUs.PNG" alt=""><figcaption></figcaption></figure>
+<figure><img src="../images/v8Screenshots/createAboutUs.PNG" alt=""><figcaption></figcaption></figure>
 
 Document Types are flexible and can be used for defining pieces of reusable content or an entire page, to act as a container or repository.
 
@@ -282,7 +282,7 @@ You can also export document types from an already existing project/installation
 * Click **...** next to the **Document type**
 * Select **Export**. When you click on the **Export** button, the Document Type is saved as a \*.udt file.
 
-![Exporting a Document Type](../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/export-document-type.png)
+![Exporting a Document Type](../images/v8Screenshots/export-document-type.png)
 
 To import a Document Type:
 
@@ -292,7 +292,7 @@ To import a Document Type:
 * Click on the **Import** button and browse to the Document Type you exported. The **Name** and **Alias** of the Document Type are displayed.
 * Click **Import** to complete the process.
 
-![Importing a Document Type](../../../../../12/umbraco-cms/fundamentals/data/images/import-document-type.png)
+![Importing a Document Type](../images/import-document-type.png)
 
 {% hint style="info" %}
 1. If your Document Type contains compositions or inherits from another Document Type, then you need to export/import the Composition/Document Type too.

--- a/15/umbraco-cms/fundamentals/data/defining-content/README.md
+++ b/15/umbraco-cms/fundamentals/data/defining-content/README.md
@@ -241,7 +241,7 @@ This is *italic*
 ![Image alt text](https://media.giphy.com/media/bezxCUK2D2TuBCJ7r5/giphy.gif)
 ```
 
-![Makrdown description example](../../../../../12/umbraco-cms/fundamentals/data/images/md-description.gif)
+![Makrdown description example](../../../../../15/umbraco-cms/fundamentals/data/images/md-description.gif)
 
 ## 5. Defining child nodes
 
@@ -270,7 +270,7 @@ Before creating a Text Page in **Content** section, allow the Text Page Document
 * Click the menu icon (•••) next to the "`Home`" node
 * **Select** the "`Text page`" Document Type. We'll name the page "`About us`". We now have a basic content structure.
 
-<figure><img src="../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/createAboutUs.PNG" alt=""><figcaption></figcaption></figure>
+<figure><img src="../images/v8Screenshots/createAboutUs.PNG" alt=""><figcaption></figcaption></figure>
 
 Document Types are flexible and can be used for defining pieces of reusable content or an entire page, to act as a container or repository.
 
@@ -282,7 +282,7 @@ You can also export document types from an already existing project/installation
 * Click **...** next to the **Document type**
 * Select **Export**. When you click on the **Export** button, the Document Type is saved as a \*.udt file.
 
-![Exporting a Document Type](../../../../../12/umbraco-cms/fundamentals/data/images/v8Screenshots/export-document-type.png)
+![Exporting a Document Type](../images/v8Screenshots/export-document-type.png)
 
 To import a Document Type:
 
@@ -292,7 +292,7 @@ To import a Document Type:
 * Click on the **Import** button and browse to the Document Type you exported. The **Name** and **Alias** of the Document Type are displayed.
 * Click **Import** to complete the process.
 
-![Importing a Document Type](../../../../../12/umbraco-cms/fundamentals/data/images/import-document-type.png)
+![Importing a Document Type](../images/import-document-type.png)
 
 {% hint style="info" %}
 1. If your Document Type contains compositions or inherits from another Document Type, then you need to export/import the Composition/Document Type too.

--- a/umbraco-cloud/product-upgrades/manual-upgrades/manual-cms-upgrade.md
+++ b/umbraco-cloud/product-upgrades/manual-upgrades/manual-cms-upgrade.md
@@ -36,7 +36,7 @@ After you have added a package reference to your project by executing the `dotne
 
 Alternatively, you can update the CMS through the `NuGet Package Manager` in Visual Studio:
 
-![NuGet Package Manager](../../../12/umbraco-forms/installation/images/Manage\_packages.png)
+![NuGet Package Manager](images/Manage\_packages.png)
 
 When the command completes, open the `.csproj` file to make sure the package reference was updated:
 

--- a/umbraco-cloud/product-upgrades/manual-upgrades/manual-upgrade-deploy.md
+++ b/umbraco-cloud/product-upgrades/manual-upgrades/manual-upgrade-deploy.md
@@ -32,7 +32,7 @@ After you have added a package reference to your project by executing the comman
 
 You can also update the Umbraco Deploy through the NuGet Package Manager in Visual studio:
 
-![NuGet Package Manager](../../../12/umbraco-forms/installation/images/Manage\_packages.png)
+![NuGet Package Manager](images/Manage\_packages.png)
 
 When the command completes, open the `.csproj` file to make sure the package reference was updated:
 


### PR DESCRIPTION
## Description

Before we unpublish the documentation for Umbraco 12 and move the directory for the version out of the main branch, some image references needed to be cleaned up.

