### PR TITLE
Update dictionary-items.md

### DIFF
--- a/15/umbraco-cms/fundamentals/data/dictionary-items.md
+++ b/15/umbraco-cms/fundamentals/data/dictionary-items.md
@@ -54,26 +54,6 @@ It will only be possible to edit the language(s) that the given user has access 
 Which language a user has access to is determined by the "Language permissions" set on the User Group. Learn more about this feature in the [Users](users.md#creating-a-user-group) article.
 {% endhint %}
 
-## Using Dictionary Values in Document Types
-
-In some cases, you might want to render the dictionary values in the Document Type. This is to display the labels depending on the language configured for the logged-in user.
-
-To use dictionary values in the Document Type, follow these steps:
-
-1. Go to the **Settings** section.
-2. Open the Document Type where you want to use the Dictionary value.
-3. Locate the label and type `#MyDictionaryKey`. For example: `#Welcome` or `#WelcomeDescription`.
-
-<figure><img src="../../.gitbook/assets/Using_Dictionary_Value.jpg" alt=""><figcaption><p>Using Dictionary Value in Document Type</p></figcaption></figure>
-
-4. Click **Save**.
-5. Go to the **Content** section.
-6. View the content node using the Welcome property. The property will display the dictionary value per the user's configured backoffice language.
-
-{% hint style="info" %}
-You can translate tabs and property groups in the backoffice as well. For more information, see [How to Translate Umbraco Backoffice Document Types](https://www.youtube.com/embed/OayHhOf47LA?si=iRZ7NE-ckv9LjrSv) video.
-{% endhint %}
-
 ## Fetching Dictionary Values in the Template
 
 To fetch dictionary values in the template, replace the text with the following snippet:


### PR DESCRIPTION
This feature was removed in the new Backoffice.

You should instead use localization in order to get the same result.

## Description

I removed the section Using Dictionary Values in Document Types, as it is no longer supported in the new Backoffice v14+
## Type of suggestion

* [ ] Typo/grammar fix
* [ x] Updated outdated content
* [ ] New content
* [x ] Updates related to a new version
* [ ] Other

