### PR TITLE
Correct reference to unregister export

### DIFF
--- a/15/umbraco-cms/customizing/extending-overview/extension-registry/replace-exclude-or-unregister.md
+++ b/15/umbraco-cms/customizing/extending-overview/extension-registry/replace-exclude-or-unregister.md
@@ -54,12 +54,12 @@ UmbExtensionRegistry.exclude('Umb.WorkspaceAction.Document.SaveAndPreview');
 
 ## Unregister
 
-You can also choose to unregister an extension, this is only preferred if you registered the extension and are in control of the flow. If its not your Extension please seek to use the `Overwrites` or `Exclude` feature.
+You can also choose to unregister an extension, this is only preferred if you registered the extension and are in control of the flow. If it's not your Extension please seek to use the `Overwrites` or `Exclude` feature.
 
 ```typescript
-import { UmbExtensionRegistry } from '@umbraco-cms/backoffice/extension-api';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 
-UmbExtensionRegistry.unregister('My.WorkspaceAction.AutoFillWithUnicorns');
+umbExtensionsRegistry.unregister('My.WorkspaceAction.AutoFillWithUnicorns');
 ```
 
 This will not prevent the Extension from being registered again.


### PR DESCRIPTION
## Description

Updated the reference when using the `umbExtensionsRegistry` to unregister an extension. The current import doesn't contain a definition for this.

![image](https://github.com/user-attachments/assets/e1e2b3cb-9567-4f04-9fb2-72cc1b2ffe5e)

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [x] Other

## Product & version (if relevant)
15.3.1


## Deadline (if relevant)

N/A
