### PR TITLE
Added note on running production mode from source

### DIFF
--- a/13/umbraco-cms/fundamentals/setup/server-setup/runtime-modes.md
+++ b/13/umbraco-cms/fundamentals/setup/server-setup/runtime-modes.md
@@ -116,6 +116,16 @@ Also, templates cannot be edited on live environment as runtime compilation is n
 
 Also ensure the `UmbracoApplicationUrl` is updated to the primary URL of your production environment, as this is used when sending emails (password reset, notifications, health check results, etc.) and the keep-alive task.
 
+{% hint style="info" %}
+Static web assets are disabled when using Production mode, following [Microsoft guidance](https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/static-files?view=aspnetcore-7.0#static-files-in-non-development-environments). If you are running a non-Development environment using the Production runtime mode from source (non-published output), you will need to explicitly enable this. You can add the following line of code to your `Program.cs` file:
+
+```csharp
+builder.WebHost.UseStaticWebAssets();
+```
+
+This should not be used in a more typical production environment where you are hosting your application from published output.
+{% endhint %}
+
 ## Customize/extend runtime mode validation
 
 Validation of the above-mentioned settings is done when determining the runtime level during startup using the new `IRuntimeModeValidationService` and when it fails, causes a `BootFailedException` to be thrown. The default implementation gets all registered `IRuntimeModeValidators` to do the validation, making it possible to remove default checks and/or add your own (inherit from `RuntimeModeProductionValidatorBase`, if you only want to validate against the production runtime mode). The following validators are added by default:

--- a/14/umbraco-cms/fundamentals/setup/server-setup/runtime-modes.md
+++ b/14/umbraco-cms/fundamentals/setup/server-setup/runtime-modes.md
@@ -115,6 +115,16 @@ Also, templates cannot be edited on live environment as runtime compilation is n
 
 Also ensure the `UmbracoApplicationUrl` is updated to the primary URL of your production environment, as this is used when sending emails (password reset, notifications, health check results, etc.) and the keep-alive task.
 
+{% hint style="info" %}
+Static web assets are disabled when using Production mode, following [Microsoft guidance](https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/static-files?view=aspnetcore-7.0#static-files-in-non-development-environments). If you are running a non-Development environment using the Production runtime mode from source (non-published output), you will need to explicitly enable this. You can add the following line of code to your `Program.cs` file:
+
+```csharp
+builder.WebHost.UseStaticWebAssets();
+```
+
+This should not be used in a more typical production environment where you are hosting your application from published output.
+{% endhint %}
+
 ## Customize/extend runtime mode validation
 
 Validation of the above-mentioned settings is done when determining the runtime level during startup using the new `IRuntimeModeValidationService` and when it fails, causes a `BootFailedException` to be thrown. The default implementation gets all registered `IRuntimeModeValidators` to do the validation, making it possible to remove default checks and/or add your own (inherit from `RuntimeModeProductionValidatorBase`, if you only want to validate against the production runtime mode). The following validators are added by default:

--- a/15/umbraco-cms/fundamentals/setup/server-setup/runtime-modes.md
+++ b/15/umbraco-cms/fundamentals/setup/server-setup/runtime-modes.md
@@ -122,6 +122,16 @@ Also, templates cannot be edited on live environment as runtime compilation is n
 
 Also ensure the `UmbracoApplicationUrl` is updated to the primary URL of your production environment, as this is used when sending emails (password reset, notifications, health check results, etc.).
 
+{% hint style="info" %}
+Static web assets are disabled when using Production mode, following [Microsoft guidance](https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/static-files?view=aspnetcore-7.0#static-files-in-non-development-environments). If you are running a non-Development environment using the Production runtime mode from source (non-published output), you will need to explicitly enable this. You can add the following line of code to your `Program.cs` file:
+
+```csharp
+builder.WebHost.UseStaticWebAssets();
+```
+
+This should not be used in a more typical production environment where you are hosting your application from published output.
+{% endhint %}
+
 ## Customize/extend runtime mode validation
 
 Validation of the above-mentioned settings is done when determining the runtime level during startup using the new `IRuntimeModeValidationService` and when it fails, causes a `BootFailedException` to be thrown. The default implementation gets all registered `IRuntimeModeValidators` to do the validation, making it possible to remove default checks and/or add your own (inherit from `RuntimeModeProductionValidatorBase`, if you only want to validate against the production runtime mode). The following validators are added by default:

--- a/15/umbraco-cms/fundamentals/setup/server-setup/runtime-modes.md
+++ b/15/umbraco-cms/fundamentals/setup/server-setup/runtime-modes.md
@@ -129,7 +129,7 @@ Static web assets are disabled when using Production mode, following [Microsoft 
 builder.WebHost.UseStaticWebAssets();
 ```
 
-This should not be used in a more typical production environment where you are hosting your application from published output.
+This should not be used in a more typical production environment where you are hosting your application from published output. 
 {% endhint %}
 
 ## Customize/extend runtime mode validation

--- a/16/umbraco-cms/fundamentals/setup/server-setup/runtime-modes.md
+++ b/16/umbraco-cms/fundamentals/setup/server-setup/runtime-modes.md
@@ -122,6 +122,16 @@ Also, templates cannot be edited on live environment as runtime compilation is n
 
 Also ensure the `UmbracoApplicationUrl` is updated to the primary URL of your production environment, as this is used when sending emails (password reset, notifications, health check results, etc.).
 
+{% hint style="info" %}
+Static web assets are disabled when using Production mode, following [Microsoft guidance](https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/static-files?view=aspnetcore-7.0#static-files-in-non-development-environments). If you are running a non-Development environment using the Production runtime mode from source (non-published output), you will need to explicitly enable this. You can add the following line of code to your `Program.cs` file:
+
+```csharp
+builder.WebHost.UseStaticWebAssets();
+```
+
+This should not be used in a more typical production environment where you are hosting your application from published output.
+{% endhint %}
+
 ## Customize/extend runtime mode validation
 
 Validation of the above-mentioned settings is done when determining the runtime level during startup using the new `IRuntimeModeValidationService` and when it fails, causes a `BootFailedException` to be thrown. The default implementation gets all registered `IRuntimeModeValidators` to do the validation, making it possible to remove default checks and/or add your own (inherit from `RuntimeModeProductionValidatorBase`, if you only want to validate against the production runtime mode). The following validators are added by default:


### PR DESCRIPTION
## Description

Added note on running production mode from source.

This came up from investigating an [issue](https://github.com/umbraco/Umbraco-CMS/issues/19043), finding a [comment on a PR](https://github.com/umbraco/Umbraco-CMS/pull/14656#discussion_r1296900457) about how to resolve it for the customer's situation, and deciding it would be useful in the documentation with an appropriate warning about when it should be used.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [X] Other

## Product & version (if relevant)

CMS 13+

## Deadline (if relevant)

Any time.
