### PR TITLE
Porting old Umbraco API Controller [Unit Testing]

### DIFF
--- a/14/umbraco-cms/implementation/unit-testing.md
+++ b/14/umbraco-cms/implementation/unit-testing.md
@@ -163,10 +163,6 @@ public class PageSurfaceControllerTests
 
 See [Reference documentation on UmbracoApiControllers](../reference/routing/umbraco-api-controllers/README.md#locally-declared-controller).
 
-{% hint style="warning" %}
-The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
-{% endhint %}
-
 ```csharp
 [ApiController]
 [Route("/umbraco/api/products")]

--- a/14/umbraco-cms/implementation/unit-testing.md
+++ b/14/umbraco-cms/implementation/unit-testing.md
@@ -197,15 +197,15 @@ public class ProductsControllerTests
 
         var result = this.controller.GetAllProducts();
 
-        Assert.AreEqual(expected, result);
+        Assert.That(expected == result);
     }
 
     [Test]
     public void WhenGetAllProductsJson_ThenReturnViewModelWithExpectedJson()
     {
-        var json = serializer.Serialize(this.controller.GetAllProductsJson().Value);
+        var json = JsonSerializer.Serialize(this.controller.GetAllProductsJson().Value);
 
-        Assert.AreEqual("[\"Table\",\"Chair\",\"Desk\",\"Computer\",\"Beer fridge\"]", json);
+        Assert.That("[\"Table\",\"Chair\",\"Desk\",\"Computer\",\"Beer fridge\"]" == json);
     }
 }
 ```

--- a/14/umbraco-cms/implementation/unit-testing.md
+++ b/14/umbraco-cms/implementation/unit-testing.md
@@ -159,7 +159,7 @@ public class PageSurfaceControllerTests
 `ServiceContext.CreatePartial()` has optional parameters, and by naming them you only need to mock the dependencies that you need, for example: `ServiceContext.CreatePartial(contentService: Mock.Of<IContentService>());`
 {% endhint %}
 
-## Testing an ApiController
+## Testing a Controller
 
 See [Reference documentation on UmbracoApiControllers](../reference/routing/umbraco-api-controllers/README.md#locally-declared-controller).
 

--- a/14/umbraco-cms/implementation/unit-testing.md
+++ b/14/umbraco-cms/implementation/unit-testing.md
@@ -159,7 +159,7 @@ public class PageSurfaceControllerTests
 `ServiceContext.CreatePartial()` has optional parameters, and by naming them you only need to mock the dependencies that you need, for example: `ServiceContext.CreatePartial(contentService: Mock.Of<IContentService>());`
 {% endhint %}
 
-## Testing an UmbracoApiController
+## Testing an ApiController
 
 See [Reference documentation on UmbracoApiControllers](../reference/routing/umbraco-api-controllers/README.md#locally-declared-controller).
 

--- a/14/umbraco-cms/implementation/unit-testing.md
+++ b/14/umbraco-cms/implementation/unit-testing.md
@@ -168,6 +168,8 @@ The example below uses UmbracoApiController which is obsolete in Umbraco 14 and 
 {% endhint %}
 
 ```csharp
+[ApiController]
+[Route("/umbraco/api/products")]
 public class ProductsController : UmbracoApiController
 {
     public IEnumerable<string> GetAllProducts()
@@ -175,7 +177,7 @@ public class ProductsController : UmbracoApiController
         return new[] { "Table", "Chair", "Desk", "Computer", "Beer fridge" };
     }
 
-    [HttpGet]
+    [HttpGet("getallproductsjson")]
     public JsonResult GetAllProductsJson()
     {
         return new JsonResult(this.GetAllProducts());

--- a/14/umbraco-cms/implementation/unit-testing.md
+++ b/14/umbraco-cms/implementation/unit-testing.md
@@ -166,7 +166,7 @@ See [Reference documentation on UmbracoApiControllers](../reference/routing/umbr
 ```csharp
 [ApiController]
 [Route("/umbraco/api/products")]
-public class ProductsController : UmbracoApiController
+public class ProductsController : Controller
 {
     public IEnumerable<string> GetAllProducts()
     {

--- a/15/umbraco-cms/implementation/unit-testing.md
+++ b/15/umbraco-cms/implementation/unit-testing.md
@@ -197,15 +197,15 @@ public class ProductsControllerTests
 
         var result = this.controller.GetAllProducts();
 
-        Assert.AreEqual(expected, result);
+        Assert.That(expected == result);
     }
 
     [Test]
     public void WhenGetAllProductsJson_ThenReturnViewModelWithExpectedJson()
     {
-        var json = serializer.Serialize(this.controller.GetAllProductsJson().Value);
+        var json = JsonSerializer.Serialize(this.controller.GetAllProductsJson().Value);
 
-        Assert.AreEqual("[\"Table\",\"Chair\",\"Desk\",\"Computer\",\"Beer fridge\"]", json);
+        Assert.That("[\"Table\",\"Chair\",\"Desk\",\"Computer\",\"Beer fridge\"]" == json);
     }
 }
 ```

--- a/15/umbraco-cms/implementation/unit-testing.md
+++ b/15/umbraco-cms/implementation/unit-testing.md
@@ -159,7 +159,7 @@ public class PageSurfaceControllerTests
 `ServiceContext.CreatePartial()` has optional parameters, and by naming them you only need to mock the dependencies that you need, for example: `ServiceContext.CreatePartial(contentService: Mock.Of<IContentService>());`
 {% endhint %}
 
-## Testing an ApiController
+## Testing a Controller
 
 See [Reference documentation on UmbracoApiControllers](../reference/routing/umbraco-api-controllers/README.md#locally-declared-controller).
 

--- a/15/umbraco-cms/implementation/unit-testing.md
+++ b/15/umbraco-cms/implementation/unit-testing.md
@@ -159,15 +159,13 @@ public class PageSurfaceControllerTests
 `ServiceContext.CreatePartial()` has optional parameters, and by naming them you only need to mock the dependencies that you need, for example: `ServiceContext.CreatePartial(contentService: Mock.Of<IContentService>());`
 {% endhint %}
 
-## Testing an UmbracoApiController
+## Testing an ApiController
 
 See [Reference documentation on UmbracoApiControllers](../reference/routing/umbraco-api-controllers/README.md#locally-declared-controller).
 
-{% hint style="warning" %}
-The example below uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
-{% endhint %}
-
 ```csharp
+[ApiController]
+[Route("/umbraco/api/products")]
 public class ProductsController : UmbracoApiController
 {
     public IEnumerable<string> GetAllProducts()
@@ -175,7 +173,7 @@ public class ProductsController : UmbracoApiController
         return new[] { "Table", "Chair", "Desk", "Computer", "Beer fridge" };
     }
 
-    [HttpGet]
+    [HttpGet("getallproductsjson")]
     public JsonResult GetAllProductsJson()
     {
         return new JsonResult(this.GetAllProducts());

--- a/15/umbraco-cms/implementation/unit-testing.md
+++ b/15/umbraco-cms/implementation/unit-testing.md
@@ -166,7 +166,7 @@ See [Reference documentation on UmbracoApiControllers](../reference/routing/umbr
 ```csharp
 [ApiController]
 [Route("/umbraco/api/products")]
-public class ProductsController : UmbracoApiController
+public class ProductsController : Controller
 {
     public IEnumerable<string> GetAllProducts()
     {


### PR DESCRIPTION
## Description

This PR belongs to: https://github.com/umbraco/UmbracoDocs/issues/6466. 

* [x] Change UmbracoApiController to a default Controller
* [x] Added route attributes
* [x] Delete obsolete warning

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
Umbraco CMS v14 & 15