### PR TITLE
Fixed misspelled method in example and description

### DIFF
--- a/14/umbraco-cms/reference/notifications/contentservice-notifications.md
+++ b/14/umbraco-cms/reference/notifications/contentservice-notifications.md
@@ -200,20 +200,20 @@ We can suppress notifications at the scope level which makes things consistent a
 
 **How to use scopes**:
 
-- Create an explicit scope and call scope.Notifications.Supress().
+- Create an explicit scope and call scope.Notifications.Suppress().
 - The result of Suppress() is IDisposable, so until it is disposed, notifications will not be added to the queue.
 
 [Example](https://github.com/umbraco/Umbraco-CMS/blob/b69afe81f3f6fcd37480b3b0295a62af44ede245/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/SupressNotificationsTests.cs#L35):
 
 ```csharp
 using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
-using (IDisposable _ = scope.Notifications.Supress())
+using (IDisposable _ = scope.Notifications.Suppress())
 {
     // TODO: Calls to service methods here will not have notifications
 }
 ```
 
-Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Supress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
+Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Suppress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
 
 **Why would one want to suppress events?**
 


### PR DESCRIPTION
## Description

I fixed a misspelling on the "Suppress()" method used in the scopes example. I also corrected the same misspelling several times in the surrounding description(s).

## Type of suggestion

* [X] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other
