### PR TITLE
feat: Update documentation on external login providers and bearer tokens

### DIFF
--- a/umbraco-heartcore/api-documentation/README.md
+++ b/umbraco-heartcore/api-documentation/README.md
@@ -107,7 +107,11 @@ Api-Key: {api-key}
 
 ### Bearer token
 
-The endpoints implements OAuth 2.0.
+{% hint style="info" %}
+This feature is currently not available when using [External Login Providers.](../../umbraco-cloud/set-up/external-login-providers.md)
+{% endhint %}
+
+The endpoints implement OAuth 2.0.
 
 A bearer token can be created by posting to `https://api.umbraco.io/oauth/token` and supplying a username and password for a backoffice user.
 This corresponds to a user logging into the backoffice and is thus only meant to be used for the Content Management API.
@@ -125,10 +129,6 @@ It can be used by passing it to the `Authorization` header.
 GET https://api.umbraco.io/
 Authorization: Bearer {token}
 ```
-
-{% hint style="info" %}
-This feature is currently not available when using [External Login Providers.](../../umbraco-cloud/set-up/external-login-providers.md)
-{% endhint %}
 
 ## Member authentication
 

--- a/umbraco-heartcore/api-documentation/README.md
+++ b/umbraco-heartcore/api-documentation/README.md
@@ -126,6 +126,10 @@ GET https://api.umbraco.io/
 Authorization: Bearer {token}
 ```
 
+{% hint style="info" %}
+This feature is currently not available when using [External Login Providers.](../../umbraco-cloud/set-up/external-login-providers.md)
+{% endhint %}
+
 ## Member authentication
 
 A member login can be used to access the Content Delivery API if it's protected. Members will only have access to Content Delivery Network (CDN) endpoints and cannot be used to access the Content Management API.


### PR DESCRIPTION
## Description

Updated Heartcore API documentation to mention that we currently do not support Bearer tokens when using `External Login providers` an Api-key should be used instead.

## Type of suggestion

* [ ] Typo/grammar fix
* [X] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Heartcore

## Deadline (if relevant)

If it is possible - medio week 6 should be fine.
