### PR TITLE
Cloud Secrets - allow Umbraco Commerce paths

### DIFF
--- a/umbraco-cloud/set-up/project-settings/secrets-management.md
+++ b/umbraco-cloud/set-up/project-settings/secrets-management.md
@@ -157,6 +157,8 @@ The following prefixes are allowed for Secrets on Umbraco Cloud:
 * `Umbraco__CMS__DeliveryAPI__`
 * `UMBRACO__LICENSES__`
 * `UMBRACO__AUTHORIZEDSERVICES__`
+* `UMBRACO__COMMERCE__`
+
 
 It is also possible to use Secrets to save API keys, Passwords, and ReChaptcha for all our Umbraco products on Umbraco Cloud.
 


### PR DESCRIPTION
## Description

I added the `UMBRACO__COMMERCE_` to allowed list of prefixes

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Cloud / Secret Management

## Deadline (if relevant)

