### PR TITLE
Updating incorrect package name for the forms package for deploy v15

### DIFF
--- a/15/umbraco-deploy/installation/install-configure.md
+++ b/15/umbraco-deploy/installation/install-configure.md
@@ -101,7 +101,7 @@ When Umbraco has been installed in a repository, we can install Umbraco Deploy i
 To install Umbraco Deploy, run `dotnet add package Umbraco.Deploy.OnPrem` from the command line or `Install-Package Umbraco.Deploy.OnPrem` from the package manager console in Visual Studio.
 
 {% hint style="info" %}
-To be able to use Umbraco Forms with Umbraco Deploy, you need to install the `Umbraco.Deploy.Forms` package as well.
+To be able to use Umbraco Forms with Umbraco Deploy, you need to install the `Umbraco.Forms.Deploy` package as well.
 {% endhint %}
 
 {% hint style="info" %}


### PR DESCRIPTION
## Description

Updated the incorrect package name so that it is the correct one.

Umbraco.Deploy.Forms have been renamed to Umbraco.Forms.Deploy

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
15


## Deadline (if relevant)

_When should the content be published?_
