### PR TITLE
Add Deploy 13.4.0, 14.3.0 and 15.1.0 release notes

### DIFF
--- a/13/umbraco-deploy/getting-started/deploy-settings.md
+++ b/13/umbraco-deploy/getting-started/deploy-settings.md
@@ -48,6 +48,7 @@ For illustration purposes, the following structure represents the full set of op
         "DiskOperationsTimeout": "0.0:05:00",
         "SourceDeployBatchSize": null,
         "PackageBatchSize": null,
+        "AllowIgnoreDependenciesOperations": "None",
         "IgnoreBrokenDependenciesBehavior": "Restore",
         "AcceptInvalidCertificates": false,
         "TransferFormsAsContent": true,
@@ -241,7 +242,22 @@ Please see the note above under _TransferFormsAsContent_ on the topic of removin
 
 This setting is to be defined and set to `false` only if you are using an external membership provider for your members. You will not want to export Member Groups that would no longer be managed by Umbraco but by an external membership provider.
 
-Setting `exportMemberGroups` to `false` will no longer export Member Groups to .uda files on disk. The default for this setting is `true`, as most sites use Umbraco's built-in membership provider and thus will want the membership groups exported.
+Setting `ExportMemberGroups` to `false` will no longer export Member Groups to .uda files on disk. The default for this setting is `true`, as most sites use Umbraco's built-in membership provider and thus will want the membership groups exported.
+
+### AllowIgnoreDependenciesOperations {#allow-ignore-dependencies}
+
+When restoring or transferring content, media or other items, Umbraco Deploy will by default make sure any dependencies that don't exist on the target environment will be included in the operation.
+
+For example, if you have a media picker on a content item, that references a media item that doesn't exist on the target environment yet, the media item will be created when only tranferring that content. This ensures the target environment doesn't end up with broken dependencies (references/links to other items that don't exist).
+
+Ignoring these dependencies will result in only restoring or tranferring the selected item(s), which allows more control over what is included in the operation (which can resolve deployment issues with a large amount of content, media or other items).
+
+You can configure which operations are allowed to ignore dependencies when these are performed in the backoffice. Note that ignoring dependencies can result in deployment errors (e.g. parent items that aren't included) or content with broken dependencies.
+
+* `None` - ignoring dependencies is not allowed (the default value if the setting is missing)
+* `Restore` - dependencies can only be ignored when restoring from upstream environments
+* `Transfer` - dependencies can only be ignored when transferring upstream environments
+* `All` - dependencies can be ignored when restoring from and transferring to upstream environments
 
 ### IgnoreBrokenDependenciesBehavior {#ignore-broken-dependencies}
 

--- a/13/umbraco-deploy/getting-started/deploy-settings.md
+++ b/13/umbraco-deploy/getting-started/deploy-settings.md
@@ -247,13 +247,13 @@ Setting `ExportMemberGroups` to `false` will no longer export Member Groups to .
 
 ### AllowIgnoreDependenciesOperations {#allow-ignore-dependencies}
 
-When restoring or transferring content, media or other items, Umbraco Deploy will by default make sure any dependencies that don't exist on the target environment will be included in the operation.
+When restoring/transferring content or other items, Deploy will ensure any dependencies that don't exist on the target environment are included in the operation.
 
-For example, if you have a media picker on a content item, that references a media item that doesn't exist on the target environment yet, the media item will be created when only tranferring that content. This ensures the target environment doesn't end up with broken dependencies (references/links to other items that don't exist).
+Example: You have a media picker on a content item, that references a media item that doesn't exist on the target environment yet. The media item will be created when transferring only that content. This ensures the target environment doesn't end up with broken dependencies (references/links to other items that don't exist).
 
-Ignoring these dependencies will result in only restoring or tranferring the selected item(s), which allows more control over what is included in the operation (which can resolve deployment issues with a large amount of content, media or other items).
+When these dependencies are ignored only the selected item(s) are restored/transferred. This allows more control over what is included in the operation (which can resolve deployment issues with a large amount of content, media, or other items).
 
-You can configure which operations are allowed to ignore dependencies when these are performed in the backoffice. Note that ignoring dependencies can result in deployment errors (e.g. parent items that aren't included) or content with broken dependencies.
+You can configure which operations are allowed to ignore dependencies when these are performed in the backoffice. Ignoring dependencies can result in deployment errors (like parent items that aren't included) or content with broken dependencies.
 
 * `None` - ignoring dependencies is not allowed (the default value if the setting is missing)
 * `Restore` - dependencies can only be ignored when restoring from upstream environments
@@ -356,7 +356,7 @@ You can amend this behavior using this setting:
 
 ### PostDeploySchemaOperation {#post-deploy-schema-operation}
 
-After the Umbraco schema is deployed from the files on disk, the current environment might still have items that don't have a corresponding file on disk.
+After the schema is deployed from the files on disk, the current environment might still have items that don't have corresponding files on disk.
 
 You can automatically perform an operation after a schema deployment to align this:
 
@@ -364,7 +364,7 @@ You can automatically perform an operation after a schema deployment to align th
 * `CleanSchema` - items that don't have a corresponding file on disk will be deleted
 * `ExtractSchema` - all items will be written to files on disk
 
-A common use-case will to be configure `CleanSchema` on local/development environments, so deleted schema items will be automatically cleaned, ensuring they aren't re-created again when one of the environments writes the item back to disk and deploys the changes. Take caution when using this value on a live environment though, because missing schema files could result in deleting all content (e.g. deleting a document type will delete all content of that type).
+A common use case is to configure `CleanSchema` on local/development environments. Deleted schema items will then be cleaned automatically, ensuring they aren't re-created when an environment writes the item back and deploys the changes. Take caution when using this value on a live environment, as missing schema files can result in additional deletions. Deleting a Document Type, for example, will also delete all content using that type.
 
 ### PreferLocalDbConnectionString
 

--- a/13/umbraco-deploy/getting-started/deploy-settings.md
+++ b/13/umbraco-deploy/getting-started/deploy-settings.md
@@ -251,7 +251,7 @@ When restoring/transferring content or other items, Deploy will ensure any depen
 
 Example: You have a media picker on a content item, that references a media item that doesn't exist on the target environment yet. The media item will be created when transferring only that content. This ensures the target environment doesn't end up with broken dependencies (references/links to other items that don't exist).
 
-When these dependencies are ignored only the selected item(s) are restored/transferred. This allows more control over what is included in the operation (which can resolve deployment issues with a large amount of content, media, or other items).
+When these dependencies are ignored only the selected item(s) are restored/transferred. This allows more control over what is included in the operation. Ignoring dependencies can also help resolve deployment issues with a large amount of content, media, or other items.
 
 You can configure which operations are allowed to ignore dependencies when these are performed in the backoffice. Ignoring dependencies can result in deployment errors (like parent items that aren't included) or content with broken dependencies.
 

--- a/13/umbraco-deploy/getting-started/deploy-settings.md
+++ b/13/umbraco-deploy/getting-started/deploy-settings.md
@@ -62,6 +62,7 @@ For illustration purposes, the following structure represents the full set of op
         "AllowDomainsDeploymentOperations": "None",
         "AllowWebhooksDeploymentOperations": "None",
         "TrashedContentDeploymentOperations": "Import",
+        "PostDeploySchemaOperation": "None",
         "PreferLocalDbConnectionString": false,
         "MediaFileChecksumCalculationMethod": "PartialFileContents",
         "NumberOfSignaturesToUseAllRelationCache": 100,
@@ -352,6 +353,18 @@ You can amend this behavior using this setting:
 * `Export` - trashed content will be included in an export
 * `Import` - trashed content will be processed and moved to the recycle bin on import
 * `All` - trashed content will be included in an export, processed and moved to the recycle bin on import
+
+### PostDeploySchemaOperation {#post-deploy-schema-operation}
+
+After the Umbraco schema is deployed from the files on disk, the current environment might still have items that don't have a corresponding file on disk.
+
+You can automatically perform an operation after a schema deployment to align this:
+
+* `None` - no operation is performed
+* `CleanSchema` - items that don't have a corresponding file on disk will be deleted
+* `ExtractSchema` - all items will be written to files on disk
+
+A common use-case will to be configure `CleanSchema` on local/development environments, so deleted schema items will be automatically cleaned, ensuring they aren't re-created again when one of the environments writes the item back to disk and deploys the changes. Take caution when using this value on a live environment though, because missing schema files could result in deleting all content (e.g. deleting a document type will delete all content of that type).
 
 ### PreferLocalDbConnectionString
 

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -1,7 +1,5 @@
 ---
-description: >-
-  Get an overview of the things changed and fixed in each version of Umbraco
-  Deploy.
+description: Get an overview of the changes and fixes in each version of Umbraco Deploy.
 ---
 
 # Release notes
@@ -14,25 +12,25 @@ If there are any breaking changes or other issues to be aware of when upgrading 
 If you are upgrading to a new major version you can find the details about the breaking changes in the [version specific updates](upgrades/version-specific.md) article.
 {% endhint %}
 
-## Release History
+## Release history
 
 This section contains the release notes for Umbraco Deploy 13 including all changes for this version.
 
-#### [13.3.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.3.2) (December 23rd 2024)
+### [13.3.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.3.2) (December 23rd 2024)
 
 * Ensure environment-to-environment actions are executed asynchronously on background job (fixes timeout issues on large deployments) [#179](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/179)
 * Only require default, allowed and master templates and their associated files to exist (avoids schema mismatches on template changes) [156](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/156)
 
-#### [13.3.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.3.1) (November 29th 2024)
+### [13.3.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.3.1) (November 29th 2024)
 
 * Update documentation links in management dashboard to include major version in the URL
 * Add `ValidateDependenciesOnImport` setting to management dashboard
 
-#### [13.3.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.3.0) (November 21st 2024)
+### [13.3.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.3.0) (November 21st 2024)
 
 * All items from 13.3.0-rc1
 
-#### [13.3.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.3.0) (November 13rd 2024)
+### [13.3.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.3.0) (November 13rd 2024)
 
 * Add option to include all schema in a workspace export
 * Add option to export from transfer queue
@@ -42,17 +40,17 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 * Fixed issue where content was not saved when transferring variant content with a release date
 * Support flexible environments on Umbraco Cloud (remove requirement for environment types to be Development, Staging or Live)
 
-#### [13.2.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.2) (October 3rd 2024)
+### [13.2.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.2) (October 3rd 2024)
 
 * Support migrating legacy Grid editor settings (config/styles) using JSON object pre-values
 
-#### [13.2.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.1) (September 17th 2024)
+### [13.2.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.1) (September 17th 2024)
 
 * Fix tree export of members by member type
 * Ensure release date of invariant content is correctly transferred [#233](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/233)
 * Parse nested JSON property values from artifact values [#234](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/234)
 
-#### [13.2.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.0) (August 15th 2024)
+### [13.2.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.0) (August 15th 2024)
 
 * All items from 13.2.0-rc1
 * Fixed `Could not create Udi node: {Id} and entity type {EntityType}` exception when exporting tree nodes without children
@@ -60,18 +58,18 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 * Allow members to be deployed when selected as items in a multi-node tree picker [#231](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/231)
 * Apply `ExcludedEntityTypes` configuration to disk operations [#232](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/232)
 
-#### [13.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.0) (July 19th 2024)
+### [13.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.0) (July 19th 2024)
 
 * Add migrators to support legacy Grid layout to Block Grid migration
 
-#### [13.1.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.1) (July 11th 2024)
+### [13.1.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.1) (July 11th 2024)
 
 * Add `[DisableRequestSizeLimit]` attribute to `UploadForImport` endpoint to remove application request size limit (server/infrastructure restrictions may still apply)
 * Determine missing `routePath` based on `$routeParams` to fix Export, Queue for transfer, and Partial Restore actions on items with children in a list view
 * Set trashed state when processing content [#223](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/223)
 * Improve exception message when parent cannot be found when getting artifact [#216](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/216)
 
-#### [13.1.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.0) (March 19th 2024)
+### [13.1.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.0) (March 19th 2024)
 
 * All items from 13.1.0-rc1
 * Fixed issue with transfer of date values within Nested Content, Block List, or Block Grid properties [#209](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/209)
@@ -80,7 +78,7 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 * Fixed deserialization issue causing problems with the compare content feature [#212](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/212)
 * Add configuration to allow control over suspension and resumption of Examine and document cache events during Deploy operation [#211](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/211)
 
-#### [13.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.0) (March 5th 2024)
+### [13.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.1.0) (March 5th 2024)
 
 * Add `IArtifactTypeResolver` to allow custom type resolving when deserializing to `IArtifact` (used by Deploy Contrib, see PR [#60](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/61))
 * Add base migrators for importing legacy artifacts (used by Deploy Contrib)
@@ -90,7 +88,7 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 * Only validate `ApiKey` and `ApiSecret` when workspaces are configured
 * Explicitly register API controller endpoints
 
-#### [13.0.4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.4) (February 20th 2024)
+### [13.0.4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.4) (February 20th 2024)
 
 * Removed the no-longer supported "live edit" feature (Deploy on Cloud only).
 * Fixed issue where the removal of a master template couldn't be deployed [#201](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/201)
@@ -99,77 +97,77 @@ This section contains the release notes for Umbraco Deploy 13 including all chan
 * User experience and message improvements on content flow exception [#202](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/202)
 * Fixed issue with transfer of empty values to overwrite non-empty ones.
 
-#### [13.0.3](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.3) (January 16th 2024)
+### [13.0.3](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.3) (January 16th 2024)
 
 * Added configurable option to avoid overwriting of dictionary items with empty values [#191](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/191)
   * For more details see the page on [Deploy's settings](getting-started/deploy-settings.md).
 * Fixed regression issue with transfer of date values.
 
-#### [13.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.2) (January 9th 2024)
+### [13.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.2) (January 9th 2024)
 
 * Fixed issue with transfer of content using language variants [#193](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/193)
 
-#### [13.0.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.1) (December 21th 2023)
+### [13.0.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.1) (December 21th 2023)
 
 * Fixes the display of the selected schedule date on queue for transfer.
 * Fixes parsing property values within Nested Content and Block List that were previously saved by the Contrib value connectors.
 * Fixed incorrectly including media files in export when 'Content files' wasn't selected.
 * Add maximum file size validation to import file upload.
 
-#### [13.0.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) (December 14th 2023)
+### [13.0.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) (December 14th 2023)
 
 * All items from the 13.0.0 RCs and latest 12.2 features.
 
-#### [13.0.0-rc5](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) (December 12th 2023)
+### [13.0.0-rc5](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) (December 12th 2023)
 
 * Align with latest CMS RC.
 
-#### [13.0.0-rc4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) (December 11th 2023)
+### [13.0.0-rc4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) (December 11th 2023)
 
 * Add weight -100 to Deploy package migration (ensuring Deploy database tables are available before other package migrations are executed).
 * Add fluent API for Deploy webhooks.
 
-#### [13.0.0-rc3](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) (November 29th 2023)
+### [13.0.0-rc3](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) (November 29th 2023)
 
 * Added optional deployment of webhooks as part of schema updates.
 * Added Deploy specific webhook events.
 
-#### [13.0.0-rc2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) (November 15th 2023)
+### [13.0.0-rc2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) (November 15th 2023)
 
 * Exclude automatic relation type aliases (used for reference tracking) from deployment.
 * Fix cyclic dependency between configuring `DeploySettings` and `ConnectionStrings`.
 
-#### [13.0.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) (November 6th 2023)
+### [13.0.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.0.0) (November 6th 2023)
 
 * Compatibility with Umbraco 13:
   * See full details of breaking changes under the [version specific upgrade guide](upgrades/version-specific.md).
   * Update Richtext value connector to handle references in blocks.
 
-## Deploy Contrib
+## Umbraco.Deploy.Contrib
 
-#### [13.3.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.3.0) (October 3rd 2024)
+### [13.3.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.3.0) (October 3rd 2024)
 
 * Migrate nested/recursive legacy pre-value property values [#71](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/71)
 
-#### [13.2.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.2.0) (August 15th 2024)
+### [13.2.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.2.0) (August 15th 2024)
 
 * All items from 13.2.0-rc1
 
-#### [13.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.2.0-rc1) (July 19th 2024)
+### [13.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.2.0-rc1) (July 19th 2024)
 
 * Skip empty pre-values [#63](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/63)
 * Add Matryoshka Group Separator artifact migrator [#67](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/67)
 * Add migrators to support DocTypeGridEditor to Block Grid migration [#66](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/66)
 
-#### [13.1.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.1.0) (March 19th 2024)
+### [13.1.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.1.0) (March 19th 2024)
 
-* All items from 10.2.0-rc1
+* All items from 13.1.0-rc1
 
-#### [13.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.1.0-rc1) (March 5th 2024)
+### [13.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.1.0-rc1) (March 5th 2024)
 
 * Add legacy migrators and type resolver to allow importing from Umbraco 7 in [#61](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/61)
 
-#### [13.0.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.0.0) (December 14th 2023)
+### [13.0.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-13.0.0) (December 14th 2023)
 
 * Compatibility with Umbraco 13
 

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -16,6 +16,17 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 13 including all changes for this version.
 
+### [13.4.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.4.0) (January 30th 2025)
+
+* Schema cleanup and item actions triggered from Deploy's management dashboard (create or delete UDA files and Umbraco items)
+* Allow ignoring dependencies in transfer/restore operations
+* Ignore `Dependencies` artifact property when calculating the checksum and fix schema comparison [#246](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/246)
+* Add 'Hide up to date' toggle to schema comparison [#245](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/245)
+* Fix parsing dictionary item root UDI range from node ID
+* Ensure work item references/action results are deallocated (reduces overall memory usage in Deploy)
+* Removed the non-functioning and non-required button from the transfer dialog complete view [#244](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/244)
+* Improve diff view in Compare dialog (compare each word instead of line in JSON values)
+
 ### [13.3.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.3.2) (December 23rd 2024)
 
 * Ensure environment-to-environment actions are executed asynchronously on background job (fixes timeout issues on large deployments) [#179](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/179)

--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -16,6 +16,10 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 13 including all changes for this version.
 
+### [13.4.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.4.0) (February 6th 2025)
+
+* All items from 13.4.0-rc1
+
 ### [13.4.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.4.0) (January 30th 2025)
 
 * Schema cleanup and item actions triggered from Deploy's management dashboard (create or delete UDA files and Umbraco items)

--- a/14/umbraco-deploy/getting-started/deploy-settings.md
+++ b/14/umbraco-deploy/getting-started/deploy-settings.md
@@ -49,6 +49,7 @@ For illustration purposes, the following structure represents the full set of op
         "SourceDeployBatchSize": null,
         "PackageBatchSize": null,
         "MaxRequestLength": null,
+        "AllowIgnoreDependenciesOperations": "None",
         "IgnoreBrokenDependenciesBehavior": "Restore",
         "AcceptInvalidCertificates": false,
         "TransferFormsAsContent": true,
@@ -248,7 +249,22 @@ Please see the note above under _TransferFormsAsContent_ on the topic of removin
 
 This setting is to be defined and set to `false` only if you are using an external membership provider for your members. You will not want to export Member Groups that would no longer be managed by Umbraco but by an external membership provider.
 
-Setting `exportMemberGroups` to `false` will no longer export Member Groups to .uda files on disk. The default for this setting is `true`, as most sites use Umbraco's built-in membership provider and thus will want the membership groups exported.
+Setting `ExportMemberGroups` to `false` will no longer export Member Groups to .uda files on disk. The default for this setting is `true`, as most sites use Umbraco's built-in membership provider and thus will want the membership groups exported.
+
+### AllowIgnoreDependenciesOperations {#allow-ignore-dependencies}
+
+When restoring or transferring content, media or other items, Umbraco Deploy will by default make sure any dependencies that don't exist on the target environment will be included in the operation.
+
+For example, if you have a media picker on a content item, that references a media item that doesn't exist on the target environment yet, the media item will be created when only tranferring that content. This ensures the target environment doesn't end up with broken dependencies (references/links to other items that don't exist).
+
+Ignoring these dependencies will result in only restoring or tranferring the selected item(s), which allows more control over what is included in the operation (which can resolve deployment issues with a large amount of content, media or other items).
+
+You can configure which operations are allowed to ignore dependencies when these are performed in the backoffice. Note that ignoring dependencies can result in deployment errors (e.g. parent items that aren't included) or content with broken dependencies.
+
+* `None` - ignoring dependencies is not allowed (the default value if the setting is missing)
+* `Restore` - dependencies can only be ignored when restoring from upstream environments
+* `Transfer` - dependencies can only be ignored when transferring upstream environments
+* `All` - dependencies can be ignored when restoring from and transferring to upstream environments
 
 ### IgnoreBrokenDependenciesBehavior {#ignore-broken-dependencies}
 

--- a/14/umbraco-deploy/getting-started/deploy-settings.md
+++ b/14/umbraco-deploy/getting-started/deploy-settings.md
@@ -254,13 +254,13 @@ Setting `ExportMemberGroups` to `false` will no longer export Member Groups to .
 
 ### AllowIgnoreDependenciesOperations {#allow-ignore-dependencies}
 
-When restoring or transferring content, media or other items, Umbraco Deploy will by default make sure any dependencies that don't exist on the target environment will be included in the operation.
+When restoring/transferring content or other items, Deploy will ensure any dependencies that don't exist on the target environment are included in the operation.
 
-For example, if you have a media picker on a content item, that references a media item that doesn't exist on the target environment yet, the media item will be created when only tranferring that content. This ensures the target environment doesn't end up with broken dependencies (references/links to other items that don't exist).
+Example: You have a media picker on a content item, that references a media item that doesn't exist on the target environment yet. The media item will be created when transferring only that content. This ensures the target environment doesn't end up with broken dependencies (references/links to other items that don't exist).
 
-Ignoring these dependencies will result in only restoring or tranferring the selected item(s), which allows more control over what is included in the operation (which can resolve deployment issues with a large amount of content, media or other items).
+When these dependencies are ignored only the selected item(s) are restored/transferred. This allows more control over what is included in the operation. Ignoring dependencies can also help resolve deployment issues with a large amount of content, media, or other items.
 
-You can configure which operations are allowed to ignore dependencies when these are performed in the backoffice. Note that ignoring dependencies can result in deployment errors (e.g. parent items that aren't included) or content with broken dependencies.
+You can configure which operations are allowed to ignore dependencies when these are performed in the backoffice. Ignoring dependencies can result in deployment errors (like parent items that aren't included) or content with broken dependencies.
 
 * `None` - ignoring dependencies is not allowed (the default value if the setting is missing)
 * `Restore` - dependencies can only be ignored when restoring from upstream environments
@@ -363,7 +363,7 @@ You can amend this behavior using this setting:
 
 ### PostDeploySchemaOperation {#post-deploy-schema-operation}
 
-After the Umbraco schema is deployed from the files on disk, the current environment might still have items that don't have a corresponding file on disk.
+After the schema is deployed from the files on disk, the current environment might still have items that don't have corresponding files on disk.
 
 You can automatically perform an operation after a schema deployment to align this:
 
@@ -371,7 +371,7 @@ You can automatically perform an operation after a schema deployment to align th
 * `CleanSchema` - items that don't have a corresponding file on disk will be deleted
 * `ExtractSchema` - all items will be written to files on disk
 
-A common use-case will to be configure `CleanSchema` on local/development environments, so deleted schema items will be automatically cleaned, ensuring they aren't re-created again when one of the environments writes the item back to disk and deploys the changes. Take caution when using this value on a live environment though, because missing schema files could result in deleting all content (e.g. deleting a document type will delete all content of that type).
+A common use case is to configure `CleanSchema` on local/development environments. Deleted schema items will then be cleaned automatically, ensuring they aren't re-created when an environment writes the item back and deploys the changes. Take caution when using this value on a live environment, as missing schema files can result in additional deletions. Deleting a Document Type, for example, will also delete all content using that type.
 
 ### PreferLocalDbConnectionString
 

--- a/14/umbraco-deploy/getting-started/deploy-settings.md
+++ b/14/umbraco-deploy/getting-started/deploy-settings.md
@@ -63,6 +63,7 @@ For illustration purposes, the following structure represents the full set of op
         "AllowDomainsDeploymentOperations": "None",
         "AllowWebhooksDeploymentOperations": "None",
         "TrashedContentDeploymentOperations": "Import",
+        "PostDeploySchemaOperation": "None",
         "PreferLocalDbConnectionString": false,
         "MediaFileChecksumCalculationMethod": "PartialFileContents",
         "NumberOfSignaturesToUseAllRelationCache": 100,
@@ -359,6 +360,18 @@ You can amend this behavior using this setting:
 * `Export` - trashed content will be included in an export
 * `Import` - trashed content will be processed and moved to the recycle bin on import
 * `All` - trashed content will be included in an export, processed and moved to the recycle bin on import
+
+### PostDeploySchemaOperation {#post-deploy-schema-operation}
+
+After the Umbraco schema is deployed from the files on disk, the current environment might still have items that don't have a corresponding file on disk.
+
+You can automatically perform an operation after a schema deployment to align this:
+
+* `None` - no operation is performed
+* `CleanSchema` - items that don't have a corresponding file on disk will be deleted
+* `ExtractSchema` - all items will be written to files on disk
+
+A common use-case will to be configure `CleanSchema` on local/development environments, so deleted schema items will be automatically cleaned, ensuring they aren't re-created again when one of the environments writes the item back to disk and deploys the changes. Take caution when using this value on a live environment though, because missing schema files could result in deleting all content (e.g. deleting a document type will delete all content of that type).
 
 ### PreferLocalDbConnectionString
 

--- a/14/umbraco-deploy/release-notes.md
+++ b/14/umbraco-deploy/release-notes.md
@@ -16,6 +16,10 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 14 including all changes for this version.
 
+### [14.3.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.3.0) (February 6th 2025)
+
+* All items from 14.3.0-rc1
+
 ### [14.3.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.3.0) (January 30th 2025)
 
 * Schema cleanup and item actions triggered from Deploy's management dashboard (create or delete UDA files and Umbraco items)

--- a/14/umbraco-deploy/release-notes.md
+++ b/14/umbraco-deploy/release-notes.md
@@ -1,7 +1,5 @@
 ---
-description: >-
-  Get an overview of the things changed and fixed in each version of Umbraco
-  Deploy.
+description: Get an overview of the things changed and fixed in each version of Umbraco Deploy.
 ---
 
 # Release notes
@@ -14,27 +12,27 @@ If there are any breaking changes or other issues to be aware of when upgrading 
 If you are upgrading to a new major version you can find the details about the breaking changes in the [version specific updates](upgrades/version-specific.md) article.
 {% endhint %}
 
-## Release History
+## Release history
 
 This section contains the release notes for Umbraco Deploy 14 including all changes for this version.
 
-#### [14.2.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.2) (December 23rd 2024)
+### [14.2.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.2) (December 23rd 2024)
 
 * Ensure environment-to-environment actions are executed asynchronously on background job (fixes timeout issues on large deployments) [#179](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/179)
 * Only require default, allowed and master templates and their associated files to exist (avoids schema mismatches on template changes) [156](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/156)
 
-#### [14.2.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.1) (November 29th 2024)
+### [14.2.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.1) (November 29th 2024)
 
 * Update documentation links in management dashboard to include major version in the URL
 * Add `ValidateDependenciesOnImport` setting to management dashboard
 * Fix tree restore for custom entities [#241](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/241)
 * Disable import button when no file is selected
 
-#### [14.2.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.0) (November 21st 2024)
+### [14.2.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.0) (November 21st 2024)
 
 * All items from 14.2.0-rc1
 
-#### [14.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.0) (November 13th 2024)
+### [14.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.0) (November 13th 2024)
 
 * Add option to include all schema in a workspace export
 * Add option to export from transfer queue
@@ -44,28 +42,28 @@ This section contains the release notes for Umbraco Deploy 14 including all chan
 * Fixed issue where content was not saved when transferring variant content with a release date
 * Support flexible environments on Umbraco Cloud (remove requirement for environment types to be Development, Staging or Live)
 
-#### [14.1.4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.4) (October 3rd 2024)
+### [14.1.4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.4) (October 3rd 2024)
 
 * Support migrating legacy Grid editor settings (config/styles) using JSON object pre-values
 * Fix parsing JSON serialized legacy Grid editor control values
 
-#### [14.1.3](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.3) (September 19th 2024)
+### [14.1.3](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.3) (September 19th 2024)
 
 * Resolved forbidden API requests on content section display when the user does not have access to the settings section.
 
-#### [14.1.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.2) (September 17th 2024)
+### [14.1.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.2) (September 17th 2024)
 
 * Fix document blueprint connector and add support for containers
 * Fix tree export of members by member type
 * Ensure release date of invariant content is correctly transferred [#233](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/233)
 * Parse nested JSON property values from artifact values [#234](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/234)
 
-#### [14.1.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.1) (August 20th 2024)
+### [14.1.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.1) (August 20th 2024)
 
 * Support getting artifacts from exploded/expanded `NamedUdiRange` with different entity types
 * Fixed typo in `DefaultLegacyDataTypeConfigurationArtifactMigrator` when migrating Color Picker items in v8 format
 
-#### [14.1.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.0) (August 15th 2024)
+### [14.1.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.0) (August 15th 2024)
 
 * All items from 14.1.0-rc1
 * Fixed `Could not create Udi node: {Id} and entity type {EntityType}` exception when exporting tree nodes without children
@@ -76,7 +74,7 @@ This section contains the release notes for Umbraco Deploy 14 including all chan
 * Fixed formatting of trial expiry days and added missing translations [#229](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/229)
 * Fixed `Could not get physical path for "umb://template-file/".` exception when deploying/exporting template without physical file on disk
 
-#### [14.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.0) (July 19th 2024)
+### [14.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.0) (July 19th 2024)
 
 * Add migrators to support legacy Grid layout to Block Grid migration
 * Fix schema mismatch when saving templates in production runtime mode [#228](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/228)
@@ -84,14 +82,14 @@ This section contains the release notes for Umbraco Deploy 14 including all chan
 * Add default migrator to update Data Type configuration
 * Support processing Document/Media Type list view keys and add migrator
 
-#### [14.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.2) (July 11th 2024)
+### [14.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.2) (July 11th 2024)
 
 * Set trashed state when processing content [#223](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/223)
 * Improve exception message when parent can't be found when getting artifact [#216](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/216)
 * Add `MaxRequestLength` Deploy setting to break file upload into multiple requests
 * Set variant names when creating new content [#222](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/222)
 
-#### [14.0.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.1) (June 6th 2024)
+### [14.0.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.1) (June 6th 2024)
 
 * Ensure remote tree uses correct entity type (if multiple entities like folders and items are present in a tree):
   * `ITransferEntityService.RegisterTransferEntityType(...)` accepts an optional `RemoteTreeDetail` that now exposes the entity type when getting remote entities;
@@ -104,29 +102,28 @@ This section contains the release notes for Umbraco Deploy 14 including all chan
 * Support import with unknown UDI types (like macro, macroscript and partial-view-macro);
 * Fix JSON serialization error in value connectors for `BlockValue`.
 
-#### [14.0.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.0) (May 30th 2024)
+### [14.0.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.0) (May 30th 2024)
 
 * Compatibility with Umbraco 14
   * See full details of breaking changes under the [Version-specific Upgrade Guide](upgrades/version-specific.md).
 
-## Deploy Contrib
+## Umbraco.Deploy.Contrib
 
-#### [14.2.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-14.2.0) (October 3rd 2024)
+### [14.2.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-14.2.0) (October 3rd 2024)
 
 * Migrate nested/recursive legacy pre-value property values [#71](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/71)
 
-
-#### [14.1.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-14.1.0) (August 15th 2024)
+### [14.1.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-14.1.0) (August 15th 2024)
 
 * All items from 14.1.0-rc1
 
-#### [14.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-14.1.0-rc1) (July 19th 2024)
+### [14.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-14.1.0-rc1) (July 19th 2024)
 
 * Add Matryoshka Group Separator artifact migrator [#67](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/67)
 * Add migrators to support DocTypeGridEditor to Block Grid migration [#66](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/66)
 * Fix and enable remaining legacy artifact migrators [#68](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/68)
 
-#### [14.0.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-14.0.0) (May 30th 2024)
+### [14.0.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-14.0.0) (May 30th 2024)
 
 * Compatibility with Umbraco 14 and Deploy 14.
 

--- a/14/umbraco-deploy/release-notes.md
+++ b/14/umbraco-deploy/release-notes.md
@@ -16,6 +16,16 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 14 including all changes for this version.
 
+### [14.3.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.3.0) (January 30th 2025)
+
+* Schema cleanup and item actions triggered from Deploy's management dashboard (create or delete UDA files and Umbraco items)
+* Allow ignoring dependencies in transfer/restore operations
+* Ignore `Dependencies` artifact property when calculating the checksum and fix schema comparison [#246](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/246)
+* Add 'Hide up to date' toggle to schema comparison [#245](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/245)
+* Fix parsing dictionary item root UDI range from node ID
+* Ensure work item references/action results are deallocated (reduces overall memory usage in Deploy)
+* Allow disabling warnings as errors on import
+
 ### [14.2.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.2) (December 23rd 2024)
 
 * Ensure environment-to-environment actions are executed asynchronously on background job (fixes timeout issues on large deployments) [#179](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/179)

--- a/14/umbraco-forms/release-notes.md
+++ b/14/umbraco-forms/release-notes.md
@@ -1,10 +1,8 @@
 ---
-description: >-
-  Get an overview of the things changed and fixed in each version of Umbraco
-  Forms.
+description: Get an overview of the things changed and fixed in each version of Umbraco Forms.
 ---
 
-# Release Notes
+# Release notes
 
 In this section, we have summarized the changes to Umbraco Forms released in each version. Each version is presented with a link to the [Forms issue tracker](https://github.com/umbraco/Umbraco.Forms.Issues/issues) showing a list of issues resolved in the release. We also link to the individual issues themselves from the detail.
 
@@ -14,20 +12,20 @@ If there are any breaking changes or other issues to be aware of when upgrading 
 If you are upgrading to a new major version, you can find information about the breaking changes in the [Version Specific Upgrade Notes](upgrading/version-specific.md) article.
 {% endhint %}
 
-## Release History
+## Release history
 
 This section contains the release notes for Umbraco Forms 14 including all changes for this version.
 
-#### [**14.2.3**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.3) **(December 5th 2024)**
+### [14.2.3](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.3) (December 5th 2024)
 
 * Fixed regression introduced in 14.2.1 that caused issues for custom field types overriding the `ProcessSubmittedValue` method  [#1328](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1328).
 
-#### [**14.2.2**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.2) **(November 28th 2024)**
+### [14.2.2](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.2) (November 28th 2024)
 
 * Fixed issue with case sensitive checkbox conditions across multi-page forms [#1325](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1325).
 * Fixed Forms dashboard form title and icon alignment.
 
-#### [**14.2.1**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.1) **(November 21st 2024)**
+### [14.2.1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.1) (November 21st 2024)
 
 * Fixed issues with multi-page forms used in conjunction with a `FormPrePopulateNotification` handler. File uploads and multi-value fields like checkbox lists now function correctly [#1317](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1317) [#1320](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1320).
 * Added a couple of missing translation keys [#1316](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1316) [#1319](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1319).
@@ -36,19 +34,19 @@ This section contains the release notes for Umbraco Forms 14 including all chang
 * Fixed issue with selection of Document Type on the "Save as Umbraco node" workflow type.
 * Used correct labels for conditions when used on fields, fieldsets, pages or workflows [#1323](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1323).
 
-#### [**14.2.0**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.0) **(November 7th 2024)**
+### [14.2.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.0) (November 7th 2024)
 
 * All items detailed under release candidates for 14.2.0.
 * Fixed issue with validation for invalid file extension on form submissions via the API [#1310](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1310).
 
-#### [**14.2.0-rc2**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.0) **November 3rd 2024**
+### [14.2.0-rc2](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.0) **November 3rd 2024**
 
 * Updated dependency on Umbraco CMS to 14.3.0.
 * Added a replacement for the AngularJS [block list label filter we provide for Forms 13](../../13/umbraco-forms/developer/blocklistfilters.md). The new implementations use [Umbraco Flavored Markdown (UFM)](https://docs.umbraco.com/umbraco-cms/reference/umbraco-flavored-markdown) and are [documented here](./developer/blocklistfilters.md).
 
-#### [**14.2.0-rc1**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.0) **October 25th 2024**
+### [14.2.0-rc1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.2.0) **October 25th 2024**
 
-##### Multi-step forms
+#### Multi-step forms
 
 The 14.2 release of Forms contains features that can improve the user experience of completing multi-page forms.
 
@@ -56,33 +54,33 @@ We have added the option for [editors to choose to display paging details on the
 
 These options are enabled and configured by editors in the Forms settings section on a per-form basis. We also provide a [configuration-based toggle for the feature as a whole](./developer/configuration/README.md#enablemultipageformsettings). In this way, editors can be given access to use the feature only once the styling or theme is prepared.
 
-##### Form picker enhancements
+#### Form picker enhancements
 
 Another improvement is found in the [form picker property editors](./developer/property-editors.md). We now support restriction of which forms can be selected by folder rather than only by individual forms.
 
 A second "form details picker" is also available, allowing editors the option of selecting the form, theme and redirect via a single property editor.
 
-##### Ship themes in Razor Class Libraries
+#### Ship themes in Razor Class Libraries
 
 Forms ships it's themes and email templates as part of a razor class library for ease of distribution. With this release we make that feature [available to your own custom themes and templates](./developer/themes.md#shipping-themes-in-a-razor-class-library) (or those created by package developers) [#795](https://github.com/umbraco/Umbraco.Forms.Issues/issues/795).
 
-##### Date picker field type
+#### Date picker field type
 
 We have made a couple of updates to the Date Picker field type. The format for the field can now be provided in configuration [#1276](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1276). And you can now override and localize the aria label provided for assistive technologies such as screen readers [#1082](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1082).
 
-##### Umbraco documents prevalue source type
+#### Umbraco documents prevalue source type
 
 When creating a prevalue source based on Umbraco documents, you can now select custom properties for the value or caption. Previously you had a choice of the content item's `Id`, `Key` or `Name`. We've extended this to allow the selection of any properties defined on the selected Document Type [#1195](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1195).
 
-##### Finer grained entries permissions
+#### Finer grained entries permissions
 
 To allow finer control over editor permissions, we have introduced a "delete entries" setting for users and user groups. Thus you can now give editors explicit permissions to view, edit, or delete entries [#1303](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1303).
 
-##### Backoffice localization
+#### Backoffice localization
 
 Finally thanks to a kind contribution from [Erik-Jan Westendorp](https://github.com/erikjanwestendorp) the backoffice is now translated into Dutch [#1264](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1264).
 
-##### Other
+#### Other
 
 Other bug fixes included in the release:
 
@@ -92,7 +90,7 @@ Other bug fixes included in the release:
 * Fixed issue with single checkbox triggering a condition on a field on a subsequent page [#1304](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1304).
 * Improved cross-platform check when exporting to Excel.
 
-#### [**14.1.5**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.5) **(October 3rd 2024)**
+### [14.1.5](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.5) (October 3rd 2024)
 
 * Handled "chunked" authentication cookie in protection of file uploads saved in the media file system [#11](https://github.com/umbraco/Umbraco.Forms.Issues/issues/11#issuecomment-2376788751).
 * Ensured field list for condition rules updates as new fields are added to the form [#1301](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1301).
@@ -100,17 +98,17 @@ Other bug fixes included in the release:
 * Fixed button labels on form copy dialog.
 * Fixed localization of SQL prevalue source labels.
 
-#### [**14.1.4**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.4) **(September 26th 2024)**
+### [14.1.4](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.2.4) (September 26th 2024)
 
 * Fixed regression in 14.1.2 that caused validation to fire on the wrong form when multiple forms are hosted on a single page [#1297](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1297).
 * Fixed issue with line breaks in form submissions breaking the entries view [#1296](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1296).
 
-#### [**14.1.3**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.3) **(September 19th 2024)**
+### [14.1.3](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.3) (September 19th 2024)
 
 * Fixed regression in 13.2.0 that prevented a form submission from saving if a workflow approved the entry [#1293](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1293).
 * Added file name validation to file uploads, rejecting files with invalid colon characters [#1295](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1295).
 
-#### [**14.1.2**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.2) **(September 12th 2024)**
+### [14.1.2](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.2) (September 12th 2024)
 
 * Added configurable field level rendering of reCAPTCHA 3 validation result [#1277](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1277).
 * Fixed validate and submit script to handle additional markup around submit buttons [#1280](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1280).
@@ -121,7 +119,7 @@ Other bug fixes included in the release:
 * Added ability to retrieve "slim" workflow entities from services [#1283](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1283).
 * Fixed the following backoffice user interface issues [#1291](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1291), [#1290](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1290), [#1288](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1288), [#1287](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1287), [#1286](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1286), [#1278](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1278) and [#1275](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1275).
 
-#### [**14.1.1**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.1) **(August 6th 2024)**
+### [14.1.1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.1) (August 6th 2024)
 
 * Fixed issues with entries export for Windows installations without access to a component necessary for auto-fit of Excel columns [#1259](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1259).
 * Resolved intermittent issues with display of entries list [#1256](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1256).
@@ -131,7 +129,7 @@ Other bug fixes included in the release:
 * Fixed issue with form block rendering from rich text content [#1268](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1268).
 * Restored the `ValueAsString` extension method on `Record`.
 
-#### [**14.1.0**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.0) **(July 23rd 2024)**
+### [14.1.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.0) (July 23rd 2024)
 
 {% hint style="warning" %}
 The 14.1.0 release contains minor changes to the mark-up in the following Razor files shipped with the product: `Form.cshtml`, `FieldType.RadioButtonList.cshtml`, and `FieldType.CheckBoxList.cshtml`. These changes were made to resolve issues [#1220](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1220) and [#1218](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1218).
@@ -142,7 +140,7 @@ Please ensure to check the rendering of these features on website forms after th
 * All issues from earlier 14.1 release candidates.
 * Ensured prevalues can be retrieved outside of an HTTP request context when they depend on a static root node [#1258](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1258).
 
-#### [**14.1.0-rc2**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.0) **(July 18th 2024)**
+### [14.1.0-rc2](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.0) (July 18th 2024)
 
 * Added configuration option `AllowedFileUploadExtensions` to provide an "allow list" of extensions that will be accepted in file uploads via forms [#1252](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1252).
   * Read more about this and related settings [here](developer/configuration/#allowedfileuploadextensions).
@@ -151,7 +149,7 @@ Please ensure to check the rendering of these features on website forms after th
 * Limited the field preview for a field containing prevalues.
 * Improved support for editing large, multi-page forms by retaining scroll position between views and adding a "jump to page" option [#1243](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1243).
 
-#### [**14.1.0-rc1**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.0) **(July 9th 2024)**
+### [14.1.0-rc1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.1.0) (July 9th 2024)
 
 * Added setting option for single and multiple choice fields to allow for vertical or horizontal display [#1218](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1218)
 * Updated themes such that accessibility is improved by having hidden labels remain in markup but be visually hidden [#1220](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1220).
@@ -166,11 +164,11 @@ Please ensure to check the rendering of these features on website forms after th
 * Ensured placeholders are parsed for accepted entry response from the delivery API [#1238](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1238).
 * Resolved issues with intermittent failures of the form entries table display [#1239](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1239).
 
-#### [**14.0.2**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.2) **(June 11th 2024)**
+### [14.0.2](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.2) (June 11th 2024)
 
 * Fixed issue with upload of text file for the prevalue source based on file contents.
 
-#### [**14.0.1**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.1) **(June 6th 2024)**
+### [14.0.1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.1) (June 6th 2024)
 
 * Ensured local links are parsed when HTML fields are returned in the delivery API results for form definitions [#1227](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1227).
 * Restored target used to generate local configuration schema information [#1226](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1226).
@@ -179,23 +177,23 @@ Please ensure to check the rendering of these features on website forms after th
 * Fixed description of management API on Swagger UI.
 * Fixed display of specific form access list for user and group security.
 
-#### [**14.0.0**](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.0) **(May 30th 2024)**
+### [14.0.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F14.0.0) (May 30th 2024)
 
 * Compatibility with Umbraco 14
   * See full details of breaking changes under the [Version-specific Upgrade Guide](upgrading/version-specific.md).
 
 ## Umbraco.Forms.Deploy
 
-#### 14.1.1 (October 3rd 2024)
+### 14.1.1 (October 3rd 2024)
 
 * Add migrator to add missing Forms editor UI aliases
 
-#### 14.1.0 (August 16th 2024)
+### 14.1.0 (August 16th 2024)
 
 * Add check for keyed services before examining the registered services implementation type (workaround for https://github.com/dotnet/runtime/issues/95789)
 * Request tree items for forms-folder entity
 
-#### 14.0.0 (May 30th 2024)
+### 14.0.0 (May 30th 2024)
 
 * Compatibility with Umbraco 14, Forms 14 and Deploy 14.
 

--- a/15/umbraco-deploy/getting-started/deploy-settings.md
+++ b/15/umbraco-deploy/getting-started/deploy-settings.md
@@ -58,6 +58,7 @@ For illustration purposes, the following structure represents the full set of op
         "AllowMembersDeploymentOperations": "None",
         "TransferMemberGroupsAsContent": false,
         "ExportMemberGroups": true,
+        "ExportUserGroups": false,
         "ReloadMemoryCacheFollowingDiskReadOperation": false,
         "AllowDomainsDeploymentOperations": "None",
         "AllowWebhooksDeploymentOperations": "None",
@@ -248,7 +249,11 @@ Please see the note above under _TransferFormsAsContent_ on the topic of removin
 
 This setting is to be defined and set to `false` only if you are using an external membership provider for your members. You will not want to export Member Groups that would no longer be managed by Umbraco but by an external membership provider.
 
-Setting `exportMemberGroups` to `false` will no longer export Member Groups to .uda files on disk. The default for this setting is `true`, as most sites use Umbraco's built-in membership provider and thus will want the membership groups exported.
+Setting `ExportMemberGroups` to `false` will no longer export Member Groups to .uda files on disk. The default for this setting is `true`, as most sites use Umbraco's built-in membership provider and thus will want the membership groups exported.
+
+### ExportUserGroups {#exporting-user-groups}
+
+By default, user groups are not exported as schema items unless they are enabled via this configuration. After enabling, user groups can be deployed as schema files between environments, ensuring the name, alias, icon and permissions (including allowed sections, languages, start content and media) are kept in-sync. Users still need to be assinged to a group, but changes to existing groups can result in giving more permissions to the assigned users. Make sure to consider the potential security implications of this and e.g. disable this setting again after the required groups are deployed between environments.
 
 ### IgnoreBrokenDependenciesBehavior {#ignore-broken-dependencies}
 

--- a/15/umbraco-deploy/getting-started/deploy-settings.md
+++ b/15/umbraco-deploy/getting-started/deploy-settings.md
@@ -64,6 +64,7 @@ For illustration purposes, the following structure represents the full set of op
         "AllowDomainsDeploymentOperations": "None",
         "AllowWebhooksDeploymentOperations": "None",
         "TrashedContentDeploymentOperations": "Import",
+        "PostDeploySchemaOperation": "None",
         "PreferLocalDbConnectionString": false,
         "MediaFileChecksumCalculationMethod": "PartialFileContents",
         "NumberOfSignaturesToUseAllRelationCache": 100,
@@ -364,6 +365,18 @@ You can amend this behavior using this setting:
 * `Export` - trashed content will be included in an export
 * `Import` - trashed content will be processed and moved to the recycle bin on import
 * `All` - trashed content will be included in an export, processed and moved to the recycle bin on import
+
+### PostDeploySchemaOperation {#post-deploy-schema-operation}
+
+After the Umbraco schema is deployed from the files on disk, the current environment might still have items that don't have a corresponding file on disk.
+
+You can automatically perform an operation after a schema deployment to align this:
+
+* `None` - no operation is performed
+* `CleanSchema` - items that don't have a corresponding file on disk will be deleted
+* `ExtractSchema` - all items will be written to files on disk
+
+A common use-case will to be configure `CleanSchema` on local/development environments, so deleted schema items will be automatically cleaned, ensuring they aren't re-created again when one of the environments writes the item back to disk and deploys the changes. Take caution when using this value on a live environment though, because missing schema files could result in deleting all content (e.g. deleting a document type will delete all content of that type).
 
 ### PreferLocalDbConnectionString
 

--- a/15/umbraco-deploy/getting-started/deploy-settings.md
+++ b/15/umbraco-deploy/getting-started/deploy-settings.md
@@ -259,13 +259,13 @@ By default, user groups are not exported as schema items unless they are enabled
 
 ### AllowIgnoreDependenciesOperations {#allow-ignore-dependencies}
 
-When restoring or transferring content, media or other items, Umbraco Deploy will by default make sure any dependencies that don't exist on the target environment will be included in the operation.
+When restoring/transferring content or other items, Deploy will ensure any dependencies that don't exist on the target environment are included in the operation.
 
-For example, if you have a media picker on a content item, that references a media item that doesn't exist on the target environment yet, the media item will be created when only tranferring that content. This ensures the target environment doesn't end up with broken dependencies (references/links to other items that don't exist).
+Example: You have a media picker on a content item, that references a media item that doesn't exist on the target environment yet. The media item will be created when transferring only that content. This ensures the target environment doesn't end up with broken dependencies (references/links to other items that don't exist).
 
-Ignoring these dependencies will result in only restoring or tranferring the selected item(s), which allows more control over what is included in the operation (which can resolve deployment issues with a large amount of content, media or other items).
+When these dependencies are ignored only the selected item(s) are restored/transferred. This allows more control over what is included in the operation. Ignoring dependencies can also help resolve deployment issues with a large amount of content, media, or other items.
 
-You can configure which operations are allowed to ignore dependencies when these are performed in the backoffice. Note that ignoring dependencies can result in deployment errors (e.g. parent items that aren't included) or content with broken dependencies.
+You can configure which operations are allowed to ignore dependencies when these are performed in the backoffice. Ignoring dependencies can result in deployment errors (like parent items that aren't included) or content with broken dependencies.
 
 * `None` - ignoring dependencies is not allowed (the default value if the setting is missing)
 * `Restore` - dependencies can only be ignored when restoring from upstream environments
@@ -368,15 +368,14 @@ You can amend this behavior using this setting:
 
 ### PostDeploySchemaOperation {#post-deploy-schema-operation}
 
-After the Umbraco schema is deployed from the files on disk, the current environment might still have items that don't have a corresponding file on disk.
-
+After the schema is deployed from the files on disk, the current environment might still have items that don't have corresponding files on disk.
 You can automatically perform an operation after a schema deployment to align this:
 
 * `None` - no operation is performed
 * `CleanSchema` - items that don't have a corresponding file on disk will be deleted
 * `ExtractSchema` - all items will be written to files on disk
 
-A common use-case will to be configure `CleanSchema` on local/development environments, so deleted schema items will be automatically cleaned, ensuring they aren't re-created again when one of the environments writes the item back to disk and deploys the changes. Take caution when using this value on a live environment though, because missing schema files could result in deleting all content (e.g. deleting a document type will delete all content of that type).
+A common use case is to configure `CleanSchema` on local/development environments. Deleted schema items will then be cleaned automatically, ensuring they aren't re-created when an environment writes the item back and deploys the changes. Take caution when using this value on a live environment, as missing schema files can result in additional deletions. Deleting a Document Type, for example, will also delete all content using that type.
 
 ### PreferLocalDbConnectionString
 

--- a/15/umbraco-deploy/getting-started/deploy-settings.md
+++ b/15/umbraco-deploy/getting-started/deploy-settings.md
@@ -255,7 +255,9 @@ Setting `ExportMemberGroups` to `false` will no longer export Member Groups to .
 
 ### ExportUserGroups {#exporting-user-groups}
 
-By default, user groups are not exported as schema items unless they are enabled via this configuration. After enabling, user groups can be deployed as schema files between environments, ensuring the name, alias, icon and permissions (including allowed sections, languages, start content and media) are kept in-sync. Users still need to be assinged to a group, but changes to existing groups can result in giving more permissions to the assigned users. Make sure to consider the potential security implications of this and e.g. disable this setting again after the required groups are deployed between environments.
+By default, user groups are not exported as schema items unless this is enabled via this configuration. When enabled, user groups can be deployed as schema files between environments. This ensures the name, alias, icon, and permissions (including allowed sections, languages, start content and media) are kept in sync.
+
+Users still need to be assigned to a group, but changes to existing groups can result in giving more permissions to the assigned users. Consider the potential security implications and disable the setting again after the required groups are deployed between environments.
 
 ### AllowIgnoreDependenciesOperations {#allow-ignore-dependencies}
 

--- a/15/umbraco-deploy/getting-started/deploy-settings.md
+++ b/15/umbraco-deploy/getting-started/deploy-settings.md
@@ -49,6 +49,7 @@ For illustration purposes, the following structure represents the full set of op
         "SourceDeployBatchSize": null,
         "PackageBatchSize": null,
         "MaxRequestLength": null,
+        "AllowIgnoreDependenciesOperations": "None",
         "IgnoreBrokenDependenciesBehavior": "Restore",
         "AcceptInvalidCertificates": false,
         "TransferFormsAsContent": true,
@@ -254,6 +255,21 @@ Setting `ExportMemberGroups` to `false` will no longer export Member Groups to .
 ### ExportUserGroups {#exporting-user-groups}
 
 By default, user groups are not exported as schema items unless they are enabled via this configuration. After enabling, user groups can be deployed as schema files between environments, ensuring the name, alias, icon and permissions (including allowed sections, languages, start content and media) are kept in-sync. Users still need to be assinged to a group, but changes to existing groups can result in giving more permissions to the assigned users. Make sure to consider the potential security implications of this and e.g. disable this setting again after the required groups are deployed between environments.
+
+### AllowIgnoreDependenciesOperations {#allow-ignore-dependencies}
+
+When restoring or transferring content, media or other items, Umbraco Deploy will by default make sure any dependencies that don't exist on the target environment will be included in the operation.
+
+For example, if you have a media picker on a content item, that references a media item that doesn't exist on the target environment yet, the media item will be created when only tranferring that content. This ensures the target environment doesn't end up with broken dependencies (references/links to other items that don't exist).
+
+Ignoring these dependencies will result in only restoring or tranferring the selected item(s), which allows more control over what is included in the operation (which can resolve deployment issues with a large amount of content, media or other items).
+
+You can configure which operations are allowed to ignore dependencies when these are performed in the backoffice. Note that ignoring dependencies can result in deployment errors (e.g. parent items that aren't included) or content with broken dependencies.
+
+* `None` - ignoring dependencies is not allowed (the default value if the setting is missing)
+* `Restore` - dependencies can only be ignored when restoring from upstream environments
+* `Transfer` - dependencies can only be ignored when transferring upstream environments
+* `All` - dependencies can be ignored when restoring from and transferring to upstream environments
 
 ### IgnoreBrokenDependenciesBehavior {#ignore-broken-dependencies}
 

--- a/15/umbraco-deploy/release-notes.md
+++ b/15/umbraco-deploy/release-notes.md
@@ -16,6 +16,17 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 15 including all changes for this version.
 
+### [15.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.1.0) (January 30th 2025)
+
+* Schema cleanup and item actions triggered from Deploy's management dashboard (create or delete UDA files and Umbraco items)
+* Allow ignoring dependencies in transfer/restore operations
+* Ignore `Dependencies` artifact property when calculating the checksum and fix schema comparison [#246](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/246)
+* Add 'Hide up to date' toggle to schema comparison [#245](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/245)
+* Fix parsing dictionary item root UDI range from node ID
+* Ensure work item references/action results are deallocated (reduces overall memory usage in Deploy)
+* Allow disabling warnings as errors on import
+* Schema deployment of user groups
+
 ### [15.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.0.2) (December 23rd 2024)
 
 * Ensure environment-to-environment actions are executed asynchronously on background job (fixes timeout issues on large deployments) [#179](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/179)

--- a/15/umbraco-deploy/release-notes.md
+++ b/15/umbraco-deploy/release-notes.md
@@ -1,7 +1,5 @@
 ---
-description: >-
-  Get an overview of the things changed and fixed in each version of Umbraco
-  Deploy.
+description: Get an overview of the things changed and fixed in each version of Umbraco Deploy.
 ---
 
 # Release notes
@@ -14,16 +12,16 @@ If there are any breaking changes or other issues to be aware of when upgrading 
 If you are upgrading to a new major version you can find the details about the breaking changes in the [version specific updates](upgrades/version-specific.md) article.
 {% endhint %}
 
-## Release History
+## Release history
 
 This section contains the release notes for Umbraco Deploy 15 including all changes for this version.
 
-#### [15.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.0.2) (December 23rd 2024)
+### [15.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.0.2) (December 23rd 2024)
 
 * Ensure environment-to-environment actions are executed asynchronously on background job (fixes timeout issues on large deployments) [#179](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/179)
 * Only require default, allowed and master templates and their associated files to exist (avoids schema mismatches on template changes) [156](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/156)
 
-#### [15.0.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.0.1) (November 29th 2024)
+### [15.0.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.0.1) (November 29th 2024)
 
 * Update documentation links in management dashboard to include major version in the URL
 * Add `ValidateDependenciesOnImport` setting to management dashboard
@@ -31,11 +29,11 @@ This section contains the release notes for Umbraco Deploy 15 including all chan
 * Fix import complete heading and description (was using export complete localization keys)
 * Disable import button when no file is selected
 
-#### [15.0.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.0.0) (November 14th 2024)
+### [15.0.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.0.0) (November 14th 2024)
 
 * Update CMS dependency to 15.0.0
 
-#### [15.0.0-rc4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.0.0) (November 13th 2024)
+### [15.0.0-rc4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.0.0) (November 13th 2024)
 
 * Update CMS dependency to 15.0.0-rc4
 * Preview of features and bug fixes due in 13.3 and 14.2:
@@ -43,11 +41,11 @@ This section contains the release notes for Umbraco Deploy 15 including all chan
   * Added `ValidateDependenciesOnImport` setting to disable dependency validation on import
   * Support flexible environments on Umbraco Cloud (remove requirement for environment types to be Development, Staging or Live)
 
-#### [15.0.0-rc3](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.0.0) (November 7th 2024)
+### [15.0.0-rc3](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.0.0) (November 7th 2024)
 
 * Update CMS dependency to 15.0.0-rc3
 
-#### [15.0.0-rc2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.0.0) (October 24th 2024)
+### [15.0.0-rc2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.0.0) (October 24th 2024)
 
 * Update CMS dependency to 15.0.0-rc2
 * Preview of features and bug fixes due in 13.3 and 14.2:
@@ -57,7 +55,7 @@ This section contains the release notes for Umbraco Deploy 15 including all chan
   * Combine migrated grid editor with default Block Grid block configuration (set `RowMinSpan` and `RowMaxSpan` to `1` and `EditorSize` to `medium`)
 * Restructure keys and add new UI localizations
 
-#### [15.0.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.0.0) (October 11th 2024)
+### [15.0.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.0.0) (October 11th 2024)
 
 * Compatibility with Umbraco 15
   * See full details of breaking changes under the [Version-specific Upgrade Guide](upgrades/version-specific.md)
@@ -65,25 +63,25 @@ This section contains the release notes for Umbraco Deploy 15 including all chan
 * Removed `RemoteTreeNode` model (use `RemoteTreeEntity` instead) and `TryParseEntityIdFromNodeIdDelegate` (use `TryParseUdiRangeFromNodeIdDelegate` instead) in `DeployTransferRegisteredEntityTypeDetail`
 * Added `MigrateAsync(...)` method to `IPropertyTypeMigrator` and updated `PropertyTypeMigratorBase` and implementations to use async instead
 
-## Deploy Contrib
+## Umbraco.Deploy.Contrib
 
-#### [15.0.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-15.0.0) (November 14th 2024)
+### [15.0.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-15.0.0) (November 14th 2024)
 
 * Update CMS and Deploy dependencies to 15.0.0
 
-#### [15.0.0-rc4](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-15.0.0-rc4) (November 13th 2024)
+### [15.0.0-rc4](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-15.0.0-rc4) (November 13th 2024)
 
 * Update CMS and Deploy dependencies to 15.0.0-rc4
 
-#### [15.0.0-rc3](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-15.0.0-rc3) (November 7th 2024)
+### [15.0.0-rc3](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-15.0.0-rc3) (November 7th 2024)
 
 * Update CMS and Deploy dependencies to 15.0.0-rc3
 
-#### [15.0.0-rc2](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-15.0.0-rc2) (October 24th 2024)
+### [15.0.0-rc2](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-15.0.0-rc2) (October 24th 2024)
 
 * Update CMS and Deploy dependencies to 15.0.0-rc2
 
-#### [15.0.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-15.0.0-rc1) (October 14th 2024)
+### [15.0.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-15.0.0-rc1) (October 14th 2024)
 
 * Compatibility with Umbraco 15 and Deploy 15
 * Removed obsolete (and unused) legacy `PrevaluePropertyValueArtifactMigratorBase`, `CheckBoxListPropertyValueArtifactMigrator` `DropDownListFlexiblePropertyValueArtifactMigrator` and `RadioButtonListPropertyValueArtifactMigrator` migrators, as they are replaced with `PrevalueArtifactMigrator` and property type migrators that support nested/recursive properties (see PR [#71](https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/71))

--- a/15/umbraco-deploy/release-notes.md
+++ b/15/umbraco-deploy/release-notes.md
@@ -16,6 +16,11 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 15 including all changes for this version.
 
+### [15.1.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.1.0) (February 6th 2025)
+
+* All items from 15.1.0-rc1
+* Add user groups to schema comparison
+
 ### [15.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.1.0) (January 30th 2025)
 
 * Schema cleanup and item actions triggered from Deploy's management dashboard (create or delete UDA files and Umbraco items)

--- a/15/umbraco-forms/release-notes.md
+++ b/15/umbraco-forms/release-notes.md
@@ -108,7 +108,6 @@ Other bug fixes included in the release:
 * Preview of features and bug fixes due in 13.3 and 14.2:
   * Permission for delete entries [#1303](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1303).
   * Configurable date format for date picker field [#1276](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1276).
-  * https://github.com/umbraco/Umbraco.Forms.Issues/issues/1304
   * Fixed issue with single checkbox triggering a condition on a field on a subsequent page [#1304](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1304).
   * Improve cross-platform check when exporting to Excel.
 
@@ -124,7 +123,7 @@ Other bug fixes included in the release:
   * Ability to provide custom themes and email templates via razor class libraries [#795](https://github.com/umbraco/Umbraco.Forms.Issues/issues/795).
   * Backoffice translations for Dutch [#1264](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1264).
 
-## Forms Deploy
+## Umbraco.Forms.Deploy
 
 This Deploy add-on adds support for transferring, restoring, exporting and importing (including migrating between major versions) of Umbraco Forms data.
 


### PR DESCRIPTION
## Description

Deploy 13.4.0, 14.3.0 and 15.1.0 release notes (and their RCs), including new `PostDeploySchemaOperation`, `AllowIgnoreDependenciesOperations` and `ExportUserGroups` settings.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Deploy 13.4.0, 14.3.0 and 15.1.0

## Deadline (if relevant)

The versions are already released, so this can be merged right away.
