### PR TITLE
Update product-adapters.md

### DIFF
--- a/13/umbraco-commerce/key-concepts/product-adapters.md
+++ b/13/umbraco-commerce/key-concepts/product-adapters.md
@@ -176,7 +176,7 @@ public static class UmbracoCommerceUmbracoBuilderExtensions
     public static IUmbracoCommerceBuilder AddMyServices(IUmbracoCommerceBuilder builder)
     {
         // Replacing the default Product Adapter implementation
-        builder.Services.AddUnique<ProductAdapterBase, MyCustomProductAdapter>();
+        builder.Services.AddUnique<IProductAdapter, MyCustomProductAdapter>();
 
         // Return the builder to continue the chain
         return builder;

--- a/14/umbraco-commerce/key-concepts/product-adapters.md
+++ b/14/umbraco-commerce/key-concepts/product-adapters.md
@@ -176,7 +176,7 @@ public static class UmbracoCommerceUmbracoBuilderExtensions
     public static IUmbracoCommerceBuilder AddMyServices(IUmbracoCommerceBuilder builder)
     {
         // Replacing the default Product Adapter implementation
-        builder.Services.AddUnique<ProductAdapterBase, MyCustomProductAdapter>();
+        builder.Services.AddUnique<IProductAdapter, MyCustomProductAdapter>();
 
         // Return the builder to continue the chain
         return builder;

--- a/15/umbraco-commerce/key-concepts/product-adapters.md
+++ b/15/umbraco-commerce/key-concepts/product-adapters.md
@@ -176,7 +176,7 @@ public static class UmbracoCommerceUmbracoBuilderExtensions
     public static IUmbracoCommerceBuilder AddMyServices(IUmbracoCommerceBuilder builder)
     {
         // Replacing the default Product Adapter implementation
-        builder.Services.AddUnique<ProductAdapterBase, MyCustomProductAdapter>();
+        builder.Services.AddUnique<IProductAdapter, MyCustomProductAdapter>();
 
         // Return the builder to continue the chain
         return builder;


### PR DESCRIPTION
Appears to require IProductAdapter to work (v13)

## Description

umbracoCommerceBuilder.Services.AddUnique<ProductAdapterBase, MyCustomProductAdapter>();
to
umbracoCommerceBuilder.Services.AddUnique<IProductAdapter, MyCustomProductAdapter>();

Although IProductAdapter is obsolete, using ProductAdapterBase as the service does not appear to result in the implementation being called

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [X] Other

## Product & version (if relevant)
13.2.0


## Deadline (if relevant)

_When should the content be published?_
