### PR TITLE
Porting old Umbraco API Controller [Extending > Database]

### DIFF
--- a/14/umbraco-cms/extending/database.md
+++ b/14/umbraco-cms/extending/database.md
@@ -263,6 +263,8 @@ using Umbraco.Cms.Web.Common.Controllers;
 
 namespace MyNamespace;
 
+[ApiController]
+[Route("/umbraco/api/blogcomments")]
 public class BlogCommentsApiController : UmbracoApiController
 {
     private readonly IScopeProvider _scopeProvider;
@@ -270,7 +272,8 @@ public class BlogCommentsApiController : UmbracoApiController
     {
         _scopeProvider = scopeProvider;
     }
-    [HttpGet]
+
+    [HttpGet("getcomments")]
     public IEnumerable<BlogComment> GetComments(int umbracoNodeId)
     {
         using var scope = _scopeProvider.CreateScope();
@@ -278,7 +281,8 @@ public class BlogCommentsApiController : UmbracoApiController
         scope.Complete();
         return queryResults;
     }
-    [HttpPost]
+    
+    [HttpPost("insertcomment")]
     public void InsertComment(BlogComment comment)
     {
         using var scope = _scopeProvider.CreateScope();

--- a/15/umbraco-cms/extending/database.md
+++ b/15/umbraco-cms/extending/database.md
@@ -259,18 +259,20 @@ The example below uses UmbracoApiController which is obsolete in Umbraco 14 and 
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using Umbraco.Cms.Infrastructure.Scoping;
-using Umbraco.Cms.Web.Common.Controllers;
 
 namespace MyNamespace;
 
-public class BlogCommentsApiController : UmbracoApiController
+[ApiController]
+[Route("/umbraco/api/blogcomments")]
+public class BlogCommentsApiController : Controller
 {
     private readonly IScopeProvider _scopeProvider;
     public BlogCommentsApiController(IScopeProvider scopeProvider)
     {
         _scopeProvider = scopeProvider;
     }
-    [HttpGet]
+
+    [HttpGet("getcomments")]
     public IEnumerable<BlogComment> GetComments(int umbracoNodeId)
     {
         using var scope = _scopeProvider.CreateScope();
@@ -278,7 +280,8 @@ public class BlogCommentsApiController : UmbracoApiController
         scope.Complete();
         return queryResults;
     }
-    [HttpPost]
+
+    [HttpPost("insertcomment")]
     public void InsertComment(BlogComment comment)
     {
         using var scope = _scopeProvider.CreateScope();


### PR DESCRIPTION
## Description

This PR belongs to: https://github.com/umbraco/UmbracoDocs/issues/6466.  Change `UmbracoApiController` to a default `Controller` and also added route attributes as suggested in the [Porting old Umbraco API Controllers article](https://docs.umbraco.com/umbraco-cms/reference/routing/umbraco-api-controllers/porting-old-umbraco-apis). Happy hacktoberfest! 🎃 

UmbracoApiController

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
Umbraco CMS v14 & 15