### PR TITLE
Removed reference to HideBackOfficeLogo content setting that is now obsolete and not used.

### DIFF
--- a/15/umbraco-cms/reference/configuration/contentsettings.md
+++ b/15/umbraco-cms/reference/configuration/contentsettings.md
@@ -26,7 +26,6 @@ The following snippet will give an overview of the keys and values in the conten
       "DisallowedUploadFiles": ["ashx", "aspx", "ascx", "config", "cshtml", "vbhtml", "asmx", "air", "axd", "xamlx"],
       "DisallowedUploadedFileExtensions": ["ashx", "aspx", "ascx", "config", "cshtml", "vbhtml", "asmx", "air", "axd", "xamlx"],
       "Error404Collection": [],
-      "HideBackOfficeLogo": false,
       "Imaging": {
         "ImageFileTypes": ["jpeg", "jpg", "gif", "bmp", "png", "tiff", "tif"],
         "AutoFillImageProperties": [
@@ -127,10 +126,6 @@ If you have multiple sites, with different cultures, setup in your tree then you
 ```
 
 If you have more than two sites and forget to add a 404 page and a culture, the default page will act as fallback. Same happens if you for some reason forget to define a hostname on a site.
-
-### Hide backoffice logo
-
-This setting can be used to hide the Umbraco logo in backoffice.
 
 ### Login background image
 


### PR DESCRIPTION
## Description

Removed reference in the CMS Content Settings page to the `HideBackOfficeLogo` content setting that is now obsolete and not used.

This was raised in https://github.com/umbraco/Umbraco-CMS/issues/18222

## Type of suggestion

* [ ] Typo/grammar fix
* [X] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Umbraco 15

## Deadline (if relevant)

Any time (I'll self-review).
