### PR TITLE
Correct typo of Suppress as "Supress"

### DIFF
--- a/10/umbraco-cms/reference/notifications/contentservice-notifications.md
+++ b/10/umbraco-cms/reference/notifications/contentservice-notifications.md
@@ -205,20 +205,20 @@ We can suppress notifications at the scope level which makes things consistent a
 
 **How to use scopes**:
 
-* Create an explicit scope and call scope.Notifications.Supress().
+* Create an explicit scope and call scope.Notifications.Suppress().
 * The result of Suppress() is IDisposable, so until it is disposed, notifications will not be added to the queue.
 
 [Example](https://github.com/umbraco/Umbraco-CMS/blob/b69afe81f3f6fcd37480b3b0295a62af44ede245/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/SupressNotificationsTests.cs#L35):
 
 ```csharp
 using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
-using (IDisposable _ = scope.Notifications.Supress())
+using (IDisposable _ = scope.Notifications.Suppress())
 {
     // TODO: Calls to service methods here will not have notifications
 }
 ```
 
-Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Supress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
+Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Suppress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
 
 **Why would one want to suppress events?**
 

--- a/10/umbraco-cms/reference/notifications/mediaservice-notifications.md
+++ b/10/umbraco-cms/reference/notifications/mediaservice-notifications.md
@@ -111,20 +111,20 @@ We can suppress notifications at the scope level which makes things consistent a
 
 **How to use scopes**:
 
-* Create an explicit scope and call scope.Notifications.Supress().
+* Create an explicit scope and call scope.Notifications.Suppress().
 * The result of Suppress() is IDisposable, so until it is disposed, notifications will not be added to the queue.
 
 [Example](https://github.com/umbraco/Umbraco-CMS/blob/b69afe81f3f6fcd37480b3b0295a62af44ede245/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/SupressNotificationsTests.cs#L35):
 
 ```csharp
 using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
-using (IDisposable _ = scope.Notifications.Supress())
+using (IDisposable _ = scope.Notifications.Suppress())
 {
     // TODO: Calls to service methods here will not have notifications
 }
 ```
 
-Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Supress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
+Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Suppress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
 
 **Why would one want to suppress events?**
 

--- a/10/umbraco-cms/reference/notifications/memberservice-notifications.md
+++ b/10/umbraco-cms/reference/notifications/memberservice-notifications.md
@@ -53,20 +53,20 @@ We can suppress notifications at the scope level which makes things consistent a
 
 **How to use scopes**:
 
-* Create an explicit scope and call scope.Notifications.Supress().
+* Create an explicit scope and call scope.Notifications.Suppress().
 * The result of Suppress() is IDisposable, so until it is disposed, notifications will not be added to the queue.
 
 [Example](https://github.com/umbraco/Umbraco-CMS/blob/b69afe81f3f6fcd37480b3b0295a62af44ede245/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/SupressNotificationsTests.cs#L35):
 
 ```csharp
 using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
-using (IDisposable _ = scope.Notifications.Supress())
+using (IDisposable _ = scope.Notifications.Suppress())
 {
     // TODO: Calls to service methods here will not have notifications
 }
 ```
 
-Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Supress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
+Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Suppress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
 
 **Why would one want to suppress events?**
 

--- a/13/umbraco-cms/reference/notifications/contentservice-notifications.md
+++ b/13/umbraco-cms/reference/notifications/contentservice-notifications.md
@@ -200,20 +200,20 @@ We can suppress notifications at the scope level which makes things consistent a
 
 **How to use scopes**:
 
-- Create an explicit scope and call scope.Notifications.Supress().
+- Create an explicit scope and call scope.Notifications.Suppress().
 - The result of Suppress() is IDisposable, so until it is disposed, notifications will not be added to the queue.
 
 [Example](https://github.com/umbraco/Umbraco-CMS/blob/b69afe81f3f6fcd37480b3b0295a62af44ede245/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/SupressNotificationsTests.cs#L35):
 
 ```csharp
 using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
-using (IDisposable _ = scope.Notifications.Supress())
+using (IDisposable _ = scope.Notifications.Suppress())
 {
     // TODO: Calls to service methods here will not have notifications
 }
 ```
 
-Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Supress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
+Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Suppress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
 
 **Why would one want to suppress events?**
 

--- a/13/umbraco-cms/reference/notifications/mediaservice-notifications.md
+++ b/13/umbraco-cms/reference/notifications/mediaservice-notifications.md
@@ -111,20 +111,20 @@ We can suppress notifications at the scope level which makes things consistent a
 
 **How to use scopes**:
 
-- Create an explicit scope and call scope.Notifications.Supress().
+- Create an explicit scope and call scope.Notifications.Suppress().
 - The result of Suppress() is IDisposable, so until it is disposed, notifications will not be added to the queue.
 
 [Example](https://github.com/umbraco/Umbraco-CMS/blob/b69afe81f3f6fcd37480b3b0295a62af44ede245/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/SupressNotificationsTests.cs#L35):
 
 ```csharp
 using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
-using (IDisposable _ = scope.Notifications.Supress())
+using (IDisposable _ = scope.Notifications.Suppress())
 {
     // TODO: Calls to service methods here will not have notifications
 }
 ```
 
-Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Supress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
+Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Suppress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
 
 **Why would one want to suppress events?**
 

--- a/13/umbraco-cms/reference/notifications/memberservice-notifications.md
+++ b/13/umbraco-cms/reference/notifications/memberservice-notifications.md
@@ -52,20 +52,20 @@ We can suppress notifications at the scope level which makes things consistent a
 
 **How to use scopes**:
 
-- Create an explicit scope and call scope.Notifications.Supress().
+- Create an explicit scope and call scope.Notifications.Suppress().
 - The result of Suppress() is IDisposable, so until it is disposed, notifications will not be added to the queue.
 
 [Example](https://github.com/umbraco/Umbraco-CMS/blob/b69afe81f3f6fcd37480b3b0295a62af44ede245/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/SupressNotificationsTests.cs#L35):
 
 ```csharp
 using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
-using (IDisposable _ = scope.Notifications.Supress())
+using (IDisposable _ = scope.Notifications.Suppress())
 {
     // TODO: Calls to service methods here will not have notifications
 }
 ```
 
-Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Supress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
+Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Suppress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
 
 **Why would one want to suppress events?**
 

--- a/14/umbraco-cms/reference/notifications/mediaservice-notifications.md
+++ b/14/umbraco-cms/reference/notifications/mediaservice-notifications.md
@@ -111,20 +111,20 @@ We can suppress notifications at the scope level which makes things consistent a
 
 **How to use scopes**:
 
-- Create an explicit scope and call scope.Notifications.Supress().
+- Create an explicit scope and call scope.Notifications.Suppress().
 - The result of Suppress() is IDisposable, so until it is disposed, notifications will not be added to the queue.
 
 [Example](https://github.com/umbraco/Umbraco-CMS/blob/b69afe81f3f6fcd37480b3b0295a62af44ede245/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/SupressNotificationsTests.cs#L35):
 
 ```csharp
 using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
-using (IDisposable _ = scope.Notifications.Supress())
+using (IDisposable _ = scope.Notifications.Suppress())
 {
     // TODO: Calls to service methods here will not have notifications
 }
 ```
 
-Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Supress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
+Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Suppress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
 
 **Why would one want to suppress events?**
 

--- a/14/umbraco-cms/reference/notifications/memberservice-notifications.md
+++ b/14/umbraco-cms/reference/notifications/memberservice-notifications.md
@@ -52,20 +52,20 @@ We can suppress notifications at the scope level which makes things consistent a
 
 **How to use scopes**:
 
-- Create an explicit scope and call scope.Notifications.Supress().
+- Create an explicit scope and call scope.Notifications.Suppress().
 - The result of Suppress() is IDisposable, so until it is disposed, notifications will not be added to the queue.
 
 [Example](https://github.com/umbraco/Umbraco-CMS/blob/b69afe81f3f6fcd37480b3b0295a62af44ede245/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/SupressNotificationsTests.cs#L35):
 
 ```csharp
 using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
-using (IDisposable _ = scope.Notifications.Supress())
+using (IDisposable _ = scope.Notifications.Suppress())
 {
     // TODO: Calls to service methods here will not have notifications
 }
 ```
 
-Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Supress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
+Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Suppress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
 
 **Why would one want to suppress events?**
 

--- a/15/umbraco-cms/reference/notifications/mediaservice-notifications.md
+++ b/15/umbraco-cms/reference/notifications/mediaservice-notifications.md
@@ -111,20 +111,20 @@ We can suppress notifications at the scope level which makes things consistent a
 
 **How to use scopes**:
 
-- Create an explicit scope and call scope.Notifications.Supress().
+- Create an explicit scope and call scope.Notifications.Suppress().
 - The result of Suppress() is IDisposable, so until it is disposed, notifications will not be added to the queue.
 
 [Example](https://github.com/umbraco/Umbraco-CMS/blob/b69afe81f3f6fcd37480b3b0295a62af44ede245/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/SupressNotificationsTests.cs#L35):
 
 ```csharp
 using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
-using (IDisposable _ = scope.Notifications.Supress())
+using (IDisposable _ = scope.Notifications.Suppress())
 {
     // TODO: Calls to service methods here will not have notifications
 }
 ```
 
-Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Supress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
+Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Suppress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
 
 **Why would one want to suppress events?**
 

--- a/15/umbraco-cms/reference/notifications/memberservice-notifications.md
+++ b/15/umbraco-cms/reference/notifications/memberservice-notifications.md
@@ -52,20 +52,20 @@ We can suppress notifications at the scope level which makes things consistent a
 
 **How to use scopes**:
 
-- Create an explicit scope and call scope.Notifications.Supress().
+- Create an explicit scope and call scope.Notifications.Suppress().
 - The result of Suppress() is IDisposable, so until it is disposed, notifications will not be added to the queue.
 
 [Example](https://github.com/umbraco/Umbraco-CMS/blob/b69afe81f3f6fcd37480b3b0295a62af44ede245/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Scoping/SupressNotificationsTests.cs#L35):
 
 ```csharp
 using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
-using (IDisposable _ = scope.Notifications.Supress())
+using (IDisposable _ = scope.Notifications.Suppress())
 {
     // TODO: Calls to service methods here will not have notifications
 }
 ```
 
-Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Supress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
+Child scope will inherit the parent Scope's notification object which means if a parent scope has notifications suppressed, then so does the child scope. You cannot call Suppress() more than once for the same outer scope instance else an exception will be thrown. This ensures that you cannot un-suppress notifications at a child level for an outer scope. It also ensures that suppressing events is an explicit thing to do.
 
 **Why would one want to suppress events?**
 


### PR DESCRIPTION
## Description

I corrected the spelling of the "Suppress" method from "Supress". The code has the correct spelling but the docs are wrong.

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [x] Other

## Product & version (if relevant)



## Deadline (if relevant)

N/A
