### PR TITLE
Fix code alignment

### DIFF
--- a/15/umbraco-cms/tutorials/creating-a-property-editor/integrating-context-with-a-property-editor.md
+++ b/15/umbraco-cms/tutorials/creating-a-property-editor/integrating-context-with-a-property-editor.md
@@ -142,25 +142,25 @@ constructor() {
   ...
 
     const trimmed = (this.value as string).substring(0, this._maxChars);
-        const modalHandler = this.#modalManagerContext?.open(this, UMB_CONFIRM_MODAL,
-            {
-                data: {
-                    headline: `Trim text`,
-                    content: `Do you want to trim the text to "${trimmed}"?`,
-                    color: "danger",
-                    confirmLabel: "Trim",
-                }
+    const modalHandler = this.#modalManagerContext?.open(this, UMB_CONFIRM_MODAL,
+        {
+            data: {
+                headline: `Trim text`,
+                content: `Do you want to trim the text to "${trimmed}"?`,
+                color: "danger",
+                confirmLabel: "Trim",
             }
-        );
-        modalHandler?.onSubmit().then(() => {
-            this.value = trimmed;
-            this.#dispatchChangeEvent();
-            const data: UmbNotificationDefaultData = {
-                headline: `Text trimmed`,
-                message: `You trimmed the text!`,
-            };
-            this.#notificationContext?.peek("positive", { data });
-        }, null);
+        }
+    );
+    modalHandler?.onSubmit().then(() => {
+        this.value = trimmed;
+        this.#dispatchChangeEvent();
+        const data: UmbNotificationDefaultData = {
+            headline: `Text trimmed`,
+            message: `You trimmed the text!`,
+        };
+        this.#notificationContext?.peek("positive", { data });
+    }, null);
 }
 ```
 {% endcode %}


### PR DESCRIPTION
The Codeblock seems to have had an extra tab, making it look like it was part of the first defined const - Making it confusing on the eyes :-)

## Description

_What did you add/update/change?_

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
