### PR TITLE
fix: correct special property alias misinformation

### DIFF
--- a/umbraco-heartcore/compare-with-umbraco-cms.md
+++ b/umbraco-heartcore/compare-with-umbraco-cms.md
@@ -48,7 +48,7 @@ Umbraco Heartcore is a headless offering, meaning the frontend is decoupled from
 
 <summary>Special property aliases</summary>
 
-Some [special property aliases](umbraco-cms/reference/routing/routing-properties) can manipulate the standard Umbraco routing pipeline in the Umbraco CMS.
+Some [special property aliases](https://docs.umbraco.com/umbraco-cms/reference/routing/routing-properties) can manipulate the standard Umbraco routing pipeline in the Umbraco CMS.
 
 Since the frontend and backend of Umbraco Heartcore are decoupled, it's not possible to use these aliases in Umbraco Heartcore.
 

--- a/umbraco-heartcore/compare-with-umbraco-cms.md
+++ b/umbraco-heartcore/compare-with-umbraco-cms.md
@@ -58,7 +58,7 @@ The aliases are:
 * `umbracoInternalRedirectId`
 * `umbracoUrlAlias`
 
-The last special property type alias `umbracoUrlName` works correctly in Umbraco Heartcore.
+The `umbracoUrlName` property type alias works correctly in Umbraco Heartcore.
 
 </details>
 

--- a/umbraco-heartcore/compare-with-umbraco-cms.md
+++ b/umbraco-heartcore/compare-with-umbraco-cms.md
@@ -48,16 +48,17 @@ Umbraco Heartcore is a headless offering, meaning the frontend is decoupled from
 
 <summary>Special property aliases</summary>
 
-Some special property aliases can manipulate the standard Umbraco routing pipeline in the Umbraco CMS.
+Some [special property aliases](umbraco-cms/reference/routing/routing-properties) can manipulate the standard Umbraco routing pipeline in the Umbraco CMS.
 
 Since the frontend and backend of Umbraco Heartcore are decoupled, it's not possible to use these aliases in Umbraco Heartcore.
 
 The aliases are:
 
-* umbracoRedirect
-* umbracoInternalRedirectId
-* umbracoUrlName
-* umbracoUrlAlias
+* `umbracoRedirect`
+* `umbracoInternalRedirectId`
+* `umbracoUrlAlias`
+
+The last special property type alias `umbracoUrlName` works correctly in Umbraco Heartcore.
 
 </details>
 


### PR DESCRIPTION
## Description

Fix some misinformation re: special property aliases in Heartcore

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Heartcore

## Deadline (if relevant)

N/A