### PR TITLE
Updated broken links - 404 and 500 section url ids

### DIFF
--- a/10/umbraco-cms/tutorials/custom-error-page.md
+++ b/10/umbraco-cms/tutorials/custom-error-page.md
@@ -8,7 +8,7 @@ Custom error handling might make your site look more on-brand and minimize the i
 
 This article contains guides on how to create custom error pages for the following types of errors:
 
-* [404 errors ("Page not found")](custom-error-page.md#404-errors)
+* [404 errors ("Page not found")](custom-error-page.md#id-404-errors)
 * [Maintenance Page](custom-error-page.md#maintenance-page)
 
 ## In-code error page handling

--- a/13/umbraco-cms/tutorials/custom-error-page.md
+++ b/13/umbraco-cms/tutorials/custom-error-page.md
@@ -8,8 +8,8 @@ Custom error handling might make your site look more on-brand and minimize the i
 
 This article contains guides on how to create custom error pages for the following types of errors:
 
-* [404 errors ("Page not found")](custom-error-page.md#404-errors)
-* [500 errors ("Internal Server Error")](custom-error-page.md#500-errors)
+* [404 errors ("Page not found")](custom-error-page.md#id-404-errors)
+* [500 errors ("Internal Server Error")](custom-error-page.md#id-500-errors)
 * [Maintenance Page](custom-error-page.md#maintenance-page)
 
 ## In-code error page handling

--- a/14/umbraco-cms/tutorials/custom-error-page.md
+++ b/14/umbraco-cms/tutorials/custom-error-page.md
@@ -16,7 +16,7 @@ In Umbraco, in-code error page handling refers to managing and displaying custom
 
 This article contains guides on how to create custom error pages for the most common scenarios:
 
-* [404 errors ("Page not found")](custom-error-page.md#404-errors)
+* [404 errors ("Page not found")](custom-error-page.md#id-404-errors)
 * [500 errors ("Internal Server Error")](custom-error-page.md#id-500-errors)
 * [Boot Failed errors](custom-error-page.md#errors-with-booting-a-project)
 

--- a/15/umbraco-cms/tutorials/custom-error-page.md
+++ b/15/umbraco-cms/tutorials/custom-error-page.md
@@ -16,7 +16,7 @@ In Umbraco, in-code error page handling refers to managing and displaying custom
 
 This article contains guides on how to create custom error pages for the most common scenarios:
 
-* [404 errors ("Page not found")](custom-error-page.md#404-errors)
+* [404 errors ("Page not found")](custom-error-page.md#id-404-errors)
 * [500 errors ("Internal Server Error")](custom-error-page.md#id-500-errors)
 * [Boot Failed errors](custom-error-page.md#errors-with-booting-a-project)
 


### PR DESCRIPTION
## Description

Fix to ensure links to 404 and 500 sections are using correct ids. Currently clicking on them does nothing as the wrong ids are being set in the URLs.

![image](https://github.com/user-attachments/assets/decccf3a-d3c9-40d8-ad6c-2a2c7cd2e4b7)


## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
Version 10, 13, 14, and 15


