### PR TITLE
Fixed a typo: Changed "extension" to "manifest" 

### DIFF
--- a/15/umbraco-cms/customizing/extending-overview/extension-types/kind.md
+++ b/15/umbraco-cms/customizing/extending-overview/extension-types/kind.md
@@ -85,5 +85,5 @@ const manifest = {
 	},
 };
 
-extensionRegistry.register(extension);
+extensionRegistry.register(manifest);
 ```


### PR DESCRIPTION
Fixed a small Typo...

TBH, for someone new to what a "Kind" is, this page doesn't really help explain what it is and why we should be using it? At least, I didn't get it the first couple of times I read it :)

## Description

Changed:

```extensionRegistry.register(extension);```

to

```extensionRegistry.register(manifest);```

## Type of suggestion

* [X] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
