### PR TITLE
Document the "Convert file names to ASCII" config

### DIFF
--- a/.github/styles/UmbracoDocs/Acronyms.yml
+++ b/.github/styles/UmbracoDocs/Acronyms.yml
@@ -88,3 +88,4 @@ exceptions:
     - JPEG
     - BCC
     - SSD
+    - ASCII

--- a/13/umbraco-cms/reference/configuration/requesthandlersettings.md
+++ b/13/umbraco-cms/reference/configuration/requesthandlersettings.md
@@ -16,6 +16,7 @@ Here is a snippet containing all the default values of the `RequestHandler` sect
     "RequestHandler": {
       "AddTrailingSlash": true,
       "ConvertUrlsToAscii": "try",
+      "ConvertFileNamesToAscii": "false",
       "EnableDefaultCharReplacements": true,
       "UserDefinedCharCollection": [
       {
@@ -124,11 +125,15 @@ Here is a snippet containing all the default values of the `RequestHandler` sect
 
 This will add a trailing slash to the URL when **`<addTrailingSlash>`** is set to "true". If you don't want to have a trailing slash, set the value to **false**.
 
-### Convert URLs to ascii
+### Convert URLs to ASCII
 
 This setting tells Umbraco to convert all URLs to ASCII: American Standard Code for Information Interchange, if set to false the URLs will remain `UTF-8`.
 
 This setting can be set to **try** This will make the engine try to convert the name to an ASCII implementation. If it fails, it will fallback to the name. Reason is that some languages don't have ASCII implementations, therefore the URLs would end up being empty.
+
+### Convert file names to ASCII
+
+This setting works the same as "Convert URLs to ASCII" above, but for Media item file names.
 
 ### Enable default character replacements
 

--- a/15/umbraco-cms/reference/configuration/requesthandlersettings.md
+++ b/15/umbraco-cms/reference/configuration/requesthandlersettings.md
@@ -16,6 +16,7 @@ Here is a snippet containing all the default values of the `RequestHandler` sect
     "RequestHandler": {
       "AddTrailingSlash": true,
       "ConvertUrlsToAscii": "try",
+      "ConvertFileNamesToAscii": "false",
       "EnableDefaultCharReplacements": true,
       "UserDefinedCharCollection": [
       {
@@ -124,11 +125,15 @@ Here is a snippet containing all the default values of the `RequestHandler` sect
 
 This will add a trailing slash to the URL when **`<addTrailingSlash>`** is set to "true". If you don't want to have a trailing slash, set the value to **false**.
 
-### Convert URLs to ascii
+### Convert URLs to ASCII
 
 This setting tells Umbraco to convert all URLs to ASCII: American Standard Code for Information Interchange, if set to false the URLs will remain `UTF-8`.
 
 This setting can be set to **try** This will make the engine try to convert the name to an ASCII implementation. If it fails, it will fallback to the name. Reason is that some languages don't have ASCII implementations, therefore the URLs would end up being empty.
+
+### Convert file names to ASCII
+
+This setting works the same as "Convert URLs to ASCII" above, but for Media item file names.
 
 ### Enable default character replacements
 


### PR DESCRIPTION
## Description

Added docs for the new configuration option that ensures ASCII conversion of file names for Media items (introduced in [this PR](https://github.com/umbraco/Umbraco-CMS/pull/17580)),

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [x] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

V15.1 & V13.6

## Deadline (if relevant)

It's not at all urgent. Sometime after both of the above versions have been released 😄 

At this moment there is no release date for V13.6. V15.1 is due December 12 - I don't expect V13.6 to be out before that, so... no rush 👍 
