### PR TITLE
Correct usage of GetModelPropertyType and GetModelContentType methods

### DIFF
--- a/13/umbraco-cms/reference/templating/modelsbuilder/understand-and-extend.md
+++ b/13/umbraco-cms/reference/templating/modelsbuilder/understand-and-extend.md
@@ -45,8 +45,10 @@ public partial class TextPage : PublishedContentModel
 What is important is the `Header` property. The rest is (a) a constructor and (b) some static helpers to get the `PublishedContentType` and the `PublishedPropertyType` objects:
 
 ```csharp
-var contentType = TextPage.GetModelContentType(); // is a PublishedContentType
-var propertyType = TextPage.GetModelPropertyType(x => x.Header); // is a PublishedPropertyType
+var contentType = TextPage.GetModelContentType(_publishedSnapshotAccessor); // is a PublishedContentType
+var propertyType = TextPage.GetModelPropertyType(_publishedSnapshotAccessor, x => x.Header); // is a PublishedPropertyType
+
+// Where _publishedSnapshotAccessor is an injected IPublishedSnapshotAccessor service
 ```
 
 ## Composition and Inheritance


### PR DESCRIPTION
## Description

I corrected the usage of the Models Builder `GetModelPropertyType` and `GetModelContentType` methods to include the `publishedSnapshotAccessor` parameter which has been required for a few Umbraco versions now.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [X] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

v9-v13 (<v8 and v14 untested)

## Deadline (if relevant)

N/A
