### PR TITLE
Fix broken links and correct json quotes

### DIFF
--- a/10/umbraco-workflow/getting-started/configuration.md
+++ b/10/umbraco-workflow/getting-started/configuration.md
@@ -36,7 +36,7 @@ All Workflow configuration is optional and will a fallback to defaults, if not s
     "ReminderNotificationPeriod": Timespan.FromHours(8),
     "EnableTestLicense": false,
     "EmailTemplatePath": "~/Views/Partials/WorkflowEmails",
-    "SettingsCustomization”: {...}
+    "SettingsCustomization": {...}
   }
 ```
 

--- a/10/umbraco-workflow/installation/licensing.md
+++ b/10/umbraco-workflow/installation/licensing.md
@@ -92,9 +92,9 @@ To impersonate the full license on a local site, set `EnableTestLicense` to `tru
 
 ```json
 {
- “Umbraco”: {
-   “Workflow”: {
-     “EnableTestLicense”: true
+ "Umbraco": {
+   "Workflow": {
+     "EnableTestLicense": true
    }
   }
 }

--- a/13/umbraco-engage/developers/analytics/forms.md
+++ b/13/umbraco-engage/developers/analytics/forms.md
@@ -5,7 +5,7 @@ icon: square-exclamation
 
 # Extending forms
 
-To track Umbraco Forms submissions, you need to install [Umbraco Forms](https://umbraco.com/products/add-ons/forms/) with a valid license from Umbraco HQ. You also need to install the Umbraco Engage[ Forms Addon package from Nuget](https://www.nuget.org/packages/Umbraco.Engage.UmbracoForms).
+To track Umbraco Forms submissions, you need to install [Umbraco Forms](https://umbraco.com/products/add-ons/forms/) with a valid license from Umbraco HQ. You also need to install the Umbraco Engage[ Forms Addon package from Nuget](https://www.nuget.org/packages/Umbraco.Engage.Forms).
 
 ## Summary
 

--- a/13/umbraco-engage/developers/analytics/forms.md
+++ b/13/umbraco-engage/developers/analytics/forms.md
@@ -5,7 +5,7 @@ icon: square-exclamation
 
 # Extending forms
 
-To track Umbraco Forms submissions, you need to install [Umbraco Forms](https://umbraco.com/products/add-ons/forms/) with a valid license from Umbraco HQ. You also need to install the Umbraco Engage[ Forms Addon package from Nuget](https://www.nuget.org/packages/Umbraco.Engage.Forms).
+To track Umbraco Forms submissions, you need to install [Umbraco Forms](https://umbraco.com/products/add-ons/forms/) with a valid license from Umbraco HQ. You also need to install the Umbraco Engage [Forms Addon package from Nuget](https://www.nuget.org/packages/Umbraco.Engage.Forms).
 
 ## Summary
 

--- a/13/umbraco-workflow/installation/licensing.md
+++ b/13/umbraco-workflow/installation/licensing.md
@@ -90,9 +90,9 @@ To impersonate the full license on a local site, set `EnableTestLicense` to `tru
 
 ```json
 {
- “Umbraco”: {
-   “Workflow”: {
-     “EnableTestLicense”: true
+ "Umbraco": {
+   "Workflow": {
+     "EnableTestLicense": true
    }
   }
 }

--- a/14/umbraco-workflow/getting-started/configuration.md
+++ b/14/umbraco-workflow/getting-started/configuration.md
@@ -44,7 +44,7 @@ All Workflow configuration is optional and will fallback to defaults, if not set
       "TimeFormat": "h:mm tt",
       "TimeFormatShort": "HH:mm"
     },
-    "SettingsCustomization”: {...}
+    "SettingsCustomization": {...}
   }
 ```
 

--- a/14/umbraco-workflow/installation/licensing.md
+++ b/14/umbraco-workflow/installation/licensing.md
@@ -91,9 +91,9 @@ To impersonate the full license on a local site, set `EnableTestLicense` to `tru
 
 ```json
 {
- “Umbraco”: {
-   “Workflow”: {
-     “EnableTestLicense”: true
+ "Umbraco": {
+   "Workflow": {
+     "EnableTestLicense": true
    }
   }
 }

--- a/15/umbraco-workflow/getting-started/configuration.md
+++ b/15/umbraco-workflow/getting-started/configuration.md
@@ -43,7 +43,7 @@ All Workflow configuration is optional and will fallback to defaults, if not set
       "TimeFormat": "h:mm tt",
       "TimeFormatShort": "HH:mm"
     },
-    "SettingsCustomization”: {...}
+    "SettingsCustomization": {...}
   }
 ```
 

--- a/15/umbraco-workflow/installation/licensing.md
+++ b/15/umbraco-workflow/installation/licensing.md
@@ -91,9 +91,9 @@ To impersonate the full license on a local site, set `EnableTestLicense` to `tru
 
 ```json
 {
- “Umbraco”: {
-   “Workflow”: {
-     “EnableTestLicense”: true
+ "Umbraco": {
+   "Workflow": {
+     "EnableTestLicense": true
    }
   }
 }
@@ -128,6 +128,7 @@ Then configure a random string as an authorization key in configuration. This is
       "EnableScheduledValidation": false,
       "ValidatedLicenseRelayAuthKey": "<your authorization key>"
     }
+  }
 ```
 
 Your Internet enabled server should make a request of the following form to the online license validation service:

--- a/generic/getting-started/developing-websites-with-umbraco/README.md
+++ b/generic/getting-started/developing-websites-with-umbraco/README.md
@@ -24,7 +24,7 @@ This will break into two sections: Extending the Umbraco backoffice and Developi
 
 The Umbraco backoffice can be extended using AngularJS and C#. Customizing the Umbraco backoffice and editing experience includes creating your own Property Editors, Dashboards, and packages. You will also find information about how to customize things like Health Checks and the built-in search functionality.
 
-Check out[ the Extending section](http://127.0.0.1:5000/s/OdQETpqkO0Kcv8KMquKL/extending) in the CMS docs for a good place to start.
+Check out [the Extending section](https://docs.umbraco.com/welcome/getting-started/developing-websites-with-umbraco/extending-the-umbraco-backoffice) in the CMS docs for a good place to start.
 
 {% hint style="info" %}
 From a frontend perspective, Umbraco does not dictate HTML, CSS, or JS in your website build. There is nothing Umbraco-specific about it.

--- a/umbraco-cloud/set-up/project-settings/secrets-management.md
+++ b/umbraco-cloud/set-up/project-settings/secrets-management.md
@@ -58,13 +58,13 @@ You should specify this with a corresponding name in a configuration file such a
 
 ```json
 {
-   “Serilog”: {
+   "Serilog": {
      …
    },
-   “Umbraco”:{
+   "Umbraco":{
      …
    },
-   “ApiKey”: “Value”,
+   "ApiKey": "Value",
 }
 ```
 


### PR DESCRIPTION
## Description

Found some broken links when browsing through the docs and corrected them. Also came across some json which used the incorrect quote symbol and corrected those too 😊.

## Type of suggestion

* [x] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

