### PR TITLE
Corrects a couple of configuration documentation errors for CMS and Forms

### DIFF
--- a/13/umbraco-cms/reference/configuration/securitysettings.md
+++ b/13/umbraco-cms/reference/configuration/securitysettings.md
@@ -19,6 +19,7 @@ A full configuration with all default values can be seen here:
       "AuthCookieDomain": "",
       "UsernameIsEmail": true,
       "MemberRequireUniqueEmail": true,
+      "AllowedUserNameCharacters": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+\\",
       "UserPassword": {
         "RequiredLength": 10,
         "RequireNonLetterOrDigit": false,
@@ -76,6 +77,10 @@ This setting specifies whether the username and email address are separate field
 ### Member require unique email
 
 By default Umbraco will not allow creation of more than one member account with the same email address. If you wish to allow this, set this value to `false`.
+
+### Allowed user name characters
+
+Defines the allowed characters for a username.
 
 ## User password settings
 

--- a/13/umbraco-forms/developer/configuration/README.md
+++ b/13/umbraco-forms/developer/configuration/README.md
@@ -77,7 +77,6 @@ For illustration purposes, the following structure represents the full set of op
     },
     "Options": {
       "IgnoreWorkFlowsOnEdit": "True",
-      "ExecuteWorkflowAsync": "False",
       "AllowEditableFormSubmissions": false,
       "AppendQueryStringOnRedirectAfterFormSubmission": false,
       "CultureToUseWhenParsingDatesForBackOffice": "",
@@ -339,10 +338,6 @@ Defines the default summary label for multi-page forms.
 ### IgnoreWorkFlowsOnEdit
 
 This configuration expects a `True` or `False` string value, or a comma-separated list of form names, and allows you to toggle if a form submission is edited again, that the workflows on the form will re-fire after an update to the form submission. This is used in conjunction with the `AllowEditableFormSubmissions` configuration value. Defaults to `True`.
-
-### ExecuteWorkflowAsync
-
-This configuration key is _experimental_ and will allow Workflows to be executed in an asynchronous manner. The value can be a `True` or `False` string value, or a comma-separated list of form names. Defaults to `False`.
 
 ### AllowEditableFormSubmissions
 

--- a/14/umbraco-cms/reference/configuration/securitysettings.md
+++ b/14/umbraco-cms/reference/configuration/securitysettings.md
@@ -18,6 +18,7 @@ A full configuration with all default values can be seen here:
       "AuthCookieName": "UMB_UCONTEXT",
       "AuthCookieDomain": "",
       "UsernameIsEmail": true,
+      "AllowedUserNameCharacters": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+\\",
       "UserPassword": {
         "RequiredLength": 10,
         "RequireNonLetterOrDigit": false,
@@ -71,6 +72,10 @@ The authentication cookie which is set in the browser when a backoffice user log
 ### Username is email
 
 This setting specifies whether the username and email address are separate fields in the backoffice editor. When set to "false", you can specify an email address and username, only the username can be used to log on. When set to "true" (the default value) the username is hidden and always the same as the email address.
+
+### Allowed user name characters
+
+Defines the allowed characters for a username.
 
 ### User default lockout time
 

--- a/14/umbraco-forms/developer/configuration/README.md
+++ b/14/umbraco-forms/developer/configuration/README.md
@@ -77,7 +77,6 @@ For illustration purposes, the following structure represents the full set of op
     },
     "Options": {
       "IgnoreWorkFlowsOnEdit": "True",
-      "ExecuteWorkflowAsync": "False",
       "AllowEditableFormSubmissions": false,
       "AppendQueryStringOnRedirectAfterFormSubmission": false,
       "CultureToUseWhenParsingDatesForBackOffice": "",
@@ -338,10 +337,6 @@ Defines the default summary label for multi-page forms.
 ### IgnoreWorkFlowsOnEdit
 
 This configuration expects a `True` or `False` string value, or a comma-separated list of form names, and allows you to toggle if a form submission is edited again, that the workflows on the form will re-fire after an update to the form submission. This is used in conjunction with the `AllowEditableFormSubmissions` configuration value. Defaults to `True`.
-
-### ExecuteWorkflowAsync
-
-This configuration key is _experimental_ and will allow Workflows to be executed in an asynchronous manner. The value can be a `True` or `False` string value, or a comma-separated list of form names. Defaults to `False`.
 
 ### AllowEditableFormSubmissions
 

--- a/15/umbraco-cms/reference/configuration/securitysettings.md
+++ b/15/umbraco-cms/reference/configuration/securitysettings.md
@@ -19,6 +19,7 @@ A full configuration with all default values can be seen here:
       "AuthCookieDomain": "",
       "UsernameIsEmail": true,
       "MemberRequireUniqueEmail": true,
+      "AllowedUserNameCharacters": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+\\",
       "UserPassword": {
         "RequiredLength": 10,
         "RequireNonLetterOrDigit": false,
@@ -78,6 +79,10 @@ This setting specifies whether the username and email address are separate field
 ### Member require unique email
 
 By default Umbraco will not allow creation of more than one member account with the same email address. If you wish to allow this, set this value to `false`.
+
+### Allowed user name characters
+
+Defines the allowed characters for a username.
 
 ### User default lockout time
 

--- a/15/umbraco-forms/developer/configuration/README.md
+++ b/15/umbraco-forms/developer/configuration/README.md
@@ -76,7 +76,6 @@ For illustration purposes, the following structure represents the full set of op
     },
     "Options": {
       "IgnoreWorkFlowsOnEdit": "True",
-      "ExecuteWorkflowAsync": "False",
       "AllowEditableFormSubmissions": false,
       "AppendQueryStringOnRedirectAfterFormSubmission": false,
       "CultureToUseWhenParsingDatesForBackOffice": "",
@@ -334,10 +333,6 @@ Defines the default summary label for multi-page forms.
 ### IgnoreWorkFlowsOnEdit
 
 This configuration expects a `True` or `False` string value, or a comma-separated list of form names, and allows you to toggle if a form submission is edited again, that the workflows on the form will re-fire after an update to the form submission. This is used in conjunction with the `AllowEditableFormSubmissions` configuration value. Defaults to `True`.
-
-### ExecuteWorkflowAsync
-
-This configuration key is _experimental_ and will allow Workflows to be executed in an asynchronous manner. The value can be a `True` or `False` string value, or a comma-separated list of form names. Defaults to `False`.
 
 ### AllowEditableFormSubmissions
 


### PR DESCRIPTION
## Description

Made a couple of updates following issues pointed out related to configuration:

1. Removed documentation of a Form's setting that was removed in Forms 13.
2. Adds details of a CMS security setting that wasn't documented in the expected place.

## Type of suggestion

* [ ] Typo/grammar fix
* [X] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Forms 13+, CMS 13+

## Deadline (if relevant)

Any time.
