### PR TITLE
Update UI Builder Licence Key Key

### DIFF
--- a/15/umbraco-ui-builder/installation/licensing-model.md
+++ b/15/umbraco-ui-builder/installation/licensing-model.md
@@ -57,7 +57,7 @@ Once you have received your license code it needs to be installed on your site.
 
 1. Open the root directory for your project files.
 2. Locate and open the `appSettings.json` file.
-3. Add your Umbraco UI builder license key to `Umbraco:Licenses:Umbraco.UIBuilder`:
+3. Add your Umbraco UI builder license key to `Umbraco:Licenses:Products:Umbraco.UIBuilder`:
 
 ```json
 "Umbraco": {


### PR DESCRIPTION
Add 'Products' to the key

In v14/v15 Umbraco have added 'Products' to the structure of the JSON for adding licences to the products, the docs have been updated with the new JSON but not the handy cut and paste configuration key

we did umbraco commerce, yesterday, this is UI builder, but likely they are all affected...