### PR TITLE
V15 CMS: Updating `IPublishedContent.Children` and `IPublishedContent.Parent` property references to extension methods

### DIFF
--- a/15/umbraco-cms/fundamentals/code/umbraco-services.md
+++ b/15/umbraco-cms/fundamentals/code/umbraco-services.md
@@ -206,7 +206,7 @@ public class CustomNewsArticleService: ICustomNewsArticleService
         using (var contextReference = _contextFactory.EnsureUmbracoContext())
         {
             IPublishedContentCache contentCache = contextReference.UmbracoContext.Content;
-            IPublishedContent newsSection = contentCache.GetAtRoot().FirstOrDefault().Children.FirstOrDefault(f => f.ContentType.Alias == "newsSection");
+            IPublishedContent newsSection = contentCache.GetAtRoot().FirstOrDefault().Children().FirstOrDefault(f => f.ContentType.Alias == "newsSection");
             if (newsSection == null)
             {
                 _logger.LogDebug("News Section Not Found");

--- a/15/umbraco-cms/fundamentals/design/templates/basic-razor-syntax.md
+++ b/15/umbraco-cms/fundamentals/design/templates/basic-razor-syntax.md
@@ -40,7 +40,7 @@ Commenting your code is important, use comments to explain what the code does. `
 @* Here we check if the name is equal to foobar *@
 @if (Model.Name == "foobar")
 {
-    @foreach (var child in Model.Children)
+    @foreach (var child in Model.Children())
     {
         @* here we write stuff for each child page *@
         <p>write stuff</p>
@@ -73,7 +73,7 @@ else
 A foreach loop goes through a collection of items, typically a collection of pages and performs an action for each item
 
 ```csharp
-@foreach (var item in Model.Children)
+@foreach (var item in Model.Children())
 {
     <p>The item name is: @Item.Name</p>
 }

--- a/15/umbraco-cms/reference/querying/ipublishedcontent/README.md
+++ b/15/umbraco-cms/reference/querying/ipublishedcontent/README.md
@@ -9,7 +9,7 @@ To access the current page in your templates, copy-paste the below Razor code.
 ```csharp
 @{
     var pageName = Model.Name;
-    var childPages = Model.Children;
+    var childPages = Model.Children();
 }
 
 <h1>@pageName</h1>

--- a/15/umbraco-cms/reference/querying/umbracohelper.md
+++ b/15/umbraco-cms/reference/querying/umbracohelper.md
@@ -71,7 +71,7 @@ Given a node ID, returns a `IPublishedContent`
 
 <h3>@pageFromGui.Value("propertyAlias")</h3>
 
-@foreach (var child in pageFromGui.Children)
+@foreach (var child in pageFromGui.Children())
 {
 	<a href="@child.Url()">@child.Name</a>
 }
@@ -83,7 +83,7 @@ Returns a collection of `IPublishedContent` objects from the Content tree.
 
 ```csharp
 @* Get the children of the first content item found in the root *@
-@foreach (var child in Umbraco.ContentAtRoot().First().Children)
+@foreach (var child in Umbraco.ContentAtRoot().First().Children())
 {
 	<a href="@child.Url()">@child.Name</a>
 }

--- a/15/umbraco-cms/reference/routing/custom-routes.md
+++ b/15/umbraco-cms/reference/routing/custom-routes.md
@@ -94,7 +94,7 @@ public IActionResult Index()
 }
 ```
 
-With this method we return the view with the content found by the `FindContent` method. This can then be used to list all the children in the view with `Model.Children`.
+With this method we return the view with the content found by the `FindContent` method. This can then be used to list all the children in the view with `Model.Children()`.
 
 Next we have our Product method:
 
@@ -195,7 +195,7 @@ public IPublishedContent FindContent(ActionExecutingContext actionExecutingConte
                         if (actionExecutingContext.ActionArguments.TryGetValue("id", out var sku))
                         {
                             return productRoot
-                                .Children
+                                .Children()
                                 .FirstOrDefault(c => c.Value<string>(_publishedValueFallback, "sku") == sku.ToString());
                         }
                         else
@@ -472,7 +472,7 @@ public class ShopControllerComposer : IComposer
                     if (actionExecutingContext.ActionArguments.TryGetValue("id", out var sku))
                     {
                         return productRoot
-                            .Children
+                            .Children()
                             .FirstOrDefault(c => c.Value<string>(publishedValueFallback, "sku") == sku.ToString());
                     }
                     else

--- a/15/umbraco-cms/reference/templating/mvc/querying.md
+++ b/15/umbraco-cms/reference/templating/mvc/querying.md
@@ -86,13 +86,13 @@ With the `IPublishedContent` model we support strongly typed LINQ queries out of
 #### Where children are visible
 
 ```csharp
-@Model.Children.Where(x => x.IsVisible())
+@Model.Children().Where(x => x.IsVisible())
 ```
 
 #### Traverse for sitemap
 
 ```csharp
-var items = @Model.Children.Where(x => x.IsVisible() && x.Level <= 4)
+var items = @Model.Children().Where(x => x.IsVisible() && x.Level <= 4)
 ```
 {% hint style="info" %}
 The two examples below have not been verified for Umbraco 9 and 10 yet.
@@ -103,7 +103,7 @@ therefore they might not work on the latest versions of Umbraco.
 #### Content sub menu
 
 ```csharp
-@Model.AncestorOrSelf(1).Children.Where(x => x.DocumentTypeAlias == "DatatypesFolder").First().Children
+@Model.AncestorOrSelf(1).Children().Where(x => x.DocumentTypeAlias == "DatatypesFolder").First().Children()
 ```
 
 #### Complex query

--- a/15/umbraco-cms/tutorials/creating-an-xml-site-map.md
+++ b/15/umbraco-cms/tutorials/creating-an-xml-site-map.md
@@ -190,10 +190,10 @@ We will add a `RenderSiteMapUrlEntriesForChildren` helper which accepts a 'Paren
     ```csharp
     void RenderSiteMapUrlEntriesForChildren(IPublishedContent parentPage)
     {
-        foreach (var page in parentPage.Children)
+        foreach (var page in parentPage.Children())
         {
             RenderSiteMapUrlEntry(page);
-            if (page.Children.Any()){
+            if (page.Children().Any()){
                 RenderSiteMapUrlEntriesForChildren(page);
             }
         }
@@ -231,11 +231,11 @@ We added a **HideFromXmlSitemap** checkbox to all Document Types via our `XmlSit
     void RenderSiteMapUrlEntriesForChildren(IPublishedContent parentPage)
     {
         // Filter the query based on the hideFromXmlSiteMap value
-        foreach (var page in parentPage.Children.Where(x =>!x.Value<bool>("hideFromXmlSiteMap")))
+        foreach (var page in parentPage.Children().Where(x =>!x.Value<bool>("hideFromXmlSiteMap")))
         {
             RenderSiteMapUrlEntry(page);
             // Filter the query based on the hideFromXmlSiteMap value
-            if (page.Children.Any(x =>!x.Value<bool>("hideFromXmlSiteMap"))){
+            if (page.Children().Any(x =>!x.Value<bool>("hideFromXmlSiteMap"))){
                 RenderSiteMapUrlEntriesForChildren(page);
             }
         }
@@ -261,11 +261,11 @@ To further control which and how many pages are shown in the sitemap you can fil
     ```csharp
     void RenderSiteMapUrlEntriesForChildren(IPublishedContent parentPage)
     {
-        foreach (var page in parentPage.Children.Where(f=>!f.Value<bool>("hideFromXmlSiteMap")))
+        foreach (var page in parentPage.Children().Where(f=>!f.Value<bool>("hideFromXmlSiteMap")))
         {
             RenderSiteMapUrlEntry(page);
             // Filter the query based on the maxSiteMapDepth value
-            if (page.Level < maxSiteMapDepth && page.Children.Any(f=>!f.Value<bool>("hideFromXmlSiteMap"))){
+            if (page.Level < maxSiteMapDepth && page.Children().Any(f=>!f.Value<bool>("hideFromXmlSiteMap"))){
                 RenderSiteMapUrlEntriesForChildren(page);
             }
         }
@@ -294,10 +294,10 @@ Finally, we need the helper to check the **Excluded Document Types** list on the
     void RenderSiteMapUrlEntriesForChildren(IPublishedContent parentPage)
     {
         // Filter the query based on the excludedDocumentTypes value
-        foreach (var page in parentPage.Children.Where(f => !excludedDocumentTypes.Contains(f.ContentType.Alias) && !f.Value<bool>("hideFromXmlSiteMap")))
+        foreach (var page in parentPage.Children().Where(f => !excludedDocumentTypes.Contains(f.ContentType.Alias) && !f.Value<bool>("hideFromXmlSiteMap")))
         {
             RenderSiteMapUrlEntry(page);
-            if (page.Level < maxSiteMapDepth && page.Children.Any(f => !f.Value<bool>("hideFromXmlSiteMap")))
+            if (page.Level < maxSiteMapDepth && page.Children().Any(f => !f.Value<bool>("hideFromXmlSiteMap")))
             {
                 RenderSiteMapUrlEntriesForChildren(page);
             }
@@ -369,11 +369,11 @@ It contains an entry for each page that is
     void RenderSiteMapUrlEntriesForChildren(IPublishedContent parentPage)
     {
         // Filter the query based on the excludedDocumentTypes and hideFromXmlSiteMap values
-        foreach (var page in parentPage.Children.Where(x => !excludedDocumentTypes.Contains(x.ContentType.Alias) && !x.Value<bool>("hideFromXmlSiteMap")))
+        foreach (var page in parentPage.Children().Where(x => !excludedDocumentTypes.Contains(x.ContentType.Alias) && !x.Value<bool>("hideFromXmlSiteMap")))
         {
             RenderSiteMapUrlEntry(page);
             // Filter the query based on the maxSiteMapDepth and hideFromXmlSiteMap values
-            if (page.Level < maxSiteMapDepth && page.Children.Any(x => !x.Value<bool>("hideFromXmlSiteMap")))
+            if (page.Level < maxSiteMapDepth && page.Children().Any(x => !x.Value<bool>("hideFromXmlSiteMap")))
             {
                 RenderSiteMapUrlEntriesForChildren(page);
             }


### PR DESCRIPTION
## Description

Updated selected articles referencing `IPublishedContent.Children` and `IPublishedContent.Parent` to use the extension methods (`IPublishedContent.Children()` and `IPublishedContent.Parent()`) instead as the properties are obsoleted and will be removed in Umbraco 16.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [X] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
15.0


## Deadline (if relevant)
No
