### PR TITLE
Fix link in Extension Registry

### DIFF
--- a/15/umbraco-cms/customizing/extending-overview/extension-registry/README.md
+++ b/15/umbraco-cms/customizing/extending-overview/extension-registry/README.md
@@ -14,6 +14,6 @@ The extension registry is a global registry that can be accessed and changed at 
 
 Each Extension Manifest has to declare its type, this is used to determine where it hooks into the system. It also looks at what data is required to declare within it.
 
-## [Replace, Exclude or Unregistere](./#replace-exclude-or-unregistere)
+## [Replace, Exclude or Unregister](./#replace-exclude-or-unregister)
 
 Once you understand how to declare your own, you may want to replace or remove existing.

--- a/15/umbraco-cms/customizing/extending-overview/extension-registry/README.md
+++ b/15/umbraco-cms/customizing/extending-overview/extension-registry/README.md
@@ -14,6 +14,6 @@ The extension registry is a global registry that can be accessed and changed at 
 
 Each Extension Manifest has to declare its type, this is used to determine where it hooks into the system. It also looks at what data is required to declare within it.
 
-## [Replace, Exclude or Unregister](./#replace-exclude-or-unregister)
+## [Replace, Exclude, or Unregister](replace-exclude-or-unregister.md)
 
 Once you understand how to declare your own, you may want to replace or remove existing.


### PR DESCRIPTION
## Description

Typo and deadlink in the docs.

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

Deadlink is currently present on the page but is accessible through the left hand side menu.
