### PR TITLE
Remove reference to removed keep-alive task

### DIFF
--- a/15/umbraco-cms/fundamentals/setup/server-setup/runtime-modes.md
+++ b/15/umbraco-cms/fundamentals/setup/server-setup/runtime-modes.md
@@ -120,7 +120,7 @@ Also, templates cannot be edited on live environment as runtime compilation is n
 <img src="../../../.gitbook/assets/TemplatedCannotBeEditedWhenRuntimeIsProduction.png" alt="" data-size="original">
 {% endhint %}
 
-Also ensure the `UmbracoApplicationUrl` is updated to the primary URL of your production environment, as this is used when sending emails (password reset, notifications, health check results, etc.) and the keep-alive task.
+Also ensure the `UmbracoApplicationUrl` is updated to the primary URL of your production environment, as this is used when sending emails (password reset, notifications, health check results, etc.).
 
 ## Customize/extend runtime mode validation
 


### PR DESCRIPTION
Keepalive was removed in v14.

## Description

Remove reference to removed keepalive task.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

14+

