### PR TITLE
Document `userinfo` endpoint

### DIFF
--- a/13/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api.md
+++ b/13/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api.md
@@ -382,6 +382,28 @@ To terminate the active session for any given member, you must redirect the brow
 GET /umbraco/delivery/api/v1/security/member/signout?post_logout_redirect_uri={valid URL from LogoutRedirectUrls}
 ```
 
+### User info
+
+The "user info" endpoint is part of the OpenId Connect core spec.
+
+This implementation returns a few of the standard claims, all of which are subject of availability:
+
+- `sub` (required claim)
+- `name` (if available)
+- `email` (if available)
+
+On top of this, the member groups (if any) are returned in the role claim.
+
+The implementation is build to be extendable, so custom claims can be added to these claims - and the core claims can be removed, too.
+
+```http
+GET /umbraco/delivery/api/v1/security/member/userinfo
+```
+
+{% hint style="warning" %}
+This was introduced in Umbraco 13.6.0.
+{% endhint %}
+
 ## Testing with Swagger
 
 The Delivery API Swagger document can be configured to support member authentication.

--- a/13/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api.md
+++ b/13/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api.md
@@ -400,7 +400,7 @@ The implementation is build to be extendable, so custom claims can be added to t
 GET /umbraco/delivery/api/v1/security/member/userinfo
 ```
 
-{% hint style="warning" %}
+{% hint style="info" %}
 This was introduced in Umbraco 13.6.0.
 {% endhint %}
 

--- a/15/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api/README.md
+++ b/15/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api/README.md
@@ -383,7 +383,6 @@ The implementation is build to be extendable, so custom claims can be added to t
 GET /umbraco/delivery/api/v1/security/member/userinfo
 ```
 
-
 ## Testing with Swagger
 
 The Delivery API Swagger document can be configured to support member authentication.

--- a/15/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api/README.md
+++ b/15/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api/README.md
@@ -365,6 +365,25 @@ To terminate the active session for any given member, you must redirect the brow
 GET /umbraco/delivery/api/v1/security/member/signout?post_logout_redirect_uri={valid URL from LogoutRedirectUrls}
 ```
 
+### User info
+
+The "user info" endpoint is part of the OpenId Connect core spec.
+
+This implementation returns a few of the standard claims, all of which are subject of availability:
+
+- `sub` (required claim)
+- `name` (if available)
+- `email` (if available)
+
+On top of this, the member groups (if any) are returned in the role claim.
+
+The implementation is build to be extendable, so custom claims can be added to these claims - and the core claims can be removed, too.
+
+```http
+GET /umbraco/delivery/api/v1/security/member/userinfo
+```
+
+
 ## Testing with Swagger
 
 The Delivery API Swagger document can be configured to support member authentication.


### PR DESCRIPTION
## Description

_What did you add/update/change?_
Documentation of new `userinfo` endpoint from Umbraco 13.6+
https://github.com/umbraco/Umbraco-CMS/pull/17719

Also document of this part would be great, e.g. a custom properties from member like `firstName` and `lastName`:
> The implementation is build to be extendable, so custom claims can be added to these claims - and the core claims can be removed, too.

Perhaps it should be mentioned `sub` contains Umbraco member guid key, but not sure if it always guid if integration with external providers.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [x] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
