### PR TITLE
Sample code is using v13 namespace and doesn't compile

### DIFF
--- a/15/umbraco-cms/reference/security/external-login-providers.md
+++ b/15/umbraco-cms/reference/security/external-login-providers.md
@@ -203,8 +203,8 @@ The configuration file is used to configure a handful of different options for t
 {% code title="GenericBackOfficeExternalLoginProviderOptions.cs" lineNumbers="true" %}
 ```csharp
 using Microsoft.Extensions.Options;
+using Umbraco.Cms.Api.Management.Security;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Web.BackOffice.Security;
 
 namespace MyUmbracoProject.CustomAuthentication;
 


### PR DESCRIPTION
## Description

The sample code is using an old namespace so will not compile

## Type of suggestion

* [ ] Typo/grammar fix
* [X] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other
