### PR TITLE
Added timestamp filtering the the AzureTableLogEntity

### DIFF
--- a/10/umbraco-cms/fundamentals/backoffice/logviewer.md
+++ b/10/umbraco-cms/fundamentals/backoffice/logviewer.md
@@ -78,12 +78,15 @@ public class AzureTableLogViewer : SerilogLogViewerSourceBase
         var requiredEntities = skip + take;
         IEnumerable<AzureTableLogEntity> results = client.Query<AzureTableLogEntity>().Take(requiredEntities);
 
-        return results
-            .Skip(skip)
-            .Take(take)
-            .Select(x => LogEventReader.ReadFromString(x.Data))
-            .Where(filter.TakeLogEvent)
-            .ToList();
+		return results
+			.Skip(skip)
+			.Take(take)
+			.Select(x => LogEventReader.ReadFromString(x.Data))
+            // Filter by timestamp to avoid retrieving all logs from the table, preventing memory and performance issues
+			.Where(evt => evt.Timestamp >= logTimePeriod.StartTime.Date &&
+				evt.Timestamp <= logTimePeriod.EndTime.Date.AddDays(1).AddSeconds(-1))
+			.Where(filter.TakeLogEvent)
+			.ToList();
     }
 
     public override IReadOnlyList<SavedLogSearch>? GetSavedSearches()


### PR DESCRIPTION
## Description
I added timestamp filtering the the AzureTableLogEntity to prevent memory issues.

I encountered a lot of memory issues when using the original version from the documentation. I think I relied on it a bit too blindly! I wanted to share my experience to help prevent others from running into the same problems 😄

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
10, 13, 14, 15