### PR TITLE
Updated AddCustomContentFinders() to AddMyCustomContentFinders()

### DIFF
--- a/10/umbraco-cms/reference/routing/request-pipeline/icontentfinder.md
+++ b/10/umbraco-cms/reference/routing/request-pipeline/icontentfinder.md
@@ -81,7 +81,7 @@ namespace RoutingDocs.Extensions
 {
     public static class UmbracoBuilderExtensions
     {
-        public static IUmbracoBuilder AddCustomContentFinders(this IUmbracoBuilder builder)
+        public static IUmbracoBuilder AddMyCustomContentFinders(this IUmbracoBuilder builder)
         {
             // Add our custom content finder just before the core ContentFinderByUrl
             builder.ContentFinders().InsertBefore<ContentFinderByUrl, MyContentFinder>();
@@ -107,7 +107,7 @@ public void ConfigureServices(IServiceCollection services)
         .AddBackOffice()
         .AddWebsite()
         .AddComposers()
-        .AddCustomContentFinders()
+        .AddMyCustomContentFinders()
         .Build();
 #pragma warning restore IDE0022 // Use expression body for methods
 }

--- a/13/umbraco-cms/reference/routing/request-pipeline/icontentfinder.md
+++ b/13/umbraco-cms/reference/routing/request-pipeline/icontentfinder.md
@@ -82,7 +82,7 @@ namespace RoutingDocs.Extensions;
 
 public static class UmbracoBuilderExtensions
 {
-    public static IUmbracoBuilder AddCustomContentFinders(this IUmbracoBuilder builder)
+    public static IUmbracoBuilder AddMyCustomContentFinders(this IUmbracoBuilder builder)
     {
         // Add our custom content finder just before the core ContentFinderByUrl
         builder.ContentFinders().InsertBefore<ContentFinderByUrl, MyContentFinder>();
@@ -105,7 +105,7 @@ builder.CreateUmbracoBuilder()
     .AddWebsite()
     .AddDeliveryApi()
     .AddComposers()
-    .AddCustomContentFinders()
+    .AddMyCustomContentFinders()
     .Build();
 ```
 

--- a/14/umbraco-cms/reference/routing/request-pipeline/icontentfinder.md
+++ b/14/umbraco-cms/reference/routing/request-pipeline/icontentfinder.md
@@ -82,7 +82,7 @@ namespace RoutingDocs.Extensions;
 
 public static class UmbracoBuilderExtensions
 {
-    public static IUmbracoBuilder AddCustomContentFinders(this IUmbracoBuilder builder)
+    public static IUmbracoBuilder AddMyCustomContentFinders(this IUmbracoBuilder builder)
     {
         // Add our custom content finder just before the core ContentFinderByUrl
         builder.ContentFinders().InsertBefore<ContentFinderByUrl, MyContentFinder>();
@@ -105,7 +105,7 @@ builder.CreateUmbracoBuilder()
     .AddWebsite()
     .AddDeliveryApi()
     .AddComposers()
-    .AddCustomContentFinders()
+    .AddMyCustomContentFinders()
     .Build();
 ```
 

--- a/15/umbraco-cms/reference/routing/request-pipeline/icontentfinder.md
+++ b/15/umbraco-cms/reference/routing/request-pipeline/icontentfinder.md
@@ -86,7 +86,7 @@ namespace RoutingDocs.Extensions;
 
 public static class UmbracoBuilderExtensions
 {
-    public static IUmbracoBuilder AddCustomContentFinders(this IUmbracoBuilder builder)
+    public static IUmbracoBuilder AddMyCustomContentFinders(this IUmbracoBuilder builder)
     {
         // Add our custom content finder just before the core ContentFinderByUrl
         builder.ContentFinders().InsertBefore<ContentFinderByUrlNew, MyContentFinder>();
@@ -109,7 +109,7 @@ builder.CreateUmbracoBuilder()
     .AddWebsite()
     .AddDeliveryApi()
     .AddComposers()
-    .AddCustomContentFinders()
+    .AddMyCustomContentFinders()
     .Build();
 ```
 


### PR DESCRIPTION
## Description

Renaming `AddCustomContentFinders()` to `AddMyCustomContentFinders()` to make it more specific and avoid confusion as mentioned in Issue #6938.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [x] Other

## Product & version (if relevant)

CMS v10, 13, 14, 15

## Deadline (if relevant)

Anytime
