### PR TITLE
Add docker documentation for V14 and V15

### DIFF
--- a/14/umbraco-cms/SUMMARY.md
+++ b/14/umbraco-cms/SUMMARY.md
@@ -16,6 +16,7 @@
   * [Requirements](fundamentals/setup/requirements.md)
   * [Installation](fundamentals/setup/install/README.md)
     * [Install using .NET CLI](fundamentals/setup/install/install-umbraco-with-templates.md)
+    * [Running Umbraco in Docker using Docker Compose](fundamentals/setup/install/running-umbraco-on-docker-locally.md)
     * [Install using Visual Studio](fundamentals/setup/install/visual-studio.md)
     * [Local IIS With Umbraco](fundamentals/setup/install/iis.md)
     * [Install using Visual Studio Code](fundamentals/setup/install/install-umbraco-with-vs-code.md)

--- a/14/umbraco-cms/fundamentals/setup/install/install-umbraco-with-templates.md
+++ b/14/umbraco-cms/fundamentals/setup/install/install-umbraco-with-templates.md
@@ -37,54 +37,98 @@ From that command's output, you will get a better understanding of what are the 
 Umbraco Project (C#)
 Author: Umbraco HQ
 Description: An empty Umbraco project ready to get started.
+
+Usage:
+  dotnet new umbraco [options] [template options]
+
 Options:
-  -v|--version                       The version of Umbraco.Cms to add as PackageReference.
-                                     string - Optional
-                                     Default: 10.0.0
+  -n, --name <name>       The name for the output being created. If no name is specified, the name of the output directory is used.
+  -o, --output <output>   Location to place the generated output.
+  --dry-run               Displays a summary of what would happen if the given command line were run if it would result in a template
+                          creation.
+  --force                 Forces content to be generated even if it would change existing files.
+  --no-update-check       Disables checking for the template package updates when instantiating a template.
+  --project <project>     The project that should be used for context evaluation.
+  -lang, --language <C#>  Specifies the template language to instantiate.
+  --type <project>        Specifies the template type to instantiate.
 
-  --use-https-redirect               Adds code to Program.cs to redirect HTTP to HTTPS and enables the UseHttps setting.
-                                     bool - Optional
-                                     Default: false
-
-  --no-restore                       If specified, skips the automatic restore of the project on create.
-                                     bool - Optional
-                                     Default: false
-
-  --exclude-gitignore                Whether to exclude .gitignore from the generated template.
-                                     bool - Optional
-                                     Default: false
-
-  --minimal-gitignore                Whether to only include minimal (Umbraco specific) rules in the .gitignore.
-                                     bool - Optional
-                                     Default: false
-
-  --connection-string                Database connection string used by Umbraco.
-                                     string - Optional
-
-  --connection-string-provider-name  Database connection string provider name used by Umbraco.
-                                     string - Optional
-                                     Default: Microsoft.Data.SqlClient
-
-  --development-database-type        Database type used by Umbraco for development.
-                                         None       - Do not configure a database for development.
-                                         SQLite     - Use embedded SQLite database.
-                                         LocalDB    - Use embedded LocalDB database (requires SQL Server Express with Advanced Services).
-                                     Default: None
-
-  --friendly-name                    Used to specify the name of the default admin user when using unattended install on development (stored as plain text).
-                                     string - Optional
-
-  --email                            Used to specify the email of the default admin user when using unattended install on development (stored as plain text).
-                                     string - Optional
-
-  --password                         Used to specify the password of the default admin user when using unattended install on development (stored as plain text).
-                                     string - Optional
-
-  --no-nodes-view-path               Path to a custom view presented with the Umbraco installation contains no published content.
-                                     string - Optional
-
-  -p|--PackageTestSiteName           The name of the package project this should be a test site for.
-                                     string - Optional
+Template options:
+  -r, --release <Latest|LTS>                 The Umbraco release to use, either latest or latest long term supported
+                                             Type: choice
+                                               Latest  The latest umbraco release
+                                               LTS     The most recent long term supported version
+                                             Default: Latest
+  --use-https-redirect                       Adds code to Startup.cs to redirect HTTP to HTTPS and enables the UseHttps setting.
+                                             Type: bool
+                                             Default: false
+  -da, --use-delivery-api                    Enables the Delivery API
+                                             Type: bool
+                                             Default: false
+  --add-docker                               Adds a docker file to the project.
+                                             Type: bool
+                                             Default: false
+  --no-restore                               If specified, skips the automatic restore of the project on create.
+                                             Type: bool
+                                             Default: false
+  --exclude-gitignore                        Whether to exclude .gitignore from the generated template.
+                                             Type: bool
+                                             Default: false
+  --minimal-gitignore                        Whether to only include minimal (Umbraco specific) rules in the .gitignore.
+                                             Type: bool
+                                             Default: false
+  --connection-string <connection-string>    Database connection string used by Umbraco.
+                                             Type: string
+  --connection-string-provider-name          Database connection string provider name used by Umbraco.
+  <connection-string-provider-name>          Type: string
+                                             Default: Microsoft.Data.SqlClient
+  --development-database-type <choice>       Database type used by Umbraco for development.
+                                             Type: choice
+                                               None     Do not configure a database for development.
+                                               SQLite   Use embedded SQLite database.
+                                               LocalDB  Use embedded LocalDB database (requires SQL Server Express with Advanced
+                                             Services).
+                                             Default: None
+  --friendly-name <friendly-name>            Used to specify the name of the default admin user when using unattended install on
+                                             development (stored as plain text).
+                                             Type: string
+  --email <email>                            Used to specify the email of the default admin user when using unattended install on
+                                             development (stored as plain text).
+                                             Type: string
+  --password <password>                      Used to specify the password of the default admin user when using unattended install on
+                                             development (stored as plain text).
+                                             Type: string
+  --no-nodes-view-path <no-nodes-view-path>  Path to a custom view presented with the Umbraco installation contains no published
+                                             content.
+                                             Type: string
+  -dm, --development-mode <choice>           Choose the development mode to use for the project.
+                                             Type: choice
+                                               BackofficeDevelopment  Enables backoffice development, allowing you to develop from
+                                             within the backoffice, this is the default behaviour.
+                                               IDEDevelopment         Configures appsettings.Development.json to Development runtime
+                                             mode and SourceCodeAuto models builder mode, and configures appsettings.json to
+                                             Production runtime mode, Nothing models builder mode, and enables UseHttps
+                                             Default: BackofficeDevelopment
+  -mm, --models-mode <choice>                Choose the models builder mode to use for the project. When development mode is set to
+                                             IDEDevelopment this only changes the models builder mode appsetttings.development.json
+                                             Type: choice
+                                               Default           Let DevelopmentMode determine the models builder mode.
+                                               InMemoryAuto      Generate models in memory, automatically updating when a content
+                                             type change, this means no need for app rebuild, however models are only available in
+                                             views.
+                                               SourceCodeManual  Generate models as source code, only updating when requested
+                                             manually, this means a interaction and rebuild is required when content type(s) change,
+                                             however models are available in code.
+                                               SourceCodeAuto    Generate models as source code, automatically updating when a
+                                             content type change, this means a rebuild is required when content type(s) change,
+                                             however models are available in code.
+                                               Nothing           No models are generated, this is recommended for production assuming
+                                             generated models are used for development.
+                                             Default: Default
+  -sk, --starter-kit <choice>                Choose a starter kit to install.
+                                             Type: choice
+                                               None                   No starter kit.
+                                               Umbraco.TheStarterKit  The Umbraco starter kit.
+                                             Default: None
 ```
 
 ## Create an Umbraco project

--- a/14/umbraco-cms/fundamentals/setup/install/running-umbraco-on-docker-locally.md
+++ b/14/umbraco-cms/fundamentals/setup/install/running-umbraco-on-docker-locally.md
@@ -1,0 +1,97 @@
+﻿---
+description: "Running Umbraco on docker locally using docker compose"
+---
+
+# Running Umbraco in Docker using Docker Compose
+
+To aid in developing Umbraco with additional services, the templates can provide the requisite files to run Umbraco with a SQL Server database in Docker.
+This setup is designed to be used for local development, and not for production.
+
+## Prerequisites
+
+Before you can run Umbraco in Docker, you need to have the following installed:
+* Version 14.3.0 or higher of the Umbraco Templates
+* Docker Desktop
+
+## Installing
+
+Installing Umbraco with the Docker file and Docker Compose file is a two-step process.
+
+First, create a folder to hold your project and enter that folder.
+
+```bash
+mkdir MyDockerProject
+cd MyDockerProject
+```
+Next create your Umbraco project using the Umbraco Templates, and remember to use the `--add-docker` flag to include the Docker files.
+Conventionally this is named the same as the folder, but is not a requirement.
+
+```bash
+dotnet new umbraco -n MyDockerProject --add-docker
+```
+
+Now we need to add some additional files to make docker compose work. We can do this using the `umbraco-compose` template, passing the project name wwe just specified to the `-P` parameter:
+
+```bash
+dotnet new umbraco-compose -P "MyDockerProject"
+```
+
+The `-P` flag is required to specify the correct paths in the docker-compose file. The project is now ready to run with docker compose.
+
+The final folder structure looks like this:
+
+* MyDockerProject
+  * MyDockerProject
+    * Typical project files
+    * DockerFile
+    * .dockerignore
+  * .env
+  * Database
+    * DockerFile
+    * healthcheck.sh
+    * setup.sql
+    * startup.sh
+  * docker-compose.yml
+
+As you can see the project now includes docker files for both Umbraco itself and the SQL server database, as well as some additional scripts to launch and configure the database.
+
+It also includes a .env file with the password for the database.
+
+## Running
+
+To run the project run the `docker compose up` command from the root of the project, same folder as `docker-compose.yml`.
+
+This command will build both the Umbraco and Sql Server images and launch them in the correct order, after a while the site will have booted and you can navigate to it in your browser like nomral on `http://localhost:44372/`
+
+### Useful commands
+
+There is some useful commands you can use to manage the docker containers:
+
+* `docker compose down --volumes` This will delete your containers AND the volumes they use, this is useful if you want to start from scratch.
+
+{% hint style="warning" %}
+This delete your database and all data in it, so be careful with this command.
+{% endhint %}
+
+* `docker compose up --build` This will rebuild the images and start the containers, this is useful if you have made changes to the project and want to see them reflected in the running site.
+* `docker compose watch` This will start the containers and watch the default models folder, this means that if the project uses source code models builder the images automatically rebuilds and restarts when you change the models.
+
+## Details
+
+The docker compose file uses bind mounts for the following folders:
+
+* /wwwroot/media
+* /wwwroot/scripts
+* /wwwroot/css
+* /Views
+* /models
+
+This is bad for production, however, for local development this means that the files necessary for development are available from outside the container in your IDE allowing you to effectively develop even though the project is running in docker.
+
+## Template options
+
+The `umbraco-compose` template has a few options that can be used to customize the setup:
+
+* -P or --project-name: The name of the project, this is required and used to set the correct paths in the docker-compose file.
+* -dbpw or --DatabasePasswor: Used to specify the database password, this is stored in the .env file, defaults to: Password1234
+* -p or --Port: Used to specify the port the site will run on, defaults to 44372

--- a/14/umbraco-cms/fundamentals/setup/install/running-umbraco-on-docker-locally.md
+++ b/14/umbraco-cms/fundamentals/setup/install/running-umbraco-on-docker-locally.md
@@ -16,20 +16,22 @@ Before you can run Umbraco in Docker, you need to have the following installed:
 
 Installing Umbraco with the Docker file and Docker Compose file is a two-step process.
 
-First, create a folder to hold your project and enter that folder.
+1. Create a folder to hold your project and enter that folder.
 
 ```bash
 mkdir MyDockerProject
 cd MyDockerProject
 ```
-Next create your Umbraco project using the Umbraco Templates, and remember to use the `--add-docker` flag to include the Docker files.
-Conventionally this is named the same as the folder, but is not a requirement.
+2. Create your Umbraco project using the Umbraco Templates, and remember to use the `--add-docker` flag to include the Docker files.
+
+
+Conventionally this is named the same as the folder, but it is not a requirement.
 
 ```bash
 dotnet new umbraco -n MyDockerProject --add-docker
 ```
 
-Now we need to add some additional files to make docker compose work. We can do this using the `umbraco-compose` template, passing the project name we specified earlier to the `-P` parameter:
+Now we need to add some additional files to make docker compose work. We can do this using the umbraco-compose template, passing the project name we specified earlier to the -P parameter:
 
 ```bash
 dotnet new umbraco-compose -P "MyDockerProject"
@@ -52,7 +54,7 @@ The final folder structure looks like this:
     * `startup.sh`
   * `docker-compose.yml`
 
-The project now includes docker files for both Umbraco and the SQL server database. 
+The project now includes docker files for both Umbraco and the SQL server database.
 
 It also includes additional scripts to launch and configure the database and a `.env` file with the database password.
 

--- a/14/umbraco-cms/fundamentals/setup/install/running-umbraco-on-docker-locally.md
+++ b/14/umbraco-cms/fundamentals/setup/install/running-umbraco-on-docker-locally.md
@@ -4,8 +4,7 @@ description: "Running Umbraco on docker locally using docker compose"
 
 # Running Umbraco in Docker using Docker Compose
 
-To aid in developing Umbraco with additional services, the templates can provide the requisite files to run Umbraco with a SQL Server database in Docker.
-This setup is designed to be used for local development, and not for production.
+To aid in developing Umbraco with additional services, the templates can provide the requisite files to run Umbraco with an SQL Server database in Docker. This setup is designed to be used for local development, and not for production.
 
 ## Prerequisites
 
@@ -44,54 +43,56 @@ The final folder structure looks like this:
   * MyDockerProject
     * Typical project files
     * DockerFile
-    * .dockerignore
-  * .env
+    * `.dockerignore`
+  * `.env`
   * Database
     * DockerFile
-    * healthcheck.sh
-    * setup.sql
-    * startup.sh
-  * docker-compose.yml
+    * `healthcheck.sh`
+    * `setup.sql`
+    * `startup.sh`
+  * `docker-compose.yml`
 
-As you can see the project now includes docker files for both Umbraco itself and the SQL server database, as well as some additional scripts to launch and configure the database.
+The project now includes docker files for both Umbraco and the SQL server database. 
 
-It also includes a .env file with the password for the database.
+It also includes additional scripts to launch and configure the database and a `.env` file with the database password.
 
 ## Running
 
-To run the project run the `docker compose up` command from the root of the project, same folder as `docker-compose.yml`.
+To run the project use the `docker compose up` command in the root of the project files where the `docker-compose.yml` is.
 
-This command will build both the Umbraco and Sql Server images and launch them in the correct order, after a while the site will have booted and you can navigate to it in your browser like nomral on `http://localhost:44372/`
+This command will build both the Umbraco and SQL Server images and launch them in the correct order. When the site is booted, access it in your browser on `http://localhost:44372/`.
 
 ### Useful commands
 
-There is some useful commands you can use to manage the docker containers:
+There are some useful commands you can use to manage the docker containers:
 
-* `docker compose down --volumes` This will delete your containers and the volumes they use, this is useful if you want to start from scratch.
+* `docker compose down --volumes`: Delete your containers and the volumes they use. This is useful if you want to start from scratch.
 
 {% hint style="warning" %}
-This delete your database and all data in it, so be careful with this command.
+Be careful with this command, as it deletes your database and all data in it.
 {% endhint %}
 
-* `docker compose up --build` This will rebuild the images and start the containers, this is useful if you have made changes to the project and want to see them reflected in the running site.
-* `docker compose watch` This will start the containers and watch the default models folder, this means that if the project uses source code models builder the images automatically rebuilds and restarts when you change the models.
+* `docker compose up --build`: Rebuild the images and start the containers. This is useful if you have made changes to the project and want to see them reflected on the running site.
+* `docker compose watch`: Start the containers and watch the default models folder. This means that if the project uses a source-code models builder the images are automatically rebuilt and restarts when you change the models.
 
 ## Details
 
 The docker compose file uses bind mounts for the following folders:
 
-* /wwwroot/media
-* /wwwroot/scripts
-* /wwwroot/css
-* /Views
-* /models
+* `/wwwroot/media`
+* `/wwwroot/scripts`
+* `/wwwroot/css`
+* `/Views`
+* `/models`
 
-This is bad for production, however, for local development this means that the files necessary for development are available from outside the container in your IDE allowing you to effectively develop even though the project is running in docker.
+This is not meant to be used in production.
+
+For local development, however, this means that the files necessary for development are available from outside the container in your IDE. This allows development even though the project is running in docker.
 
 ## Template options
 
 The `umbraco-compose` template has a few options that can be used to customize the setup:
 
-* -P or --project-name: The name of the project, this is required and used to set the correct paths in the docker-compose file.
-* -dbpw or --DatabasePasswor: Used to specify the database password, this is stored in the .env file, defaults to: Password1234
-* -p or --Port: Used to specify the port the site will run on, defaults to 44372
+* `-P` or `--project-name`: The name of the project. This is required and used to set the correct paths in the docker-compose file.
+* `-dbpw` or `--DatabasePasswor`: Used to specify the database password. This is stored in the `.env` file and defaults to: `Password1234`.
+* `-p` or `--Port`: Used to specify the port the site will run on. Defaults to `44372`.

--- a/14/umbraco-cms/fundamentals/setup/install/running-umbraco-on-docker-locally.md
+++ b/14/umbraco-cms/fundamentals/setup/install/running-umbraco-on-docker-locally.md
@@ -30,7 +30,7 @@ Conventionally this is named the same as the folder, but is not a requirement.
 dotnet new umbraco -n MyDockerProject --add-docker
 ```
 
-Now we need to add some additional files to make docker compose work. We can do this using the `umbraco-compose` template, passing the project name wwe just specified to the `-P` parameter:
+Now we need to add some additional files to make docker compose work. We can do this using the `umbraco-compose` template, passing the project name we specified earlier to the `-P` parameter:
 
 ```bash
 dotnet new umbraco-compose -P "MyDockerProject"
@@ -67,7 +67,7 @@ This command will build both the Umbraco and Sql Server images and launch them i
 
 There is some useful commands you can use to manage the docker containers:
 
-* `docker compose down --volumes` This will delete your containers AND the volumes they use, this is useful if you want to start from scratch.
+* `docker compose down --volumes` This will delete your containers and the volumes they use, this is useful if you want to start from scratch.
 
 {% hint style="warning" %}
 This delete your database and all data in it, so be careful with this command.

--- a/15/umbraco-cms/SUMMARY.md
+++ b/15/umbraco-cms/SUMMARY.md
@@ -11,6 +11,7 @@
   * [Requirements](fundamentals/setup/requirements.md)
   * [Installation](fundamentals/setup/install/README.md)
     * [Install using .NET CLI](fundamentals/setup/install/install-umbraco-with-templates.md)
+    * [Running Umbraco in Docker using Docker Compose](fundamentals/setup/install/running-umbraco-on-docker-locally.md)
     * [Install using Visual Studio](fundamentals/setup/install/visual-studio.md)
     * [Local IIS With Umbraco](fundamentals/setup/install/iis.md)
     * [Install using Visual Studio Code](fundamentals/setup/install/install-umbraco-with-vs-code.md)

--- a/15/umbraco-cms/fundamentals/setup/install/install-umbraco-with-templates.md
+++ b/15/umbraco-cms/fundamentals/setup/install/install-umbraco-with-templates.md
@@ -37,54 +37,98 @@ From that command's output, you will get a better understanding of what are the 
 Umbraco Project (C#)
 Author: Umbraco HQ
 Description: An empty Umbraco project ready to get started.
+
+Usage:
+  dotnet new umbraco [options] [template options]
+
 Options:
-  -v|--version                       The version of Umbraco.Cms to add as PackageReference.
-                                     string - Optional
-                                     Default: 10.0.0
+  -n, --name <name>       The name for the output being created. If no name is specified, the name of the output directory is used.
+  -o, --output <output>   Location to place the generated output.
+  --dry-run               Displays a summary of what would happen if the given command line were run if it would result in a template
+                          creation.
+  --force                 Forces content to be generated even if it would change existing files.
+  --no-update-check       Disables checking for the template package updates when instantiating a template.
+  --project <project>     The project that should be used for context evaluation.
+  -lang, --language <C#>  Specifies the template language to instantiate.
+  --type <project>        Specifies the template type to instantiate.
 
-  --use-https-redirect               Adds code to Program.cs to redirect HTTP to HTTPS and enables the UseHttps setting.
-                                     bool - Optional
-                                     Default: false
-
-  --no-restore                       If specified, skips the automatic restore of the project on create.
-                                     bool - Optional
-                                     Default: false
-
-  --exclude-gitignore                Whether to exclude .gitignore from the generated template.
-                                     bool - Optional
-                                     Default: false
-
-  --minimal-gitignore                Whether to only include minimal (Umbraco specific) rules in the .gitignore.
-                                     bool - Optional
-                                     Default: false
-
-  --connection-string                Database connection string used by Umbraco.
-                                     string - Optional
-
-  --connection-string-provider-name  Database connection string provider name used by Umbraco.
-                                     string - Optional
-                                     Default: Microsoft.Data.SqlClient
-
-  --development-database-type        Database type used by Umbraco for development.
-                                         None       - Do not configure a database for development.
-                                         SQLite     - Use embedded SQLite database.
-                                         LocalDB    - Use embedded LocalDB database (requires SQL Server Express with Advanced Services).
-                                     Default: None
-
-  --friendly-name                    Used to specify the name of the default admin user when using unattended install on development (stored as plain text).
-                                     string - Optional
-
-  --email                            Used to specify the email of the default admin user when using unattended install on development (stored as plain text).
-                                     string - Optional
-
-  --password                         Used to specify the password of the default admin user when using unattended install on development (stored as plain text).
-                                     string - Optional
-
-  --no-nodes-view-path               Path to a custom view presented with the Umbraco installation contains no published content.
-                                     string - Optional
-
-  -p|--PackageTestSiteName           The name of the package project this should be a test site for.
-                                     string - Optional
+Template options:
+  -r, --release <Latest|LTS>                 The Umbraco release to use, either latest or latest long term supported
+                                             Type: choice
+                                               Latest  The latest umbraco release
+                                               LTS     The most recent long term supported version
+                                             Default: Latest
+  --use-https-redirect                       Adds code to Startup.cs to redirect HTTP to HTTPS and enables the UseHttps setting.
+                                             Type: bool
+                                             Default: false
+  -da, --use-delivery-api                    Enables the Delivery API
+                                             Type: bool
+                                             Default: false
+  --add-docker                               Adds a docker file to the project.
+                                             Type: bool
+                                             Default: false
+  --no-restore                               If specified, skips the automatic restore of the project on create.
+                                             Type: bool
+                                             Default: false
+  --exclude-gitignore                        Whether to exclude .gitignore from the generated template.
+                                             Type: bool
+                                             Default: false
+  --minimal-gitignore                        Whether to only include minimal (Umbraco specific) rules in the .gitignore.
+                                             Type: bool
+                                             Default: false
+  --connection-string <connection-string>    Database connection string used by Umbraco.
+                                             Type: string
+  --connection-string-provider-name          Database connection string provider name used by Umbraco.
+  <connection-string-provider-name>          Type: string
+                                             Default: Microsoft.Data.SqlClient
+  --development-database-type <choice>       Database type used by Umbraco for development.
+                                             Type: choice
+                                               None     Do not configure a database for development.
+                                               SQLite   Use embedded SQLite database.
+                                               LocalDB  Use embedded LocalDB database (requires SQL Server Express with Advanced
+                                             Services).
+                                             Default: None
+  --friendly-name <friendly-name>            Used to specify the name of the default admin user when using unattended install on
+                                             development (stored as plain text).
+                                             Type: string
+  --email <email>                            Used to specify the email of the default admin user when using unattended install on
+                                             development (stored as plain text).
+                                             Type: string
+  --password <password>                      Used to specify the password of the default admin user when using unattended install on
+                                             development (stored as plain text).
+                                             Type: string
+  --no-nodes-view-path <no-nodes-view-path>  Path to a custom view presented with the Umbraco installation contains no published
+                                             content.
+                                             Type: string
+  -dm, --development-mode <choice>           Choose the development mode to use for the project.
+                                             Type: choice
+                                               BackofficeDevelopment  Enables backoffice development, allowing you to develop from
+                                             within the backoffice, this is the default behaviour.
+                                               IDEDevelopment         Configures appsettings.Development.json to Development runtime
+                                             mode and SourceCodeAuto models builder mode, and configures appsettings.json to
+                                             Production runtime mode, Nothing models builder mode, and enables UseHttps
+                                             Default: BackofficeDevelopment
+  -mm, --models-mode <choice>                Choose the models builder mode to use for the project. When development mode is set to
+                                             IDEDevelopment this only changes the models builder mode appsetttings.development.json
+                                             Type: choice
+                                               Default           Let DevelopmentMode determine the models builder mode.
+                                               InMemoryAuto      Generate models in memory, automatically updating when a content
+                                             type change, this means no need for app rebuild, however models are only available in
+                                             views.
+                                               SourceCodeManual  Generate models as source code, only updating when requested
+                                             manually, this means a interaction and rebuild is required when content type(s) change,
+                                             however models are available in code.
+                                               SourceCodeAuto    Generate models as source code, automatically updating when a
+                                             content type change, this means a rebuild is required when content type(s) change,
+                                             however models are available in code.
+                                               Nothing           No models are generated, this is recommended for production assuming
+                                             generated models are used for development.
+                                             Default: Default
+  -sk, --starter-kit <choice>                Choose a starter kit to install.
+                                             Type: choice
+                                               None                   No starter kit.
+                                               Umbraco.TheStarterKit  The Umbraco starter kit.
+                                             Default: None
 ```
 
 ## Create an Umbraco project

--- a/15/umbraco-cms/fundamentals/setup/install/running-umbraco-on-docker-locally.md
+++ b/15/umbraco-cms/fundamentals/setup/install/running-umbraco-on-docker-locally.md
@@ -1,0 +1,97 @@
+﻿---
+description: "Running Umbraco on docker locally using docker compose"
+---
+
+# Running Umbraco in Docker using Docker Compose
+
+To aid in developing Umbraco with additional services, the templates can provide the requisite files to run Umbraco with a SQL Server database in Docker.
+This setup is designed to be used for local development, and not for production.
+
+## Prerequisites
+
+Before you can run Umbraco in Docker, you need to have the following installed:
+* Version 14.3.0 or higher of the Umbraco Templates
+* Docker Desktop
+
+## Installing
+
+Installing Umbraco with the Docker file and Docker Compose file is a two-step process.
+
+First, create a folder to hold your project and enter that folder.
+
+```bash
+mkdir MyDockerProject
+cd MyDockerProject
+```
+Next create your Umbraco project using the Umbraco Templates, and remember to use the `--add-docker` flag to include the Docker files.
+Conventionally this is named the same as the folder, but is not a requirement.
+
+```bash
+dotnet new umbraco -n MyDockerProject --add-docker
+```
+
+Now we need to add some additional files to make docker compose work. We can do this using the `umbraco-compose` template, passing the project name wwe just specified to the `-P` parameter:
+
+```bash
+dotnet new umbraco-compose -P "MyDockerProject"
+```
+
+The `-P` flag is required to specify the correct paths in the docker-compose file. The project is now ready to run with docker compose.
+
+The final folder structure looks like this:
+
+* MyDockerProject
+  * MyDockerProject
+    * Typical project files
+    * DockerFile
+    * .dockerignore
+  * .env
+  * Database
+    * DockerFile
+    * healthcheck.sh
+    * setup.sql
+    * startup.sh
+  * docker-compose.yml
+
+As you can see the project now includes docker files for both Umbraco itself and the SQL server database, as well as some additional scripts to launch and configure the database.
+
+It also includes a .env file with the password for the database.
+
+## Running
+
+To run the project run the `docker compose up` command from the root of the project, same folder as `docker-compose.yml`.
+
+This command will build both the Umbraco and Sql Server images and launch them in the correct order, after a while the site will have booted and you can navigate to it in your browser like nomral on `http://localhost:44372/`
+
+### Useful commands
+
+There is some useful commands you can use to manage the docker containers:
+
+* `docker compose down --volumes` This will delete your containers AND the volumes they use, this is useful if you want to start from scratch.
+
+{% hint style="warning" %}
+This delete your database and all data in it, so be careful with this command.
+{% endhint %}
+
+* `docker compose up --build` This will rebuild the images and start the containers, this is useful if you have made changes to the project and want to see them reflected in the running site.
+* `docker compose watch` This will start the containers and watch the default models folder, this means that if the project uses source code models builder the images automatically rebuilds and restarts when you change the models.
+
+## Details
+
+The docker compose file uses bind mounts for the following folders:
+
+* /wwwroot/media
+* /wwwroot/scripts
+* /wwwroot/css
+* /Views
+* /models
+
+This is bad for production, however, for local development this means that the files necessary for development are available from outside the container in your IDE allowing you to effectively develop even though the project is running in docker.
+
+## Template options
+
+The `umbraco-compose` template has a few options that can be used to customize the setup:
+
+* -P or --project-name: The name of the project, this is required and used to set the correct paths in the docker-compose file.
+* -dbpw or --DatabasePasswor: Used to specify the database password, this is stored in the .env file, defaults to: Password1234
+* -p or --Port: Used to specify the port the site will run on, defaults to 44372

--- a/15/umbraco-cms/fundamentals/setup/install/running-umbraco-on-docker-locally.md
+++ b/15/umbraco-cms/fundamentals/setup/install/running-umbraco-on-docker-locally.md
@@ -4,8 +4,7 @@ description: "Running Umbraco on docker locally using docker compose"
 
 # Running Umbraco in Docker using Docker Compose
 
-To aid in developing Umbraco with additional services, the templates can provide the requisite files to run Umbraco with a SQL Server database in Docker.
-This setup is designed to be used for local development, and not for production.
+To aid in developing Umbraco with additional services, the templates can provide the requisite files to run Umbraco with an SQL Server database in Docker. This setup is designed to be used for local development, and not for production.
 
 ## Prerequisites
 
@@ -17,20 +16,22 @@ Before you can run Umbraco in Docker, you need to have the following installed:
 
 Installing Umbraco with the Docker file and Docker Compose file is a two-step process.
 
-First, create a folder to hold your project and enter that folder.
+1. Create a folder to hold your project and enter that folder.
 
 ```bash
 mkdir MyDockerProject
 cd MyDockerProject
 ```
-Next create your Umbraco project using the Umbraco Templates, and remember to use the `--add-docker` flag to include the Docker files.
-Conventionally this is named the same as the folder, but is not a requirement.
+2. Create your Umbraco project using the Umbraco Templates, and remember to use the `--add-docker` flag to include the Docker files.
+
+
+Conventionally this is named the same as the folder, but it is not a requirement.
 
 ```bash
 dotnet new umbraco -n MyDockerProject --add-docker
 ```
 
-Now we need to add some additional files to make docker compose work. We can do this using the `umbraco-compose` template, passing the project name we specified earlier to the `-P` parameter:
+Now we need to add some additional files to make docker compose work. We can do this using the umbraco-compose template, passing the project name we specified earlier to the -P parameter:
 
 ```bash
 dotnet new umbraco-compose -P "MyDockerProject"
@@ -44,54 +45,56 @@ The final folder structure looks like this:
   * MyDockerProject
     * Typical project files
     * DockerFile
-    * .dockerignore
-  * .env
+    * `.dockerignore`
+  * `.env`
   * Database
     * DockerFile
-    * healthcheck.sh
-    * setup.sql
-    * startup.sh
-  * docker-compose.yml
+    * `healthcheck.sh`
+    * `setup.sql`
+    * `startup.sh`
+  * `docker-compose.yml`
 
-As you can see the project now includes docker files for both Umbraco itself and the SQL server database, as well as some additional scripts to launch and configure the database.
+The project now includes docker files for both Umbraco and the SQL server database.
 
-It also includes a .env file with the password for the database.
+It also includes additional scripts to launch and configure the database and a `.env` file with the database password.
 
 ## Running
 
-To run the project run the `docker compose up` command from the root of the project, same folder as `docker-compose.yml`.
+To run the project use the `docker compose up` command in the root of the project files where the `docker-compose.yml` is.
 
-This command will build both the Umbraco and Sql Server images and launch them in the correct order, after a while the site will have booted and you can navigate to it in your browser like nomral on `http://localhost:44372/`
+This command will build both the Umbraco and SQL Server images and launch them in the correct order. When the site is booted, access it in your browser on `http://localhost:44372/`.
 
 ### Useful commands
 
-There is some useful commands you can use to manage the docker containers:
+There are some useful commands you can use to manage the docker containers:
 
-* `docker compose down --volumes` This will delete your containers and the volumes they use, this is useful if you want to start from scratch.
+* `docker compose down --volumes`: Delete your containers and the volumes they use. This is useful if you want to start from scratch.
 
 {% hint style="warning" %}
-This delete your database and all data in it, so be careful with this command.
+Be careful with this command, as it deletes your database and all data in it.
 {% endhint %}
 
-* `docker compose up --build` This will rebuild the images and start the containers, this is useful if you have made changes to the project and want to see them reflected in the running site.
-* `docker compose watch` This will start the containers and watch the default models folder, this means that if the project uses source code models builder the images automatically rebuilds and restarts when you change the models.
+* `docker compose up --build`: Rebuild the images and start the containers. This is useful if you have made changes to the project and want to see them reflected on the running site.
+* `docker compose watch`: Start the containers and watch the default models folder. This means that if the project uses a source-code models builder the images are automatically rebuilt and restarts when you change the models.
 
 ## Details
 
 The docker compose file uses bind mounts for the following folders:
 
-* /wwwroot/media
-* /wwwroot/scripts
-* /wwwroot/css
-* /Views
-* /models
+* `/wwwroot/media`
+* `/wwwroot/scripts`
+* `/wwwroot/css`
+* `/Views`
+* `/models`
 
-This is bad for production, however, for local development this means that the files necessary for development are available from outside the container in your IDE allowing you to effectively develop even though the project is running in docker.
+This is not meant to be used in production.
+
+For local development, however, this means that the files necessary for development are available from outside the container in your IDE. This allows development even though the project is running in docker.
 
 ## Template options
 
 The `umbraco-compose` template has a few options that can be used to customize the setup:
 
-* -P or --project-name: The name of the project, this is required and used to set the correct paths in the docker-compose file.
-* -dbpw or --DatabasePasswor: Used to specify the database password, this is stored in the .env file, defaults to: Password1234
-* -p or --Port: Used to specify the port the site will run on, defaults to 44372
+* `-P` or `--project-name`: The name of the project. This is required and used to set the correct paths in the docker-compose file.
+* `-dbpw` or `--DatabasePasswor`: Used to specify the database password. This is stored in the `.env` file and defaults to: `Password1234`.
+* `-p` or `--Port`: Used to specify the port the site will run on. Defaults to `44372`.

--- a/15/umbraco-cms/fundamentals/setup/install/running-umbraco-on-docker-locally.md
+++ b/15/umbraco-cms/fundamentals/setup/install/running-umbraco-on-docker-locally.md
@@ -30,7 +30,7 @@ Conventionally this is named the same as the folder, but is not a requirement.
 dotnet new umbraco -n MyDockerProject --add-docker
 ```
 
-Now we need to add some additional files to make docker compose work. We can do this using the `umbraco-compose` template, passing the project name wwe just specified to the `-P` parameter:
+Now we need to add some additional files to make docker compose work. We can do this using the `umbraco-compose` template, passing the project name we specified earlier to the `-P` parameter:
 
 ```bash
 dotnet new umbraco-compose -P "MyDockerProject"
@@ -67,7 +67,7 @@ This command will build both the Umbraco and Sql Server images and launch them i
 
 There is some useful commands you can use to manage the docker containers:
 
-* `docker compose down --volumes` This will delete your containers AND the volumes they use, this is useful if you want to start from scratch.
+* `docker compose down --volumes` This will delete your containers and the volumes they use, this is useful if you want to start from scratch.
 
 {% hint style="warning" %}
 This delete your database and all data in it, so be careful with this command.

--- a/15/umbraco-cms/release-candidate-guide.md
+++ b/15/umbraco-cms/release-candidate-guide.md
@@ -12,7 +12,7 @@ description: >-
 To install the Umbraco 15 Release Candidate you need the latest [.NET SDK 9.0.0](https://dotnet.microsoft.com/en-us/download/dotnet/9.0).
 {% endhint %}
 
-The[ release candidate is available on NuGet](https://www.nuget.org/packages/Umbraco.Cms/15.0.0-rc1).
+The[ release candidate is available on NuGet](https://www.nuget.org/packages/Umbraco.Cms/15.0.0-rc2).
 
 1. Install the Umbraco dotnet template for the Release Candidate.
 
@@ -63,6 +63,7 @@ Here is a list of all the articles that are new to this version or have been upd
 ### New articles
 
 * [Tutorial: Extending the Help Menu](tutorials/extending-the-help-menu.md)
+* [Running Umbraco in Docker using Docker Compose](fundamentals/setup/install/running-umbraco-on-docker-locally.md)
 
 ### Updated articles
 


### PR DESCRIPTION
## Description

Updated the help output in the  `install-umbraco-with-templates.md` to include the new options, I also added an article about how you can run Umbraco locally with Docker using Docker Compose.  Note that this is only relevant for 14.3 and up, but I still added it to the V14 section as well.

## Type of suggestion

* [ ] Typo/grammar fix
* [X] Updated outdated content
* [X] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

CMS v14 and v15

