### PR TITLE
V15: Localization property `translations` does not exist

### DIFF
--- a/14/umbraco-cms/customizing/extending-overview/extension-types/localization.md
+++ b/14/umbraco-cms/customizing/extending-overview/extension-types/localization.md
@@ -48,7 +48,7 @@ export default {
 
 The sections and keys will be formatted into a map in Umbraco with the format `section_key1` and `section_key2.` These form the unique key they are requested.
 
-If you do not have many translations, you can also choose to include them directly in the meta-object:
+If you do not have many translations, you can also choose to include them directly in the meta-object using the `localizations` property:
 
 {% code title="umbraco-package.json" %}
 ```json
@@ -62,10 +62,10 @@ If you do not have many translations, you can also choose to include them direct
       "meta": {
         "culture": "en",
         "localizations": {
-            "section": {
-                "key1": "value1",
-                "key2": "value2"
-            }
+          "section": {
+            "key1": "value1",
+            "key2": "value2"
+          }
         }
       },
     }

--- a/15/umbraco-cms/customizing/extending-overview/extension-types/localization.md
+++ b/15/umbraco-cms/customizing/extending-overview/extension-types/localization.md
@@ -48,7 +48,7 @@ export default {
 
 The sections and keys will be formatted into a map in Umbraco with the format `section_key1` and `section_key2.` These form the unique key they are requested.
 
-If you do not have many translations, you can also choose to include them directly in the meta-object:
+If you do not have many translations, you can also choose to include them directly in the meta-object using the `localizations` property:
 
 {% code title="umbraco-package.json" %}
 ```json
@@ -61,11 +61,11 @@ If you do not have many translations, you can also choose to include them direct
       "name": "English",
       "meta": {
         "culture": "en",
-        "translations": {
-            "section": {
-                "key1": "value1",
-                "key2": "value2"
-            }
+        "localizations": {
+          "section": {
+            "key1": "value1",
+            "key2": "value2"
+          }
         }
       },
     }


### PR DESCRIPTION
## Description

Use the correct property `localizations` (and not `translations`). Credits to #6635 & @PerplexDaniel for discovering this on V14 - this PR brings the same fix to V15.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
15


## Deadline (if relevant)

ASAP
