### PR TITLE
Typo

### DIFF
--- a/umbraco-cloud/set-up/external-login-providers.md
+++ b/umbraco-cloud/set-up/external-login-providers.md
@@ -128,7 +128,7 @@ Before you move on, take note of the following keys:
 
 * **Client ID** (generated through the steps above)
 * **Client Secret** (generated through the steps above)
-* **Authority URL** (found on your [Google Account](https://accounts.google.com))
+* **Authority URL** https://accounts.google.com
 {% endtab %}
 {% endtabs %}
 

--- a/umbraco-cloud/set-up/external-login-providers.md
+++ b/umbraco-cloud/set-up/external-login-providers.md
@@ -128,7 +128,7 @@ Before you move on, take note of the following keys:
 
 * **Client ID** (generated through the steps above)
 * **Client Secret** (generated through the steps above)
-* **Authority ID** (found on your [Google Account](https://accounts.google.com))
+* **Authority URL** (found on your [Google Account](https://accounts.google.com))
 {% endtab %}
 {% endtabs %}
 

--- a/umbraco-cloud/set-up/external-login-providers.md
+++ b/umbraco-cloud/set-up/external-login-providers.md
@@ -128,7 +128,7 @@ Before you move on, take note of the following keys:
 
 * **Client ID** (generated through the steps above)
 * **Client Secret** (generated through the steps above)
-* **Authority URL** https://accounts.google.com
+* **Authority URL** (`https://accounts.google.com`)
 {% endtab %}
 {% endtabs %}
 

--- a/umbraco-cloud/set-up/external-login-providers.md
+++ b/umbraco-cloud/set-up/external-login-providers.md
@@ -113,7 +113,7 @@ Ensure you have already set up a tenant/organization.
 {% tab title="Google Authentication" %}
 1. Access the Google Developer Console.
 2. Select **Create Project** and give it a name.
-3. Go to the **Auth consent screen** page.
+3. Go to the **OAuth consent screen** page.
 4. Select the **Internal** User Type and click **Create**.
 5. Fill in the required information.
 6. Add **Authorized domains** from where login should be allowed.


### PR DESCRIPTION
## Description

"Auth consent screen" should be "OAuth consent screen"

## Type of suggestion

* [x] Typo/grammar fix


## Product & version (if relevant)

Cloud / External Login Providers
