### PR TITLE
fix: redirect for old link in Deploy backoffice dashboard

### DIFF
--- a/umbraco-cloud/.gitbook.yaml
+++ b/umbraco-cloud/.gitbook.yaml
@@ -35,6 +35,7 @@ redirects:
     set-up/2-factor-authentication-on-cloud: set-up/multi-factor-authentication-on-cloud.md
     getting-started/baselines/high-level-overview: getting-started/baselines/README.md
     set-up/working-with-mac: set-up/working-with-linux-macos.md
+    deployment: deployments/deployment.md
     deployments/deploy-operations: deployment/deploy-dashboard.md
     deployments/deploy-operations/clearing-cached-signatures: deployment/deploy-dashboard.md
     deployments/deploy-operations/deploy-schema: deployment/deploy-dashboard.md


### PR DESCRIPTION
## Description

Fix for [this issue](https://github.com/umbraco/Umbraco.Heartcore.Issues/issues/146) reported on the Heartcore tracker, but probably present in all Cloud sites.

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Cloud

## Deadline (if relevant)

N/A
