### PR TITLE
Update Date Time property editor article

### DIFF
--- a/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/date-time.md
+++ b/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/date-time.md
@@ -14,7 +14,7 @@ Displays a calendar UI for selecting dates which are saved as a DateTime value.
 
 There is one setting available for manipulating the DateTime property.
 
-The setting involved defining the format. By default the format of the date in the Umbraco backoffice will be `YYYY-MM-DD HH:mm:ss`, but you can change this to something else. See [MomentJS.com](https://momentjs.com/) for the supported formats.
+The setting involves defining the format. The default date format in the Umbraco backoffice is `YYYY-MM-DD HH:mm:ss`, but you can change it to a different format. See [MomentJS.com](https://momentjs.com/) for the supported formats.
 
 ## Content Example
 

--- a/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/date-time.md
+++ b/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/date-time.md
@@ -12,15 +12,13 @@ Displays a calendar UI for selecting dates which are saved as a DateTime value.
 
 ![Data Type Definiton](images/date-time.png)
 
-There are two settings available for manipulating the DateTime property.
+There is one setting available for manipulating the DateTime property.
 
-One is to set a format. By default the format of the date in the Umbraco backoffice will be `YYYY-MM-DD HH:mm:ss`, but you can change this to something else. See [MomentJS.com](https://momentjs.com/) for the supported formats.
-
-The second setting is "Offset time". When enabling this setting the displayed time will be offset with the servers timezone. This can be useful in cases where an editor is in a different timezone than the hosted server.
+The setting involved defining the format. By default the format of the date in the Umbraco backoffice will be `YYYY-MM-DD HH:mm:ss`, but you can change this to something else. See [MomentJS.com](https://momentjs.com/) for the supported formats.
 
 ## Content Example
 
-![Content Example](../../../../../../10/umbraco-cms/fundamentals/backoffice/property-editors/built-in-property-editors/images/date-picker-v8.png)
+![Content Example](../built-in-property-editors/images/date-picker-v8.png)
 
 ## MVC View Example - displays a datetime
 

--- a/15/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/date-time.md
+++ b/15/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/date-time.md
@@ -14,7 +14,7 @@ Displays a calendar UI for selecting dates which are saved as a DateTime value.
 
 There is one setting available for manipulating the DateTime property.
 
-The setting involved defining the format. By default the format of the date in the Umbraco backoffice will be `YYYY-MM-DD HH:mm:ss`, but you can change this to something else. See [MomentJS.com](https://momentjs.com/) for the supported formats.
+The setting involves defining the format. The default date format in the Umbraco backoffice is `YYYY-MM-DD HH:mm:ss`, but you can change it to a different format. See [MomentJS.com](https://momentjs.com/) for the supported formats.
 
 ## Content Example
 

--- a/15/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/date-time.md
+++ b/15/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/date-time.md
@@ -12,15 +12,13 @@ Displays a calendar UI for selecting dates which are saved as a DateTime value.
 
 ![Data Type Definiton](images/date-time.png)
 
-There are two settings available for manipulating the DateTime property.
+There is one setting available for manipulating the DateTime property.
 
-One is to set a format. By default the format of the date in the Umbraco backoffice will be `YYYY-MM-DD HH:mm:ss`, but you can change this to something else. See [MomentJS.com](https://momentjs.com/) for the supported formats.
-
-The second setting is "Offset time". When enabling this setting the displayed time will be offset with the servers timezone. This can be useful in cases where an editor is in a different timezone than the hosted server.
+The setting involved defining the format. By default the format of the date in the Umbraco backoffice will be `YYYY-MM-DD HH:mm:ss`, but you can change this to something else. See [MomentJS.com](https://momentjs.com/) for the supported formats.
 
 ## Content Example
 
-![Content Example](../../../../../../10/umbraco-cms/fundamentals/backoffice/property-editors/built-in-property-editors/images/date-picker-v8.png)
+![Content Example](../built-in-property-editors/images/date-picker-v8.png)
 
 ## MVC View Example - displays a datetime
 


### PR DESCRIPTION
## Description

The offset setting is no longer available in the Date Time property - this is from 14+.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

14 + 15

