### PR TITLE
Update umbraco-flavored-markdown.md

### DIFF
--- a/15/umbraco-cms/reference/umbraco-flavored-markdown.md
+++ b/15/umbraco-cms/reference/umbraco-flavored-markdown.md
@@ -60,12 +60,12 @@ The following UFM filters are available to use.
 
 | Name       | Alias        | Example syntax                         |
 | ---------- | ------------ | -------------------------------------- |
-| Lowercase  | `lowercase`  | `{umbValue: headline | lowercase}`     |
-| Strip HTML | `strip-html` | `{umbValue: bodyText | strip-html}`    |
-| Title Case | `title-case` | `{umbValue: headline | title-case}`    |
-| Truncate   | `truncate`   | `{umbValue: intro | truncate:30:...}`  |
-| Uppercase  | `uppercase`  | `{umbValue: headline | uppercase}`     |
-| Word Limit | `word-limit` | `{umbValue: intro | word-limit:15}`    |
+| Lowercase  | `lowercase`  | `{umbValue: headline \| lowercase}`     |
+| Strip HTML | `strip-html` | `{umbValue: bodyText \| strip-html}`    |
+| Title Case | `title-case` | `{umbValue: headline \| title-case}`    |
+| Truncate   | `truncate`   | `{umbValue: intro \| truncate:30:...}`  |
+| Uppercase  | `uppercase`  | `{umbValue: headline \| uppercase}`     |
+| Word Limit | `word-limit` | `{umbValue: intro \| word-limit:15}`    |
 
 
 ## UFM components


### PR DESCRIPTION
Pipes are not escaped with a slash and this broke the table

Before it looked like this:

![afbeelding](https://github.com/user-attachments/assets/942ef3c4-434f-4bd3-8e55-df350122ceb7)

After it looked like this (at least in preview): 

![afbeelding](https://github.com/user-attachments/assets/491baa85-3f58-45c5-8447-5912746df8c1)
