### PR TITLE
V15: Updated and additional articles to Extension Manifests and sub topics

### DIFF
--- a/14/umbraco-cms/customizing/extending-overview/custom-extension-type/custom-extension-type.md
+++ b/14/umbraco-cms/customizing/extending-overview/custom-extension-type/custom-extension-type.md
@@ -1,0 +1,23 @@
+# Custom Extension Type
+
+The extension registry is an open system, which can hold any Extension Manifest Type. This article describes how you can declare your own types.
+Either for your own re-useability/maintainability or to open up for other extensions of your package.
+
+## Manifest Type Declaration
+
+A Manifest Type is declared via a TypeScript Interface, declared in this manner:
+
+```typescript
+import type { ManifestBase } from '@umbraco-cms/backoffice/extension-api';
+
+export interface ManifestPreviewAppProvider extends ManifestBase {
+    type: 'myPrefixedExtensionType';
+}
+
+// Declare the Manifest Type in the global UmbExtensionManifestMap interface:
+declare global {
+    interface UmbExtensionManifestMap {
+        MyPrefixedExtensionManifest: MyExtensionManifestType;
+    }
+}
+```

--- a/14/umbraco-cms/customizing/extending-overview/custom-extension-type/custom-extension-type.md
+++ b/14/umbraco-cms/customizing/extending-overview/custom-extension-type/custom-extension-type.md
@@ -1,11 +1,11 @@
 # Custom Extension Type
 
-The extension registry is an open system, which can hold any Extension Manifest Type. This article describes how you can declare your own types.
-Either for your own re-useability/maintainability or to open up for other extensions of your package.
+The extension registry is an open system, which can hold any Extension Manifest Type. This article describes how you can declare your types.
+Types can be declared for re-useability/maintainability or to open up for other package extensions.
 
 ## Manifest Type Declaration
 
-A Manifest Type is declared via a TypeScript Interface, declared in this manner:
+A Manifest Type is declared via a TypeScript Interface, like shown below:
 
 ```typescript
 import type { ManifestBase } from '@umbraco-cms/backoffice/extension-api';

--- a/14/umbraco-cms/customizing/extending-overview/extension-conditions/extension-conditions.md
+++ b/14/umbraco-cms/customizing/extending-overview/extension-conditions/extension-conditions.md
@@ -1,0 +1,44 @@
+# Extension Conditions
+
+{% hint style="warning" %}
+This page is a work in progress and may undergo further revisions, updates, or amendments. The information contained herein is subject to change without notice.
+{% endhint %}
+
+Extension Manifest Conditions enables declaring requirements for an Extension before it becomes available.
+
+## Utilizing Conditions in your Manifest
+
+Conditions are referenced via their alias. The Declaration of a condition is done in this manner:
+
+```typescript
+const manifest = {
+    type: 'workspaceView',
+    ...
+    conditions: [
+        {
+            alias: 'Umb.Condition.WorkspaceAlias',
+            match: 'Umb.Workspace.Document',
+        },
+    ],
+};
+```
+
+By declaring a condition the extension will only become available once condition is permitted.
+The example above requires the nearest Workspaces Alias to be equal to `'Umb.Workspace.Document'`.
+
+When declaring multiple conditions all of them must be permitted for the extension to be available.
+
+## Condition Configuration <a href="#using-conditions" id="using-conditions"></a>
+
+The conditions are defined as an array of condition configurations. Each entry can contain the following properties:
+
+* `alias`- The alias of the condition to utilize.
+* `...` - The rest of the properties of the object are specific to the condition configuration.
+
+## Learn more
+
+Learn about built-in conditions and how to create your own:
+
+{% content-ref url="../extension-types/condition.md" %}
+[Condition Extension Type](../extension-types/condition.md)
+{% endcontent-ref %}

--- a/14/umbraco-cms/customizing/extending-overview/extension-conditions/extension-conditions.md
+++ b/14/umbraco-cms/customizing/extending-overview/extension-conditions/extension-conditions.md
@@ -1,14 +1,18 @@
+---
+description: Learn how to use Extension Conditions when working with the Umbraco backoffice.
+---
+
 # Extension Conditions
 
 {% hint style="warning" %}
 This page is a work in progress and may undergo further revisions, updates, or amendments. The information contained herein is subject to change without notice.
 {% endhint %}
 
-Extension Manifest Conditions enables declaring requirements for an Extension before it becomes available.
+Extension Manifest Conditions enable you to declare requirements for an Extension before it becomes available.
 
 ## Utilizing Conditions in your Manifest
 
-Conditions are referenced via their alias. The Declaration of a condition is done in this manner:
+Conditions are referenced via their alias. The Declaration of a Condition is shown in the following example:
 
 ```typescript
 const manifest = {
@@ -23,12 +27,17 @@ const manifest = {
 };
 ```
 
-By declaring a condition the extension will only become available once condition is permitted.
+By declaring a condition the extension will become available only once the condition is permitted.
+
 The example above requires the nearest Workspaces Alias to be equal to `'Umb.Workspace.Document'`.
 
 When declaring multiple conditions all of them must be permitted for the extension to be available.
 
-## Condition Configuration <a href="#using-conditions" id="using-conditions"></a>
+## Condition Configuration
+
+```html
+<a href="#using-conditions" id="using-conditions"></a>
+```
 
 The conditions are defined as an array of condition configurations. Each entry can contain the following properties:
 

--- a/14/umbraco-cms/customizing/extending-overview/extension-kind/extension-kind.md
+++ b/14/umbraco-cms/customizing/extending-overview/extension-kind/extension-kind.md
@@ -1,3 +1,7 @@
+---
+description: Learn how to use the Kind extension in your manifest files when extending the Umbraco CMS backoffice.
+---
+
 # Extension Kind
 
 {% hint style="warning" %}
@@ -6,11 +10,11 @@ This page is a work in progress and may undergo further revisions, updates, or a
 
 Extension Manifest Kind enables declarations to be based upon a preset Manifest.
 
-Either for maintainability or to inherit existing features.
+This is used for maintainability or to inherit existing features.
 
 ## Manifest Kind Declaration
 
-A kind is utilized by declaring it in the `kind` field of a Manifest:
+A Kind is utilized by declaring it in the `kind` field of a Manifest:
 
 ```typescript
 const manifest = {
@@ -20,13 +24,13 @@ const manifest = {
 };
 ```
 
-By declaring a kind the Manifest will inherit fields of the defined kind preset manifest.
+By declaring a kind, the Manifest will inherit fields of the defined Kind.
 
-Typical use case is a kind that provides a element, but requires additional Meta fields, to fulfill the needs of its element.
+A typical use case is a Kind that provides an element, but requires additional meta fields, to fulfill the needs of its element.
 
-In the following example a Manifest using the type `headerApp` utilizes the kind `button` which brings an element and requires some additional information as part of the meta object.
+In the following example, a manifest using the type 'headerApp' utilizes the 'button' kind. This brings an element and requires some additional information as part of the meta object.
 
-Providing the ability to use and configure existing functionality to a specific need:
+Adding the metadata provides the ability to use and configure existing functionality to a specific need.
 
 ```typescript
 const manifest = {
@@ -44,7 +48,7 @@ const manifest = {
 
 ## Learn more
 
-Learn more about kinds and how to create your own:
+Learn more about Kinds and how to create your own:
 
 {% content-ref url="../extension-types/kind.md" %}
 [Kind Extension Type](../extension-types/kind.md)

--- a/14/umbraco-cms/customizing/extending-overview/extension-kind/extension-kind.md
+++ b/14/umbraco-cms/customizing/extending-overview/extension-kind/extension-kind.md
@@ -1,0 +1,51 @@
+# Extension Kind
+
+{% hint style="warning" %}
+This page is a work in progress and may undergo further revisions, updates, or amendments. The information contained herein is subject to change without notice.
+{% endhint %}
+
+Extension Manifest Kind enables declarations to be based upon a preset Manifest.
+
+Either for maintainability or to inherit existing features.
+
+## Manifest Kind Declaration
+
+A kind is utilized by declaring it in the `kind` field of a Manifest:
+
+```typescript
+const manifest = {
+    type: 'headerApp',
+    kind: 'button',
+    ...
+};
+```
+
+By declaring a kind the Manifest will inherit fields of the defined kind preset manifest.
+
+Typical use case is a kind that provides a element, but requires additional Meta fields, to fulfill the needs of its element.
+
+In the following example a Manifest using the type `headerApp` utilizes the kind `button` which brings an element and requires some additional information as part of the meta object.
+
+Providing the ability to use and configure existing functionality to a specific need:
+
+```typescript
+const manifest = {
+    type: 'headerApp',
+    kind: 'button',
+    name: 'My Header App Example',
+    alias: 'My.HeaderApp.Example',
+    meta: {
+        label: 'My Example',
+        icon: 'icon-home',
+        href: '/some/path/to/open/when/clicked',
+    },
+};
+```
+
+## Learn more
+
+Learn more about kinds and how to create your own:
+
+{% content-ref url="../extension-types/kind.md" %}
+[Kind Extension Type](../extension-types/kind.md)
+{% endcontent-ref %}

--- a/14/umbraco-cms/customizing/extending-overview/extension-registry/extension-manifest.md
+++ b/14/umbraco-cms/customizing/extending-overview/extension-registry/extension-manifest.md
@@ -4,9 +4,8 @@
 This page is a work in progress and may undergo further revisions, updates, or amendments. The information contained herein is subject to change without notice.
 {% endhint %}
 
-Each Extension Manifest has to declare its type, this is used to determine where it hooks into the system. It also looks at what data is required to declare within it.
+The Extension Manifest is the point of entry for any extension. This is the declaration of what you like to register.
 
-The abilities of the extensions rely on the specific extension type. The Type sets the scene for what the extension can do and what it needs to be utilized. Some extension types rely on a reference to other extensions.
 
 The pages of this article describe all the extension types that Backoffice supports. Here is a list of the most common types:
 
@@ -22,30 +21,41 @@ The pages of this article describe all the extension types that Backoffice suppo
 [section-trees](../../section-trees/)
 {% endcontent-ref %}
 
-## Declare Extension Manifest
+## Manifest Data
 
-Extension Manifest and can be declared in multiple ways. One of these is to declare it as part of the [Umbraco Package Manifest](../../package-manifest.md).
+Each Extension Manifest has to declare its type, this is used to determine where it hooks into the system. It also determines what data is required of this manifest.
 
-You can declare new Extension Manifests in JavaScript at any given point.
+The abilities of the extensions rely on the specific extension type. The Type sets the scene for what the extension can do and what it needs to be utilized. Some extension types can be made purely via the manifest. Other requires files, like a JavaScript file containing a Web Component.
 
-```typescript
-import { umbExtensionsRegistry } from "@umbraco-cms/backoffice/extension-registry"
+The required fields of any extension manifest are:
 
-const manifest = {
-    type: '...',
-    ...
-};
+* `type` - The type defines the type and purpose of the extension. It is used to determine where the extension will be used and defines the data needed for this manifest.
+* `alias`- The alias is used to identify the extension. This has to be unique for each extension.
+* `name` - The name of the extension. This is used to identify the extension in the UI.
 
-umbExtensionsRegistry.register(extension);
-```
+Additionally, many extensions supports the use of the following fields:
 
-Backoffice also comes with two Extension types which can be used to register more extensions.
+* `weight` - Define a weight, to determine the importance or visual order of this extension.
+* `conditions` - Define one or more conditions which must be permitted for the extension to become available. [Extension Conditions](../extension-conditions/extension-conditions.md).
+* `kind` - Define a kind-alias of which this manifest should be based upon. Kinds acts like a preset for your manifest. [Extension Kinds](../extension-kind/extension-kind.md).
+
+Many of the Extension Types requires additional information declared as part of a `meta` field.
+
+## Registration
+
+An Extension Manifest can be declared in multiple ways.
+
+The primary way is to declare it as part of the [Umbraco Package Manifest](../../package-manifest.md).
+
+Additionally there is two Extension types which can be used to register other extensions.
+
+A typical use case is to declare one main Extension Manifest as part of the [Umbraco Package Manifest](../../package-manifest.md). Such main Extension Manifest would be using one of the following types:
 
 ### Using `bundle` to declare other Extension Manifest
 
-The bundle extension type can be used for declaring multiple Extension Manifests with JavaScript in a single file.
+The Bundle extension type can be used for declaring multiple Extension Manifests with JavaScript in a single file.
 
-The bundle declares a single JavaScript file that will be loaded at startup. All the Extension Manifests exported from this Module will be registered in the Extension Registry.
+The Bundle declares a single JavaScript file that will be loaded at startup. All the Extension Manifests exported of this Module will be registered in the Extension Registry.
 
 Read more about the `bundle` extension type in the [Bundle](../../../extending/extending-overview/extension-registry/bundle.md) article.
 
@@ -58,3 +68,20 @@ The entry point declares a single JavaScript file that will be loaded and run wh
 The `entryPbackofficeEntryPointoint` extension is also the way to go if you want to load in external libraries such as jQuery, Angular, React, etc. You can use the `backofficeEntryPoint` to load in the external libraries to be shared by all your extensions. Loading **global CSS files** can also be used in the `backofficeEntryPoint` extension.
 
 Read more about the `backofficeEntryPoint` extension type in the [Entry Point](../../../extending/extending-overview/extension-registry/entry-point.md) article.
+
+## Registration via any JavaScript code
+
+Alternatively a Extension Manifests can be declared in JavaScript at any given point.
+
+The following example shows how to register an extension manifest via javascript code:
+
+```typescript
+import { umbExtensionsRegistry } from "@umbraco-cms/backoffice/extension-registry"
+
+const manifest = {
+    type: '...',
+    ...
+};
+
+umbExtensionsRegistry.register(extension);
+```

--- a/14/umbraco-cms/customizing/extending-overview/extension-registry/extension-manifest.md
+++ b/14/umbraco-cms/customizing/extending-overview/extension-registry/extension-manifest.md
@@ -1,13 +1,16 @@
+---
+description: Learn about the different methods for declaring an Extension Manifest.
+---
+
 # Extension Manifest
 
 {% hint style="warning" %}
 This page is a work in progress and may undergo further revisions, updates, or amendments. The information contained herein is subject to change without notice.
 {% endhint %}
 
-The Extension Manifest is the point of entry for any extension. This is the declaration of what you like to register.
+The Extension Manifest is the point of entry for any extension. This is the declaration of what you want to register.
 
-
-The pages of this article describe all the extension types that Backoffice supports. Here is a list of the most common types:
+The content in this section describes all the extension types that the Backoffice supports. Here is a list of the most common types:
 
 {% content-ref url="../../../tutorials/creating-a-custom-dashboard/" %}
 [creating-a-custom-dashboard](../../../tutorials/creating-a-custom-dashboard/)
@@ -23,7 +26,7 @@ The pages of this article describe all the extension types that Backoffice suppo
 
 ## Manifest Data
 
-Each Extension Manifest has to declare its type, this is used to determine where it hooks into the system. It also determines what data is required of this manifest.
+Each Extension Manifest has to declare its type. This is used to determine where it hooks into the system. It also determines what data is required of this manifest.
 
 The abilities of the extensions rely on the specific extension type. The Type sets the scene for what the extension can do and what it needs to be utilized. Some extension types can be made purely via the manifest. Other requires files, like a JavaScript file containing a Web Component.
 
@@ -47,11 +50,11 @@ An Extension Manifest can be declared in multiple ways.
 
 The primary way is to declare it as part of the [Umbraco Package Manifest](../../package-manifest.md).
 
-Additionally there is two Extension types which can be used to register other extensions.
+Additionally, two Extension types can be used to register other extensions.
 
 A typical use case is to declare one main Extension Manifest as part of the [Umbraco Package Manifest](../../package-manifest.md). Such main Extension Manifest would be using one of the following types:
 
-### Using `bundle` to declare other Extension Manifest
+### The `bundle` extension type
 
 The Bundle extension type can be used for declaring multiple Extension Manifests with JavaScript in a single file.
 
@@ -59,21 +62,21 @@ The Bundle declares a single JavaScript file that will be loaded at startup. All
 
 Read more about the `bundle` extension type in the [Bundle](../../../extending/extending-overview/extension-registry/bundle.md) article.
 
-### Using `backofficeEntryPoint` as your foundation
+### The `backofficeEntryPoint` extension type
 
-The `backofficeEntryPoint` extension type is special, it can be used to run any JavaScript code at startup.\
-This can be used as an entry point for a package.\
+The `backofficeEntryPoint` extension type can run any JavaScript code at startup. This can be used as an entry point for a package.
+
 The entry point declares a single JavaScript file that will be loaded and run when the Backoffice starts.
 
-The `entryPbackofficeEntryPointoint` extension is also the way to go if you want to load in external libraries such as jQuery, Angular, React, etc. You can use the `backofficeEntryPoint` to load in the external libraries to be shared by all your extensions. Loading **global CSS files** can also be used in the `backofficeEntryPoint` extension.
+The `entryPbackofficeEntryPointoint` extension is also the way to go if you want to load in external libraries such as jQuery, Angular, or React. You can use the `backofficeEntryPoint` type to load in the external libraries to be shared by all your extensions. Loading **global CSS files** can also be used in the `backofficeEntryPoint` extension.
 
 Read more about the `backofficeEntryPoint` extension type in the [Entry Point](../../../extending/extending-overview/extension-registry/entry-point.md) article.
 
 ## Registration via any JavaScript code
 
-Alternatively a Extension Manifests can be declared in JavaScript at any given point.
+Alternatively, an Extension Manifest can be declared in JavaScript at any given point.
 
-The following example shows how to register an extension manifest via javascript code:
+The following example shows how to register an extension manifest via JavaScript code:
 
 ```typescript
 import { umbExtensionsRegistry } from "@umbraco-cms/backoffice/extension-registry"

--- a/14/umbraco-cms/customizing/extending-overview/extension-registry/extension-registry.md
+++ b/14/umbraco-cms/customizing/extending-overview/extension-registry/extension-registry.md
@@ -16,11 +16,3 @@ Declaring a new extension is done by declaring an [extension manifest](extension
 These two options can be combined as you like.
 
 A typical use case of such is achieved by registering a single extension manifest in your Umbraco Package JSON file. This manifest would then load a JS file, that registers the rest of your extensions. Learn more about these abilities in the [bundle](../extension-types/bundle.md) or [backoffice entry point](../extension-types/backoffice-entry-point.md) articles.
-
-## Extension Manifest Data <a href="#extension-manifest" id="extension-manifest"></a>
-
-The necessary properties that any extension manifest needs are:
-
-* `type` - The type defines the type and purpose of the extension. It is used to determine where the extension will be used and defines the data needed for this manifest.
-* `alias`- The alias is used to identify the extension. This has to be unique for each extension.
-* `name` - The name of the extension. This is used to identify the extension in the UI.

--- a/14/umbraco-cms/customizing/extending-overview/extension-types/condition.md
+++ b/14/umbraco-cms/customizing/extending-overview/extension-types/condition.md
@@ -1,49 +1,29 @@
 # Extension Conditions
 
-Extension conditions are used to determine if an extension should be used or not. Many of the Extension Types support conditions, but not all of them.
+Extension Conditions declares requirements that should be permitted for the extension to be available. Many of the Extension Types support Conditions, but not all of them.
 
-{% hint style="warning" %}
-This page is a work in progress and may undergo further revisions, updates, or amendments. The information contained herein is subject to change without notice.
-{% endhint %}
-
-All given conditions for an extension must be valid for an extension to be utilized.
-
-## Using conditions <a href="#using-conditions" id="using-conditions"></a>
-
-In the following example we define the manifest for a Workspace Action, this action will only be available in the workspace with the alias `My.Example.Workspace`.
-
-```typescript
-{
- type: 'workspaceAction',
- name: 'example-workspace-action',
- alias: 'My.Example.WorkspaceAction',
- elementName: 'my-workspace-action-element',
- conditions: [
-  {
-   alias: 'Umb.Condition.SectionAlias',
-   match: 'My.Example.Workspace'
-  }
- ]
-}
-```
-
-The conditions are defined as an array of conditions. Each condition is an object with the following properties:
-
-* `alias`- The alias of the condition to utilize.
-* `...` - The rest of the properties of the object are specific to the condition.
-
-In the above example the `Umb.Condition.SectionAlias` condition is used, this condition takes a property `match` which must be set to the alias of the section to match.
+[Read about utilizing conditions in Manifests](../extension-conditions/extension-conditions.md)
 
 ## Built-in conditions types <a href="#core-conditions-types" id="core-conditions-types"></a>
 
-The following conditions are available out of the box, for all extension types that support conditions.
+The following conditions are available out of the box, for all extension types that support Conditions.
 
-* `Umb.Condition.SectionAlias` - Checks if the current section alias matches the one specified.
-* `Umb.Condition.WorkspaceAlias` - Checks if the current workspace alias matches the one specified.
+* `Umb.Condition.SectionAlias` - Requires the current Section Alias matches the one specified.
+* `Umb.Condition.MenuAlias` - Requires the current Menu Alias matches the one specified.
+* `Umb.Condition.WorkspaceAlias` - Requires the current Workspace Alias matches the one specified.
+* `Umb.Condition.WorkspaceEntityType` - Requires the current workspace is working on the given Entity Type. Examples: 'document', 'block' or 'user'.
+* `Umb.Condition.WorkspaceContentTypeAlias` - Requires the current workspace to be based on a Content Type which Alias matches the one specified.
+* `Umb.Condition.Workspace.ContentHasProperties` - Requires the Content Type of the current Workspace to have properties.
+* `Umb.Condition.WorkspaceHasCollection` - Requires the current Workspace to have a Collection.
+* `Umb.Condition.WorkspaceEntityIsNew` - Requires the current Workspace data to be new, not yet persisted on the server.
+* `Umb.Condition.EntityIsTrashed` - Requires the current entity to be trashed.
+* `Umb.Condition.EntityIsNotTrashed` - Requires the current entity to not be trashed.
+* `Umb.Condition.SectionUserPermission` - Requires the current user to have permissions to the given Section Alias.
+* `Umb.Condition.UserPermission.Document` - Requires the current user to have specific Document permissions. Example: 'Umb.Document.Save'
 
 ## Make your own conditions <a href="#make-your-own-conditions" id="make-your-own-conditions"></a>
 
-You can make your own conditions by creating a class that implements the `UmbExtensionCondition` interface.
+You can make your own Conditions by creating a class that implements the `UmbExtensionCondition` interface.
 
 ```typescript
 import {
@@ -55,12 +35,12 @@ import {
 import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
-export type MyConditionConfig = UmbConditionConfigBase & {
+export type MyExtensionConditionConfig = UmbConditionConfigBase & {
   match: string;
 };
 
-export class MyExtensionCondition extends UmbConditionBase<MyConditionConfig> implements UmbExtensionCondition {
-  constructor(host: UmbControllerHost, args: UmbConditionControllerArguments<MyConditionConfig>) {
+export class MyExtensionCondition extends UmbConditionBase<MyExtensionConditionConfig> implements UmbExtensionCondition {
+  constructor(host: UmbControllerHost, args: UmbConditionControllerArguments<MyExtensionConditionConfig>) {
     super(host, args);
 
     // enable extension after 10 seconds
@@ -69,6 +49,13 @@ export class MyExtensionCondition extends UmbConditionBase<MyConditionConfig> im
       args.onChange();
     }, 10000);
   }
+}
+
+// Declare the Condition Configuration Type in the global UmbExtensionConditionConfigMap interface:
+declare global {
+    interface UmbExtensionConditionConfigMap {
+        MyExtensionConditionConfig: MyExtensionCondition;
+    }
 }
 ```
 
@@ -108,8 +95,8 @@ As can be seen in the code above, we never make use of `match`. We can do this b
 ```typescript
 // ...
 
-export class MyExtensionCondition extends UmbConditionBase<MyConditionConfig> implements UmbExtensionCondition {
-  constructor(host: UmbControllerHost, args: UmbConditionControllerArguments<MyConditionConfig>) {
+export class MyExtensionCondition extends UmbConditionBase<MyExtensionConditionConfig> implements UmbExtensionCondition {
+  constructor(host: UmbControllerHost, args: UmbConditionControllerArguments<MyExtensionConditionConfig>) {
     super(host, args);
 
     if (args.config.match === 'Yes') {
@@ -132,7 +119,7 @@ With all that in place, the configuration can look like shown below:
   {
     alias: 'My.Condition.CustomName',
     match: 'Yes'
-  } as MyConditionConfig
+  }
  ]
 }
 ```

--- a/14/umbraco-cms/customizing/extending-overview/extension-types/condition.md
+++ b/14/umbraco-cms/customizing/extending-overview/extension-types/condition.md
@@ -1,17 +1,17 @@
 # Extension Conditions
 
-Extension Conditions declares requirements that should be permitted for the extension to be available. Many of the Extension Types support Conditions, but not all of them.
+Extension Conditions declare requirements that should be permitted for the extension to be available. Many, but not all, Extension Types support Conditions.
 
-[Read about utilizing conditions in Manifests](../extension-conditions/extension-conditions.md)
+[Read about utilizing conditions in Manifests](../extension-conditions/extension-conditions.md).
 
 ## Built-in conditions types <a href="#core-conditions-types" id="core-conditions-types"></a>
 
 The following conditions are available out of the box, for all extension types that support Conditions.
 
-* `Umb.Condition.SectionAlias` - Requires the current Section Alias matches the one specified.
-* `Umb.Condition.MenuAlias` - Requires the current Menu Alias matches the one specified.
-* `Umb.Condition.WorkspaceAlias` - Requires the current Workspace Alias matches the one specified.
-* `Umb.Condition.WorkspaceEntityType` - Requires the current workspace is working on the given Entity Type. Examples: 'document', 'block' or 'user'.
+* `Umb.Condition.SectionAlias` - Requires the current Section Alias to match the one specified.
+* `Umb.Condition.MenuAlias` - Requires the current Menu Alias to match the one specified.
+* `Umb.Condition.WorkspaceAlias` - Requires the current Workspace Alias to match the one specified.
+* `Umb.Condition.WorkspaceEntityType` - Requires the current workspace to work on the given Entity Type. Examples: 'document', 'block' or 'user'.
 * `Umb.Condition.WorkspaceContentTypeAlias` - Requires the current workspace to be based on a Content Type which Alias matches the one specified.
 * `Umb.Condition.Workspace.ContentHasProperties` - Requires the Content Type of the current Workspace to have properties.
 * `Umb.Condition.WorkspaceHasCollection` - Requires the current Workspace to have a Collection.
@@ -21,7 +21,11 @@ The following conditions are available out of the box, for all extension types t
 * `Umb.Condition.SectionUserPermission` - Requires the current user to have permissions to the given Section Alias.
 * `Umb.Condition.UserPermission.Document` - Requires the current user to have specific Document permissions. Example: 'Umb.Document.Save'
 
-## Make your own conditions <a href="#make-your-own-conditions" id="make-your-own-conditions"></a>
+## Make your own conditions
+
+```html
+<a href="#make-your-own-conditions" id="make-your-own-conditions"></a>
+```
 
 You can make your own Conditions by creating a class that implements the `UmbExtensionCondition` interface.
 
@@ -59,7 +63,7 @@ declare global {
 }
 ```
 
-This has to be registered in the extension registry like shown below:
+This has to be registered in the extension registry, shown below:
 
 ```typescript
 export const manifest: ManifestCondition = {

--- a/14/umbraco-cms/customizing/extending-overview/extension-types/condition.md
+++ b/14/umbraco-cms/customizing/extending-overview/extension-types/condition.md
@@ -1,3 +1,7 @@
+---
+description: Learn how to declare requirements for your extensions using the Extension Conditions.
+---
+
 # Extension Conditions
 
 Extension Conditions declare requirements that should be permitted for the extension to be available. Many, but not all, Extension Types support Conditions.


### PR DESCRIPTION
## Description

Notice this is only correct for v.15

Update and additional articles to the topic of Extension Manifests and sub topics.

Writting your own extension type is changed slitghly in v.15 — this lead me to update a write a bit more about Extension Manifest.

And then related topics of Conditions and Kinds have been updated with additional articles from an overview perspective. But notice the structural challenge of both kinds and conditions begin an extension type of them self but also a Extension Manifest Feature. The point to understand here is that its a Core feature, which can be extended with additional opportunities. hence the two perspectives.

Please see changes to get a better overview of this PR.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [x] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
