### PR TITLE
docs: describe default document types in more detail

### DIFF
--- a/14/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
+++ b/14/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
@@ -2,29 +2,15 @@
 
 On this page, you will find the default Document Types in Umbraco. If you want to use these document types, you can create them in the Settings section.
 
-![Create doc type](/14/umbraco-cms/fundamentals/data/images/CreateDoctype.png)
-
-## Document type with template
-
-Creating document types with templates allows you to define both the content structure and the visual presentation of a particular type of content item. It ensures a consistent and cohesive look and feel across your website while also enabling structured content management. This approach helps separate content from design, making it easier to manage and update your website's content and appearance independently through templates.
+![Create Document Type](/14/umbraco-cms/fundamentals/data/images/CreateDoctype.png)
 
 ## Document type
 
 Creating a Document Type (without a template) is about defining the content structure and fields that can be used across different content items. You might use document types without templates for creating consistent, structured content that doesn't require a predefined page layout. For example blog posts or product listings.
 
-## Compositions
+## Document type with template
 
-Compositions provide a way to create reusable sets of properties that can be added to one or more document types. This can help simplify the management and consistency of content types across your website.
-
-When using a mixed setup, you can take advantage of nesting and use compositions by clicking on "**Compositions**..." option.
-
-![Create group](/14/umbraco-cms/fundamentals/data/images/createGroup_new.png)
-{% hint style="warning" %}
-
-If you create 2 compositions that contain some common properties it is only possible to pick one of the compositions in a Document Type. If preferred, those compositions that cannot be used can be marked as hidden by checkmarking the `Hide unavailable options`.
-
-![Composition](/14/umbraco-cms/fundamentals/data/images/composition.png)
-{% endhint %}
+Creating document types with templates allows you to define both the content structure and the visual presentation of a particular type of content item. It ensures a consistent and cohesive look and feel across your website while also enabling structured content management. This approach helps separate content from design, making it easier to manage and update your website's content and appearance independently through templates.
 
 ## Element Type
 
@@ -35,3 +21,21 @@ Element Types cannot be used to create content that resides in the Content tree.
 ![Element type](/14/umbraco-cms/fundamentals/data/images/element-type.png)
 
 Element Types are created using the same workflow as regular Document Types but usually contain fewer properties. You can also create Element Types as part of configuring a Block Grid or Block List Data Type.
+
+## Folder
+
+A Folder is a special type of Document Type that can be used to organize content in the Content tree. Folders can contain other content items, such as other folders or content nodes. They are useful for organizing content in a logical hierarchy, making it easier to manage and navigate your website's content. They cannot be used to create content that is displayed on the front end of your website.
+
+## Compositions
+
+Compositions provide a way to create reusable sets of properties that can be added to one or more Document Types. This can help simplify the management and consistency of content types across your website. Compositions can be used to define common properties that are shared across multiple Document Types, such as metadata fields or social media links.
+
+To get started with compositions, you will first have to create the needed Document Types as described above. Later you can take advantage of nesting and use compositions by clicking on "**Compositions**..." option on the Document Type editor. Here you will be able to select the Document Types you want to use as compositions for the current Document Type. The fields of the selected compositions will hereafter be available on the current Document Type.
+
+![Create group](/14/umbraco-cms/fundamentals/data/images/createGroup_new.png)
+{% hint style="warning" %}
+
+If you create 2 compositions that contain some common properties it is only possible to pick one of the compositions in a Document Type. If preferred, those compositions that cannot be used can be marked as hidden by checkmarking the `Hide unavailable options`.
+
+![Composition](/14/umbraco-cms/fundamentals/data/images/composition.png)
+{% endhint %}

--- a/14/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
+++ b/14/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
@@ -6,7 +6,7 @@ On this page, you will find the default Document Types in Umbraco. If you want t
 
 ## Document type
 
-Creating a Document Type (without a template) is about defining the content structure and fields that can be used across different content items. You might use document types without templates for creating consistent, structured content that doesn't require a predefined page layout. For example blog posts or product listings.
+Creating a Document Type (without a template) defines the content structure and fields that can be used across different content items. You might use document types without templates to create consistent, structured content that doesn't require a predefined page layout. For example blog posts or product listings.
 
 ## Document type with template
 

--- a/14/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
+++ b/14/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
@@ -28,7 +28,7 @@ Folders are a special type of Document Type that can be used to organize content
 
 ## Compositions
 
-Compositions provide a way to create reusable sets of properties that can be added to one or more Document Types. This can help simplify the management and consistency of content types across your website. Compositions can be used to define common properties that are shared across multiple Document Types, such as metadata fields or social media links.
+Compositions provide a way to create reusable sets of properties that can be added to one or more Document Types. This can help simplify the management and consistency of content types across your website. Compositions can be used to define common properties shared across multiple Document Types, such as metadata fields or social media links.
 
 To get started with compositions, you will first have to create the needed Document Types as described above. Later you can take advantage of nesting and use compositions by clicking on "**Compositions**..." option on the Document Type editor. Here you will be able to select the Document Types you want to use as compositions for the current Document Type. The fields of the selected compositions will hereafter be available on the current Document Type.
 

--- a/14/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
+++ b/14/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
@@ -14,7 +14,7 @@ Creating document types with templates allows you to define both the content str
 
 ## Element Type
 
-An Element Type is a Document Type without a template containing schema configurations for repeating a set of properties. These are for defining schema in the Block List Editor, Block Grid Editor, or other Element Type based editors.
+An Element Type is a Document Type without a template containing schema configurations for repeating a set of properties. These are for defining schema in the Block List Editor, Block Grid Editor, or other Element Type-based editors.
 
 Element Types cannot be used to create content that resides in the Content tree. When you create an Element type, it automatically sets the **Is Element Type** flag to **True** on the **Permissions** tab.
 

--- a/14/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
+++ b/14/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
@@ -24,7 +24,7 @@ Element Types are created using the same workflow as regular Document Types but 
 
 ## Folder
 
-A Folder is a special type of Document Type that can be used to organize content in the Content tree. Folders can contain other content items, such as other folders or content nodes. They are useful for organizing content in a logical hierarchy, making it easier to manage and navigate your website's content. They cannot be used to create content that is displayed on the front end of your website.
+Folders are a special type of Document Type that can be used to organize content in the Content tree. Folders can contain other content items, such as other folders or content nodes. They are useful for organizing content in a logical hierarchy, making it easier to manage and navigate your website's content. They cannot be used to create content displayed on the front end of your website.
 
 ## Compositions
 

--- a/14/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
+++ b/14/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
@@ -30,7 +30,7 @@ Folders are a special type of Document Type that can be used to organize content
 
 Compositions provide a way to create reusable sets of properties that can be added to one or more Document Types. This can help simplify the management and consistency of content types across your website. Compositions can be used to define common properties shared across multiple Document Types, such as metadata fields or social media links.
 
-To get started with compositions, you will first have to create the needed Document Types as described above. Later you can take advantage of nesting and use compositions by clicking on "**Compositions**..." option on the Document Type editor. Here you will be able to select the Document Types you want to use as compositions for the current Document Type. The fields of the selected compositions will hereafter be available on the current Document Type.
+To get started with compositions, you have to create the needed Document Types as described above. Later you can take advantage of nesting and use compositions by clicking on "**Compositions**..." option on the Document Type editor. Here you will be able to select the Document Types you want to use as compositions for the current Document Type. The fields of the selected compositions will then be available on the current Document Type.
 
 ![Create group](/14/umbraco-cms/fundamentals/data/images/createGroup_new.png)
 {% hint style="warning" %}

--- a/15/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
+++ b/15/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
@@ -6,7 +6,7 @@ On this page, you will find the default Document Types in Umbraco. If you want t
 
 ## Document type
 
-Creating a Document Type (without a template) is about defining the content structure and fields that can be used across different content items. You might use document types without templates for creating consistent, structured content that doesn't require a predefined page layout. For example blog posts or product listings.
+Creating a Document Type (without a template) defines the content structure and fields that can be used across different content items. You might use document types without templates to create consistent, structured content that doesn't require a predefined page layout. For example blog posts or product listings.
 
 ## Document type with template
 

--- a/15/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
+++ b/15/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
@@ -28,7 +28,7 @@ Folders are a special type of Document Type that can be used to organize content
 
 ## Compositions
 
-Compositions provide a way to create reusable sets of properties that can be added to one or more Document Types. This can help simplify the management and consistency of content types across your website. Compositions can be used to define common properties that are shared across multiple Document Types, such as metadata fields or social media links.
+Compositions provide a way to create reusable sets of properties that can be added to one or more Document Types. This can help simplify the management and consistency of content types across your website. Compositions can be used to define common properties shared across multiple Document Types, such as metadata fields or social media links.
 
 To get started with compositions, you will first have to create the needed Document Types as described above. Later you can take advantage of nesting and use compositions by clicking on "**Compositions**..." option on the Document Type editor. Here you will be able to select the Document Types you want to use as compositions for the current Document Type. The fields of the selected compositions will hereafter be available on the current Document Type.
 

--- a/15/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
+++ b/15/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
@@ -2,29 +2,15 @@
 
 On this page, you will find the default Document Types in Umbraco. If you want to use these document types, you can create them in the Settings section.
 
-![Create doc type](/14/umbraco-cms/fundamentals/data/images/CreateDoctype.png)
-
-## Document type with template
-
-Creating document types with templates allows you to define both the content structure and the visual presentation of a particular type of content item. It ensures a consistent and cohesive look and feel across your website while also enabling structured content management. This approach helps separate content from design, making it easier to manage and update your website's content and appearance independently through templates.
+![Create Document Type](/15/umbraco-cms/fundamentals/data/images/CreateDoctype.png)
 
 ## Document type
 
 Creating a Document Type (without a template) is about defining the content structure and fields that can be used across different content items. You might use document types without templates for creating consistent, structured content that doesn't require a predefined page layout. For example blog posts or product listings.
 
-## Compositions
+## Document type with template
 
-Compositions provide a way to create reusable sets of properties that can be added to one or more document types. This can help simplify the management and consistency of content types across your website.
-
-When using a mixed setup, you can take advantage of nesting and use compositions by clicking on "**Compositions**..." option.
-
-![Create group](/14/umbraco-cms/fundamentals/data/images/createGroup_new.png)
-{% hint style="warning" %}
-
-If you create 2 compositions that contain some common properties it is only possible to pick one of the compositions in a Document Type. If preferred, those compositions that cannot be used can be marked as hidden by checkmarking the `Hide unavailable options`.
-
-![Composition](/14/umbraco-cms/fundamentals/data/images/composition.png)
-{% endhint %}
+Creating document types with templates allows you to define both the content structure and the visual presentation of a particular type of content item. It ensures a consistent and cohesive look and feel across your website while also enabling structured content management. This approach helps separate content from design, making it easier to manage and update your website's content and appearance independently through templates.
 
 ## Element Type
 
@@ -32,6 +18,24 @@ An Element Type is a Document Type without a template containing schema configur
 
 Element Types cannot be used to create content that resides in the Content tree. When you create an Element type, it automatically sets the **Is Element Type** flag to **True** on the **Permissions** tab.
 
-![Element type](/14/umbraco-cms/fundamentals/data/images/element-type.png)
+![Element type](/15/umbraco-cms/fundamentals/data/images/element-type.png)
 
 Element Types are created using the same workflow as regular Document Types but usually contain fewer properties. You can also create Element Types as part of configuring a Block Grid or Block List Data Type.
+
+## Folder
+
+A Folder is a special type of Document Type that can be used to organize content in the Content tree. Folders can contain other content items, such as other folders or content nodes. They are useful for organizing content in a logical hierarchy, making it easier to manage and navigate your website's content. They cannot be used to create content that is displayed on the front end of your website.
+
+## Compositions
+
+Compositions provide a way to create reusable sets of properties that can be added to one or more Document Types. This can help simplify the management and consistency of content types across your website. Compositions can be used to define common properties that are shared across multiple Document Types, such as metadata fields or social media links.
+
+To get started with compositions, you will first have to create the needed Document Types as described above. Later you can take advantage of nesting and use compositions by clicking on "**Compositions**..." option on the Document Type editor. Here you will be able to select the Document Types you want to use as compositions for the current Document Type. The fields of the selected compositions will hereafter be available on the current Document Type.
+
+![Create group](/15/umbraco-cms/fundamentals/data/images/createGroup_new.png)
+{% hint style="warning" %}
+
+If you create 2 compositions that contain some common properties it is only possible to pick one of the compositions in a Document Type. If preferred, those compositions that cannot be used can be marked as hidden by checkmarking the `Hide unavailable options`.
+
+![Composition](/15/umbraco-cms/fundamentals/data/images/composition.png)
+{% endhint %}

--- a/15/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
+++ b/15/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
@@ -14,7 +14,7 @@ Creating document types with templates allows you to define both the content str
 
 ## Element Type
 
-An Element Type is a Document Type without a template containing schema configurations for repeating a set of properties. These are for defining schema in the Block List Editor, Block Grid Editor, or other Element Type based editors.
+An Element Type is a Document Type without a template containing schema configurations for repeating a set of properties. These are for defining schema in the Block List Editor, Block Grid Editor, or other Element Type-based editors.
 
 Element Types cannot be used to create content that resides in the Content tree. When you create an Element type, it automatically sets the **Is Element Type** flag to **True** on the **Permissions** tab.
 

--- a/15/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
+++ b/15/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
@@ -24,7 +24,7 @@ Element Types are created using the same workflow as regular Document Types but 
 
 ## Folder
 
-A Folder is a special type of Document Type that can be used to organize content in the Content tree. Folders can contain other content items, such as other folders or content nodes. They are useful for organizing content in a logical hierarchy, making it easier to manage and navigate your website's content. They cannot be used to create content that is displayed on the front end of your website.
+Folders are a special type of Document Type that can be used to organize content in the Content tree. Folders can contain other content items, such as other folders or content nodes. They are useful for organizing content in a logical hierarchy, making it easier to manage and navigate your website's content. They cannot be used to create content displayed on the front end of your website.
 
 ## Compositions
 

--- a/15/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
+++ b/15/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
@@ -35,7 +35,7 @@ To get started with compositions, you will first have to create the needed Docum
 ![Create group](/15/umbraco-cms/fundamentals/data/images/createGroup_new.png)
 {% hint style="warning" %}
 
-If you create 2 compositions that contain some common properties it is only possible to pick one of the compositions in a Document Type. If preferred, those compositions that cannot be used can be marked as hidden by checkmarking the `Hide unavailable options`.
+If you create 2 compositions that contain some common properties it is only possible to pick one of the compositions in a Document Type. If preferred, those compositions that cannot be used can be marked as hidden by check marking the `Hide unavailable options`.
 
 ![Composition](/15/umbraco-cms/fundamentals/data/images/composition.png)
 {% endhint %}

--- a/15/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
+++ b/15/umbraco-cms/fundamentals/data/defining-content/default-document-types.md
@@ -16,7 +16,7 @@ Creating document types with templates allows you to define both the content str
 
 An Element Type is a Document Type without a template containing schema configurations for repeating a set of properties. These are for defining schema in the Block List Editor, Block Grid Editor, or other Element Type-based editors.
 
-Element Types cannot be used to create content that resides in the Content tree. When you create an Element type, it automatically sets the **Is Element Type** flag to **True** on the **Permissions** tab.
+Element Types cannot be used to create content in the Content tree. When you create an Element type, it automatically sets the **Is Element Type** flag to **True** on the **Permissions** tab.
 
 ![Element type](/15/umbraco-cms/fundamentals/data/images/element-type.png)
 


### PR DESCRIPTION
## Description

- move around the sections to match that of the top-most screenshot
- describe compositions in more detail detailing how you need to create the document types first (unlike v13 where there was a "Composition" option)
- fixed Vale issues

Fixes https://github.com/umbraco/Umbraco-CMS/issues/17173

## Type of suggestion

* [x] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
14 & 15


## Deadline (if relevant)

ASAP