### PR TITLE
Adding note about migrating from latest Vendr version

### DIFF
--- a/10/umbraco-commerce/upgrading/migrate-from-vendr-to-umbraco-commerce/README.md
+++ b/10/umbraco-commerce/upgrading/migrate-from-vendr-to-umbraco-commerce/README.md
@@ -6,6 +6,12 @@ description: Learn how to migrate a Vendr solution to Umbraco Commerce.
 
 This guide provides a step-by-step approach to migrating a default Vendr solution to Umbraco Commerce.
 
+{% hint style="warning" %}
+Upgrade to the latest version of Vendr before continuing with the migration.
+
+You can upgrade your installation by installation the [latest version](https://www.nuget.org/packages/Vendr/) on top of the existing one.
+{% endhint %}
+
 You can find details on migrating the Checkout package as well as custom Payment Providers in the [Further Migrations section](./#further-migrations) of this article.
 
 ## Key changes

--- a/13/umbraco-commerce/upgrading/migrate-from-vendr-to-umbraco-commerce/README.md
+++ b/13/umbraco-commerce/upgrading/migrate-from-vendr-to-umbraco-commerce/README.md
@@ -6,6 +6,12 @@ description: Learn how to migrate a Vendr solution to Umbraco Commerce.
 
 This guide provides a step-by-step approach to migrating a default Vendr solution to Umbraco Commerce.
 
+{% hint style="warning" %}
+Upgrade to the latest version of Vendr before continuing with the migration.
+
+You can upgrade your installation by installation the [latest version](https://www.nuget.org/packages/Vendr/) on top of the existing one.
+{% endhint %}
+
 You can find details on migrating the Checkout package as well as custom Payment Providers in the [Further Migrations section](./#further-migrations) of this article.
 
 ## Key changes

--- a/14/umbraco-commerce/upgrading/migrate-from-vendr-to-umbraco-commerce/README.md
+++ b/14/umbraco-commerce/upgrading/migrate-from-vendr-to-umbraco-commerce/README.md
@@ -6,6 +6,12 @@ description: Learn how to migrate a Vendr solution to Umbraco Commerce.
 
 This guide provides a step-by-step approach to migrating a default Vendr solution to Umbraco Commerce.
 
+{% hint style="warning" %}
+Upgrade to the latest version of Vendr before continuing with the migration.
+
+You can upgrade your installation by installation the [latest version](https://www.nuget.org/packages/Vendr/) on top of the existing one.
+{% endhint %}
+
 You can find details on migrating the Checkout package as well as custom Payment Providers in the [Further Migrations section](./#further-migrations) of this article.
 
 ## Key changes

--- a/15/umbraco-commerce/upgrading/migrate-from-vendr-to-umbraco-commerce/README.md
+++ b/15/umbraco-commerce/upgrading/migrate-from-vendr-to-umbraco-commerce/README.md
@@ -6,6 +6,12 @@ description: Learn how to migrate a Vendr solution to Umbraco Commerce.
 
 This guide provides a step-by-step approach to migrating a default Vendr solution to Umbraco Commerce.
 
+{% hint style="warning" %}
+Upgrade to the latest version of Vendr before continuing with the migration.
+
+You can upgrade your installation by installation the [latest version](https://www.nuget.org/packages/Vendr/) on top of the existing one.
+{% endhint %}
+
 You can find details on migrating the Checkout package as well as custom Payment Providers in the [Further Migrations section](./#further-migrations) of this article.
 
 ## Key changes


### PR DESCRIPTION
## Description

When you're migrating from Vendr to Umbraco Commerce, you need to be using the latest version of Vendr.
A note about this has been added to all versions of the Commerce docs.

Fixed #6478 

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

