### PR TITLE
Clarifying management API authentication

### DIFF
--- a/14/umbraco-cms/reference/management-api/README.md
+++ b/14/umbraco-cms/reference/management-api/README.md
@@ -48,7 +48,7 @@ You can see an example of how to connect a backoffice user via OAuth2 in Postman
 
 To test a Management API endpoint, follow these steps:
 
-1. Authenticate via the **Authorize** button. Make sure you use `umbraco-swagger` as the `client_id` and in non-production environments you need to leave the `client_secret` blank:
+1. Authenticate via the **Authorize** button. Make sure you use `umbraco-swagger` as the `client_id` and leave the `client_secret` blank in non-production environments:
 
 ![Umbraco Management API when Authenticated](../images/management-api-swagger-authenticated.png)
 

--- a/14/umbraco-cms/reference/management-api/README.md
+++ b/14/umbraco-cms/reference/management-api/README.md
@@ -48,7 +48,7 @@ You can see an example of how to connect a backoffice user via OAuth2 in Postman
 
 To test a Management API endpoint, follow these steps:
 
-1. Authenticate via the **Authorize** button. Make sure you use `umbraco-swagger` as the `client_id`:
+1. Authenticate via the **Authorize** button. Make sure you use `umbraco-swagger` as the `client_id` and in non-production environments you need to leave the `client_secret` blank:
 
 ![Umbraco Management API when Authenticated](../images/management-api-swagger-authenticated.png)
 


### PR DESCRIPTION
Added a note with the client_id, that you need to leave the client_secret empty for non-production environments as it's easy to miss the hint below the screen shot that lets you know that you need to leave the client_secret empty.