### PR TITLE
add note about ensuring Umbraco Forms version compatibility

### DIFF
--- a/10/umbraco-forms/installation/install.md
+++ b/10/umbraco-forms/installation/install.md
@@ -25,6 +25,10 @@ To install the Umbraco Forms package (**Umbraco.Forms**), follow these steps:
     ```
      dotnet run
     ```
+    
+{% hint style="info" %}
+**Note:** Ensure that the version of Umbraco Forms is compatible with the version of Umbraco you are using. For example, if you are using Umbraco 10, you should use Umbraco.Forms version 10.5.7 or a compatible version.
+{% endhint %}
 
 ## Start Building Forms
 

--- a/10/umbraco-forms/installation/install.md
+++ b/10/umbraco-forms/installation/install.md
@@ -15,20 +15,18 @@ Umbraco contains the **Forms** section, by default. You will see a similar inter
 
 To install the Umbraco Forms package (**Umbraco.Forms**), follow these steps:
 
-1.  Run the following command on a command prompt of your choice:
+1.  Identify the Umbraco CMS version your project is running.
+2.  Find a compatible version of Umbraco Forms that matches your Umbraco CMS version. A list of Umbraco Forms versions can be found on [nuget.org](https://www.nuget.org/packages/Umbraco.Forms#versions-body-tab).
+3.  Run the following command on a command prompt of your choice, replacing `<version_number>` with the appropriate version identified above:
 
     ```
-    dotnet add package Umbraco.Forms
+    dotnet add package Umbraco.Forms --version <version_number>
     ```
-2.  Restart the web application using the following command:
+4.  Restart the web application using the following command:
 
     ```
      dotnet run
     ```
-    
-{% hint style="info" %}
-**Note:** Ensure that the version of Umbraco Forms is compatible with the version of Umbraco you are using. For example, if you are using Umbraco 10, you should use Umbraco.Forms version 10.5.7 or a compatible version.
-{% endhint %}
 
 ## Start Building Forms
 

--- a/13/umbraco-forms/installation/install.md
+++ b/13/umbraco-forms/installation/install.md
@@ -14,21 +14,18 @@ Umbraco contains the **Forms** section, by default. You will see a similar inter
 
 To install the Umbraco Forms package (**Umbraco.Forms**), follow these steps:
 
-1. Run the following command on a command prompt of your choice:
+1.  Identify the Umbraco CMS version your project is running.
+2.  Find a compatible version of Umbraco Forms that matches your Umbraco CMS version. A list of Umbraco Forms versions can be found on [nuget.org](https://www.nuget.org/packages/Umbraco.Forms#versions-body-tab).
+3.  Run the following command on a command prompt of your choice, replacing `<version_number>` with the appropriate version identified above:
 
-```
-dotnet add package Umbraco.Forms
-```
+    ```
+    dotnet add package Umbraco.Forms --version <version_number>
+    ```
+4.  Restart the web application using the following command:
 
-2. Restart the web application using the following command:
-
-```
-    dotnet run
-```
-    
-{% hint style="info" %}
-**Note:** Ensure that the version of Umbraco Forms is compatible with the version of Umbraco you are using. For example, if you are using Umbraco 13, you should use Umbraco.Forms version 13.4.0 or a compatible version.
-{% endhint %}
+    ```
+     dotnet run
+    ```
 
 ## Start Building Forms
 

--- a/13/umbraco-forms/installation/install.md
+++ b/13/umbraco-forms/installation/install.md
@@ -25,6 +25,10 @@ dotnet add package Umbraco.Forms
 ```
     dotnet run
 ```
+    
+{% hint style="info" %}
+**Note:** Ensure that the version of Umbraco Forms is compatible with the version of Umbraco you are using. For example, if you are using Umbraco 13, you should use Umbraco.Forms version 13.4.0 or a compatible version.
+{% endhint %}
 
 ## Start Building Forms
 

--- a/14/umbraco-forms/installation/install.md
+++ b/14/umbraco-forms/installation/install.md
@@ -25,6 +25,10 @@ To install the Umbraco Forms package (**Umbraco.Forms**), follow these steps:
     ```cs
         dotnet run
     ```
+    
+{% hint style="info" %}
+**Note:** Ensure that the version of Umbraco Forms is compatible with the version of Umbraco you are using. For example, if you are using Umbraco 14, you should use Umbraco.Forms version 14.2.3 or a compatible version.
+{% endhint %}
 
 ## Start Building Forms
 

--- a/14/umbraco-forms/installation/install.md
+++ b/14/umbraco-forms/installation/install.md
@@ -14,21 +14,18 @@ Umbraco contains the **Forms** section, by default. You will see a similar inter
 
 To install the Umbraco Forms package (**Umbraco.Forms**), follow these steps:
 
-1. Run the following command on a command prompt of your choice:
+1.  Identify the Umbraco CMS version your project is running.
+2.  Find a compatible version of Umbraco Forms that matches your Umbraco CMS version. A list of Umbraco Forms versions can be found on [nuget.org](https://www.nuget.org/packages/Umbraco.Forms#versions-body-tab).
+3.  Run the following command on a command prompt of your choice, replacing `<version_number>` with the appropriate version identified above:
 
     ```cs
-    dotnet add package Umbraco.Forms
+    dotnet add package Umbraco.Forms --version <version_number>
     ```
-
-2. Restart the web application using the following command:
+4.  Restart the web application using the following command:
 
     ```cs
-        dotnet run
+     dotnet run
     ```
-    
-{% hint style="info" %}
-**Note:** Ensure that the version of Umbraco Forms is compatible with the version of Umbraco you are using. For example, if you are using Umbraco 14, you should use Umbraco.Forms version 14.2.3 or a compatible version.
-{% endhint %}
 
 ## Start Building Forms
 

--- a/15/umbraco-forms/installation/install.md
+++ b/15/umbraco-forms/installation/install.md
@@ -14,21 +14,18 @@ Umbraco contains the **Forms** section, by default. You will see a similar inter
 
 To install the Umbraco Forms package (**Umbraco.Forms**), follow these steps:
 
-1. Run the following command on a command prompt of your choice:
+1.  Identify the Umbraco CMS version your project is running.
+2.  Find a compatible version of Umbraco Forms that matches your Umbraco CMS version. A list of Umbraco Forms versions can be found on [nuget.org](https://www.nuget.org/packages/Umbraco.Forms#versions-body-tab).
+3.  Run the following command on a command prompt of your choice, replacing `<version_number>` with the appropriate version identified above:
 
     ```cs
-    dotnet add package Umbraco.Forms
+    dotnet add package Umbraco.Forms --version <version_number>
     ```
-
-2. Restart the web application using the following command:
+4.  Restart the web application using the following command:
 
     ```cs
-        dotnet run
+     dotnet run
     ```
-    
-{% hint style="info" %}
-**Note:** Ensure that the version of Umbraco Forms is compatible with the version of Umbraco you are using. For example, if you are using Umbraco 15, you should use Umbraco.Forms version 15.1.0 or a compatible version.
-{% endhint %}
 
 ## Start Building Forms
 

--- a/15/umbraco-forms/installation/install.md
+++ b/15/umbraco-forms/installation/install.md
@@ -25,6 +25,10 @@ To install the Umbraco Forms package (**Umbraco.Forms**), follow these steps:
     ```cs
         dotnet run
     ```
+    
+{% hint style="info" %}
+**Note:** Ensure that the version of Umbraco Forms is compatible with the version of Umbraco you are using. For example, if you are using Umbraco 15, you should use Umbraco.Forms version 15.1.0 or a compatible version.
+{% endhint %}
 
 ## Start Building Forms
 


### PR DESCRIPTION
## Description

When installing Umbraco Forms on my Umbraco 13 installation, I made the mistake of installing the latest version of umbraco forms when running `dotnet add package Umbraco.Forms`

As a result, Umbraco Forms was not loading in my backoffice. After searching on [Discord](https://discord.com/channels/869656431308189746/1326916296796934297) and [GitHub](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1188#issuecomment-2003832548), I discovered that the issue was due to version incompatibility. I felt sharing this would help others as well.

Please let me know if the note can be improved or changed.

_What did you add/update/change?_
Added a note about ensuring that the version of Umbraco Forms is compatible with the version of Umbraco being used.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [x] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
Umbraco 10, 13, 14, 15
