### PR TITLE
AllowMembersDeploymentOperations transfer operation

### DIFF
--- a/umbraco-cloud/deployment/content-transfer.md
+++ b/umbraco-cloud/deployment/content-transfer.md
@@ -46,7 +46,7 @@ To be able to transfer Members and Member groups make sure that `AllowMembersDep
 "Umbraco": {
     "Deploy": {
         "Settings": {
-            "AllowMembersDeploymentOperations": "transfer",
+            "AllowMembersDeploymentOperations": "Transfer",
             "TransferMemberGroupsAsContent": true,
         }
     }


### PR DESCRIPTION
## Description

_What did you add/update/change?_
Value of `AllowMembersDeploymentOperations` should be `Transfer` not `transfer`, otherwise intellisense shows a warning.

![image](https://github.com/user-attachments/assets/61e6cf94-7212-40ac-b2d8-a77db379e6b6)


## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
