### PR TITLE
Fixed reference to typed value when rendering rich text property values

### DIFF
--- a/10/umbraco-cms/fundamentals/design/rendering-content.md
+++ b/10/umbraco-cms/fundamentals/design/rendering-content.md
@@ -19,15 +19,20 @@ Each property in your [Document Type](../data/defining-content/#what-is-a-docume
 
 ### Specifying types of data
 
-You can specify the type of data being returned to help you format the value for display, consider the publish date in our example:
+You can specify the type of data being returned to help you format the value for display.
 
-To use the `<IHtmlContent>` as the data return type, add the `@using Microsoft.AspNetCore.Html;` directive.
+In our example, we have a string, a date and some rich text:
 
 ```html
 <h1>@(Model.Value<string>("pageTitle"))</h1>
-<div>@(Model.Value<IHtmlContent>("bodyContent"))</div>
+<div>@(Model.Value<IHtmlEncodedString>("bodyContent"))</div>
 <p>Article date: <time>@(Model.Value<DateTime>("articleDate").ToString("dd/MM/yyyy"))</time></p>
 ```
+
+{% hint style="info" %}
+To use `IHtmlEncodedString` as the typed value, add the `@using Umbraco.Cms.Core.Strings;` directive.
+{% endhint %}
+
 
 ### Using ModelsBuilder
 

--- a/13/umbraco-cms/fundamentals/design/rendering-content.md
+++ b/13/umbraco-cms/fundamentals/design/rendering-content.md
@@ -14,15 +14,19 @@ Each property in your [Document Type](../data/defining-content/#what-is-a-docume
 
 ### Specifying types of data
 
-You can specify the type of data being returned to help you format the value for display, consider the publish date in our example:
+You can specify the type of data being returned to help you format the value for display.
 
-To use the `<IHtmlContent>` as the data return type, add the `@using Microsoft.AspNetCore.Html;` directive.
+In our example, we have a string, a date and some rich text:
 
 ```html
 <h1>@(Model.Value<string>("pageTitle"))</h1>
-<div>@(Model.Value<IHtmlContent>("bodyContent"))</div>
+<div>@(Model.Value<IHtmlEncodedString>("bodyContent"))</div>
 <p>Article date: <time>@(Model.Value<DateTime>("articleDate").ToString("dd/MM/yyyy"))</time></p>
 ```
+
+{% hint style="info" %}
+To use `IHtmlEncodedString` as the typed value, add the `@using Umbraco.Cms.Core.Strings;` directive.
+{% endhint %}
 
 ### Using ModelsBuilder
 

--- a/14/umbraco-cms/fundamentals/design/rendering-content.md
+++ b/14/umbraco-cms/fundamentals/design/rendering-content.md
@@ -14,15 +14,19 @@ Each property in your [Document Type](../data/defining-content/#what-is-a-docume
 
 ### Specifying types of data
 
-You can specify the type of data being returned to help you format the value for display, consider the publish date in our example:
+You can specify the type of data being returned to help you format the value for display.
 
-To use the `<IHtmlContent>` as the data return type, add the `@using Microsoft.AspNetCore.Html;` directive.
+In our example, we have a string, a date and some rich text:
 
 ```html
 <h1>@(Model.Value<string>("pageTitle"))</h1>
-<div>@(Model.Value<IHtmlContent>("bodyContent"))</div>
+<div>@(Model.Value<IHtmlEncodedString>("bodyContent"))</div>
 <p>Article date: <time>@(Model.Value<DateTime>("articleDate").ToString("dd/MM/yyyy"))</time></p>
 ```
+
+{% hint style="info" %}
+To use `IHtmlEncodedString` as the typed value, add the `@using Umbraco.Cms.Core.Strings;` directive.
+{% endhint %}
 
 ### Using ModelsBuilder
 

--- a/15/umbraco-cms/fundamentals/design/rendering-content.md
+++ b/15/umbraco-cms/fundamentals/design/rendering-content.md
@@ -14,15 +14,19 @@ Each property in your [Document Type](../data/defining-content/#what-is-a-docume
 
 ### Specifying types of data
 
-You can specify the type of data being returned to help you format the value for display, consider the publish date in our example:
+You can specify the type of data being returned to help you format the value for display.
 
-To use the `<IHtmlContent>` as the data return type, add the `@using Microsoft.AspNetCore.Html;` directive.
+In our example, we have a string, a date and some rich text:
 
 ```html
 <h1>@(Model.Value<string>("pageTitle"))</h1>
-<div>@(Model.Value<IHtmlContent>("bodyContent"))</div>
+<div>@(Model.Value<IHtmlEncodedString>("bodyContent"))</div>
 <p>Article date: <time>@(Model.Value<DateTime>("articleDate").ToString("dd/MM/yyyy"))</time></p>
 ```
+
+{% hint style="info" %}
+To use `IHtmlEncodedString` as the typed value, add the `@using Umbraco.Cms.Core.Strings;` directive.
+{% endhint %}
 
 ### Using ModelsBuilder
 


### PR DESCRIPTION
## Description

Fixed reference to typed value when rendering rich text property values which were raised as incorrect in https://github.com/umbraco/Umbraco-CMS/issues/18738

## Type of suggestion

* [ ] Typo/grammar fix
* [X] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Umbraco 10+

## Deadline (if relevant)

Any time.
