### PR TITLE
Use correct GitHub casing

### DIFF
--- a/.github/styles/UmbracoDocs/Brands.yml
+++ b/.github/styles/UmbracoDocs/Brands.yml
@@ -8,4 +8,6 @@ swap:
   slack: "'Slack'"
   azure: "'Azure'"
   gitbook: "'GitBook'"
+  Gitbook: "'GitBook'"
   github: "'GitHub'"
+  Github: "'GitHub'"

--- a/.github/workflows/Vale-Linter.yml
+++ b/.github/workflows/Vale-Linter.yml
@@ -11,6 +11,6 @@ jobs:
         with:
           fail_on_error: true
         env:
-          # Required, set by GitHub actions automatically:
+          # Required, set by GitHub Actions automatically:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/10/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
+++ b/10/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
@@ -44,7 +44,7 @@ The correct package will have be installed in your project.
 
 ## Configuring Blob storage
 
-The next step is to configure your blob storage. There are multiple approaches for this, but in this document, we're going to do it through `appsettings.json`. For more configuration options, see the [readme](https://github.com/umbraco/Umbraco.StorageProviders#umbracostorageproviders) on the Github repository.
+The next step is to configure your blob storage. There are multiple approaches for this, but in this document, we're going to do it through `appsettings.json`. For more configuration options, see the [readme](https://github.com/umbraco/Umbraco.StorageProviders#umbracostorageproviders) on the GitHub repository.
 
 Open up your `appsettings.json` file and add the connection string and container name under `Umbraco:Storage:AzureBlob:Media`. Your Umbraco section of appsettings will look something like this:
 

--- a/10/umbraco-cms/extending/packages/creating-a-package.md
+++ b/10/umbraco-cms/extending/packages/creating-a-package.md
@@ -147,7 +147,7 @@ The `Title`, `Description`, `PackageTags` came with the template and we added so
 | ------------------------ | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Version                  | 1.0.0               | This is automatically set to 1.0.0 but can be changed as appropriate.                                                                                                                                       |
 | Authors                  | Your name           | Here you get to take credit for your awesome work!                                                                                                                                                          |
-| PackageProjectUrl        | https://umbraco.com | This URL will be shown as the package's URL when others install it. It will likely be a Github repository, or similar.                                                                                      |
+| PackageProjectUrl        | https://umbraco.com | This URL will be shown as the package's URL when others install it. It will likely be a GitHub repository, or similar.                                                                                      |
 | PackageLicenseExpression | MIT                 | The license is set to MIT. Please consider how you want your package licensed. If in doubt when deciding an open-source license there are [good resources available](https://choosealicense.com/licenses/). |
 
 ### Pack it

--- a/10/umbraco-cms/extending/packages/example-package-repository.md
+++ b/10/umbraco-cms/extending/packages/example-package-repository.md
@@ -44,7 +44,7 @@ Finally there's an [example Umbraco website](https://github.com/umbraco/Umbraco.
 
 As well as the projects, the following files are added to the solution:
 
-- [.artifactignore](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.artifactignore) - used by AzureDevOps services to [control which files are uploaded when you publish](https://learn.microsoft.com/en-us/azure/devops/artifacts/reference/artifactignore?view=azure-devops). This helps to reduce pipeline execution time.
+- [.artifactignore](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.artifactignore) - used by Azure DevOps services to [control which files are uploaded when you publish](https://learn.microsoft.com/en-us/azure/devops/artifacts/reference/artifactignore?view=azure-devops). This helps to reduce pipeline execution time.
 - [.editorconfig](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.editorconfig) - used to [enforce consistent coding styles](https://editorconfig.org/) for multiple developers working on the same project across editors and IDEs.
 - [.gitignore](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.gitignore) - controls which files are added to source control.
 - [.globalconfig](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.globalconfig) - provides [further styling rules for the project files, even if stored outside of the project directory](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files#global-analyzerconfig).
@@ -58,7 +58,7 @@ As well as the projects, the following files are added to the solution:
 
 ## Build and Deployment
 
-We use AzureDevOps pipelines for continuous integration and releasing new versions of the package. The definition of how the project is built is defined in a `.yaml` file that's part of the source code repository.
+We use Azure DevOps pipelines for continuous integration and releasing new versions of the package. The definition of how the project is built is defined in a `.yaml` file that's part of the source code repository.
 
 The file can be found [here](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/azure-pipeline%20-%20Umbraco.AuthorizedServices.yml).
 
@@ -68,13 +68,13 @@ Even if using another tool it may be worth reviewing how we have setup our pipel
 
 The build consists of two stages: building the solution and running unit tests. Only if both succeed is the build as a whole considered successful.
 
-![AzureDevOps build pipeline](./images/azuredevops-build.png)
+![Azure DevOps build pipeline](./images/azuredevops-build.png)
 
 ### Releasing the Package
 
-We release the package manually in AzureDevOps, with a two stage process. Firstly we release to a "pre-releases" feed, and then after manual approval, to NuGet.
+We release the package manually in Azure DevOps, with a two stage process. Firstly we release to a "pre-releases" feed, and then after manual approval, to NuGet.
 
-![AzureDevOps release pipeline](./images/azuredevops-release.png)
+![Azure DevOps release pipeline](./images/azuredevops-release.png)
 
 
 

--- a/10/umbraco-cms/extending/ui-library.md
+++ b/10/umbraco-cms/extending/ui-library.md
@@ -24,7 +24,7 @@ You can also change the stylesheet of custom properties to see how the component
 
 ## Installing the UI Library Components
 
-You can download the UI Library package from [Github](https://github.com/umbraco/Umbraco.UI/tree/v1/contrib/packages).
+You can download the UI Library package from [GitHub](https://github.com/umbraco/Umbraco.UI/tree/v1/contrib/packages).
 
 If you are installing a component via npm, there are two ways to import it:
 
@@ -40,7 +40,7 @@ If you are installing a component via npm, there are two ways to import it:
     '@umbraco-ui/uui-button/lib/uui-button.element';
     ```
 
-For more information on installation, Content Delivery Networks (CDN), or included components, see the [Readme file in the Github](https://github.com/umbraco/Umbraco.UI#readme) project.
+For more information on installation, Content Delivery Networks (CDN), or included components, see the [Readme file in the GitHub](https://github.com/umbraco/Umbraco.UI#readme) project.
 
 ## Getting Started with the UI Library
 

--- a/10/umbraco-cms/reference/security/cookies.md
+++ b/10/umbraco-cms/reference/security/cookies.md
@@ -33,4 +33,4 @@ services.AddSession(options =>
     });
 ```
 
-For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/v10/contrib/src/Umbraco.Core/Constants-Web.cs) file on Github.
+For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/v10/contrib/src/Umbraco.Core/Constants-Web.cs) file on GitHub.

--- a/10/umbraco-cms/tutorials/creating-and-distributing-a-package.md
+++ b/10/umbraco-cms/tutorials/creating-and-distributing-a-package.md
@@ -12,10 +12,10 @@ The content in this article is valid _only_ for Umbraco version 8. For Umbraco v
 * [Creating a test site locally](creating-and-distributing-a-package.md#creating-a-test-site-locally)
 * [Creating a package from the backoffice](creating-and-distributing-a-package.md#creating-a-package-from-the-backoffice)
 * [Creating a draft package on Our](creating-and-distributing-a-package.md#creating-a-draft-package-on-our)
-* [Pushing your package to Github](creating-and-distributing-a-package.md#pushing-your-package-to-github)
+* [Pushing your package to GitHub](creating-and-distributing-a-package.md#pushing-your-package-to-github)
 * [Pack up your package locally using UmbPack](creating-and-distributing-a-package.md#pack-up-your-package-locally-using-umbpack)
 * [Pushing your package to Our using UmbPack](creating-and-distributing-a-package.md#pushing-your-package-to-our-using-umbpack)
-* [Deploy your package using Github Actions](creating-and-distributing-a-package.md#deploy-your-package-using-github-actions)
+* [Deploy your package using GitHub Actions](creating-and-distributing-a-package.md#deploy-your-package-using-github-actions)
 * [Archive older versions on push](creating-and-distributing-a-package.md#archive-older-versions-on-push)
 
 ## Prerequisites
@@ -23,7 +23,7 @@ The content in this article is valid _only_ for Umbraco version 8. For Umbraco v
 To run this tutorial you will need the following:
 
 * Be able to run an Umbraco site locally
-* Git + Github account
+* Git + GitHub account
 * [Our Umbraco member account](https://our.umbraco.com/member/Signup) with access to upload packages
 * UmbPack installed
 * Umbraco Package templates installed
@@ -60,7 +60,7 @@ It will show you all the options you have for creating a new Umbraco site + pack
 dotnet new umbraco-v8-package -n PackageWorkshop -d
 ```
 
-This will create a new package called `PackageWorkshop`, and add a custom Dashboard for us to use in this tutorial. By default you will also get a Github Action added that we will return to later.
+This will create a new package called `PackageWorkshop`, and add a custom Dashboard for us to use in this tutorial. By default you will also get a GitHub Action added that we will return to later.
 
 After running you will have a folder called `PackageWorkshop`, inside that you will have your site and solution files. So try to open it in Visual Studio or Rider by opening the `PackageWorkshop.sln` file.
 
@@ -234,13 +234,13 @@ Now your package is on Our, and if the "Go live" button is clicked it is visible
 
 The next step is to make it a bit simpler to deploy updates to the package. It is perfectly fine to log in here and upload a new version each time. The next steps will show an easier way though.
 
-## Pushing your package to Github
+## Pushing your package to GitHub
 
 If you are creating a package in order to share it with others it is a great idea to also share the source code. It is the open source way.
 
-To share it, and make it easier to manage and deploy updates we will set up a Github repository for the package. This tutorial assumes you know what Github is, and that you have an account.
+To share it, and make it easier to manage and deploy updates we will set up a GitHub repository for the package. This tutorial assumes you know what GitHub is, and that you have an account.
 
-Create a fresh repo, with no readme, gitignore or license - do not choose a repository template (set to 'No Template'). On the second screen it will give you a command to push an existing repository to the new Github repo, should look like this but with your own user in the link:
+Create a fresh repo, with no readme, gitignore or license - do not choose a repository template (set to 'No Template'). On the second screen it will give you a command to push an existing repository to the new GitHub repo, should look like this but with your own user in the link:
 
 ```none
 git remote add origin https://github.com/jmayntzhusen/package-workshop.git
@@ -257,7 +257,7 @@ git add .
 git commit -m "Initial commit, dashboard package"
 ```
 
-At this point you have your solution in a local git repository, and we can then use the command from Github to push it up:
+At this point you have your solution in a local git repository, and we can then use the command from GitHub to push it up:
 
 ```none
 git remote add origin https://github.com/jmayntzhusen/package-workshop.git
@@ -265,18 +265,18 @@ git branch -M main
 git push -u origin main
 ```
 
-Now you have it all on Github:
+Now you have it all on GitHub:
 
-![Github repo](<images/github-repo (1).png>)
+![GitHub repo](<images/github-repo (1).png>)
 
 ## Pack up your package locally using UmbPack
 
-At this point you know how to create a package from the backoffice, upload it to Our and push your changes to Github. That's what it takes to create and maintain a package.
+At this point you know how to create a package from the backoffice, upload it to Our and push your changes to GitHub. That's what it takes to create and maintain a package.
 
 If you want to make changes and push a new version you can carry out the following steps:
 
 * Create the new package in the backoffice
-* Sync your code to Github
+* Sync your code to GitHub
 * Go to Our and upload a new zip version
 * Set that to the current version
 * Optionally archive the previous one
@@ -399,15 +399,15 @@ You can edit all of these defaults, and also specify older versions of your pack
 
 So at this point we can work on our package locally, build a new version within seconds by running the pack command and then deploy it to Our using the push command.
 
-Not easy enough for you? Let's try automating this entire thing with Github actions then.
+Not easy enough for you? Let's try automating this entire thing with GitHub actions then.
 
-## Deploy your package using Github Actions
+## Deploy your package using GitHub Actions
 
-If you think back to the beginning when we set up our sites using the Package Templates you may remember that by default you get a Github action installed as well.
+If you think back to the beginning when we set up our sites using the Package Templates you may remember that by default you get a GitHub action installed as well.
 
 If you check out the `~/.github/workflows` folder in your solution, you will see there is a readme file and a build.yml file.
 
-The build.yml file is used by Github actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
+The build.yml file is used by GitHub actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
 
 The build.yml file contains several things, let's have a quick overview:
 
@@ -433,9 +433,9 @@ The action that it performs is what is under `jobs:build:steps`. There is a step
 It sets the version of the package to be what we've set in the release tag based on a previous step.
 {% endhint %}
 
-Below this there is another step to push the package to Our, which again is like our approach locally - except now we add the API key as a Github secret so it's not public to everyone.
+Below this there is another step to push the package to Our, which again is like our approach locally - except now we add the API key as a GitHub secret so it's not public to everyone.
 
-![Github secret](images/gh-secret.png)
+![GitHub secret](images/gh-secret.png)
 
 ```yml
 - name: Push to Our
@@ -444,7 +444,7 @@ Below this there is another step to push the package to Our, which again is like
 
 With these 2 commands and a few previous ones setting up the prerequisite build and nuget tools it is now ready to be fully automated.
 
-Ensure you have set a Github secret with the name `UMBRACO_DEPLOY_KEY` and the value of the key from Our, and then go to your local solution and uncomment the UmbPack push command in the \~/.github/workflows/build.yml file.
+Ensure you have set a GitHub secret with the name `UMBRACO_DEPLOY_KEY` and the value of the key from Our, and then go to your local solution and uncomment the UmbPack push command in the \~/.github/workflows/build.yml file.
 
 Then make sure it is added and committed locally:
 
@@ -454,14 +454,14 @@ git commit -m "Enable umbpack push in GH action"
 git push
 ```
 
-Your solution and Github repo are now in sync, and the umbpack commands in the Github action are enabled and ready to run. Final step is to create a release tag and push it to Github:
+Your solution and GitHub repo are now in sync, and the umbpack commands in the GitHub action are enabled and ready to run. Final step is to create a release tag and push it to GitHub:
 
 ```none
 git tag release/1.0.0
 git push origin release/1.0.0
 ```
 
-At this point you can go to Github and visit the Action tab to see your Github action run. When it's completed successfully you can go to your package overview on Our and see the package there.
+At this point you can go to GitHub and visit the Action tab to see your GitHub action run. When it's completed successfully you can go to your package overview on Our and see the package there.
 
 ## Archive older versions on push
 

--- a/10/umbraco-cms/tutorials/creating-and-distributing-a-package.md
+++ b/10/umbraco-cms/tutorials/creating-and-distributing-a-package.md
@@ -399,7 +399,7 @@ You can edit all of these defaults, and also specify older versions of your pack
 
 So at this point we can work on our package locally, build a new version within seconds by running the pack command and then deploy it to Our using the push command.
 
-Not easy enough for you? Let's try automating this entire thing with GitHub actions then.
+Not easy enough for you? Let's try automating this entire thing with GitHub Actions then.
 
 ## Deploy your package using GitHub Actions
 
@@ -407,7 +407,7 @@ If you think back to the beginning when we set up our sites using the Package Te
 
 If you check out the `~/.github/workflows` folder in your solution, you will see there is a readme file and a build.yml file.
 
-The build.yml file is used by GitHub actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
+The build.yml file is used by GitHub Actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
 
 The build.yml file contains several things, let's have a quick overview:
 

--- a/10/umbraco-commerce/release-notes.md
+++ b/10/umbraco-commerce/release-notes.md
@@ -90,4 +90,4 @@ This section contains the release notes for Umbraco Commerce 10 including all ch
 
 ## Legacy release notes
 
-You can find the release notes for **Vendr** in the [Change log file on Github](../../13/umbraco-commerce/changelog-archive/Vendr-core.md).
+You can find the release notes for **Vendr** in the [Change log file on GitHub](../../13/umbraco-commerce/changelog-archive/Vendr-core.md).

--- a/10/umbraco-commerce/upgrading/version-specific-upgrades.md
+++ b/10/umbraco-commerce/upgrading/version-specific-upgrades.md
@@ -20,4 +20,4 @@ See the [Migrate from Vendr to Umbraco Commerce guide](../upgrading/migrate-from
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;

--- a/10/umbraco-deploy/SUMMARY.md
+++ b/10/umbraco-deploy/SUMMARY.md
@@ -20,7 +20,7 @@
 * [Getting started](getting-started/get-started-with-deploy.md)
 * [CI/CD Build and Deployment Pipeline](getting-started/cicd-pipeline/README.md)
   * [Azure DevOps](getting-started/cicd-pipeline/ci-cd-azure-dev-ops.md)
-  * [GitHub actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
+  * [GitHub Actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
 * [Streamlining Local Development](getting-started/streamlining-local-development.md)
 * [Configuration](getting-started/deploy-settings.md)
 

--- a/10/umbraco-deploy/SUMMARY.md
+++ b/10/umbraco-deploy/SUMMARY.md
@@ -20,7 +20,7 @@
 * [Getting started](getting-started/get-started-with-deploy.md)
 * [CI/CD Build and Deployment Pipeline](getting-started/cicd-pipeline/README.md)
   * [Azure DevOps](getting-started/cicd-pipeline/ci-cd-azure-dev-ops.md)
-  * [Github actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
+  * [GitHub actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
 * [Streamlining Local Development](getting-started/streamlining-local-development.md)
 * [Configuration](getting-started/deploy-settings.md)
 

--- a/10/umbraco-deploy/deployment-workflow/README.md
+++ b/10/umbraco-deploy/deployment-workflow/README.md
@@ -19,7 +19,7 @@ Umbraco Deploy uses a two-part deployment approach where we keep meta data (Docu
 
 In summary:
 
-1. Meta data such as Document Types, Templates, Forms, Views and config files are stored in a repository and are **deployed** between environments. This can be achieved using a CI/CD deployment pipeline with something like Github Actions or Azure DevOps.
+1. Meta data such as Document Types, Templates, Forms, Views and config files are stored in a repository and are **deployed** between environments. This can be achieved using a CI/CD deployment pipeline with something like GitHub Actions or Azure DevOps.
 2. Content and Media items are **not** stored in the repository. These need to be **transferred** directly from the Umbraco backoffice using the _"Queue for Transfer"_ option. Once a content editor has all the items needed for a transfer they will use the Deployment Dashboard in the Content section to transfer the items in the queue.
 
 ### Deploying meta data

--- a/10/umbraco-deploy/getting-started/cicd-pipeline/README.md
+++ b/10/umbraco-deploy/getting-started/cicd-pipeline/README.md
@@ -10,7 +10,7 @@ The build server will extract the changes that has been pushed to the repository
 
 This is something that can be done in many different ways depending on where your website is hosted and your setup.
 
-Umbraco Deploy does not require the use of any particular build or deployment tools and hence we expect that you should be able to continue using the tool or tools of your choice. Any that have support for .NET website deployments and the running of Powershell scripts. such as Azure DevOps or Github Actions, would be appropriate.
+Umbraco Deploy does not require the use of any particular build or deployment tools and hence we expect that you should be able to continue using the tool or tools of your choice. Any that have support for .NET website deployments and the running of Powershell scripts. such as Azure DevOps or GitHub Actions, would be appropriate.
 
 Above and beyond the normal steps of a build pipeline for a .NET web application - tasks like NuGet restore, solution build, running of tests etc. - Umbraco Deploy requires three additional steps.
 
@@ -34,9 +34,9 @@ Umbraco Deploy On-Premises also ships with a Powershell script, that when execut
 
 So while it may be possible to have the CI/CD step directly write the file or call the endpoint, so long as the build used supports running Powershell scripts this is the method we’d recommend, as it has some necessary error checking and retry logic built-in.
 
-## [Setting up CI/CD pipeline with Github Actions](ci-cd-github-actions.md)
+## [Setting up CI/CD pipeline with GitHub Actions](ci-cd-github-actions.md)
 
-Details the setup of a CI/CD pipeline using Github Actions.
+Details the setup of a CI/CD pipeline using GitHub Actions.
 
 ## [Setting up CI/CD pipeline with Azure DevOps](ci-cd-azure-dev-ops.md)
 

--- a/10/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
+++ b/10/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
@@ -2,7 +2,7 @@
 description: Steps and examples on how to setup a build and deployment pipeline for Umbraco Deploy using GitHub Actions.
 ---
 
-# GitHub actions
+# GitHub Actions
 
 {% hint style="info" %}
 In this example we will show how you can set up a CI/CD build server using GitHub Actions in Azure Web Apps.

--- a/10/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
+++ b/10/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
@@ -2,10 +2,10 @@
 description: Steps and examples on how to setup a build and deployment pipeline for Umbraco Deploy using GitHub Actions.
 ---
 
-# Github actions
+# GitHub actions
 
 {% hint style="info" %}
-In this example we will show how you can set up a CI/CD build server using Github Actions in Azure Web Apps.
+In this example we will show how you can set up a CI/CD build server using GitHub Actions in Azure Web Apps.
 
 We will not cover how you can set up the site itself as this is beyond this documentation.
 {% endhint %}
@@ -16,15 +16,15 @@ The following steps will take you through setting up a build server in Azure Web
 
 ![Azure deployments](../../../../10/umbraco-deploy/installing-deploy/images/Deployment-center.png)
 
-In the Deployment Center we can set up the CI/CD build server. With this example we are going to set up our build server by using Github Actions. It is possible to set up the build server however you want as long as it supports executing powershell scripts.
+In the Deployment Center we can set up the CI/CD build server. With this example we are going to set up our build server by using GitHub Actions. It is possible to set up the build server however you want as long as it supports executing powershell scripts.
 
 1. Go to the Settings tab.
 2. Choose which source and build provider to use.
-   * In this case we want to choose Github.
+   * In this case we want to choose GitHub.
 
 ![Build server clean](../../../../10/umbraco-deploy/installing-deploy/cicd-pipeline/images/Build-server-v10.png)
 
-1. Choose the Organization which you created our Github repository under.
+1. Choose the Organization which you created our GitHub repository under.
 2. Choose the repository that was set up earlier in this guide.
 3. Select which branch that we want the build server to build into.
 
@@ -36,9 +36,9 @@ Once the information has been added we can go ahead and preview the YAML file th
 
 1. Save the workflow.
 
-The website and the Github repository are now connected.
+The website and the GitHub repository are now connected.
 
-If we go back to the Github repository we can see that a new folder have been created called Workflows:
+If we go back to the GitHub repository we can see that a new folder have been created called Workflows:
 
 ![Workflows](../../../../10/umbraco-deploy/installing-deploy/images/workflows.png)
 
@@ -132,7 +132,7 @@ As well as enabling Unattended install in the **appSettings.json** file so Umbra
 
 Before the build can work, we will need to set up our generated API key to work with the build server in GitHub Actions.
 
-1. Open your Github repository.
+1. Open your GitHub repository.
 2. Navigate to Settings.
 3. Go to the Secrets tab.
 4. Select "New repository secret".
@@ -142,7 +142,7 @@ Before the build can work, we will need to set up our generated API key to work 
 
 We can now go ahead and commit the configured YAML file and push up all the files to the repository.
 
-Go to Github where you will now be able to see that the CI/CD build has started running:
+Go to GitHub where you will now be able to see that the CI/CD build has started running:
 
 ![Deployment build started](../../../../10/umbraco-deploy/installing-deploy/images/Deploying-meta-data.png)
 
@@ -152,7 +152,7 @@ The build server will go through the steps in the YAML file, and once it is done
 
 You can now start creating content on the local machine. Once you create something like a Document Type, the changes will get picked up in Git.
 
-When you're done making changes, commit them and deploy them to Github. The build server will run and extract the changes into the website in Azure.
+When you're done making changes, commit them and deploy them to GitHub. The build server will run and extract the changes into the website in Azure.
 
 This will only deploy the schema data for our local site to your website.
 

--- a/10/umbraco-deploy/getting-started/get-started-with-deploy.md
+++ b/10/umbraco-deploy/getting-started/get-started-with-deploy.md
@@ -14,7 +14,7 @@ These items are entities like Document Types, Media Types, Data Types, etc, and 
 
 For example, when working locally you might create a new Document Type. This will automatically create a new on-disk file in the `umbraco/Deploy/Revision` folder which is the serialized version of the new Document Type. You would then commit this file to your repository and push this change to your hosted source control (for example GitHub).
 
-When you want this deployed to your next environment, you would trigger your CI/CD process (for example Azure DevOps or Github Actions). This will push the changes to your environment. Once the build deployment completes successfully, a Deployment Trigger would be executed as an HTTPS request to your target environment. All changes found in the `umbraco/Deploy/Revision` folder will then be extracted into the Umbraco target environment.
+When you want this deployed to your next environment, you would trigger your CI/CD process (for example Azure DevOps or GitHub Actions). This will push the changes to your environment. Once the build deployment completes successfully, a Deployment Trigger would be executed as an HTTPS request to your target environment. All changes found in the `umbraco/Deploy/Revision` folder will then be extracted into the Umbraco target environment.
 
 ![Deploy workflow](../images/Deploy_concept%20(1).png)
 

--- a/10/umbraco-deploy/installation/install-configure.md
+++ b/10/umbraco-deploy/installation/install-configure.md
@@ -24,7 +24,7 @@ Here we will cover how to install and set up Umbraco Deploy on a new website.
 
 **Set up the Git repository and Umbraco project**
 
-The first step to get Umbraco Deploy up and running is to set up a GitHub repository. This will be where source code is stored, and, following the GitHub actions example, act as our environment where we will set up a CI/CD pipeline.
+The first step to get Umbraco Deploy up and running is to set up a GitHub repository. This will be where source code is stored, and, following the GitHub Actions example, act as our environment where we will set up a CI/CD pipeline.
 
 1. Using the Visual Studio template, set up a GitHub repository with a .gitignore file.
 2. Clone down the repository to your local machine.

--- a/10/umbraco-deploy/installation/install-configure.md
+++ b/10/umbraco-deploy/installation/install-configure.md
@@ -26,7 +26,7 @@ Here we will cover how to install and set up Umbraco Deploy on a new website.
 
 The first step to get Umbraco Deploy up and running is to set up a GitHub repository. This will be where source code is stored, and, following the GitHub actions example, act as our environment where we will set up a CI/CD pipeline.
 
-1. Using the Visual Studio template, set up a Github repository with a .gitignore file.
+1. Using the Visual Studio template, set up a GitHub repository with a .gitignore file.
 2. Clone down the repository to your local machine.
 3. Create a new Umbraco project.
 4. Run the project.

--- a/10/umbraco-deploy/release-notes.md
+++ b/10/umbraco-deploy/release-notes.md
@@ -548,4 +548,4 @@ This section contains the release notes for Umbraco Deploy 4 and 10 including al
 
 ## Legacy release notes
 
-You can find the release notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/release-notes.md) and [Umbraco Deploy Package page.](https://our.umbraco.com/packages/developer-tools/umbraco-deploy/)
+You can find the release notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/release-notes.md) and [Umbraco Deploy Package page.](https://our.umbraco.com/packages/developer-tools/umbraco-deploy/)

--- a/10/umbraco-deploy/upgrades/version-specific.md
+++ b/10/umbraco-deploy/upgrades/version-specific.md
@@ -99,4 +99,4 @@ If you are upgrading from Umbraco 9 and already have a LocalDB instance, you can
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/upgrades/version-specific.md).&#x20;
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/upgrades/version-specific.md).&#x20;

--- a/10/umbraco-forms/release-notes.md
+++ b/10/umbraco-forms/release-notes.md
@@ -815,4 +815,4 @@ Breaking changes:
 
 ## Legacy release notes
 
-You can find the release notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/release-notes.md) and [Umbraco Forms Package page](https://our.umbraco.com/packages/developer-tools/umbraco-forms/).
+You can find the release notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/release-notes.md) and [Umbraco Forms Package page](https://our.umbraco.com/packages/developer-tools/umbraco-forms/).

--- a/10/umbraco-forms/upgrading/version-specific.md
+++ b/10/umbraco-forms/upgrading/version-specific.md
@@ -143,4 +143,4 @@ The easiest way to proceed is to unzip the file you downloaded and copy and over
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/installation/version-specific.md).&#x20;
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/installation/version-specific.md).&#x20;

--- a/10/umbraco-ui-builder/release-notes.md
+++ b/10/umbraco-ui-builder/release-notes.md
@@ -47,4 +47,4 @@ This section contains the release notes for Umbraco UI Builder 10 including all 
 
 ## Legacy release notes
 
-You can find the release notes for **Konstrukt** in the [Change log file on Github](changelog-archive/changelog.md).
+You can find the release notes for **Konstrukt** in the [Change log file on GitHub](changelog-archive/changelog.md).

--- a/10/umbraco-ui-builder/upgrading/version-specific.md
+++ b/10/umbraco-ui-builder/upgrading/version-specific.md
@@ -20,4 +20,4 @@ See the [Migrate from Konstrukt to Umbraco UI Builder guide](../upgrading/migrat
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;

--- a/10/umbraco-workflow/release-notes.md
+++ b/10/umbraco-workflow/release-notes.md
@@ -148,4 +148,4 @@ The above fixes introduce an updated UI for requesting workflow approvals. For m
 
 ## Legacy release notes
 
-You can find the release notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-workflow/release-notes.md)
+You can find the release notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-workflow/release-notes.md)

--- a/13/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
+++ b/13/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
@@ -32,7 +32,7 @@ The correct packages will have been installed in your project.
 
 ## Configuring Blob storage
 
-The next step is to configure your blob storage. There are multiple approaches for this, but in this document, we're going to do it through `appsettings.json`. For more configuration options, see the [readme](https://github.com/umbraco/Umbraco.StorageProviders#umbracostorageproviders) on the Github repository.
+The next step is to configure your blob storage. There are multiple approaches for this, but in this document, we're going to do it through `appsettings.json`. For more configuration options, see the [readme](https://github.com/umbraco/Umbraco.StorageProviders#umbracostorageproviders) on the GitHub repository.
 
 Open up your `appsettings.json` file and add the connection string and container name under `Umbraco:Storage:AzureBlob:Media`. Your Umbraco section of appsettings will look something like this:
 

--- a/13/umbraco-cms/extending/packages/creating-a-package.md
+++ b/13/umbraco-cms/extending/packages/creating-a-package.md
@@ -146,7 +146,7 @@ The `Title`, `Description`, `PackageTags` came with the template and we added so
 | ------------------------ | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Version                  | 1.0.0               | This is automatically set to 1.0.0 but can be changed as appropriate.                                                                                                                                       |
 | Authors                  | Your name           | Here you get to take credit for your awesome work!                                                                                                                                                          |
-| PackageProjectUrl        | https://umbraco.com | This URL will be shown as the package's URL when others install it. It will likely be a Github repository, or similar.                                                                                      |
+| PackageProjectUrl        | https://umbraco.com | This URL will be shown as the package's URL when others install it. It will likely be a GitHub repository, or similar.                                                                                      |
 | PackageLicenseExpression | MIT                 | The license is set to MIT. Please consider how you want your package licensed. If in doubt when deciding an open-source license there are [good resources available](https://choosealicense.com/licenses/). |
 
 ### Pack it

--- a/13/umbraco-cms/extending/packages/example-package-repository.md
+++ b/13/umbraco-cms/extending/packages/example-package-repository.md
@@ -44,7 +44,7 @@ Finally there's an [example Umbraco website](https://github.com/umbraco/Umbraco.
 
 As well as the projects, the following files are added to the solution:
 
-- [.artifactignore](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.artifactignore) - used by AzureDevOps services to [control which files are uploaded when you publish](https://learn.microsoft.com/en-us/azure/devops/artifacts/reference/artifactignore?view=azure-devops). This helps to reduce pipeline execution time.
+- [.artifactignore](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.artifactignore) - used by Azure DevOps services to [control which files are uploaded when you publish](https://learn.microsoft.com/en-us/azure/devops/artifacts/reference/artifactignore?view=azure-devops). This helps to reduce pipeline execution time.
 - [.editorconfig](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.editorconfig) - used to [enforce consistent coding styles](https://editorconfig.org/) for multiple developers working on the same project across editors and IDEs.
 - [.gitignore](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.gitignore) - controls which files are added to source control.
 - [.globalconfig](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.globalconfig) - provides [further styling rules for the project files, even if stored outside of the project directory](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files#global-analyzerconfig).
@@ -58,7 +58,7 @@ As well as the projects, the following files are added to the solution:
 
 ## Build and Deployment
 
-We use AzureDevOps pipelines for continuous integration and releasing new versions of the package. The definition of how the project is built is defined in a `.yaml` file that's part of the source code repository.
+We use Azure DevOps pipelines for continuous integration and releasing new versions of the package. The definition of how the project is built is defined in a `.yaml` file that's part of the source code repository.
 
 The file can be found [here](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/azure-pipeline%20-%20Umbraco.AuthorizedServices.yml).
 
@@ -68,13 +68,13 @@ Even if using another tool it may be worth reviewing how we have setup our pipel
 
 The build consists of two stages: building the solution and running unit tests. Only if both succeed is the build as a whole considered successful.
 
-![AzureDevOps build pipeline](../../../../10/umbraco-cms/extending/packages/images/azuredevops-build.png)
+![Azure DevOps build pipeline](../../../../10/umbraco-cms/extending/packages/images/azuredevops-build.png)
 
 ### Releasing the Package
 
-We release the package manually in AzureDevOps, with a two stage process. Firstly we release to a "pre-releases" feed, and then after manual approval, to NuGet.
+We release the package manually in Azure DevOps, with a two stage process. Firstly we release to a "pre-releases" feed, and then after manual approval, to NuGet.
 
-![AzureDevOps release pipeline](../../../../10/umbraco-cms/extending/packages/images/azuredevops-release.png)
+![Azure DevOps release pipeline](../../../../10/umbraco-cms/extending/packages/images/azuredevops-release.png)
 
 
 

--- a/13/umbraco-cms/extending/ui-library.md
+++ b/13/umbraco-cms/extending/ui-library.md
@@ -24,7 +24,7 @@ You can also change the stylesheet of custom properties to see how the component
 
 ## Installing the UI Library Components
 
-You can download the UI Library package from [Github](https://github.com/umbraco/Umbraco.UI/tree/v1/contrib/packages).
+You can download the UI Library package from [GitHub](https://github.com/umbraco/Umbraco.UI/tree/v1/contrib/packages).
 
 If you are installing a component via npm, there are two ways to import it:
 
@@ -40,7 +40,7 @@ If you are installing a component via npm, there are two ways to import it:
     '@umbraco-ui/uui-button/lib/uui-button.element';
     ```
 
-For more information on installation, Content Delivery Networks (CDN), or included components, see the[ Readme file in the Github ](https://github.com/umbraco/Umbraco.UI#readme)project.
+For more information on installation, Content Delivery Networks (CDN), or included components, see the[ Readme file in the GitHub ](https://github.com/umbraco/Umbraco.UI#readme)project.
 
 ## Getting Started with the UI Library
 

--- a/13/umbraco-cms/fundamentals/backoffice/login.md
+++ b/13/umbraco-cms/fundamentals/backoffice/login.md
@@ -39,7 +39,7 @@ The login screen features a greeting which you can personalize by overriding the
 
 * Before the changes takes place you will need to restart the site.
 
-You can customize other text on the login screen as well. First, grab the default values and keys from the [en\_us.xml](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/EmbeddedResources/Lang/en\_us.xml) in the Umbraco CMS Github repository. Thereafter copy the ones you want to translate into `~/config/lang/en_us.user.xml` file.
+You can customize other text on the login screen as well. First, grab the default values and keys from the [en\_us.xml](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/EmbeddedResources/Lang/en\_us.xml) in the Umbraco CMS GitHub repository. Thereafter copy the ones you want to translate into `~/config/lang/en_us.user.xml` file.
 
 ## Password reset
 
@@ -155,4 +155,4 @@ The following CSS properties are available for customization:
 | `--umb-login-curves-color`               | The color of the curves                        | `#f5c1bc`                                                                                  |
 | `--umb-login-curves-display`             | The display of the curves                      | `inline`                                                                                   |
 
-The CSS custom properties may change in future versions of Umbraco. You can always find the latest values in the [login layout element](https://github.com/umbraco/Umbraco-CMS/blob/v13/dev/src/Umbraco.Web.UI.Login/src/components/layouts/auth-layout.element.ts) in the Umbraco CMS Github repository.
+The CSS custom properties may change in future versions of Umbraco. You can always find the latest values in the [login layout element](https://github.com/umbraco/Umbraco-CMS/blob/v13/dev/src/Umbraco.Web.UI.Login/src/components/layouts/auth-layout.element.ts) in the Umbraco CMS GitHub repository.

--- a/13/umbraco-cms/reference/security/cookies.md
+++ b/13/umbraco-cms/reference/security/cookies.md
@@ -28,4 +28,4 @@ builder.Services.AddSession(options =>
     });
 ```
 
-For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/Constants-Web.cs) file on Github.
+For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/Constants-Web.cs) file on GitHub.

--- a/13/umbraco-cms/tutorials/creating-and-distributing-a-package.md
+++ b/13/umbraco-cms/tutorials/creating-and-distributing-a-package.md
@@ -12,10 +12,10 @@ The content in this article is valid _only_ for Umbraco version 8. For Umbraco v
 * [Creating a test site locally](creating-and-distributing-a-package.md#creating-a-test-site-locally)
 * [Creating a package from the backoffice](creating-and-distributing-a-package.md#creating-a-package-from-the-backoffice)
 * [Creating a draft package on Our](creating-and-distributing-a-package.md#creating-a-draft-package-on-our)
-* [Pushing your package to Github](creating-and-distributing-a-package.md#pushing-your-package-to-github)
+* [Pushing your package to GitHub](creating-and-distributing-a-package.md#pushing-your-package-to-github)
 * [Pack up your package locally using UmbPack](creating-and-distributing-a-package.md#pack-up-your-package-locally-using-umbpack)
 * [Pushing your package to Our using UmbPack](creating-and-distributing-a-package.md#pushing-your-package-to-our-using-umbpack)
-* [Deploy your package using Github Actions](creating-and-distributing-a-package.md#deploy-your-package-using-github-actions)
+* [Deploy your package using GitHub Actions](creating-and-distributing-a-package.md#deploy-your-package-using-github-actions)
 * [Archive older versions on push](creating-and-distributing-a-package.md#archive-older-versions-on-push)
 
 ## Prerequisites
@@ -23,7 +23,7 @@ The content in this article is valid _only_ for Umbraco version 8. For Umbraco v
 To run this tutorial you will need the following:
 
 * Be able to run an Umbraco site locally
-* Git + Github account
+* Git + GitHub account
 * [Our Umbraco member account](https://our.umbraco.com/member/Signup) with access to upload packages
 * UmbPack installed
 * Umbraco Package templates installed
@@ -60,7 +60,7 @@ It will show you all the options you have for creating a new Umbraco site + pack
 dotnet new umbraco-v8-package -n PackageWorkshop -d
 ```
 
-This will create a new package called `PackageWorkshop`, and add a custom Dashboard for us to use in this tutorial. By default you will also get a Github Action added that we will return to later.
+This will create a new package called `PackageWorkshop`, and add a custom Dashboard for us to use in this tutorial. By default you will also get a GitHub Action added that we will return to later.
 
 After running you will have a folder called `PackageWorkshop`, inside that you will have your site and solution files. So try to open it in Visual Studio or Rider by opening the `PackageWorkshop.sln` file.
 
@@ -234,13 +234,13 @@ Now your package is on Our, and if the "Go live" button is clicked it is visible
 
 The next step is to make it a bit simpler to deploy updates to the package. It is perfectly fine to log in here and upload a new version each time. The next steps will show an easier way though.
 
-## Pushing your package to Github
+## Pushing your package to GitHub
 
 If you are creating a package in order to share it with others it is a great idea to also share the source code. It is the open source way.
 
-To share it, and make it easier to manage and deploy updates we will set up a Github repository for the package. This tutorial assumes you know what Github is, and that you have an account.
+To share it, and make it easier to manage and deploy updates we will set up a GitHub repository for the package. This tutorial assumes you know what GitHub is, and that you have an account.
 
-Create a fresh repo, with no readme, gitignore or license - do not choose a repository template (set to 'No Template'). On the second screen it will give you a command to push an existing repository to the new Github repo, should look like this but with your own user in the link:
+Create a fresh repo, with no readme, gitignore or license - do not choose a repository template (set to 'No Template'). On the second screen it will give you a command to push an existing repository to the new GitHub repo, should look like this but with your own user in the link:
 
 ```
 git remote add origin https://github.com/jmayntzhusen/package-workshop.git
@@ -257,7 +257,7 @@ git add .
 git commit -m "Initial commit, dashboard package"
 ```
 
-At this point you have your solution in a local git repository, and we can then use the command from Github to push it up:
+At this point you have your solution in a local git repository, and we can then use the command from GitHub to push it up:
 
 ```
 git remote add origin https://github.com/jmayntzhusen/package-workshop.git
@@ -265,18 +265,18 @@ git branch -M main
 git push -u origin main
 ```
 
-Now you have it all on Github:
+Now you have it all on GitHub:
 
-![Github repo](images/github-repo.png)
+![GitHub repo](images/github-repo.png)
 
 ## Pack up your package locally using UmbPack
 
-At this point you know how to create a package from the backoffice, upload it to Our and push your changes to Github. That's what it takes to create and maintain a package.
+At this point you know how to create a package from the backoffice, upload it to Our and push your changes to GitHub. That's what it takes to create and maintain a package.
 
 If you want to make changes and push a new version you can carry out the following steps:
 
 * Create the new package in the backoffice
-* Sync your code to Github
+* Sync your code to GitHub
 * Go to Our and upload a new zip version
 * Set that to the current version
 * Optionally archive the previous one
@@ -399,15 +399,15 @@ You can edit all of these defaults, and also specify older versions of your pack
 
 So at this point we can work on our package locally, build a new version within seconds by running the pack command and then deploy it to Our using the push command.
 
-Not easy enough for you? Let's try automating this entire thing with Github actions then.
+Not easy enough for you? Let's try automating this entire thing with GitHub actions then.
 
-## Deploy your package using Github Actions
+## Deploy your package using GitHub Actions
 
-If you think back to the beginning when we set up our sites using the Package Templates you may remember that by default you get a Github action installed as well.
+If you think back to the beginning when we set up our sites using the Package Templates you may remember that by default you get a GitHub action installed as well.
 
 If you check out the `~/.github/workflows` folder in your solution, you will see there is a readme file and a build.yml file.
 
-The build.yml file is used by Github actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
+The build.yml file is used by GitHub actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
 
 The build.yml file contains several things, let's have a quick overview:
 
@@ -433,9 +433,9 @@ The action that it performs is what is under `jobs:build:steps`. There is a step
 It sets the version of the package to be what we've set in the release tag based on a previous step.
 {% endhint %}
 
-Below this there is another step to push the package to Our, which again is like our approach locally - except now we add the API key as a Github secret so it's not public to everyone.
+Below this there is another step to push the package to Our, which again is like our approach locally - except now we add the API key as a GitHub secret so it's not public to everyone.
 
-![Github secret](images/gh-secret.png)
+![GitHub secret](images/gh-secret.png)
 
 ```yml
 - name: Push to Our
@@ -444,7 +444,7 @@ Below this there is another step to push the package to Our, which again is like
 
 With these 2 commands and a few previous ones setting up the prerequisite build and nuget tools it is now ready to be fully automated.
 
-Ensure you have set a Github secret with the name `UMBRACO_DEPLOY_KEY` and the value of the key from Our, and then go to your local solution and uncomment the UmbPack push command in the \~/.github/workflows/build.yml file.
+Ensure you have set a GitHub secret with the name `UMBRACO_DEPLOY_KEY` and the value of the key from Our, and then go to your local solution and uncomment the UmbPack push command in the \~/.github/workflows/build.yml file.
 
 Then make sure it is added and committed locally:
 
@@ -454,14 +454,14 @@ git commit -m "Enable umbpack push in GH action"
 git push
 ```
 
-Your solution and Github repo are now in sync, and the umbpack commands in the Github action are enabled and ready to run. Final step is to create a release tag and push it to Github:
+Your solution and GitHub repo are now in sync, and the umbpack commands in the GitHub action are enabled and ready to run. Final step is to create a release tag and push it to GitHub:
 
 ```
 git tag release/1.0.0
 git push origin release/1.0.0
 ```
 
-At this point you can go to Github and visit the Action tab to see your Github action run. When it's completed successfully you can go to your package overview on Our and see the package there.
+At this point you can go to GitHub and visit the Action tab to see your GitHub action run. When it's completed successfully you can go to your package overview on Our and see the package there.
 
 ## Archive older versions on push
 

--- a/13/umbraco-cms/tutorials/creating-and-distributing-a-package.md
+++ b/13/umbraco-cms/tutorials/creating-and-distributing-a-package.md
@@ -399,7 +399,7 @@ You can edit all of these defaults, and also specify older versions of your pack
 
 So at this point we can work on our package locally, build a new version within seconds by running the pack command and then deploy it to Our using the push command.
 
-Not easy enough for you? Let's try automating this entire thing with GitHub actions then.
+Not easy enough for you? Let's try automating this entire thing with GitHub Actions then.
 
 ## Deploy your package using GitHub Actions
 
@@ -407,7 +407,7 @@ If you think back to the beginning when we set up our sites using the Package Te
 
 If you check out the `~/.github/workflows` folder in your solution, you will see there is a readme file and a build.yml file.
 
-The build.yml file is used by GitHub actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
+The build.yml file is used by GitHub Actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
 
 The build.yml file contains several things, let's have a quick overview:
 

--- a/13/umbraco-commerce/release-notes/README.md
+++ b/13/umbraco-commerce/release-notes/README.md
@@ -154,4 +154,4 @@ Read the [v13.1.0-RC release post](./v13.1.0-rc.md) for further background on th
 
 ## Legacy release notes
 
-You can find the release notes for **Vendr** in the [Change log file on Github](changelog-archive/Vendr-core.md).
+You can find the release notes for **Vendr** in the [Change log file on GitHub](changelog-archive/Vendr-core.md).

--- a/13/umbraco-commerce/upgrading/version-specific-upgrades.md
+++ b/13/umbraco-commerce/upgrading/version-specific-upgrades.md
@@ -19,4 +19,4 @@ See the [Migrate from Vendr to Umbraco Commerce guide](migrate-from-vendr-to-umb
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;

--- a/13/umbraco-deploy/SUMMARY.md
+++ b/13/umbraco-deploy/SUMMARY.md
@@ -20,7 +20,7 @@
 * [Getting started](getting-started/get-started-with-deploy.md)
 * [CI/CD Build and Deployment Pipeline](getting-started/cicd-pipeline/README.md)
   * [Azure DevOps](getting-started/cicd-pipeline/ci-cd-azure-dev-ops.md)
-  * [GitHub actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
+  * [GitHub Actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
 * [Streamlining Local Development](getting-started/streamlining-local-development.md)
 * [Configuration](getting-started/deploy-settings.md)
 

--- a/13/umbraco-deploy/SUMMARY.md
+++ b/13/umbraco-deploy/SUMMARY.md
@@ -20,7 +20,7 @@
 * [Getting started](getting-started/get-started-with-deploy.md)
 * [CI/CD Build and Deployment Pipeline](getting-started/cicd-pipeline/README.md)
   * [Azure DevOps](getting-started/cicd-pipeline/ci-cd-azure-dev-ops.md)
-  * [Github actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
+  * [GitHub actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
 * [Streamlining Local Development](getting-started/streamlining-local-development.md)
 * [Configuration](getting-started/deploy-settings.md)
 

--- a/13/umbraco-deploy/deployment-workflow/README.md
+++ b/13/umbraco-deploy/deployment-workflow/README.md
@@ -18,7 +18,7 @@ Umbraco Deploy uses a two-part deployment approach where we keep meta data (Docu
 
 In summary:
 
-1. Meta data such as Document Types, Templates, Forms, Views and config files are stored in a repository and are **deployed** between environments. This can be achieved using a CI/CD deployment pipeline with something like Github Actions or Azure DevOps.
+1. Meta data such as Document Types, Templates, Forms, Views and config files are stored in a repository and are **deployed** between environments. This can be achieved using a CI/CD deployment pipeline with something like GitHub Actions or Azure DevOps.
 2. Content and Media items are **not** stored in the repository. These need to be **transferred** directly from the Umbraco backoffice using the _"Queue for Transfer"_ option. Once a content editor has all the items needed for a transfer they will use the Deployment Dashboard in the Content section to transfer the items in the queue.
 
 ### Deploying meta data

--- a/13/umbraco-deploy/getting-started/cicd-pipeline/README.md
+++ b/13/umbraco-deploy/getting-started/cicd-pipeline/README.md
@@ -12,7 +12,7 @@ The build server will extract the changes that has been pushed to the repository
 
 This is something that can be done in many different ways depending on where your website is hosted and your setup.
 
-Umbraco Deploy does not require the use of any particular build or deployment tools and hence we expect that you should be able to continue using the tool or tools of your choice. Any that have support for .NET website deployments and the running of Powershell scripts. such as Azure DevOps or Github Actions, would be appropriate.
+Umbraco Deploy does not require the use of any particular build or deployment tools and hence we expect that you should be able to continue using the tool or tools of your choice. Any that have support for .NET website deployments and the running of Powershell scripts. such as Azure DevOps or GitHub Actions, would be appropriate.
 
 Above and beyond the normal steps of a build pipeline for a .NET web application - tasks like NuGet restore, solution build, running of tests etc. - Umbraco Deploy requires three additional steps.
 
@@ -36,9 +36,9 @@ Umbraco Deploy On-Premises also ships with a Powershell script, that when execut
 
 So while it may be possible to have the CI/CD step directly write the file or call the endpoint, so long as the build used supports running Powershell scripts this is the method we’d recommend, as it has some necessary error checking and retry logic built-in.
 
-## [Setting up CI/CD pipeline with Github Actions](ci-cd-github-actions.md)
+## [Setting up CI/CD pipeline with GitHub Actions](ci-cd-github-actions.md)
 
-Details the setup of a CI/CD pipeline using Github Actions.
+Details the setup of a CI/CD pipeline using GitHub Actions.
 
 ## [Setting up CI/CD pipeline with Azure DevOps](ci-cd-azure-dev-ops.md)
 

--- a/13/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
+++ b/13/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
@@ -4,7 +4,7 @@ description: >-
   Deploy using GitHub Actions.
 ---
 
-# GitHub actions
+# GitHub Actions
 
 {% hint style="info" %}
 In this example we will show how you can set up a CI/CD build server using GitHub Actions in Azure Web Apps.

--- a/13/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
+++ b/13/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
@@ -4,10 +4,10 @@ description: >-
   Deploy using GitHub Actions.
 ---
 
-# Github actions
+# GitHub actions
 
 {% hint style="info" %}
-In this example we will show how you can set up a CI/CD build server using Github Actions in Azure Web Apps.
+In this example we will show how you can set up a CI/CD build server using GitHub Actions in Azure Web Apps.
 
 We will not cover how you can set up the site itself as this is beyond this documentation.
 {% endhint %}
@@ -18,15 +18,15 @@ The following steps will take you through setting up a build server in Azure Web
 
 ![Azure deployments](<../../../../10/umbraco-deploy/getting-started/images/Deployment-center (1) (1).png>)
 
-In the Deployment Center we can set up the CI/CD build server. With this example we are going to set up our build server by using Github Actions. It is possible to set up the build server however you want as long as it supports executing powershell scripts.
+In the Deployment Center we can set up the CI/CD build server. With this example we are going to set up our build server by using GitHub Actions. It is possible to set up the build server however you want as long as it supports executing powershell scripts.
 
 2. Go to the Settings tab.
 3. Choose which source and build provider to use.
-   * In this case we want to choose Github.
+   * In this case we want to choose GitHub.
 
 ![Build server clean](./images/Build-server-v10.png)
 
-4. Choose the Organization which you created our Github repository under.
+4. Choose the Organization which you created our GitHub repository under.
 5. Choose the repository that was set up earlier in this guide.
 6. Select which branch that we want the build server to build into.
 
@@ -38,9 +38,9 @@ Once the information has been added we can go ahead and preview the YAML file th
 
 7. Save the workflow.
 
-The website and the Github repository are now connected.
+The website and the GitHub repository are now connected.
 
-If we go back to the Github repository we can see that a new folder have been created called Workflows:
+If we go back to the GitHub repository we can see that a new folder have been created called Workflows:
 
 ![Workflows](<../../../../10/umbraco-deploy/getting-started/images/workflows (1).png>)
 
@@ -138,7 +138,7 @@ As well as enabling Unattended install in the **appsettings.json** file so Umbra
 
 Before the build can work, we will need to set up our generated API key to work with the build server in GitHub Actions.
 
-1. Open your Github repository.
+1. Open your GitHub repository.
 2. Navigate to Settings.
 3. Go to the Secrets tab.
 4. Select "New repository secret".
@@ -148,7 +148,7 @@ Before the build can work, we will need to set up our generated API key to work 
 
 We can now go ahead and commit the configured YAML file and push up all the files to the repository.
 
-Go to Github where you will now be able to see that the CI/CD build has started running:
+Go to GitHub where you will now be able to see that the CI/CD build has started running:
 
 ![Deployment build started](<../../../../10/umbraco-deploy/getting-started/images/Deploying-meta-data (1).png>)
 
@@ -158,7 +158,7 @@ The build server will go through the steps in the YAML file, and once it is done
 
 You can now start creating content on the local machine. Once you create something like a Document Type, the changes will get picked up in Git.
 
-When you're done making changes, commit them and deploy them to Github. The build server will run and extract the changes into the website in Azure.
+When you're done making changes, commit them and deploy them to GitHub. The build server will run and extract the changes into the website in Azure.
 
 This will only deploy the schema data for our local site to your website.
 

--- a/13/umbraco-deploy/getting-started/get-started-with-deploy.md
+++ b/13/umbraco-deploy/getting-started/get-started-with-deploy.md
@@ -14,7 +14,7 @@ These items are entities like Document Types, Media Types, Data Types, etc, and 
 
 For example, when working locally you might create a new Document Type. This will automatically create a new on-disk file in the `umbraco/Deploy/Revision` folder which is the serialized version of the new Document Type. You would then commit this file to your repository and push this change to your hosted source control (for example GitHub).
 
-When you want this deployed to your next environment, you would trigger your CI/CD process (for example Azure DevOps or Github Actions). This will push the changes to your environment. Once the build deployment completes successfully, a Deployment Trigger would be executed as an HTTPS request to your target environment. All changes found in the `umbraco/Deploy/Revision` folder will then be extracted into the Umbraco target environment.
+When you want this deployed to your next environment, you would trigger your CI/CD process (for example Azure DevOps or GitHub Actions). This will push the changes to your environment. Once the build deployment completes successfully, a Deployment Trigger would be executed as an HTTPS request to your target environment. All changes found in the `umbraco/Deploy/Revision` folder will then be extracted into the Umbraco target environment.
 
 ![Deploy workflow](../images/Deploy_concept.png)
 

--- a/13/umbraco-deploy/installation/install-configure.md
+++ b/13/umbraco-deploy/installation/install-configure.md
@@ -24,7 +24,7 @@ Here we will cover how to install and set up Umbraco Deploy on a new website.
 
 **Set up the Git repository and Umbraco project**
 
-The first step to get Umbraco Deploy up and running is to set up a GitHub repository. This will be where source code is stored, and, following the GitHub actions example, act as our environment where we will set up a CI/CD pipeline.
+The first step to get Umbraco Deploy up and running is to set up a GitHub repository. This will be where source code is stored, and, following the GitHub Actions example, act as our environment where we will set up a CI/CD pipeline.
 
 1. Using the Visual Studio template, set up a GitHub repository with a .gitignore file.
 2. Clone down the repository to your local machine.

--- a/13/umbraco-deploy/installation/install-configure.md
+++ b/13/umbraco-deploy/installation/install-configure.md
@@ -26,7 +26,7 @@ Here we will cover how to install and set up Umbraco Deploy on a new website.
 
 The first step to get Umbraco Deploy up and running is to set up a GitHub repository. This will be where source code is stored, and, following the GitHub actions example, act as our environment where we will set up a CI/CD pipeline.
 
-1. Using the Visual Studio template, set up a Github repository with a .gitignore file.
+1. Using the Visual Studio template, set up a GitHub repository with a .gitignore file.
 2. Clone down the repository to your local machine.
 3. Create a new Umbraco project.
 4. Run the project.

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -161,4 +161,4 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 
 ## Legacy release notes
 
-You can find the release notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/release-notes.md) and [Umbraco Deploy Package page](https://our.umbraco.com/packages/developer-tools/umbraco-deploy/)
+You can find the release notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/release-notes.md) and [Umbraco Deploy Package page](https://our.umbraco.com/packages/developer-tools/umbraco-deploy/)

--- a/13/umbraco-deploy/upgrades/version-specific.md
+++ b/13/umbraco-deploy/upgrades/version-specific.md
@@ -84,4 +84,4 @@ These updates are more minor. We don't expect many projects to be affected by th
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/upgrades/version-specific.md).
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/upgrades/version-specific.md).

--- a/13/umbraco-forms/release-notes.md
+++ b/13/umbraco-forms/release-notes.md
@@ -202,4 +202,4 @@ And there are a couple of further additions to improve the performance and acces
 
 ## Legacy release notes
 
-You can find the release notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/release-notes.md) and [Umbraco Forms Package page](https://our.umbraco.com/packages/developer-tools/umbraco-forms/).
+You can find the release notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/release-notes.md) and [Umbraco Forms Package page](https://our.umbraco.com/packages/developer-tools/umbraco-forms/).

--- a/13/umbraco-forms/upgrading/version-specific.md
+++ b/13/umbraco-forms/upgrading/version-specific.md
@@ -64,4 +64,4 @@ These updates are more minor. We don't expect many projects to be affected by th
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/installation/version-specific.md).&#x20;
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/installation/version-specific.md).&#x20;

--- a/13/umbraco-ui-builder/release-notes.md
+++ b/13/umbraco-ui-builder/release-notes.md
@@ -76,7 +76,7 @@ You can read more about this in the [retrieve child collections](collections/ret
 
 This update addresses the configuration of collections that use as foreign key a reference to an Umbraco entity. If the FK type is `Integer`, the persisted value defaults to 0. This is because the UDI value of the entity cannot be converted from `String` to `Int`. Based on the UDI value, we are retrieving and persisting the `Id` of the Umbraco entity.
 
-A use case can be found in the [Github issue #86](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/86).
+A use case can be found in the [GitHub issue #86](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/86).
 
 
 #### [**13.0.3**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.3) **(February 20th 2024)**
@@ -103,4 +103,4 @@ A use case can be found in the [Github issue #86](https://github.com/umbraco/Umb
 
 ## Legacy release notes
 
-You can find the release notes for **Konstrukt** in the [Change log file on Github](changelog-archive/changelog.md).
+You can find the release notes for **Konstrukt** in the [Change log file on GitHub](changelog-archive/changelog.md).

--- a/13/umbraco-ui-builder/upgrading/version-specific.md
+++ b/13/umbraco-ui-builder/upgrading/version-specific.md
@@ -19,4 +19,4 @@ See the [Migrate from Konstrukt to Umbraco UI Builder guide](./migrating-from-ko
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;

--- a/13/umbraco-workflow/release-notes.md
+++ b/13/umbraco-workflow/release-notes.md
@@ -85,4 +85,4 @@ The above fixes introduce an updated UI for requesting workflow approvals. For m
 
 ## Legacy release notes
 
-You can find the release notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-workflow/release-notes.md)
+You can find the release notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-workflow/release-notes.md)

--- a/13/umbraco-workflow/upgrading/version-specific.md
+++ b/13/umbraco-workflow/upgrading/version-specific.md
@@ -31,4 +31,4 @@ Version 13 is primarily a dependency update, but does remove some properties pre
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;

--- a/14/umbraco-cms/customizing/foundation/icons.md
+++ b/14/umbraco-cms/customizing/foundation/icons.md
@@ -1,3 +1,3 @@
 # Icons
 
-The icons from the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for getting the icons starts with`icon-`. You can find the list of all icons in the [Icon registry list on Github](https://github.com/umbraco/Umbraco.CMS.Backoffice/tree/762e43b2f49ca483df9cfe28de20f31ca07bb22b/src/packages/core/icon-registry/icons).
+The icons from the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for getting the icons starts with`icon-`. You can find the list of all icons in the [Icon registry list on GitHub](https://github.com/umbraco/Umbraco.CMS.Backoffice/tree/762e43b2f49ca483df9cfe28de20f31ca07bb22b/src/packages/core/icon-registry/icons).

--- a/14/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
+++ b/14/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
@@ -32,7 +32,7 @@ The correct packages will have been installed in your project.
 
 ## Configuring Blob storage
 
-The next step is to configure your blob storage. There are multiple approaches for this, but in this document, we're going to do it through `appsettings.json`. For more configuration options, see the [readme](https://github.com/umbraco/Umbraco.StorageProviders#umbracostorageproviders) on the Github repository.
+The next step is to configure your blob storage. There are multiple approaches for this, but in this document, we're going to do it through `appsettings.json`. For more configuration options, see the [readme](https://github.com/umbraco/Umbraco.StorageProviders#umbracostorageproviders) on the GitHub repository.
 
 Open up your `appsettings.json` file and add the connection string and container name under `Umbraco:Storage:AzureBlob:Media`. Your Umbraco section of appsettings will look something like this:
 

--- a/14/umbraco-cms/extending/packages/creating-a-package.md
+++ b/14/umbraco-cms/extending/packages/creating-a-package.md
@@ -145,7 +145,7 @@ The `Title`, `Description`, `PackageTags` came with the template and we added so
 | ------------------------ | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Version                  | 1.0.0               | This is automatically set to 1.0.0 but can be changed as appropriate.                                                                                                                                       |
 | Authors                  | Your name           | Here you get to take credit for your awesome work!                                                                                                                                                          |
-| PackageProjectUrl        | https://umbraco.com | This URL will be shown as the package's URL when others install it. It will likely be a Github repository, or similar.                                                                                      |
+| PackageProjectUrl        | https://umbraco.com | This URL will be shown as the package's URL when others install it. It will likely be a GitHub repository, or similar.                                                                                      |
 | PackageLicenseExpression | MIT                 | The license is set to MIT. Please consider how you want your package licensed. If in doubt when deciding an open-source license there are [good resources available](https://choosealicense.com/licenses/). |
 
 ### Pack it

--- a/14/umbraco-cms/extending/packages/example-package-repository.md
+++ b/14/umbraco-cms/extending/packages/example-package-repository.md
@@ -44,7 +44,7 @@ Finally there's an [example Umbraco website](https://github.com/umbraco/Umbraco.
 
 As well as the projects, the following files are added to the solution:
 
-- [.artifactignore](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.artifactignore) - used by AzureDevOps services to [control which files are uploaded when you publish](https://learn.microsoft.com/en-us/azure/devops/artifacts/reference/artifactignore?view=azure-devops). This helps to reduce pipeline execution time.
+- [.artifactignore](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.artifactignore) - used by Azure DevOps services to [control which files are uploaded when you publish](https://learn.microsoft.com/en-us/azure/devops/artifacts/reference/artifactignore?view=azure-devops). This helps to reduce pipeline execution time.
 - [.editorconfig](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.editorconfig) - used to [enforce consistent coding styles](https://editorconfig.org/) for multiple developers working on the same project across editors and IDEs.
 - [.gitignore](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.gitignore) - controls which files are added to source control.
 - [.globalconfig](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.globalconfig) - provides [further styling rules for the project files, even if stored outside of the project directory](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files#global-analyzerconfig).
@@ -58,7 +58,7 @@ As well as the projects, the following files are added to the solution:
 
 ## Build and Deployment
 
-We use AzureDevOps pipelines for continuous integration and releasing new versions of the package. The definition of how the project is built is defined in a `.yaml` file that's part of the source code repository.
+We use Azure DevOps pipelines for continuous integration and releasing new versions of the package. The definition of how the project is built is defined in a `.yaml` file that's part of the source code repository.
 
 The file can be found [here](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/azure-pipeline%20-%20Umbraco.AuthorizedServices.yml).
 
@@ -68,13 +68,13 @@ Even if using another tool it may be worth reviewing how we have setup our pipel
 
 The build consists of two stages: building the solution and running unit tests. Only if both succeed is the build as a whole considered successful.
 
-![AzureDevOps build pipeline](../../../../10/umbraco-cms/extending/packages/images/azuredevops-build.png)
+![Azure DevOps build pipeline](../../../../10/umbraco-cms/extending/packages/images/azuredevops-build.png)
 
 ### Releasing the Package
 
-We release the package manually in AzureDevOps, with a two stage process. Firstly we release to a "pre-releases" feed, and then after manual approval, to NuGet.
+We release the package manually in Azure DevOps, with a two stage process. Firstly we release to a "pre-releases" feed, and then after manual approval, to NuGet.
 
-![AzureDevOps release pipeline](../../../../10/umbraco-cms/extending/packages/images/azuredevops-release.png)
+![Azure DevOps release pipeline](../../../../10/umbraco-cms/extending/packages/images/azuredevops-release.png)
 
 
 

--- a/14/umbraco-cms/fundamentals/backoffice/login.md
+++ b/14/umbraco-cms/fundamentals/backoffice/login.md
@@ -71,7 +71,7 @@ This will override the default greetings with the ones you provide. The login sc
 The login screen has its own set of localization files independent of the rest of the Backoffice. You can read more about Backoffice localization in the [UI Localization](../../customizing/foundation/localization.md) article.
 {% endhint %}
 
-You can customize other text on the login screen as well. First, grab the default values and keys from the [en.ts](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Web.UI.Login/src/localization/lang/en.ts) in the Umbraco CMS Github repository. Thereafter copy the ones you want to translate into `~/App_Plugins/Login/umbraco-package.json` file.
+You can customize other text on the login screen as well. First, grab the default values and keys from the [en.ts](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Web.UI.Login/src/localization/lang/en.ts) in the Umbraco CMS GitHub repository. Thereafter copy the ones you want to translate into `~/App_Plugins/Login/umbraco-package.json` file.
 
 ## Password reset
 
@@ -210,7 +210,7 @@ The following CSS properties are available for customization:
 | `--umb-login-curves-color`               | The color of the curves                        | `#f5c1bc`                                                                                  |
 | `--umb-login-curves-display`             | The display of the curves                      | `inline`                                                                                   |
 
-The CSS custom properties may change in future versions of Umbraco. You can always find the latest values in the [login layout element](https://github.com/umbraco/Umbraco-CMS/blob/v14/dev/src/Umbraco.Web.UI.Login/src/components/layouts/auth-layout.element.ts) in the Umbraco CMS Github repository.
+The CSS custom properties may change in future versions of Umbraco. You can always find the latest values in the [login layout element](https://github.com/umbraco/Umbraco-CMS/blob/v14/dev/src/Umbraco.Web.UI.Login/src/components/layouts/auth-layout.element.ts) in the Umbraco CMS GitHub repository.
 
 ## The Time Out Screen
 

--- a/14/umbraco-cms/reference/security/cookies.md
+++ b/14/umbraco-cms/reference/security/cookies.md
@@ -31,4 +31,4 @@ builder.Services.AddSession(options =>
     });
 ```
 
-For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/Constants-Web.cs) file on Github.
+For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/Constants-Web.cs) file on GitHub.

--- a/14/umbraco-cms/tutorials/creating-and-distributing-a-package.md
+++ b/14/umbraco-cms/tutorials/creating-and-distributing-a-package.md
@@ -12,10 +12,10 @@ The content in this article is valid _only_ for Umbraco version 8. For Umbraco v
 * [Creating a test site locally](creating-and-distributing-a-package.md#creating-a-test-site-locally)
 * [Creating a package from the backoffice](creating-and-distributing-a-package.md#creating-a-package-from-the-backoffice)
 * [Creating a draft package on Our](creating-and-distributing-a-package.md#creating-a-draft-package-on-our)
-* [Pushing your package to Github](creating-and-distributing-a-package.md#pushing-your-package-to-github)
+* [Pushing your package to GitHub](creating-and-distributing-a-package.md#pushing-your-package-to-github)
 * [Pack up your package locally using UmbPack](creating-and-distributing-a-package.md#pack-up-your-package-locally-using-umbpack)
 * [Pushing your package to Our using UmbPack](creating-and-distributing-a-package.md#pushing-your-package-to-our-using-umbpack)
-* [Deploy your package using Github Actions](creating-and-distributing-a-package.md#deploy-your-package-using-github-actions)
+* [Deploy your package using GitHub Actions](creating-and-distributing-a-package.md#deploy-your-package-using-github-actions)
 * [Archive older versions on push](creating-and-distributing-a-package.md#archive-older-versions-on-push)
 
 ## Prerequisites
@@ -23,7 +23,7 @@ The content in this article is valid _only_ for Umbraco version 8. For Umbraco v
 To run this tutorial you will need the following:
 
 * Be able to run an Umbraco site locally
-* Git + Github account
+* Git + GitHub account
 * [Our Umbraco member account](https://our.umbraco.com/member/Signup) with access to upload packages
 * UmbPack installed
 * Umbraco Package templates installed
@@ -60,7 +60,7 @@ It will show you all the options you have for creating a new Umbraco site + pack
 dotnet new umbraco-v8-package -n PackageWorkshop -d
 ```
 
-This will create a new package called `PackageWorkshop`, and add a custom Dashboard for us to use in this tutorial. By default you will also get a Github Action added that we will return to later.
+This will create a new package called `PackageWorkshop`, and add a custom Dashboard for us to use in this tutorial. By default you will also get a GitHub Action added that we will return to later.
 
 After running you will have a folder called `PackageWorkshop`, inside that you will have your site and solution files. So try to open it in Visual Studio or Rider by opening the `PackageWorkshop.sln` file.
 
@@ -233,13 +233,13 @@ Now your package is on Our, and if the "Go live" button is clicked it is visible
 
 The next step is to make it a bit simpler to deploy updates to the package. It is perfectly fine to log in here and upload a new version each time. The next steps will show an easier way though.
 
-## Pushing your package to Github
+## Pushing your package to GitHub
 
 If you are creating a package in order to share it with others it is a great idea to also share the source code. It is the open source way.
 
-To share it, and make it easier to manage and deploy updates we will set up a Github repository for the package. This tutorial assumes you know what Github is, and that you have an account.
+To share it, and make it easier to manage and deploy updates we will set up a GitHub repository for the package. This tutorial assumes you know what GitHub is, and that you have an account.
 
-Create a fresh repo, with no readme, gitignore or license - do not choose a repository template (set to 'No Template'). On the second screen it will give you a command to push an existing repository to the new Github repo, should look like this but with your own user in the link:
+Create a fresh repo, with no readme, gitignore or license - do not choose a repository template (set to 'No Template'). On the second screen it will give you a command to push an existing repository to the new GitHub repo, should look like this but with your own user in the link:
 
 ```
 git remote add origin https://github.com/jmayntzhusen/package-workshop.git
@@ -256,7 +256,7 @@ git add .
 git commit -m "Initial commit, dashboard package"
 ```
 
-At this point you have your solution in a local git repository, and we can then use the command from Github to push it up:
+At this point you have your solution in a local git repository, and we can then use the command from GitHub to push it up:
 
 ```
 git remote add origin https://github.com/jmayntzhusen/package-workshop.git
@@ -264,18 +264,18 @@ git branch -M main
 git push -u origin main
 ```
 
-Now you have it all on Github:
+Now you have it all on GitHub:
 
-![Github repo](images/github-repo.png)
+![GitHub repo](images/github-repo.png)
 
 ## Pack up your package locally using UmbPack
 
-At this point you know how to create a package from the backoffice, upload it to Our and push your changes to Github. That's what it takes to create and maintain a package.
+At this point you know how to create a package from the backoffice, upload it to Our and push your changes to GitHub. That's what it takes to create and maintain a package.
 
 If you want to make changes and push a new version you can carry out the following steps:
 
 * Create the new package in the backoffice
-* Sync your code to Github
+* Sync your code to GitHub
 * Go to Our and upload a new zip version
 * Set that to the current version
 * Optionally archive the previous one
@@ -398,15 +398,15 @@ You can edit all of these defaults, and also specify older versions of your pack
 
 So at this point we can work on our package locally, build a new version within seconds by running the pack command and then deploy it to Our using the push command.
 
-Not easy enough for you? Let's try automating this entire thing with Github actions then.
+Not easy enough for you? Let's try automating this entire thing with GitHub actions then.
 
-## Deploy your package using Github Actions
+## Deploy your package using GitHub Actions
 
-If you think back to the beginning when we set up our sites using the Package Templates you may remember that by default you get a Github action installed as well.
+If you think back to the beginning when we set up our sites using the Package Templates you may remember that by default you get a GitHub action installed as well.
 
 If you check out the `~/.github/workflows` folder in your solution, you will see there is a readme file and a build.yml file.
 
-The build.yml file is used by Github actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
+The build.yml file is used by GitHub actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
 
 The build.yml file contains several things, let's have a quick overview:
 
@@ -432,9 +432,9 @@ The action that it performs is what is under `jobs:build:steps`. There is a step
 It sets the version of the package to be what we've set in the release tag based on a previous step.
 {% endhint %}
 
-Below this there is another step to push the package to Our, which again is like our approach locally - except now we add the API key as a Github secret so it's not public to everyone.
+Below this there is another step to push the package to Our, which again is like our approach locally - except now we add the API key as a GitHub secret so it's not public to everyone.
 
-![Github secret](images/gh-secret.png)
+![GitHub secret](images/gh-secret.png)
 
 ```yml
 - name: Push to Our
@@ -443,7 +443,7 @@ Below this there is another step to push the package to Our, which again is like
 
 With these 2 commands and a few previous ones setting up the prerequisite build and nuget tools it is now ready to be fully automated.
 
-Ensure you have set a Github secret with the name `UMBRACO_DEPLOY_KEY` and the value of the key from Our, and then go to your local solution and uncomment the UmbPack push command in the \~/.github/workflows/build.yml file.
+Ensure you have set a GitHub secret with the name `UMBRACO_DEPLOY_KEY` and the value of the key from Our, and then go to your local solution and uncomment the UmbPack push command in the \~/.github/workflows/build.yml file.
 
 Then make sure it is added and committed locally:
 
@@ -453,14 +453,14 @@ git commit -m "Enable umbpack push in GH action"
 git push
 ```
 
-Your solution and Github repo are now in sync, and the umbpack commands in the Github action are enabled and ready to run. Final step is to create a release tag and push it to Github:
+Your solution and GitHub repo are now in sync, and the umbpack commands in the GitHub action are enabled and ready to run. Final step is to create a release tag and push it to GitHub:
 
 ```
 git tag release/1.0.0
 git push origin release/1.0.0
 ```
 
-At this point you can go to Github and visit the Action tab to see your Github action run. When it's completed successfully you can go to your package overview on Our and see the package there.
+At this point you can go to GitHub and visit the Action tab to see your GitHub action run. When it's completed successfully you can go to your package overview on Our and see the package there.
 
 ## Archive older versions on push
 

--- a/14/umbraco-cms/tutorials/creating-and-distributing-a-package.md
+++ b/14/umbraco-cms/tutorials/creating-and-distributing-a-package.md
@@ -398,7 +398,7 @@ You can edit all of these defaults, and also specify older versions of your pack
 
 So at this point we can work on our package locally, build a new version within seconds by running the pack command and then deploy it to Our using the push command.
 
-Not easy enough for you? Let's try automating this entire thing with GitHub actions then.
+Not easy enough for you? Let's try automating this entire thing with GitHub Actions then.
 
 ## Deploy your package using GitHub Actions
 
@@ -406,7 +406,7 @@ If you think back to the beginning when we set up our sites using the Package Te
 
 If you check out the `~/.github/workflows` folder in your solution, you will see there is a readme file and a build.yml file.
 
-The build.yml file is used by GitHub actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
+The build.yml file is used by GitHub Actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
 
 The build.yml file contains several things, let's have a quick overview:
 

--- a/14/umbraco-commerce/release-notes/README.md
+++ b/14/umbraco-commerce/release-notes/README.md
@@ -156,4 +156,4 @@ Read the [v14.0.0-Alpha release post](./v14.0.0-alpha.md) for further background
 
 ## Legacy release notes
 
-You can find the release notes for **Vendr** in the [Change log file on Github](changelog-archive/Vendr-core.md).
+You can find the release notes for **Vendr** in the [Change log file on GitHub](changelog-archive/Vendr-core.md).

--- a/14/umbraco-commerce/upgrading/version-specific-upgrades.md
+++ b/14/umbraco-commerce/upgrading/version-specific-upgrades.md
@@ -29,4 +29,4 @@ See the [Migrate from Vendr to Umbraco Commerce guide](migrate-from-vendr-to-umb
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;

--- a/14/umbraco-deploy/SUMMARY.md
+++ b/14/umbraco-deploy/SUMMARY.md
@@ -20,7 +20,7 @@
 * [Getting started](getting-started/get-started-with-deploy.md)
 * [CI/CD Build and Deployment Pipeline](getting-started/cicd-pipeline/README.md)
   * [Azure DevOps](getting-started/cicd-pipeline/ci-cd-azure-dev-ops.md)
-  * [GitHub actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
+  * [GitHub Actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
 * [Streamlining Local Development](getting-started/streamlining-local-development.md)
 * [Configuration](getting-started/deploy-settings.md)
 

--- a/14/umbraco-deploy/SUMMARY.md
+++ b/14/umbraco-deploy/SUMMARY.md
@@ -20,7 +20,7 @@
 * [Getting started](getting-started/get-started-with-deploy.md)
 * [CI/CD Build and Deployment Pipeline](getting-started/cicd-pipeline/README.md)
   * [Azure DevOps](getting-started/cicd-pipeline/ci-cd-azure-dev-ops.md)
-  * [Github actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
+  * [GitHub actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
 * [Streamlining Local Development](getting-started/streamlining-local-development.md)
 * [Configuration](getting-started/deploy-settings.md)
 

--- a/14/umbraco-deploy/deployment-workflow/README.md
+++ b/14/umbraco-deploy/deployment-workflow/README.md
@@ -18,7 +18,7 @@ Umbraco Deploy uses a two-part deployment approach where we keep meta data (Docu
 
 In summary:
 
-1. Meta data such as Document Types, Templates, Forms, Views and config files are stored in a repository and are **deployed** between environments. This can be achieved using a CI/CD deployment pipeline with something like Github Actions or Azure DevOps.
+1. Meta data such as Document Types, Templates, Forms, Views and config files are stored in a repository and are **deployed** between environments. This can be achieved using a CI/CD deployment pipeline with something like GitHub Actions or Azure DevOps.
 2. Content and Media items are **not** stored in the repository. These need to be **transferred** directly from the Umbraco backoffice using the _"Queue for Transfer"_ option. Once a content editor has all the items needed for a transfer they will use the Deployment Dashboard in the Content section to transfer the items in the queue.
 
 ### Deploying meta data

--- a/14/umbraco-deploy/getting-started/cicd-pipeline/README.md
+++ b/14/umbraco-deploy/getting-started/cicd-pipeline/README.md
@@ -12,7 +12,7 @@ The build server will extract the changes that has been pushed to the repository
 
 This is something that can be done in many different ways depending on where your website is hosted and your setup.
 
-Umbraco Deploy does not require the use of any particular build or deployment tools and hence we expect that you should be able to continue using the tool or tools of your choice. Any that have support for .NET website deployments and the running of Powershell scripts. such as Azure DevOps or Github Actions, would be appropriate.
+Umbraco Deploy does not require the use of any particular build or deployment tools and hence we expect that you should be able to continue using the tool or tools of your choice. Any that have support for .NET website deployments and the running of Powershell scripts. such as Azure DevOps or GitHub Actions, would be appropriate.
 
 Above and beyond the normal steps of a build pipeline for a .NET web application - tasks like NuGet restore, solution build, running of tests etc. - Umbraco Deploy requires three additional steps.
 
@@ -36,9 +36,9 @@ Umbraco Deploy On-Premises also ships with a Powershell script, that when execut
 
 So while it may be possible to have the CI/CD step directly write the file or call the endpoint, so long as the build used supports running Powershell scripts this is the method we’d recommend, as it has some necessary error checking and retry logic built-in.
 
-## [Setting up CI/CD pipeline with Github Actions](ci-cd-github-actions.md)
+## [Setting up CI/CD pipeline with GitHub Actions](ci-cd-github-actions.md)
 
-Details the setup of a CI/CD pipeline using Github Actions.
+Details the setup of a CI/CD pipeline using GitHub Actions.
 
 ## [Setting up CI/CD pipeline with Azure DevOps](ci-cd-azure-dev-ops.md)
 

--- a/14/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
+++ b/14/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
@@ -4,7 +4,7 @@ description: >-
   Deploy using GitHub Actions.
 ---
 
-# GitHub actions
+# GitHub Actions
 
 {% hint style="info" %}
 In this example we will show how you can set up a CI/CD build server using GitHub Actions in Azure Web Apps.

--- a/14/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
+++ b/14/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
@@ -4,10 +4,10 @@ description: >-
   Deploy using GitHub Actions.
 ---
 
-# Github actions
+# GitHub actions
 
 {% hint style="info" %}
-In this example we will show how you can set up a CI/CD build server using Github Actions in Azure Web Apps.
+In this example we will show how you can set up a CI/CD build server using GitHub Actions in Azure Web Apps.
 
 We will not cover how you can set up the site itself as this is beyond this documentation.
 {% endhint %}
@@ -18,15 +18,15 @@ The following steps will take you through setting up a build server in Azure Web
 
 ![Azure deployments](<../../../../10/umbraco-deploy/getting-started/images/Deployment-center (1) (1).png>)
 
-In the Deployment Center we can set up the CI/CD build server. With this example we are going to set up our build server by using Github Actions. It is possible to set up the build server however you want as long as it supports executing powershell scripts.
+In the Deployment Center we can set up the CI/CD build server. With this example we are going to set up our build server by using GitHub Actions. It is possible to set up the build server however you want as long as it supports executing powershell scripts.
 
 2. Go to the Settings tab.
 3. Choose which source and build provider to use.
-   * In this case we want to choose Github.
+   * In this case we want to choose GitHub.
 
 ![Build server clean](./images/Build-server-v10.png)
 
-4. Choose the Organization which you created our Github repository under.
+4. Choose the Organization which you created our GitHub repository under.
 5. Choose the repository that was set up earlier in this guide.
 6. Select which branch that we want the build server to build into.
 
@@ -38,9 +38,9 @@ Once the information has been added we can go ahead and preview the YAML file th
 
 7. Save the workflow.
 
-The website and the Github repository are now connected.
+The website and the GitHub repository are now connected.
 
-If we go back to the Github repository we can see that a new folder have been created called Workflows:
+If we go back to the GitHub repository we can see that a new folder have been created called Workflows:
 
 ![Workflows](<../../../../10/umbraco-deploy/getting-started/images/workflows (1).png>)
 
@@ -138,7 +138,7 @@ As well as enabling Unattended install in the **appsettings.json** file so Umbra
 
 Before the build can work, we will need to set up our generated API key to work with the build server in GitHub Actions.
 
-1. Open your Github repository.
+1. Open your GitHub repository.
 2. Navigate to Settings.
 3. Go to the Secrets tab.
 4. Select "New repository secret".
@@ -148,7 +148,7 @@ Before the build can work, we will need to set up our generated API key to work 
 
 We can now go ahead and commit the configured YAML file and push up all the files to the repository.
 
-Go to Github where you will now be able to see that the CI/CD build has started running:
+Go to GitHub where you will now be able to see that the CI/CD build has started running:
 
 ![Deployment build started](<../../../../10/umbraco-deploy/getting-started/images/Deploying-meta-data (1).png>)
 
@@ -158,7 +158,7 @@ The build server will go through the steps in the YAML file, and once it is done
 
 You can now start creating content on the local machine. Once you create something like a Document Type, the changes will get picked up in Git.
 
-When you're done making changes, commit them and deploy them to Github. The build server will run and extract the changes into the website in Azure.
+When you're done making changes, commit them and deploy them to GitHub. The build server will run and extract the changes into the website in Azure.
 
 This will only deploy the schema data for our local site to your website.
 

--- a/14/umbraco-deploy/getting-started/get-started-with-deploy.md
+++ b/14/umbraco-deploy/getting-started/get-started-with-deploy.md
@@ -14,7 +14,7 @@ These items are entities like Document Types, Media Types, Data Types, etc, and 
 
 For example, when working locally you might create a new Document Type. This will automatically create a new on-disk file in the `umbraco/Deploy/Revision` folder which is the serialized version of the new Document Type. You would then commit this file to your repository and push this change to your hosted source control (for example GitHub).
 
-When you want this deployed to your next environment, you would trigger your CI/CD process (for example Azure DevOps or Github Actions). This will push the changes to your environment. Once the build deployment completes successfully, a Deployment Trigger would be executed as an HTTPS request to your target environment. All changes found in the `umbraco/Deploy/Revision` folder will then be extracted into the Umbraco target environment.
+When you want this deployed to your next environment, you would trigger your CI/CD process (for example Azure DevOps or GitHub Actions). This will push the changes to your environment. Once the build deployment completes successfully, a Deployment Trigger would be executed as an HTTPS request to your target environment. All changes found in the `umbraco/Deploy/Revision` folder will then be extracted into the Umbraco target environment.
 
 ![Deploy workflow](../images/Deploy_concept.png)
 

--- a/14/umbraco-deploy/installation/install-configure.md
+++ b/14/umbraco-deploy/installation/install-configure.md
@@ -24,7 +24,7 @@ Here we will cover how to install and set up Umbraco Deploy on a new website.
 
 **Set up the Git repository and Umbraco project**
 
-The first step to get Umbraco Deploy up and running is to set up a GitHub repository. This will be where source code is stored, and, following the GitHub actions example, act as our environment where we will set up a CI/CD pipeline.
+The first step to get Umbraco Deploy up and running is to set up a GitHub repository. This will be where source code is stored, and, following the GitHub Actions example, act as our environment where we will set up a CI/CD pipeline.
 
 1. Using the Visual Studio template, set up a GitHub repository with a .gitignore file.
 2. Clone down the repository to your local machine.

--- a/14/umbraco-deploy/installation/install-configure.md
+++ b/14/umbraco-deploy/installation/install-configure.md
@@ -26,7 +26,7 @@ Here we will cover how to install and set up Umbraco Deploy on a new website.
 
 The first step to get Umbraco Deploy up and running is to set up a GitHub repository. This will be where source code is stored, and, following the GitHub actions example, act as our environment where we will set up a CI/CD pipeline.
 
-1. Using the Visual Studio template, set up a Github repository with a .gitignore file.
+1. Using the Visual Studio template, set up a GitHub repository with a .gitignore file.
 2. Clone down the repository to your local machine.
 3. Create a new Umbraco project.
 4. Run the project.

--- a/14/umbraco-deploy/release-notes.md
+++ b/14/umbraco-deploy/release-notes.md
@@ -116,4 +116,4 @@ This section contains the release notes for Umbraco Deploy 14 including all chan
 
 ## Legacy release notes
 
-You can find the release notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/release-notes.md) and [Umbraco Deploy Package page](https://our.umbraco.com/packages/developer-tools/umbraco-deploy/)
+You can find the release notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/release-notes.md) and [Umbraco Deploy Package page](https://our.umbraco.com/packages/developer-tools/umbraco-deploy/)

--- a/14/umbraco-deploy/upgrades/version-specific.md
+++ b/14/umbraco-deploy/upgrades/version-specific.md
@@ -108,4 +108,4 @@ The setting `TransferFormsAsContent` has moved to `FormsDeploySettings` in the F
 * Umbraco CMS dependency was updated to `14.0.0`.
 
 ## Legacy version specific upgrade notes
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/upgrades/version-specific.md).
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/upgrades/version-specific.md).

--- a/14/umbraco-forms/release-notes.md
+++ b/14/umbraco-forms/release-notes.md
@@ -192,4 +192,4 @@ Please ensure to check the rendering of these features on website forms after th
 
 ## Legacy release notes
 
-You can find the release notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/release-notes.md) and [Umbraco Forms Package page](https://our.umbraco.com/packages/developer-tools/umbraco-forms/).
+You can find the release notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/release-notes.md) and [Umbraco Forms Package page](https://our.umbraco.com/packages/developer-tools/umbraco-forms/).

--- a/14/umbraco-forms/upgrading/version-specific.md
+++ b/14/umbraco-forms/upgrading/version-specific.md
@@ -49,4 +49,4 @@ The following updates describe the more significant changes to the codebase and 
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/installation/version-specific.md).
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/installation/version-specific.md).

--- a/14/umbraco-ui-builder/release-notes.md
+++ b/14/umbraco-ui-builder/release-notes.md
@@ -26,4 +26,4 @@ You can read more about the new Backoffice [in the Umbraco CMS documentation](ht
 
 ## Legacy release notes
 
-You can find the release notes for **Konstrukt** in the [Change log file on Github](changelog-archive/changelog.md).
+You can find the release notes for **Konstrukt** in the [Change log file on GitHub](changelog-archive/changelog.md).

--- a/14/umbraco-ui-builder/upgrading/version-specific.md
+++ b/14/umbraco-ui-builder/upgrading/version-specific.md
@@ -19,4 +19,4 @@ See the [Migrate from Konstrukt to Umbraco UI Builder guide](./migrating-from-ko
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;

--- a/14/umbraco-workflow/release-notes.md
+++ b/14/umbraco-workflow/release-notes.md
@@ -70,4 +70,4 @@ This section contains the release notes for Umbraco Workflow 14 including all ch
 
 ## Legacy release notes
 
-You can find the release notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-workflow/release-notes.md)
+You can find the release notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-workflow/release-notes.md)

--- a/14/umbraco-workflow/upgrading/version-specific.md
+++ b/14/umbraco-workflow/upgrading/version-specific.md
@@ -40,4 +40,4 @@ Workflow 14 includes a non-trivial number of breaking code changes, primarily re
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).

--- a/15/umbraco-cms/customizing/foundation/icons.md
+++ b/15/umbraco-cms/customizing/foundation/icons.md
@@ -1,3 +1,3 @@
 # Icons
 
-The icons from the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for getting the icons starts with`icon-`. You can find the list of all icons in the [Icon registry list on Github](https://github.com/umbraco/Umbraco.CMS.Backoffice/tree/762e43b2f49ca483df9cfe28de20f31ca07bb22b/src/packages/core/icon-registry/icons).
+The icons from the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for getting the icons starts with`icon-`. You can find the list of all icons in the [Icon registry list on GitHub](https://github.com/umbraco/Umbraco.CMS.Backoffice/tree/762e43b2f49ca483df9cfe28de20f31ca07bb22b/src/packages/core/icon-registry/icons).

--- a/15/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
+++ b/15/umbraco-cms/extending/filesystemproviders/azure-blob-storage.md
@@ -32,7 +32,7 @@ The correct packages will have been installed in your project.
 
 ## Configuring Blob storage
 
-The next step is to configure your blob storage. There are multiple approaches for this, but in this document, we're going to do it through `appsettings.json`. For more configuration options, see the [readme](https://github.com/umbraco/Umbraco.StorageProviders#umbracostorageproviders) on the Github repository.
+The next step is to configure your blob storage. There are multiple approaches for this, but in this document, we're going to do it through `appsettings.json`. For more configuration options, see the [readme](https://github.com/umbraco/Umbraco.StorageProviders#umbracostorageproviders) on the GitHub repository.
 
 Open up your `appsettings.json` file and add the connection string and container name under `Umbraco:Storage:AzureBlob:Media`. Your Umbraco section of appsettings will look something like this:
 

--- a/15/umbraco-cms/extending/packages/creating-a-package.md
+++ b/15/umbraco-cms/extending/packages/creating-a-package.md
@@ -145,7 +145,7 @@ The `Title`, `Description`, `PackageTags` came with the template and we added so
 | ------------------------ | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Version                  | 1.0.0               | This is automatically set to 1.0.0 but can be changed as appropriate.                                                                                                                                       |
 | Authors                  | Your name           | Here you get to take credit for your awesome work!                                                                                                                                                          |
-| PackageProjectUrl        | https://umbraco.com | This URL will be shown as the package's URL when others install it. It will likely be a Github repository, or similar.                                                                                      |
+| PackageProjectUrl        | https://umbraco.com | This URL will be shown as the package's URL when others install it. It will likely be a GitHub repository, or similar.                                                                                      |
 | PackageLicenseExpression | MIT                 | The license is set to MIT. Please consider how you want your package licensed. If in doubt when deciding an open-source license there are [good resources available](https://choosealicense.com/licenses/). |
 
 ### Pack it

--- a/15/umbraco-cms/extending/packages/example-package-repository.md
+++ b/15/umbraco-cms/extending/packages/example-package-repository.md
@@ -44,7 +44,7 @@ Finally there's an [example Umbraco website](https://github.com/umbraco/Umbraco.
 
 As well as the projects, the following files are added to the solution:
 
-- [.artifactignore](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.artifactignore) - used by AzureDevOps services to [control which files are uploaded when you publish](https://learn.microsoft.com/en-us/azure/devops/artifacts/reference/artifactignore?view=azure-devops). This helps to reduce pipeline execution time.
+- [.artifactignore](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.artifactignore) - used by Azure DevOps services to [control which files are uploaded when you publish](https://learn.microsoft.com/en-us/azure/devops/artifacts/reference/artifactignore?view=azure-devops). This helps to reduce pipeline execution time.
 - [.editorconfig](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.editorconfig) - used to [enforce consistent coding styles](https://editorconfig.org/) for multiple developers working on the same project across editors and IDEs.
 - [.gitignore](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.gitignore) - controls which files are added to source control.
 - [.globalconfig](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/.globalconfig) - provides [further styling rules for the project files, even if stored outside of the project directory](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files#global-analyzerconfig).
@@ -58,7 +58,7 @@ As well as the projects, the following files are added to the solution:
 
 ## Build and Deployment
 
-We use AzureDevOps pipelines for continuous integration and releasing new versions of the package. The definition of how the project is built is defined in a `.yaml` file that's part of the source code repository.
+We use Azure DevOps pipelines for continuous integration and releasing new versions of the package. The definition of how the project is built is defined in a `.yaml` file that's part of the source code repository.
 
 The file can be found [here](https://github.com/umbraco/Umbraco.AuthorizedServices/blob/main/azure-pipeline%20-%20Umbraco.AuthorizedServices.yml).
 
@@ -68,13 +68,13 @@ Even if using another tool it may be worth reviewing how we have setup our pipel
 
 The build consists of two stages: building the solution and running unit tests. Only if both succeed is the build as a whole considered successful.
 
-![AzureDevOps build pipeline](../../../../10/umbraco-cms/extending/packages/images/azuredevops-build.png)
+![Azure DevOps build pipeline](../../../../10/umbraco-cms/extending/packages/images/azuredevops-build.png)
 
 ### Releasing the Package
 
-We release the package manually in AzureDevOps, with a two stage process. Firstly we release to a "pre-releases" feed, and then after manual approval, to NuGet.
+We release the package manually in Azure DevOps, with a two stage process. Firstly we release to a "pre-releases" feed, and then after manual approval, to NuGet.
 
-![AzureDevOps release pipeline](../../../../10/umbraco-cms/extending/packages/images/azuredevops-release.png)
+![Azure DevOps release pipeline](../../../../10/umbraco-cms/extending/packages/images/azuredevops-release.png)
 
 
 

--- a/15/umbraco-cms/fundamentals/backoffice/login.md
+++ b/15/umbraco-cms/fundamentals/backoffice/login.md
@@ -71,7 +71,7 @@ This will override the default greetings with the ones you provide. The login sc
 The login screen has its own set of localization files independent of the rest of the Backoffice. You can read more about Backoffice localization in the [UI Localization](../../customizing/ui-localization.md) article.
 {% endhint %}
 
-You can customize other text on the login screen as well. First, grab the default values and keys from the [en.ts](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Web.UI.Login/src/localization/lang/en.ts) in the Umbraco CMS Github repository. Thereafter copy the ones you want to translate into `~/App_Plugins/Login/umbraco-package.json` file.
+You can customize other text on the login screen as well. First, grab the default values and keys from the [en.ts](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Web.UI.Login/src/localization/lang/en.ts) in the Umbraco CMS GitHub repository. Thereafter copy the ones you want to translate into `~/App_Plugins/Login/umbraco-package.json` file.
 
 ## Password reset
 
@@ -210,7 +210,7 @@ The following CSS properties are available for customization:
 | `--umb-login-curves-color`               | The color of the curves                        | `#f5c1bc`                                                                                  |
 | `--umb-login-curves-display`             | The display of the curves                      | `inline`                                                                                   |
 
-The CSS custom properties may change in future versions of Umbraco. You can always find the latest values in the [login layout element](https://github.com/umbraco/Umbraco-CMS/blob/v14/dev/src/Umbraco.Web.UI.Login/src/components/layouts/auth-layout.element.ts) in the Umbraco CMS Github repository.
+The CSS custom properties may change in future versions of Umbraco. You can always find the latest values in the [login layout element](https://github.com/umbraco/Umbraco-CMS/blob/v14/dev/src/Umbraco.Web.UI.Login/src/components/layouts/auth-layout.element.ts) in the Umbraco CMS GitHub repository.
 
 ## The Time Out Screen
 

--- a/15/umbraco-cms/reference/security/cookies.md
+++ b/15/umbraco-cms/reference/security/cookies.md
@@ -31,4 +31,4 @@ builder.Services.AddSession(options =>
     });
 ```
 
-For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/Constants-Web.cs) file on Github.
+For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/Constants-Web.cs) file on GitHub.

--- a/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
+++ b/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
@@ -402,7 +402,7 @@ Not enough? Let's try automating this entire thing with GitHub Actions then.
 
 ## Deploy your package using GitHub Actions
 
-If you think back to the beginning when we set up our sites using the Package Templates you may remember that by default you get a GitHub action installed as well.
+When we set up our sites with Package Templates, a GitHub action is installed by default.
 
 If you check out the `~/.github/workflows` folder in your solution, you will see there is a readme file and a build.yml file.
 

--- a/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
+++ b/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
@@ -12,10 +12,10 @@ The content in this article is valid _only_ for Umbraco version 8. For Umbraco v
 * [Creating a test site locally](creating-and-distributing-a-package.md#creating-a-test-site-locally)
 * [Creating a package from the backoffice](creating-and-distributing-a-package.md#creating-a-package-from-the-backoffice)
 * [Creating a draft package on Our](creating-and-distributing-a-package.md#creating-a-draft-package-on-our)
-* [Pushing your package to Github](creating-and-distributing-a-package.md#pushing-your-package-to-github)
+* [Pushing your package to GitHub](creating-and-distributing-a-package.md#pushing-your-package-to-github)
 * [Pack up your package locally using UmbPack](creating-and-distributing-a-package.md#pack-up-your-package-locally-using-umbpack)
 * [Pushing your package to Our using UmbPack](creating-and-distributing-a-package.md#pushing-your-package-to-our-using-umbpack)
-* [Deploy your package using Github Actions](creating-and-distributing-a-package.md#deploy-your-package-using-github-actions)
+* [Deploy your package using GitHub Actions](creating-and-distributing-a-package.md#deploy-your-package-using-github-actions)
 * [Archive older versions on push](creating-and-distributing-a-package.md#archive-older-versions-on-push)
 
 ## Prerequisites
@@ -23,7 +23,7 @@ The content in this article is valid _only_ for Umbraco version 8. For Umbraco v
 To run this tutorial you will need the following:
 
 * Be able to run an Umbraco site locally
-* Git + Github account
+* Git + GitHub account
 * [Our Umbraco member account](https://our.umbraco.com/member/Signup) with access to upload packages
 * UmbPack installed
 * Umbraco Package templates installed
@@ -60,7 +60,7 @@ It will show you all the options you have for creating a new Umbraco site + pack
 dotnet new umbraco-v8-package -n PackageWorkshop -d
 ```
 
-This will create a new package called `PackageWorkshop`, and add a custom Dashboard for us to use in this tutorial. By default you will also get a Github Action added that we will return to later.
+This will create a new package called `PackageWorkshop`, and add a custom Dashboard for us to use in this tutorial. By default you will also get a GitHub Action added that we will return to later.
 
 After running you will have a folder called `PackageWorkshop`, inside that you will have your site and solution files. So try to open it in Visual Studio or Rider by opening the `PackageWorkshop.sln` file.
 
@@ -233,13 +233,13 @@ Now your package is on Our, and if the "Go live" button is clicked it is visible
 
 The next step is to make it a bit simpler to deploy updates to the package. It is perfectly fine to log in here and upload a new version each time. The next steps will show an easier way though.
 
-## Pushing your package to Github
+## Pushing your package to GitHub
 
 If you are creating a package in order to share it with others it is a great idea to also share the source code. It is the open source way.
 
-To share it, and make it easier to manage and deploy updates we will set up a Github repository for the package. This tutorial assumes you know what Github is, and that you have an account.
+To share it, and make it easier to manage and deploy updates we will set up a GitHub repository for the package. This tutorial assumes you know what GitHub is, and that you have an account.
 
-Create a fresh repo, with no readme, gitignore or license - do not choose a repository template (set to 'No Template'). On the second screen it will give you a command to push an existing repository to the new Github repo, should look like this but with your own user in the link:
+Create a fresh repo, with no readme, gitignore or license - do not choose a repository template (set to 'No Template'). On the second screen it will give you a command to push an existing repository to the new GitHub repo, should look like this but with your own user in the link:
 
 ```
 git remote add origin https://github.com/jmayntzhusen/package-workshop.git
@@ -256,7 +256,7 @@ git add .
 git commit -m "Initial commit, dashboard package"
 ```
 
-At this point you have your solution in a local git repository, and we can then use the command from Github to push it up:
+At this point you have your solution in a local git repository, and we can then use the command from GitHub to push it up:
 
 ```
 git remote add origin https://github.com/jmayntzhusen/package-workshop.git
@@ -264,18 +264,18 @@ git branch -M main
 git push -u origin main
 ```
 
-Now you have it all on Github:
+Now you have it all on GitHub:
 
-![Github repo](images/github-repo.png)
+![GitHub repo](images/github-repo.png)
 
 ## Pack up your package locally using UmbPack
 
-At this point you know how to create a package from the backoffice, upload it to Our and push your changes to Github. That's what it takes to create and maintain a package.
+At this point you know how to create a package from the backoffice, upload it to Our and push your changes to GitHub. That's what it takes to create and maintain a package.
 
 If you want to make changes and push a new version you can carry out the following steps:
 
 * Create the new package in the backoffice
-* Sync your code to Github
+* Sync your code to GitHub
 * Go to Our and upload a new zip version
 * Set that to the current version
 * Optionally archive the previous one
@@ -398,15 +398,15 @@ You can edit all of these defaults, and also specify older versions of your pack
 
 So at this point we can work on our package locally, build a new version within seconds by running the pack command and then deploy it to Our using the push command.
 
-Not easy enough for you? Let's try automating this entire thing with Github actions then.
+Not easy enough for you? Let's try automating this entire thing with GitHub actions then.
 
-## Deploy your package using Github Actions
+## Deploy your package using GitHub Actions
 
-If you think back to the beginning when we set up our sites using the Package Templates you may remember that by default you get a Github action installed as well.
+If you think back to the beginning when we set up our sites using the Package Templates you may remember that by default you get a GitHub action installed as well.
 
 If you check out the `~/.github/workflows` folder in your solution, you will see there is a readme file and a build.yml file.
 
-The build.yml file is used by Github actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
+The build.yml file is used by GitHub actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
 
 The build.yml file contains several things, let's have a quick overview:
 
@@ -432,9 +432,9 @@ The action that it performs is what is under `jobs:build:steps`. There is a step
 It sets the version of the package to be what we've set in the release tag based on a previous step.
 {% endhint %}
 
-Below this there is another step to push the package to Our, which again is like our approach locally - except now we add the API key as a Github secret so it's not public to everyone.
+Below this there is another step to push the package to Our, which again is like our approach locally - except now we add the API key as a GitHub secret so it's not public to everyone.
 
-![Github secret](images/gh-secret.png)
+![GitHub secret](images/gh-secret.png)
 
 ```yml
 - name: Push to Our
@@ -443,7 +443,7 @@ Below this there is another step to push the package to Our, which again is like
 
 With these 2 commands and a few previous ones setting up the prerequisite build and nuget tools it is now ready to be fully automated.
 
-Ensure you have set a Github secret with the name `UMBRACO_DEPLOY_KEY` and the value of the key from Our, and then go to your local solution and uncomment the UmbPack push command in the \~/.github/workflows/build.yml file.
+Ensure you have set a GitHub secret with the name `UMBRACO_DEPLOY_KEY` and the value of the key from Our, and then go to your local solution and uncomment the UmbPack push command in the \~/.github/workflows/build.yml file.
 
 Then make sure it is added and committed locally:
 
@@ -453,14 +453,14 @@ git commit -m "Enable umbpack push in GH action"
 git push
 ```
 
-Your solution and Github repo are now in sync, and the umbpack commands in the Github action are enabled and ready to run. Final step is to create a release tag and push it to Github:
+Your solution and GitHub repo are now in sync, and the umbpack commands in the GitHub action are enabled and ready to run. Final step is to create a release tag and push it to GitHub:
 
 ```
 git tag release/1.0.0
 git push origin release/1.0.0
 ```
 
-At this point you can go to Github and visit the Action tab to see your Github action run. When it's completed successfully you can go to your package overview on Our and see the package there.
+At this point you can go to GitHub and visit the Action tab to see your GitHub action run. When it's completed successfully you can go to your package overview on Our and see the package there.
 
 ## Archive older versions on push
 

--- a/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
+++ b/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
@@ -406,7 +406,7 @@ When we set up our sites with Package Templates, a GitHub action is installed by
 
 If you check out the `~/.github/workflows` folder in your solution, you will see there is a readme file and a build.yml file.
 
-The build.yml file is used by GitHub Actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
+The build.yml file is used by GitHub Actions, which will perform some tasks for you when certain criteria are met. If you’re new to continuous integration and deployment (CI/CD), we’ll go through the commands together.
 
 The build.yml file contains several things, let's have a quick overview:
 

--- a/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
+++ b/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
@@ -432,7 +432,7 @@ The action that it performs is what is under `jobs:build:steps`. There is a step
 It sets the version of the package to be what we've set in the release tag based on a previous step.
 {% endhint %}
 
-Below this there is another step to push the package to Our, which again is like our approach locally - except now we add the API key as a GitHub secret so it's not public to everyone.
+To push the package to Our, we add the API key as a GitHub secret to keep it private.
 
 ![GitHub secret](images/gh-secret.png)
 

--- a/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
+++ b/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
@@ -239,7 +239,7 @@ If you are creating a package in order to share it with others it is a great ide
 
 To share it, and make it easier to manage and deploy updates we will set up a GitHub repository for the package. This tutorial assumes you know what GitHub is, and that you have an account.
 
-Create a fresh repo, with no readme, gitignore or license - do not choose a repository template (set to 'No Template'). On the second screen it will give you a command to push an existing repository to the new GitHub repo, should look like this but with your own user in the link:
+Create a fresh repo, with no readme, gitignore or license - do not choose a repository template (set to 'No Template'). The second screen will provide a command to push an existing repository to your new GitHub repo. It will look like this but with your own username in the link:
 
 ```
 git remote add origin https://github.com/jmayntzhusen/package-workshop.git

--- a/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
+++ b/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
@@ -398,7 +398,7 @@ You can edit all of these defaults, and also specify older versions of your pack
 
 So at this point we can work on our package locally, build a new version within seconds by running the pack command and then deploy it to Our using the push command.
 
-Not easy enough for you? Let's try automating this entire thing with GitHub actions then.
+Not easy enough for you? Let's try automating this entire thing with GitHub Actions then.
 
 ## Deploy your package using GitHub Actions
 
@@ -406,7 +406,7 @@ If you think back to the beginning when we set up our sites using the Package Te
 
 If you check out the `~/.github/workflows` folder in your solution, you will see there is a readme file and a build.yml file.
 
-The build.yml file is used by GitHub actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
+The build.yml file is used by GitHub Actions, which will perform some tasks for you when certain criteria are met. If you haven't worked with continuous integration and deployment (CI/CD) before, then this may seem like magic - but don't worry we will run through the commands.
 
 The build.yml file contains several things, let's have a quick overview:
 

--- a/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
+++ b/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
@@ -443,7 +443,7 @@ To push the package to Our, we add the API key as a GitHub secret to keep it pri
 
 With these 2 commands and a few previous ones setting up the prerequisite build and nuget tools it is now ready to be fully automated.
 
-Ensure you have set a GitHub secret with the name `UMBRACO_DEPLOY_KEY` and the value of the key from Our, and then go to your local solution and uncomment the UmbPack push command in the \~/.github/workflows/build.yml file.
+Ensure you have set a GitHub secret with the name `UMBRACO_DEPLOY_KEY` and the value of the key from Our. Go to your local solution and uncomment the UmbPack push command in the \~/.github/workflows/build.yml file.
 
 Then make sure it is added and committed locally:
 

--- a/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
+++ b/15/umbraco-cms/tutorials/creating-and-distributing-a-package.md
@@ -398,7 +398,7 @@ You can edit all of these defaults, and also specify older versions of your pack
 
 So at this point we can work on our package locally, build a new version within seconds by running the pack command and then deploy it to Our using the push command.
 
-Not easy enough for you? Let's try automating this entire thing with GitHub Actions then.
+Not enough? Let's try automating this entire thing with GitHub Actions then.
 
 ## Deploy your package using GitHub Actions
 

--- a/15/umbraco-commerce/release-notes/README.md
+++ b/15/umbraco-commerce/release-notes/README.md
@@ -25,4 +25,4 @@ Read the [v15.0.0-rc release post](./v15.0.0-rc.md) for further background on th
 
 ## Legacy release notes
 
-You can find the release notes for **Vendr** in the [Change log file on Github](changelog-archive/Vendr-core.md).
+You can find the release notes for **Vendr** in the [Change log file on GitHub](changelog-archive/Vendr-core.md).

--- a/15/umbraco-commerce/upgrading/version-specific-upgrades.md
+++ b/15/umbraco-commerce/upgrading/version-specific-upgrades.md
@@ -25,4 +25,4 @@ See the [Migrate from Vendr to Umbraco Commerce guide](migrate-from-vendr-to-umb
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;

--- a/15/umbraco-deploy/SUMMARY.md
+++ b/15/umbraco-deploy/SUMMARY.md
@@ -20,7 +20,7 @@
 * [Getting started](getting-started/get-started-with-deploy.md)
 * [CI/CD Build and Deployment Pipeline](getting-started/cicd-pipeline/README.md)
   * [Azure DevOps](getting-started/cicd-pipeline/ci-cd-azure-dev-ops.md)
-  * [GitHub actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
+  * [GitHub Actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
 * [Streamlining Local Development](getting-started/streamlining-local-development.md)
 * [Configuration](getting-started/deploy-settings.md)
 

--- a/15/umbraco-deploy/SUMMARY.md
+++ b/15/umbraco-deploy/SUMMARY.md
@@ -20,7 +20,7 @@
 * [Getting started](getting-started/get-started-with-deploy.md)
 * [CI/CD Build and Deployment Pipeline](getting-started/cicd-pipeline/README.md)
   * [Azure DevOps](getting-started/cicd-pipeline/ci-cd-azure-dev-ops.md)
-  * [Github actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
+  * [GitHub actions](getting-started/cicd-pipeline/ci-cd-github-actions.md)
 * [Streamlining Local Development](getting-started/streamlining-local-development.md)
 * [Configuration](getting-started/deploy-settings.md)
 

--- a/15/umbraco-deploy/deployment-workflow/README.md
+++ b/15/umbraco-deploy/deployment-workflow/README.md
@@ -18,7 +18,7 @@ Umbraco Deploy uses a two-part deployment approach where we keep meta data (Docu
 
 In summary:
 
-1. Meta data such as Document Types, Templates, Forms, Views and config files are stored in a repository and are **deployed** between environments. This can be achieved using a CI/CD deployment pipeline with something like Github Actions or Azure DevOps.
+1. Meta data such as Document Types, Templates, Forms, Views and config files are stored in a repository and are **deployed** between environments. This can be achieved using a CI/CD deployment pipeline with something like GitHub Actions or Azure DevOps.
 2. Content and Media items are **not** stored in the repository. These need to be **transferred** directly from the Umbraco backoffice using the _"Queue for Transfer"_ option. Once a content editor has all the items needed for a transfer they will use the Deployment Dashboard in the Content section to transfer the items in the queue.
 
 ### Deploying meta data

--- a/15/umbraco-deploy/getting-started/cicd-pipeline/README.md
+++ b/15/umbraco-deploy/getting-started/cicd-pipeline/README.md
@@ -12,7 +12,7 @@ The build server will extract the changes that has been pushed to the repository
 
 This is something that can be done in many different ways depending on where your website is hosted and your setup.
 
-Umbraco Deploy does not require the use of any particular build or deployment tools and hence we expect that you should be able to continue using the tool or tools of your choice. Any that have support for .NET website deployments and the running of Powershell scripts. such as Azure DevOps or Github Actions, would be appropriate.
+Umbraco Deploy does not require the use of any particular build or deployment tools and hence we expect that you should be able to continue using the tool or tools of your choice. Any that have support for .NET website deployments and the running of Powershell scripts. such as Azure DevOps or GitHub Actions, would be appropriate.
 
 Above and beyond the normal steps of a build pipeline for a .NET web application - tasks like NuGet restore, solution build, running of tests etc. - Umbraco Deploy requires three additional steps.
 
@@ -36,9 +36,9 @@ Umbraco Deploy On-Premises also ships with a Powershell script, that when execut
 
 So while it may be possible to have the CI/CD step directly write the file or call the endpoint, so long as the build used supports running Powershell scripts this is the method we’d recommend, as it has some necessary error checking and retry logic built-in.
 
-## [Setting up CI/CD pipeline with Github Actions](ci-cd-github-actions.md)
+## [Setting up CI/CD pipeline with GitHub Actions](ci-cd-github-actions.md)
 
-Details the setup of a CI/CD pipeline using Github Actions.
+Details the setup of a CI/CD pipeline using GitHub Actions.
 
 ## [Setting up CI/CD pipeline with Azure DevOps](ci-cd-azure-dev-ops.md)
 

--- a/15/umbraco-deploy/getting-started/cicd-pipeline/README.md
+++ b/15/umbraco-deploy/getting-started/cicd-pipeline/README.md
@@ -12,7 +12,7 @@ The build server will extract the changes that has been pushed to the repository
 
 This is something that can be done in many different ways depending on where your website is hosted and your setup.
 
-Umbraco Deploy does not require the use of any particular build or deployment tools and hence we expect that you should be able to continue using the tool or tools of your choice. Any that have support for .NET website deployments and the running of Powershell scripts. such as Azure DevOps or GitHub Actions, would be appropriate.
+Umbraco Deploy does not require any specific build or deployment tools. You are free to use the tools of your choice, as long as they support .NET website deployments and can run PowerShell scripts. Examples of suitable tools include Azure DevOps or GitHub Actions.
 
 Above and beyond the normal steps of a build pipeline for a .NET web application - tasks like NuGet restore, solution build, running of tests etc. - Umbraco Deploy requires three additional steps.
 

--- a/15/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
+++ b/15/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
@@ -4,7 +4,7 @@ description: >-
   Deploy using GitHub Actions.
 ---
 
-# GitHub actions
+# GitHub Actions
 
 {% hint style="info" %}
 In this example we will show how you can set up a CI/CD build server using GitHub Actions in Azure Web Apps.

--- a/15/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
+++ b/15/umbraco-deploy/getting-started/cicd-pipeline/ci-cd-github-actions.md
@@ -4,10 +4,10 @@ description: >-
   Deploy using GitHub Actions.
 ---
 
-# Github actions
+# GitHub actions
 
 {% hint style="info" %}
-In this example we will show how you can set up a CI/CD build server using Github Actions in Azure Web Apps.
+In this example we will show how you can set up a CI/CD build server using GitHub Actions in Azure Web Apps.
 
 We will not cover how you can set up the site itself as this is beyond this documentation.
 {% endhint %}
@@ -18,15 +18,15 @@ The following steps will take you through setting up a build server in Azure Web
 
 ![Azure deployments](<../../../../10/umbraco-deploy/getting-started/images/Deployment-center (1) (1).png>)
 
-In the Deployment Center we can set up the CI/CD build server. With this example we are going to set up our build server by using Github Actions. It is possible to set up the build server however you want as long as it supports executing powershell scripts.
+In the Deployment Center we can set up the CI/CD build server. With this example we are going to set up our build server by using GitHub Actions. It is possible to set up the build server however you want as long as it supports executing powershell scripts.
 
 2. Go to the Settings tab.
 3. Choose which source and build provider to use.
-   * In this case we want to choose Github.
+   * In this case we want to choose GitHub.
 
 ![Build server clean](./images/Build-server-v10.png)
 
-4. Choose the Organization which you created our Github repository under.
+4. Choose the Organization which you created our GitHub repository under.
 5. Choose the repository that was set up earlier in this guide.
 6. Select which branch that we want the build server to build into.
 
@@ -38,9 +38,9 @@ Once the information has been added we can go ahead and preview the YAML file th
 
 7. Save the workflow.
 
-The website and the Github repository are now connected.
+The website and the GitHub repository are now connected.
 
-If we go back to the Github repository we can see that a new folder have been created called Workflows:
+If we go back to the GitHub repository we can see that a new folder have been created called Workflows:
 
 ![Workflows](<../../../../10/umbraco-deploy/getting-started/images/workflows (1).png>)
 
@@ -138,7 +138,7 @@ As well as enabling Unattended install in the **appsettings.json** file so Umbra
 
 Before the build can work, we will need to set up our generated API key to work with the build server in GitHub Actions.
 
-1. Open your Github repository.
+1. Open your GitHub repository.
 2. Navigate to Settings.
 3. Go to the Secrets tab.
 4. Select "New repository secret".
@@ -148,7 +148,7 @@ Before the build can work, we will need to set up our generated API key to work 
 
 We can now go ahead and commit the configured YAML file and push up all the files to the repository.
 
-Go to Github where you will now be able to see that the CI/CD build has started running:
+Go to GitHub where you will now be able to see that the CI/CD build has started running:
 
 ![Deployment build started](<../../../../10/umbraco-deploy/getting-started/images/Deploying-meta-data (1).png>)
 
@@ -158,7 +158,7 @@ The build server will go through the steps in the YAML file, and once it is done
 
 You can now start creating content on the local machine. Once you create something like a Document Type, the changes will get picked up in Git.
 
-When you're done making changes, commit them and deploy them to Github. The build server will run and extract the changes into the website in Azure.
+When you're done making changes, commit them and deploy them to GitHub. The build server will run and extract the changes into the website in Azure.
 
 This will only deploy the schema data for our local site to your website.
 

--- a/15/umbraco-deploy/getting-started/get-started-with-deploy.md
+++ b/15/umbraco-deploy/getting-started/get-started-with-deploy.md
@@ -14,7 +14,7 @@ These items are entities like Document Types, Media Types, Data Types, etc, and 
 
 For example, when working locally you might create a new Document Type. This will automatically create a new on-disk file in the `umbraco/Deploy/Revision` folder which is the serialized version of the new Document Type. You would then commit this file to your repository and push this change to your hosted source control (for example GitHub).
 
-When you want this deployed to your next environment, you would trigger your CI/CD process (for example Azure DevOps or Github Actions). This will push the changes to your environment. Once the build deployment completes successfully, a Deployment Trigger would be executed as an HTTPS request to your target environment. All changes found in the `umbraco/Deploy/Revision` folder will then be extracted into the Umbraco target environment.
+When you want this deployed to your next environment, you would trigger your CI/CD process (for example Azure DevOps or GitHub Actions). This will push the changes to your environment. Once the build deployment completes successfully, a Deployment Trigger would be executed as an HTTPS request to your target environment. All changes found in the `umbraco/Deploy/Revision` folder will then be extracted into the Umbraco target environment.
 
 ![Deploy workflow](../images/Deploy_concept.png)
 

--- a/15/umbraco-deploy/installation/install-configure.md
+++ b/15/umbraco-deploy/installation/install-configure.md
@@ -24,7 +24,7 @@ Here we will cover how to install and set up Umbraco Deploy on a new website.
 
 **Set up the Git repository and Umbraco project**
 
-The first step to get Umbraco Deploy up and running is to set up a GitHub repository. This will be where source code is stored, and, following the GitHub actions example, act as our environment where we will set up a CI/CD pipeline.
+The first step to get Umbraco Deploy up and running is to set up a GitHub repository. This will be where source code is stored, and, following the GitHub Actions example, act as our environment where we will set up a CI/CD pipeline.
 
 1. Using the Visual Studio template, set up a GitHub repository with a .gitignore file.
 2. Clone down the repository to your local machine.

--- a/15/umbraco-deploy/installation/install-configure.md
+++ b/15/umbraco-deploy/installation/install-configure.md
@@ -26,7 +26,7 @@ Here we will cover how to install and set up Umbraco Deploy on a new website.
 
 The first step to get Umbraco Deploy up and running is to set up a GitHub repository. This will be where source code is stored, and, following the GitHub actions example, act as our environment where we will set up a CI/CD pipeline.
 
-1. Using the Visual Studio template, set up a Github repository with a .gitignore file.
+1. Using the Visual Studio template, set up a GitHub repository with a .gitignore file.
 2. Clone down the repository to your local machine.
 3. Create a new Umbraco project.
 4. Run the project.

--- a/15/umbraco-deploy/installation/install-configure.md
+++ b/15/umbraco-deploy/installation/install-configure.md
@@ -24,7 +24,7 @@ Here we will cover how to install and set up Umbraco Deploy on a new website.
 
 **Set up the Git repository and Umbraco project**
 
-The first step to get Umbraco Deploy up and running is to set up a GitHub repository. This will be where source code is stored, and, following the GitHub Actions example, act as our environment where we will set up a CI/CD pipeline.
+The first step to get Umbraco Deploy up and running is to set up a GitHub repository. This will store the source code and serve as our environment for setting up a CI/CD pipeline, following the GitHub Actions example.
 
 1. Using the Visual Studio template, set up a GitHub repository with a .gitignore file.
 2. Clone down the repository to your local machine.

--- a/15/umbraco-deploy/release-notes.md
+++ b/15/umbraco-deploy/release-notes.md
@@ -79,4 +79,4 @@ This section contains the release notes for Umbraco Deploy 15 including all chan
 
 ## Legacy release notes
 
-You can find the release notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/release-notes.md) and [Umbraco Deploy Package page](https://our.umbraco.com/packages/developer-tools/umbraco-deploy/)
+You can find the release notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/release-notes.md) and [Umbraco Deploy Package page](https://our.umbraco.com/packages/developer-tools/umbraco-deploy/)

--- a/15/umbraco-deploy/upgrades/version-specific.md
+++ b/15/umbraco-deploy/upgrades/version-specific.md
@@ -50,4 +50,4 @@ builder.Services.AddHttpClient<DeployHttpClient>().ConfigurePrimaryHttpMessageHa
 
 ## Legacy version-specific upgrade notes
 
-You can find the version-specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/upgrades/version-specific.md).
+You can find the version-specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/upgrades/version-specific.md).

--- a/15/umbraco-forms/release-notes.md
+++ b/15/umbraco-forms/release-notes.md
@@ -93,4 +93,4 @@ This Deploy add-on adds support for transferring, restoring, exporting and impor
 
 ## Legacy release notes
 
-You can find the release notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/12/umbraco-forms/release-notes.md) and [Umbraco Forms Package page](https://our.umbraco.com/packages/developer-tools/umbraco-forms/).
+You can find the release notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/12/umbraco-forms/release-notes.md) and [Umbraco Forms Package page](https://our.umbraco.com/packages/developer-tools/umbraco-forms/).

--- a/15/umbraco-forms/upgrading/version-specific.md
+++ b/15/umbraco-forms/upgrading/version-specific.md
@@ -54,4 +54,4 @@ For reference, the full details are listed here:
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/installation/version-specific.md).
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/installation/version-specific.md).

--- a/15/umbraco-ui-builder/release-notes.md
+++ b/15/umbraco-ui-builder/release-notes.md
@@ -20,4 +20,4 @@ This section contains the release notes for Umbraco UI Builder 14 including all 
 
 ## Legacy release notes
 
-You can find the release notes for **Konstrukt** in the [Change log file on Github](changelog-archive/changelog.md).
+You can find the release notes for **Konstrukt** in the [Change log file on GitHub](changelog-archive/changelog.md).

--- a/15/umbraco-ui-builder/upgrading/version-specific.md
+++ b/15/umbraco-ui-builder/upgrading/version-specific.md
@@ -19,4 +19,4 @@ See the [Migrate from Konstrukt to Umbraco UI Builder guide](./migrating-from-ko
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;

--- a/15/umbraco-workflow/release-notes.md
+++ b/15/umbraco-workflow/release-notes.md
@@ -32,4 +32,4 @@ This section contains the release notes for Umbraco Workflow 15 including all ch
 
 ## Legacy release notes
 
-You can find the release notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-workflow/release-notes.md)
+You can find the release notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-workflow/release-notes.md)

--- a/15/umbraco-workflow/upgrading/version-specific.md
+++ b/15/umbraco-workflow/upgrading/version-specific.md
@@ -40,4 +40,4 @@ Workflow 14 includes a non-trivial number of breaking code changes, primarily re
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on Github](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).
+You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).

--- a/commerce-add-ons/packages/checkout/release-notes.md
+++ b/commerce-add-ons/packages/checkout/release-notes.md
@@ -5,7 +5,7 @@ In this section, we have summarized the changes to Checkout package for Umbraco 
 If there are any breaking changes or other issues to be aware of when upgrading they are also noted here.
 
 {% hint style="info" %}
-For details of releases for **Checkout package for Vendr**, refer to the [Change log file on Github](../../changelog-archive/package-checkout.md).
+For details of releases for **Checkout package for Vendr**, refer to the [Change log file on GitHub](../../changelog-archive/package-checkout.md).
 {% endhint %}
 
 ## Release History

--- a/commerce-add-ons/packages/deploy/release-notes.md
+++ b/commerce-add-ons/packages/deploy/release-notes.md
@@ -5,7 +5,7 @@ In this section, we have summarized the changes to Deploy package for Umbraco Co
 If there are any breaking changes or other issues to be aware of when upgrading they are also noted here.
 
 {% hint style="info" %}
-For details of releases for **Deploy package for Vendr**, refer to the [Change log file on Github](../../changelog-archive/package-deploy.md).
+For details of releases for **Deploy package for Vendr**, refer to the [Change log file on GitHub](../../changelog-archive/package-deploy.md).
 {% endhint %}
 
 ## Release History

--- a/commerce-add-ons/payment-providers/buckaroo/release-notes.md
+++ b/commerce-add-ons/payment-providers/buckaroo/release-notes.md
@@ -10,7 +10,7 @@ In this section, you can find the release notes for each version of Buckaroo Pay
 
 #### Version 13.1.0 and above
 
-* For details of changes for v13.1.0 and above for **Buckaroo Payment Provider for Umbraco Commerce**, refer to the [Releases section on Github](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Buckaroo/releases).&#x20;
+* For details of changes for v13.1.0 and above for **Buckaroo Payment Provider for Umbraco Commerce**, refer to the [Releases section on GitHub](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Buckaroo/releases).&#x20;
 
 **Version 13.0.0 (December 13th 2023)**
 

--- a/commerce-add-ons/payment-providers/klarna/release-notes.md
+++ b/commerce-add-ons/payment-providers/klarna/release-notes.md
@@ -10,7 +10,7 @@ In this section, you can find the release notes for each version of Klarna Payme
 
 #### Version 12 and above
 
-* For details of changes for v12 and above for **Klarna Payment Provider for Umbraco Commerce**, refer to the [Releases section on Github](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Klarna/releases).&#x20;
+* For details of changes for v12 and above for **Klarna Payment Provider for Umbraco Commerce**, refer to the [Releases section on GitHub](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Klarna/releases).&#x20;
 
 #### Version [**10.0.1 (January 12th 2024)**](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Klarna/issues?q=label%3Arelease%2F10.0.1+)
 
@@ -23,4 +23,4 @@ In this section, you can find the release notes for each version of Klarna Payme
 
 ## Legacy release notes
 
-You can find the release notes for **Klarna Payment Provider for Vendr** in the [Change log file on Github](../../changelog-archive/klarna.md).
+You can find the release notes for **Klarna Payment Provider for Vendr** in the [Change log file on GitHub](../../changelog-archive/klarna.md).

--- a/commerce-add-ons/payment-providers/mollie/release-notes.md
+++ b/commerce-add-ons/payment-providers/mollie/release-notes.md
@@ -10,7 +10,7 @@ In this section, you can find the release notes for each version of Mollie Payme
 
 #### Version 12 and above
 
-* For details of changes for v12 and above for **Mollie Payment Provider for Umbraco Commerce**, refer to the [Releases section on Github](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Mollie/releases).&#x20;
+* For details of changes for v12 and above for **Mollie Payment Provider for Umbraco Commerce**, refer to the [Releases section on GitHub](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Mollie/releases).&#x20;
 
 #### Version 10 **(July 5th 2023)**
 
@@ -18,4 +18,4 @@ In this section, you can find the release notes for each version of Mollie Payme
 
 ## Legacy release notes
 
-You can find the release notes for **Mollie Payment Provider for Vendr** in the [Change log file on Github](../../changelog-archive/mollie.md).
+You can find the release notes for **Mollie Payment Provider for Vendr** in the [Change log file on GitHub](../../changelog-archive/mollie.md).

--- a/commerce-add-ons/payment-providers/nets/release-notes.md
+++ b/commerce-add-ons/payment-providers/nets/release-notes.md
@@ -10,7 +10,7 @@ In this section, you can find the release notes for each version of Nets Payment
 
 #### Version 12 and above
 
-* For details of changes for v12 and above for **Nets Payment Provider for Umbraco Commerce**, refer to the [Releases section on Github](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Nets/releases).&#x20;
+* For details of changes for v12 and above for **Nets Payment Provider for Umbraco Commerce**, refer to the [Releases section on GitHub](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Nets/releases).&#x20;
 
 #### Version 10 **(July 5th 2023)**
 
@@ -18,4 +18,4 @@ In this section, you can find the release notes for each version of Nets Payment
 
 ## Legacy release notes
 
-You can find the release notes for **Nets Payment Provider for Vendr** in the [Change log file on Github](../../changelog-archive/nets.md).
+You can find the release notes for **Nets Payment Provider for Vendr** in the [Change log file on GitHub](../../changelog-archive/nets.md).

--- a/commerce-add-ons/payment-providers/opayo/release-notes.md
+++ b/commerce-add-ons/payment-providers/opayo/release-notes.md
@@ -10,7 +10,7 @@ In this section, you can find the release notes for each version of Opayo Paymen
 
 #### Version 12 and above
 
-* For details of changes for v12 and above for **Opayo Payment Provider for Umbraco Commerce**, refer to the [Releases section on Github](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Opayo/releases).&#x20;
+* For details of changes for v12 and above for **Opayo Payment Provider for Umbraco Commerce**, refer to the [Releases section on GitHub](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Opayo/releases).&#x20;
 
 #### Version 10 **(July 5th 2023)**
 

--- a/commerce-add-ons/payment-providers/paypal/release-notes.md
+++ b/commerce-add-ons/payment-providers/paypal/release-notes.md
@@ -10,7 +10,7 @@ In this section, you can find the release notes for each version of PayPal Payme
 
 #### Version 12 and above
 
-* For details of changes for v12 and above for **PayPal Payment Provider for Umbraco Commerce**, refer to the [Releases section on Github](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.PayPal/releases).&#x20;
+* For details of changes for v12 and above for **PayPal Payment Provider for Umbraco Commerce**, refer to the [Releases section on GitHub](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.PayPal/releases).&#x20;
 
 #### Version 10 **(July 5th 2023)**
 
@@ -18,4 +18,4 @@ In this section, you can find the release notes for each version of PayPal Payme
 
 ## Legacy release notes
 
-You can find the release notes for **PayPal Payment Provider for Vendr** in the [Change log file on Github](../../changelog-archive/paypal.md).
+You can find the release notes for **PayPal Payment Provider for Vendr** in the [Change log file on GitHub](../../changelog-archive/paypal.md).

--- a/commerce-add-ons/payment-providers/quickpay/release-notes.md
+++ b/commerce-add-ons/payment-providers/quickpay/release-notes.md
@@ -10,7 +10,7 @@ In this section, you can find the release notes for each version of Quickpay Pay
 
 #### Version 12 and above
 
-* For details of changes for v12 and above for **Quickpay Payment Provider for Umbraco Commerce**, refer to the [Releases section on Github](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Quickpay/releases).&#x20;
+* For details of changes for v12 and above for **Quickpay Payment Provider for Umbraco Commerce**, refer to the [Releases section on GitHub](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Quickpay/releases).&#x20;
 
 #### Version 10 **(July 5th 2023)**
 
@@ -18,4 +18,4 @@ In this section, you can find the release notes for each version of Quickpay Pay
 
 ## Legacy release notes
 
-You can find the release notes for **Quickpay Payment Provider for Vendr** in the [Change log file on Github](../../changelog-archive/quickpay.md).
+You can find the release notes for **Quickpay Payment Provider for Vendr** in the [Change log file on GitHub](../../changelog-archive/quickpay.md).

--- a/commerce-add-ons/payment-providers/stripe/release-notes.md
+++ b/commerce-add-ons/payment-providers/stripe/release-notes.md
@@ -5,7 +5,7 @@ In this section, we have summarized the changes to Stripe Payment Provider for C
 If there are any breaking changes or other issues to be aware of when upgrading they are also noted here.
 
 {% hint style="info" %}
-For details of releases for **Stripe Payment Provider for Vendr**, refer to the [Change log file on Github](../../changelog-archive/stripe.md).
+For details of releases for **Stripe Payment Provider for Vendr**, refer to the [Change log file on GitHub](../../changelog-archive/stripe.md).
 {% endhint %}
 
 ## Release History

--- a/commerce-add-ons/payment-providers/worldpay/release-notes.md
+++ b/commerce-add-ons/payment-providers/worldpay/release-notes.md
@@ -10,7 +10,7 @@ In this section, you can find the release notes for each version of Worldpay Pay
 
 #### Version 12 and above
 
-* For details of changes for v12 and above for **Worldpay Payment Provider for Umbraco Commerce**, refer to the [Releases section on Github](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Worldpay/releases).&#x20;
+* For details of changes for v12 and above for **Worldpay Payment Provider for Umbraco Commerce**, refer to the [Releases section on GitHub](https://github.com/umbraco/Umbraco.Commerce.PaymentProviders.Worldpay/releases).&#x20;
 
 #### Version 10 **(July 5th 2023)**
 

--- a/contributing/SUMMARY.md
+++ b/contributing/SUMMARY.md
@@ -32,7 +32,7 @@
 
 * [How to contribute](ui-library/contributing.md)
 * [Components](ui-library/components.md)
-* [Umbraco.UI on Github](https://github.com/umbraco/Umbraco.UI)
+* [Umbraco.UI on GitHub](https://github.com/umbraco/Umbraco.UI)
 
 ## Backoffice Project
 

--- a/contributing/umbraco-cms/first-issue.md
+++ b/contributing/umbraco-cms/first-issue.md
@@ -87,7 +87,7 @@ You can get in touch with [the core contributors team][core collabs] in multiple
 
 
 [sync fork ext]: http://robots.thoughtbot.com/post/5133345960/keeping-a-git-fork-updated	"Details on keeping a git fork updated"
-[draft prs]: https://github.blog/2019-02-14-introducing-draft-pull-requests/	"Github's blog post providing details on draft pull requests"
+[draft prs]: https://github.blog/2019-02-14-introducing-draft-pull-requests/	"GitHub's blog post providing details on draft pull requests"
 [contrib forum]: https://our.umbraco.com/forum/contributing-to-umbraco-cms/
 [Umbraco CMS repo]: https://github.com/umbraco/Umbraco-CMS
 [up for grabs issues]: https://github.com/umbraco/Umbraco-CMS/issues?q=is%3Aissue+is%3Aopen+label%3Acommunity%2Fup-for-grabs

--- a/umbraco-cloud/set-up/project-settings/umbraco-cicd/Troubleshooting.md
+++ b/umbraco-cloud/set-up/project-settings/umbraco-cicd/Troubleshooting.md
@@ -99,7 +99,7 @@ We currently have a size limit set to 134217728 bytes or about ~128 MB.
 
 Make sure that the package you are trying to upload does not contain anything unnecessary.
 
-You can see an example of how you could zip your repository before uploading it, by referring to our [GitHub](samplecicdpipeline/github-actions.md) or [Azure Devops](samplecicdpipeline/azure-devops.md) samples. 
+You can see an example of how you could zip your repository before uploading it, by referring to our [GitHub](samplecicdpipeline/github-actions.md) or [Azure DevOps](samplecicdpipeline/azure-devops.md) samples. 
 
 ## Deployment failed
 

--- a/umbraco-cloud/set-up/project-settings/umbraco-cicd/Troubleshooting.md
+++ b/umbraco-cloud/set-up/project-settings/umbraco-cicd/Troubleshooting.md
@@ -99,7 +99,7 @@ We currently have a size limit set to 134217728 bytes or about ~128 MB.
 
 Make sure that the package you are trying to upload does not contain anything unnecessary.
 
-You can see an example of how you could zip your repository before uploading it, by referring to our [Github](samplecicdpipeline/github-actions.md) or [Azure Devops](samplecicdpipeline/azure-devops.md) samples. 
+You can see an example of how you could zip your repository before uploading it, by referring to our [GitHub](samplecicdpipeline/github-actions.md) or [Azure Devops](samplecicdpipeline/azure-devops.md) samples. 
 
 ## Deployment failed
 

--- a/umbraco-cloud/set-up/project-settings/umbraco-cicd/samplecicdpipeline/README.md
+++ b/umbraco-cloud/set-up/project-settings/umbraco-cicd/samplecicdpipeline/README.md
@@ -18,7 +18,7 @@ Once you commit your code to Cloud the build pipeline converts your C# code to D
 In Umbraco Cloud only C# code is built, and all frontend artifacts need to be built and committed to the repository.
 {% endhint %}
 
-You can use Azure DevOps as an external repository and with the pipelines, it will automatically keep your Azure Devops source code repository in sync. The sync is done with the git repository of Umbraco Cloud of the development environment.
+You can use Azure DevOps as an external repository and with the pipelines, it will automatically keep your Azure DevOps source code repository in sync. The sync is done with the git repository of Umbraco Cloud of the development environment.
 
 ![UmbracoCloud CI/CD sample pipeline](../../../images/UmbracoCloudCicdSample.png)
 

--- a/umbraco-cloud/set-up/project-settings/umbraco-cicd/samplecicdpipeline/azure-devops.md
+++ b/umbraco-cloud/set-up/project-settings/umbraco-cicd/samplecicdpipeline/azure-devops.md
@@ -22,7 +22,7 @@ You'll need to adapt and integrate the script into your own pipelines to gain th
 
 The sample includes YAML-files and custom Powershell and Bash scripts to interact with the Umbraco Cloud API.
 
-You can get the samples for both `Azure DevOps` and `GitHub Actions` from the [Github repository](https://github.com/umbraco/Umbraco.Cloud.CICDFlow.Samples).
+You can get the samples for both `Azure DevOps` and `GitHub Actions` from the [GitHub repository](https://github.com/umbraco/Umbraco.Cloud.CICDFlow.Samples).
 {% endhint %}
 
 {% hint style="warning" %}

--- a/umbraco-cloud/set-up/project-settings/umbraco-cicd/samplecicdpipeline/github-actions.md
+++ b/umbraco-cloud/set-up/project-settings/umbraco-cicd/samplecicdpipeline/github-actions.md
@@ -22,7 +22,7 @@ You'll need to adapt and integrate the script to fit your pipelines to gain the 
 
 The sample includes YAML files and custom Powershell and Bash scripts to interact with the Umbraco Cloud API.
 
-You can get the samples for both `Azure DevOps` and `GitHub Actions` from the [Github repository](https://github.com/umbraco/Umbraco.Cloud.CICDFlow.Samples).
+You can get the samples for both `Azure DevOps` and `GitHub Actions` from the [GitHub repository](https://github.com/umbraco/Umbraco.Cloud.CICDFlow.Samples).
 {% endhint %}
 
 {% hint style="warning" %}
@@ -58,7 +58,7 @@ git push -u origin --all
 
 Now we can move on to setting up a pipeline.
 
-## Set up Github repository variables
+## Set up GitHub repository variables
 
 The pipeline needs to know which Umbraco Cloud project to deploy to. In order to do this you will need the `Project ID` and the `API Key`. [This article](./#obtaining-the-project-id-and-api-key) describes how to get those values.
 
@@ -90,7 +90,7 @@ jobs:
 ```
 {% endhint %}
 
-Now Github is set up with the needed information to be able to run a deployment back to Umbraco Cloud.
+Now GitHub is set up with the needed information to be able to run a deployment back to Umbraco Cloud.
 
 Next up it setting up the actual pipeline.
 
@@ -216,7 +216,7 @@ You can add your Build and Test jobs between the `cloud-sync` and `cloud-deploym
 
 ### Cloud-sync
 
-The `cloud-sync.yml` shows how you can sync your Github repository with the left-most environment of your Cloud project. In this sample, it accepts any change from the API and applies and commits it back to the branch which triggered the pipeline. However the commit does not trigger the pipeline again.
+The `cloud-sync.yml` shows how you can sync your GitHub repository with the left-most environment of your Cloud project. In this sample, it accepts any change from the API and applies and commits it back to the branch which triggered the pipeline. However the commit does not trigger the pipeline again.
 
 If you don't want the pipeline to commit back to the triggering branch, this is where you need to change the pipeline.
 

--- a/umbraco-heartcore/client-libraries/node-js.md
+++ b/umbraco-heartcore/client-libraries/node-js.md
@@ -76,7 +76,7 @@ content.management.content.create()
 content.management.contentType.all()
 ```
 
-In the examples above, the first methods shows how the Content Management API is called in order to _create new content_ and the second methods gives an example of how to get a list of all available content types. Find a full list of the available methods for the Content Management API on the [sample repository on GitHub](https://github.com/umbraco/Umbraco.Headless.Client.NodeJs#content-management).
+In the examples above, the first method shows how to _create new content_  using the Content Management API. The second method gives an example of how to retrieve a list of all available content types. Find a full list of the available methods for the Content Management API on the [sample repository on GitHub](https://github.com/umbraco/Umbraco.Headless.Client.NodeJs#content-management).
 
 ## References
 

--- a/umbraco-heartcore/client-libraries/node-js.md
+++ b/umbraco-heartcore/client-libraries/node-js.md
@@ -10,9 +10,9 @@ You will have to have Node.js version 10 or above to be able to work with this c
 
 ## Download and install
 
-You can find the Client library on Github: [Umbraco Heartcore Node.js](https://github.com/umbraco/Umbraco.Headless.Client.NodeJs).
+You can find the Client library on GitHub: [Umbraco Heartcore Node.js](https://github.com/umbraco/Umbraco.Headless.Client.NodeJs).
 
-You can either clone or download the Client library from Github or you can install it with npm.
+You can either clone or download the Client library from GitHub or you can install it with npm.
 
 ```
 npm install @umbraco/headless-client
@@ -64,7 +64,7 @@ content.delivery.content.root()
 content.delivery.media.root()
 ```
 
-In the examples above all content / media from the `root` is called. You can also call specific content items by ID or URL, and you can even get related content items by calling e.g. `children()` or `ancestors()`. Find a full list of the available methods for the Content Delivery API on the [sample repository on Github](https://github.com/umbraco/Umbraco.Headless.Client.NodeJs#content-delivery).
+In the examples above all content / media from the `root` is called. You can also call specific content items by ID or URL, and you can even get related content items by calling e.g. `children()` or `ancestors()`. Find a full list of the available methods for the Content Delivery API on the [sample repository on GitHub](https://github.com/umbraco/Umbraco.Headless.Client.NodeJs#content-delivery).
 
 ### Calls to the Content Management API
 
@@ -76,7 +76,7 @@ content.management.content.create()
 content.management.contentType.all()
 ```
 
-In the examples above, the first methods shows how the Content Management API is called in order to _create new content_ and the second methods gives an example of how to get a list of all available content types. Find a full list of the available methods for the Content Management API on the [sample repository on Github](https://github.com/umbraco/Umbraco.Headless.Client.NodeJs#content-management).
+In the examples above, the first methods shows how the Content Management API is called in order to _create new content_ and the second methods gives an example of how to get a list of all available content types. Find a full list of the available methods for the Content Management API on the [sample repository on GitHub](https://github.com/umbraco/Umbraco.Headless.Client.NodeJs#content-management).
 
 ## References
 


### PR DESCRIPTION
## Description

Casing of 'GitHub', as most occurrences didn't use the uppercase H. I've also added this to the Vale brands substitution rule.

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Not relevant.

## Deadline (if relevant)

No deadline.