### PR TITLE
Plan requirement change

### DIFF
--- a/umbraco-heartcore/getting-started/preview.md
+++ b/umbraco-heartcore/getting-started/preview.md
@@ -9,7 +9,7 @@ The Preview API is always protected, this means it requires an API Key with **Br
 You will also need a client consuming the Content Delivery API. If you don't already have one you can use one of the samples included with the Client Libraries.
 
 {% hint style="info" %}
-The Preview feature is currently only available on the [Professional Plan](https://umbraco.com/umbraco-heartcore-pricing/).
+The Preview feature is currently only available on the [Standard Plan](https://umbraco.com/umbraco-heartcore-pricing/).
 {% endhint %}
 
 ## Enabling preview for editors


### PR DESCRIPTION
The Preview API is available on Standard Plan and above

## Description

The documentation said that the Preview API is available on Professional Plans.
I changed it to Standard, as the Preview API is also available there now.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [x] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
