### PR TITLE
Ammends SignalR docs to be simpier as the umbraco path can not be con…

### DIFF
--- a/10/umbraco-cms/implementation/custom-routing/signalR.md
+++ b/10/umbraco-cms/implementation/custom-routing/signalR.md
@@ -34,53 +34,9 @@ public class TestHub : Hub<ITestHubEvents>
 }
 ```
 
-## Define a custom route
-
-Next up, is defining a custom route. For this, we are going to use a `IAreaRoutes` and the base umbrace backend path so we dont have to reserve another path in the settings.
-
-```csharp
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Cms.Web.Common.ApplicationBuilder;
-using Umbraco.Extensions;
-
-public class TestHubRoutes : IAreaRoutes
-{
-    private readonly IRuntimeState _runtimeState;
-    private readonly string _umbracoPathSegment;
-
-    public TestHubRoutes(
-        IOptions<GlobalSettings> globalSettings,
-        IHostingEnvironment hostingEnvironment,
-        IRuntimeState runtimeState)
-    {
-        _runtimeState = runtimeState;
-        _umbracoPathSegment = globalSettings.Value.GetUmbracoMvcArea(hostingEnvironment);
-    }
-
-    public void CreateRoutes(IEndpointRouteBuilder endpoints)
-    {
-        switch (_runtimeState.Level)
-        {
-            case Umbraco.Cms.Core.RuntimeLevel.Run:
-                endpoints.MapHub<TestHub>(GetTestHubRoute());
-                break;
-        }
-
-    }
-
-    public string GetTestHubRoute()
-    {
-        return $"/{_umbracoPathSegment}/{nameof(TestHub)}";
-    }
-}
-```
-
 ### Add the routing to the Umbraco Composer
 
-Last step in the setup is registering our custom route:
+The next step in the setup is registering our custom route:
 
 ```csharp
 using Microsoft.AspNetCore.Builder;
@@ -101,18 +57,17 @@ public class TestHubComposer : IComposer
             builder.Services.AddSignalR();
         }
         
-        // next is adding the routes we defined earlier
-        builder.Services.AddUnique<TestHubRoutes>();
         builder.Services.Configure<UmbracoPipelineOptions>(options =>
         {
             options.AddFilter(new UmbracoPipelineFilter(
-                "test",
-                 endpoints: applicationBuilder =>
+                "Signalr",
+                endpoints: applicationBuilder =>
                 {
                     applicationBuilder.UseEndpoints(e =>
                     {
-                        var hubRoutes = applicationBuilder.ApplicationServices.GetRequiredService<TestHubRoutes>();
-                        hubRoutes.CreateRoutes(e);
+                        e.MapHub<TestHub>($"/umbraco/{nameof(TestHub)}");
+
+                        // Register more SignalR hubs or routes here...
                     });
                 }
             ));

--- a/13/umbraco-cms/implementation/custom-routing/signalR.md
+++ b/13/umbraco-cms/implementation/custom-routing/signalR.md
@@ -34,7 +34,6 @@ public class TestHub : Hub<ITestHubEvents>
 }
 ```
 
-
 ### Add the routing to the Umbraco Composer
 
 The next step in the setup is registering our custom route:

--- a/13/umbraco-cms/implementation/custom-routing/signalR.md
+++ b/13/umbraco-cms/implementation/custom-routing/signalR.md
@@ -34,53 +34,10 @@ public class TestHub : Hub<ITestHubEvents>
 }
 ```
 
-## Define a custom route
-
-Next up, is defining a custom route. For this, we are going to use a `IAreaRoutes` and the base umbrace backend path so we dont have to reserve another path in the settings.
-
-```csharp
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Cms.Web.Common.ApplicationBuilder;
-using Umbraco.Extensions;
-
-public class TestHubRoutes : IAreaRoutes
-{
-    private readonly IRuntimeState _runtimeState;
-    private readonly string _umbracoPathSegment;
-
-    public TestHubRoutes(
-        IOptions<GlobalSettings> globalSettings,
-        IHostingEnvironment hostingEnvironment,
-        IRuntimeState runtimeState)
-    {
-        _runtimeState = runtimeState;
-        _umbracoPathSegment = globalSettings.Value.GetUmbracoMvcArea(hostingEnvironment);
-    }
-
-    public void CreateRoutes(IEndpointRouteBuilder endpoints)
-    {
-        switch (_runtimeState.Level)
-        {
-            case Umbraco.Cms.Core.RuntimeLevel.Run:
-                endpoints.MapHub<TestHub>(GetTestHubRoute());
-                break;
-        }
-
-    }
-
-    public string GetTestHubRoute()
-    {
-        return $"/{_umbracoPathSegment}/{nameof(TestHub)}";
-    }
-}
-```
 
 ### Add the routing to the Umbraco Composer
 
-Last step in the setup is registering our custom route:
+The next step in the setup is registering our custom route:
 
 ```csharp
 using Microsoft.AspNetCore.Builder;
@@ -101,18 +58,17 @@ public class TestHubComposer : IComposer
             builder.Services.AddSignalR();
         }
         
-        // next is adding the routes we defined earlier
-        builder.Services.AddUnique<TestHubRoutes>();
         builder.Services.Configure<UmbracoPipelineOptions>(options =>
         {
             options.AddFilter(new UmbracoPipelineFilter(
-                "test",
-                 endpoints: applicationBuilder =>
+                "Signalr",
+                endpoints: applicationBuilder =>
                 {
                     applicationBuilder.UseEndpoints(e =>
                     {
-                        var hubRoutes = applicationBuilder.ApplicationServices.GetRequiredService<TestHubRoutes>();
-                        hubRoutes.CreateRoutes(e);
+                        e.MapHub<TestHub>($"/umbraco/{nameof(TestHub)}");
+
+                        // Register more SignalR hubs or routes here...
                     });
                 }
             ));

--- a/14/umbraco-cms/implementation/custom-routing/signalR.md
+++ b/14/umbraco-cms/implementation/custom-routing/signalR.md
@@ -34,53 +34,9 @@ public class TestHub : Hub<ITestHubEvents>
 }
 ```
 
-## Define a custom route
-
-Next up, is defining a custom route. For this, we are going to use a `IAreaRoutes` and the base umbrace backend path so we dont have to reserve another path in the settings.
-
-```csharp
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Cms.Web.Common.ApplicationBuilder;
-using Umbraco.Extensions;
-
-public class TestHubRoutes : IAreaRoutes
-{
-    private readonly IRuntimeState _runtimeState;
-    private readonly string _umbracoPathSegment;
-
-    public TestHubRoutes(
-        IOptions<GlobalSettings> globalSettings,
-        IHostingEnvironment hostingEnvironment,
-        IRuntimeState runtimeState)
-    {
-        _runtimeState = runtimeState;
-        _umbracoPathSegment = globalSettings.Value.GetUmbracoMvcArea(hostingEnvironment);
-    }
-
-    public void CreateRoutes(IEndpointRouteBuilder endpoints)
-    {
-        switch (_runtimeState.Level)
-        {
-            case Umbraco.Cms.Core.RuntimeLevel.Run:
-                endpoints.MapHub<TestHub>(GetTestHubRoute());
-                break;
-        }
-
-    }
-
-    public string GetTestHubRoute()
-    {
-        return $"/{_umbracoPathSegment}/{nameof(TestHub)}";
-    }
-}
-```
-
 ### Add the routing to the Umbraco Composer
 
-Last step in the setup is registering our custom route:
+The next step in the setup is registering our custom route:
 
 ```csharp
 using Microsoft.AspNetCore.Builder;
@@ -101,18 +57,17 @@ public class TestHubComposer : IComposer
             builder.Services.AddSignalR();
         }
         
-        // next is adding the routes we defined earlier
-        builder.Services.AddUnique<TestHubRoutes>();
         builder.Services.Configure<UmbracoPipelineOptions>(options =>
         {
             options.AddFilter(new UmbracoPipelineFilter(
-                "test",
-                 endpoints: applicationBuilder =>
+                "Signalr",
+                endpoints: applicationBuilder =>
                 {
                     applicationBuilder.UseEndpoints(e =>
                     {
-                        var hubRoutes = applicationBuilder.ApplicationServices.GetRequiredService<TestHubRoutes>();
-                        hubRoutes.CreateRoutes(e);
+                        e.MapHub<TestHub>($"/umbraco/{nameof(TestHub)}");
+
+                        // Register more SignalR hubs or routes here...
                     });
                 }
             ));

--- a/14/umbraco-cms/implementation/custom-routing/signalR.md
+++ b/14/umbraco-cms/implementation/custom-routing/signalR.md
@@ -1,5 +1,5 @@
 ---
-description: "Umbraco ships with signalR installed, find out how to add your own hub(s) to the existing setup"
+description: "Umbraco ships with SignalR installed, find out how to add your own hub(s) to the existing setup"
 ---
 
 # Adding a hub with SignalR and Umbraco

--- a/15/umbraco-cms/implementation/custom-routing/signalR.md
+++ b/15/umbraco-cms/implementation/custom-routing/signalR.md
@@ -34,53 +34,9 @@ public class TestHub : Hub<ITestHubEvents>
 }
 ```
 
-## Define a custom route
-
-Next up, is defining a custom route. Use `IAreaRoutes` and the base Umbraco backend path so there's no need to reserve another path in the settings.
-
-```csharp
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Cms.Web.Common.ApplicationBuilder;
-using Umbraco.Extensions;
-
-public class TestHubRoutes : IAreaRoutes
-{
-    private readonly IRuntimeState _runtimeState;
-    private readonly string _umbracoPathSegment;
-
-    public TestHubRoutes(
-        IOptions<GlobalSettings> globalSettings,
-        IHostingEnvironment hostingEnvironment,
-        IRuntimeState runtimeState)
-    {
-        _runtimeState = runtimeState;
-        _umbracoPathSegment = globalSettings.Value.GetUmbracoMvcArea(hostingEnvironment);
-    }
-
-    public void CreateRoutes(IEndpointRouteBuilder endpoints)
-    {
-        switch (_runtimeState.Level)
-        {
-            case Umbraco.Cms.Core.RuntimeLevel.Run:
-                endpoints.MapHub<TestHub>(GetTestHubRoute());
-                break;
-        }
-
-    }
-
-    public string GetTestHubRoute()
-    {
-        return $"/{_umbracoPathSegment}/{nameof(TestHub)}";
-    }
-}
-```
-
 ### Add the routing to the Umbraco Composer
 
-Last step in the setup is registering our custom route:
+The next step in the setup is registering our custom route:
 
 ```csharp
 using Microsoft.AspNetCore.Builder;
@@ -101,18 +57,17 @@ public class TestHubComposer : IComposer
             builder.Services.AddSignalR();
         }
         
-        // next is adding the routes we defined earlier
-        builder.Services.AddUnique<TestHubRoutes>();
         builder.Services.Configure<UmbracoPipelineOptions>(options =>
         {
             options.AddFilter(new UmbracoPipelineFilter(
-                "test",
-                 endpoints: applicationBuilder =>
+                "Signalr",
+                endpoints: applicationBuilder =>
                 {
                     applicationBuilder.UseEndpoints(e =>
                     {
-                        var hubRoutes = applicationBuilder.ApplicationServices.GetRequiredService<TestHubRoutes>();
-                        hubRoutes.CreateRoutes(e);
+                        e.MapHub<TestHub>($"/umbraco/{nameof(TestHub)}");
+
+                        // Register more SignalR hubs or routes here...
                     });
                 }
             ));

--- a/16/umbraco-cms/implementation/custom-routing/signalR.md
+++ b/16/umbraco-cms/implementation/custom-routing/signalR.md
@@ -34,53 +34,9 @@ public class TestHub : Hub<ITestHubEvents>
 }
 ```
 
-## Define a custom route
-
-Next up, is defining a custom route. Use `IAreaRoutes` and the base Umbraco backend path so there's no need to reserve another path in the settings.
-
-```csharp
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Cms.Web.Common.ApplicationBuilder;
-using Umbraco.Extensions;
-
-public class TestHubRoutes : IAreaRoutes
-{
-    private readonly IRuntimeState _runtimeState;
-    private readonly string _umbracoPathSegment;
-
-    public TestHubRoutes(
-        IOptions<GlobalSettings> globalSettings,
-        IHostingEnvironment hostingEnvironment,
-        IRuntimeState runtimeState)
-    {
-        _runtimeState = runtimeState;
-        _umbracoPathSegment = globalSettings.Value.GetUmbracoMvcArea(hostingEnvironment);
-    }
-
-    public void CreateRoutes(IEndpointRouteBuilder endpoints)
-    {
-        switch (_runtimeState.Level)
-        {
-            case Umbraco.Cms.Core.RuntimeLevel.Run:
-                endpoints.MapHub<TestHub>(GetTestHubRoute());
-                break;
-        }
-
-    }
-
-    public string GetTestHubRoute()
-    {
-        return $"/{_umbracoPathSegment}/{nameof(TestHub)}";
-    }
-}
-```
-
 ### Add the routing to the Umbraco Composer
 
-Last step in the setup is registering our custom route:
+The next step in the setup is registering our custom route:
 
 ```csharp
 using Microsoft.AspNetCore.Builder;
@@ -101,18 +57,17 @@ public class TestHubComposer : IComposer
             builder.Services.AddSignalR();
         }
         
-        // next is adding the routes we defined earlier
-        builder.Services.AddUnique<TestHubRoutes>();
         builder.Services.Configure<UmbracoPipelineOptions>(options =>
         {
             options.AddFilter(new UmbracoPipelineFilter(
-                "test",
-                 endpoints: applicationBuilder =>
+                "Signalr",
+                endpoints: applicationBuilder =>
                 {
                     applicationBuilder.UseEndpoints(e =>
                     {
-                        var hubRoutes = applicationBuilder.ApplicationServices.GetRequiredService<TestHubRoutes>();
-                        hubRoutes.CreateRoutes(e);
+                        e.MapHub<TestHub>($"/umbraco/{nameof(TestHub)}");
+
+                        // Register more SignalR hubs or routes here...
                     });
                 }
             ));


### PR DESCRIPTION
## Description
Amends SignalR docs to be simpler as the [Umbraco path can not be configured past V9](https://github.com/umbraco/Umbraco-CMS/issues/12593#issuecomment-1607150190)


## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
I only done this to the v13 docs, but if present in the other versions then I would say this change could be copied to the other versions of the page


## Deadline (if relevant)
N/A
