### PR TITLE
Update Bundle article

### DIFF
--- a/15/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
+++ b/15/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
@@ -68,3 +68,5 @@ Ensure you have set up your `tsconfig.json` to include the extension-types as gl
         ]
     }
 }
+```
+{% endhint %}

--- a/15/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
+++ b/15/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
@@ -38,9 +38,7 @@ The following example shows an `umbraco-package.json` that refers to one bundle,
 {% code title="manifests.ts" %}
 
 ```typescript
-import type { ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
-
-export const manifests: Array<ManifestTypes> = [
+export const manifests: Array<UmbExtensionManifest> = [
 	{
 		type: 'dashboard',
 		name: 'Example Dashboard',
@@ -55,5 +53,19 @@ export const manifests: Array<ManifestTypes> = [
 	// ... insert as many manifests as you like
 ]
 ```
-
 {% endcode %}
+
+:::note
+Please make sure you have setup your tsconfig.json to include the extension-types as global types. Like this:
+
+```json
+{
+    "compilerOptions": {
+        ...
+        "types": [
+            "@umbraco-cms/backoffice/extension-types"
+        ]
+    }
+}
+```
+:::

--- a/15/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
+++ b/15/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
@@ -55,8 +55,9 @@ export const manifests: Array<UmbExtensionManifest> = [
 ```
 {% endcode %}
 
-:::note
-Please make sure you have setup your tsconfig.json to include the extension-types as global types. Like this:
+
+{% hint style="info" %}
+Ensure you have set up your `tsconfig.json` to include the extension-types as global types. Like this:
 
 ```json
 {
@@ -67,5 +68,3 @@ Please make sure you have setup your tsconfig.json to include the extension-type
         ]
     }
 }
-```
-:::


### PR DESCRIPTION
## Description

Update the [bundle artice](https://docs.umbraco.com/umbraco-cms/customizing/extending-overview/extension-types/bundle) since `ManifestTypes` deprecaded in v15 and `UmbExtensionManifest` should be used instead.  See also #6767
## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
Umbraco CMS v15