### PR TITLE
404 Page Tutorial Fix

### DIFF
--- a/14/umbraco-cms/tutorials/custom-error-page.md
+++ b/14/umbraco-cms/tutorials/custom-error-page.md
@@ -36,7 +36,8 @@ This method will use a 404 page created via the backoffice.
 
 1. Navigate to the **Settings** section.
 2. Create a new "_Document Type with Template_".
-3. Name the Document Type **404**.
+3. Name the Document Type **404 Page**.
+   1. Note: By default, Umbraco will generate the alias for this DocType as simply "Page," omitting the "404." You may want to manually adjust the alias to "404Page."
 4. \[Optional] Add properties on the Document Type.
    1. In most cases, the 404 not found page would be static.
 5. Fill out the Template with your custom markup.
@@ -44,10 +45,10 @@ This method will use a 404 page created via the backoffice.
 7. Call this Document Type **Statuscodes**.
 8. Open the **Structure** Workspace view.
 9. Check the **Allow at root** option.
-10. Add the **404** Document Type as an **Allowed child note type**.
+10. Add the **404 Page** Document Type as an **Allowed child note type**.
 11. Navigate to the **Content** section.
 12. Create a **Statuscodes** content item called **Statuscodes**.
-13. Create a **404** content item under the **Statuscodes** content.
+13. Create a **404 Page** content item under the **Statuscodes** content.
 
 ### Set a custom 404 page in the configuration
 
@@ -116,7 +117,7 @@ public class Error404Page : IContentLastChanceFinder
 
   // Find the first notFound page at the root level through the published content cache by its documentTypeAlias
   // You can make this search as complex as you want, you can return different pages based on anything in the original request
-  var notFoundPage = umbracoContext.Content?.GetAtRoot().FirstOrDefault(c => c.ContentType.Alias == "Page404");
+  var notFoundPage = umbracoContext.Content?.GetAtRoot().FirstOrDefault(c => c.ContentType.Alias == "404Page");
   if (notFoundPage == null)
   {
    return Task.FromResult(false);

--- a/14/umbraco-cms/tutorials/custom-error-page.md
+++ b/14/umbraco-cms/tutorials/custom-error-page.md
@@ -36,19 +36,19 @@ This method will use a 404 page created via the backoffice.
 
 1. Navigate to the **Settings** section.
 2. Create a new "_Document Type with Template_".
-3. Name the Document Type **404 Page**.
-   1. Note: By default, Umbraco will generate the alias for this DocType as simply "Page," omitting the "404." You may want to manually adjust the alias to "404Page."
-4. \[Optional] Add properties on the Document Type.
+3. Name the Document Type **404**.
+4. Before saving the Document Type, adjust the alias to "Page404." Umbraco will not allow you to create a Document Type with a numeric alias.
+5. \[Optional] Add properties on the Document Type.
    1. In most cases, the 404 not found page would be static.
-5. Fill out the Template with your custom markup.
-6. Create another **Document Type**, but create it without the Template.
-7. Call this Document Type **Statuscodes**.
-8. Open the **Structure** Workspace view.
-9. Check the **Allow at root** option.
-10. Add the **404 Page** Document Type as an **Allowed child note type**.
-11. Navigate to the **Content** section.
-12. Create a **Statuscodes** content item called **Statuscodes**.
-13. Create a **404 Page** content item under the **Statuscodes** content.
+6. Fill out the Template with your custom markup.
+7. Create another **Document Type**, but create it without the Template.
+8. Call this Document Type **Statuscodes**.
+9. Open the **Structure** Workspace view.
+10. Check the **Allow at root** option.
+11. Add the **404 Page** Document Type as an **Allowed child note type**.
+12. Navigate to the **Content** section.
+13. Create a **Statuscodes** content item called **Statuscodes**.
+14. Create a **404 Page** content item under the **Statuscodes** content.
 
 ### Set a custom 404 page in the configuration
 
@@ -117,7 +117,7 @@ public class Error404Page : IContentLastChanceFinder
 
   // Find the first notFound page at the root level through the published content cache by its documentTypeAlias
   // You can make this search as complex as you want, you can return different pages based on anything in the original request
-  var notFoundPage = umbracoContext.Content?.GetAtRoot().FirstOrDefault(c => c.ContentType.Alias == "404Page");
+  var notFoundPage = umbracoContext.Content?.GetAtRoot().FirstOrDefault(c => c.ContentType.Alias == "Page404");
   if (notFoundPage == null)
   {
    return Task.FromResult(false);

--- a/14/umbraco-cms/tutorials/custom-error-page.md
+++ b/14/umbraco-cms/tutorials/custom-error-page.md
@@ -37,7 +37,7 @@ This method will use a 404 page created via the backoffice.
 1. Navigate to the **Settings** section.
 2. Create a new "_Document Type with Template_".
 3. Name the Document Type **404**.
-4. Before saving the Document Type, adjust the alias to "Page404." Umbraco will not allow you to create a Document Type with a numeric alias.
+4. Adjust the alias to "Page404" before saving the Document Type. Umbraco will not allow you to create a Document Type with a numeric alias.
 5. \[Optional] Add properties on the Document Type.
    1. In most cases, the 404 not found page would be static.
 6. Fill out the Template with your custom markup.


### PR DESCRIPTION
## Description

The "Implement Custom Error Pages" tutorial instructs users to create a doc type with the name "404."

`3. Name the Document Type 404.`

This is an invalid name, and the CMS will not allow the user to create/save the new doc type.

![umbraco-404-not-allowed](https://github.com/user-attachments/assets/be1dafdd-7c0a-418e-a164-5d5429c7b841)

I reworked the existing content to instruct users to name the doc type "404 Page" and manually set the alias to "404Page."

This should tighten up the tutorial and add a little clarity with what the CMS does/doesn't allow.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [x] Other

## Product & version (if relevant)

v14

## Deadline (if relevant)

N/A
