### PR TITLE
Adds `BackOfficeLogo` to the `ContentSettings`

### DIFF
--- a/15/umbraco-cms/reference/configuration/contentsettings.md
+++ b/15/umbraco-cms/reference/configuration/contentsettings.md
@@ -26,6 +26,7 @@ The following snippet will give an overview of the keys and values in the conten
       "DisallowedUploadFiles": ["ashx", "aspx", "ascx", "config", "cshtml", "vbhtml", "asmx", "air", "axd", "xamlx"],
       "DisallowedUploadedFileExtensions": ["ashx", "aspx", "ascx", "config", "cshtml", "vbhtml", "asmx", "air", "axd", "xamlx"],
       "Error404Collection": [],
+      "BackOfficeLogo": "../media/qyci4xti/logo.png",
       "HideBackOfficeLogo": false,
       "Imaging": {
         "ImageFileTypes": ["jpeg", "jpg", "gif", "bmp", "png", "tiff", "tif"],
@@ -127,6 +128,10 @@ If you have multiple sites, with different cultures, setup in your tree then you
 ```
 
 If you have more than two sites and forget to add a 404 page and a culture, the default page will act as fallback. Same happens if you for some reason forget to define a hostname on a site.
+
+### Backoffice logo
+
+This setting can be used to set a custom image path to replace the Umbraco logo in backoffice.
 
 ### Hide backoffice logo
 


### PR DESCRIPTION
## Description

Updated [**Content Settings** documentation](https://docs.umbraco.com/umbraco-cms/reference/configuration/contentsettings) to add `BackOfficeLogo` setting, (added in Umbraco CMS 15.2.0).

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Umbraco CMS 15.2.0

## Deadline (if relevant)

As soon as possible.
