### PR TITLE
Porting old Umbraco API Controller [Getting started with Entity Framework (EF) Core]

### DIFF
--- a/14/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
+++ b/14/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
@@ -252,18 +252,19 @@ The example below creates a `UmbracoApiController` to be able to fetch and inser
 ```csharp
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Persistence.EFCore.Scoping;
-using Umbraco.Cms.Web.Common.Controllers;
 
 namespace Umbraco.Demo;
 
-public class BlogCommentsController : UmbracoApiController
+[ApiController]
+[Route("/umbraco/api/blogcomments")]
+public class BlogCommentsController : Controller
 {
     private readonly IEFCoreScopeProvider<BlogContext> _efCoreScopeProvider;
 
     public BlogCommentsController(IEFCoreScopeProvider<BlogContext> efCoreScopeProvider)
         => _efCoreScopeProvider = efCoreScopeProvider;
 
-    [HttpGet]
+    [HttpGet("all")]
     public async Task<IActionResult> All()
     {
         using IEfCoreScope<BlogContext> scope = _efCoreScopeProvider.CreateScope();
@@ -272,7 +273,7 @@ public class BlogCommentsController : UmbracoApiController
         return Ok(comments);
     }
 
-    [HttpGet]
+    [HttpGet("getcomments")]
     public async Task<IActionResult> GetComments(Guid umbracoNodeKey)
     {
         using IEfCoreScope<BlogContext> scope = _efCoreScopeProvider.CreateScope();
@@ -285,7 +286,7 @@ public class BlogCommentsController : UmbracoApiController
         return Ok(comments);
     }
 
-    [HttpPost]
+    [HttpPost("insertcomment")]
     public async Task InsertComment(BlogComment comment)
     {
         using IEfCoreScope<BlogContext> scope = _efCoreScopeProvider.CreateScope();

--- a/14/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
+++ b/14/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
@@ -245,7 +245,6 @@ The example below creates a `UmbracoApiController` to be able to fetch and inser
 {% hint style="warning" %}
 
 * This example uses the `BlogComment` class, which is a database model. The recommended approach would be to map these over to a ViewModel instead, that way your database & UI layers are not coupled. Be aware that things like error handling and data validation have been omitted for brevity.
-* The example uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
 
 {% endhint %}
 

--- a/15/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
+++ b/15/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
@@ -245,25 +245,25 @@ The example below creates a `UmbracoApiController` to be able to fetch and inser
 {% hint style="warning" %}
 
 * This example uses the `BlogComment` class, which is a database model. The recommended approach would be to map these over to a ViewModel instead, that way your database & UI layers are not coupled. Be aware that things like error handling and data validation have been omitted for brevity.
-* The example uses UmbracoApiController which is obsolete in Umbraco 14 and will be removed in Umbraco 15.
 
 {% endhint %}
 
 ```csharp
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Persistence.EFCore.Scoping;
-using Umbraco.Cms.Web.Common.Controllers;
 
 namespace Umbraco.Demo;
 
-public class BlogCommentsController : UmbracoApiController
+[ApiController]
+[Route("/umbraco/api/blogcomments")]
+public class BlogCommentsController : Controller
 {
     private readonly IEFCoreScopeProvider<BlogContext> _efCoreScopeProvider;
 
     public BlogCommentsController(IEFCoreScopeProvider<BlogContext> efCoreScopeProvider)
         => _efCoreScopeProvider = efCoreScopeProvider;
 
-    [HttpGet]
+    [HttpGet("all")]
     public async Task<IActionResult> All()
     {
         using IEfCoreScope<BlogContext> scope = _efCoreScopeProvider.CreateScope();
@@ -272,7 +272,7 @@ public class BlogCommentsController : UmbracoApiController
         return Ok(comments);
     }
 
-    [HttpGet]
+    [HttpGet("getcomments")]
     public async Task<IActionResult> GetComments(Guid umbracoNodeKey)
     {
         using IEfCoreScope<BlogContext> scope = _efCoreScopeProvider.CreateScope();
@@ -285,7 +285,7 @@ public class BlogCommentsController : UmbracoApiController
         return Ok(comments);
     }
 
-    [HttpPost]
+    [HttpPost("insertcomment")]
     public async Task InsertComment(BlogComment comment)
     {
         using IEfCoreScope<BlogContext> scope = _efCoreScopeProvider.CreateScope();


### PR DESCRIPTION
## Description
This PR belongs to: https://github.com/umbraco/UmbracoDocs/issues/6466.

* [x] Change `UmbracoApiController` to `Controller`
* [x] Remove using statement 'using Umbraco.Cms.Web.Common.Controllers;'
* [x] Add Attributes

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version

## Product & version (if relevant)
Umbraco CMS v14 & 15