### PR TITLE
Fix casing of Umb.PropertyEditorUi.Tiptap

### DIFF
--- a/15/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/README.md
+++ b/15/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/README.md
@@ -1,6 +1,6 @@
 # Rich Text Editor
 
-`Schema Alias: Umbraco.RichText` `UI Alias: Umb.PropertyEditorUi.TipTap`
+`Schema Alias: Umbraco.RichText` `UI Alias: Umb.PropertyEditorUi.Tiptap`
 
 `Returns: HTML`
 


### PR DESCRIPTION
## Description

Fixed the casing of `Umb.PropertyEditorUi.Tiptap`.  This is case sensitive, at least in some contexts, so updating to it's correct casing.

## Type of suggestion

* [X] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

CMS 15+

## Deadline (if relevant)

Any time.
