### PR TITLE
Fixes mentions of `contrib` and replaces with `main`

### DIFF
--- a/10/umbraco-cms/extending/language-files.md
+++ b/10/umbraco-cms/extending/language-files.md
@@ -194,4 +194,4 @@ In the above example of a missing translation for "assignDomain", locate this st
 </language>
 ```
 
-If you modify core language files or introduce a new language, you can assist the community by sharing your updates. This can be done by [submitting a pull request](https://github.com/umbraco/Umbraco-CMS/blob/contrib/.github/CONTRIBUTING.md) so that your changes are merged into the core.
+If you modify core language files or introduce a new language, you can assist the community by sharing your updates. This can be done by [submitting a pull request](https://github.com/umbraco/Umbraco-CMS/blob/main/.github/CONTRIBUTING.md) so that your changes are merged into the core.

--- a/10/umbraco-cms/extending/packages/language-files-for-packages.md
+++ b/10/umbraco-cms/extending/packages/language-files-for-packages.md
@@ -22,7 +22,7 @@ The `App_Plugins` version of the `Lang` directory is case sensitive on Linux sys
 
 Each language file can include one or more area. Each area contains a collection of language keys with the translation.
 
-For reference on the language file format see the core [language files on GitHub](https://github.com/umbraco/Umbraco-CMS/tree/contrib/src/Umbraco.Core/EmbeddedResources/Lang)
+For reference on the language file format see the core [language files on GitHub](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Core/EmbeddedResources/Lang)
 
 ### Sample structure
 

--- a/10/umbraco-cms/implementation/integration-testing.md
+++ b/10/umbraco-cms/implementation/integration-testing.md
@@ -5,7 +5,7 @@ description: A guide to getting started with integration testing in Umbraco
 
 # Integration Testing
 
-These examples are for Umbraco 10. They use [NUnit](https://nunit.org/) as the testing framework. Leveraging [Umbraco.Cms.Tests.Integration](https://github.com/umbraco/Umbraco-CMS/tree/contrib/tests/Umbraco.Tests.Integration) providing base classes. Beware that the Nuget package has an issue fixed in v10.3.1. So it is recommended to use this version.
+These examples are for Umbraco 10. They use [NUnit](https://nunit.org/) as the testing framework. Leveraging [Umbraco.Cms.Tests.Integration](https://github.com/umbraco/Umbraco-CMS/tree/main/tests/Umbraco.Tests.Integration) providing base classes. Beware that the Nuget package has an issue fixed in v10.3.1. So it is recommended to use this version.
 
 ## Getting started
 

--- a/10/umbraco-cms/reference/angular/directives/umbproperty.md
+++ b/10/umbraco-cms/reference/angular/directives/umbproperty.md
@@ -30,4 +30,4 @@ var property = {
 
 The `view` property specifies the URL to the property editor that should be used for this property. To use one of the built-in property editors in Umbraco, you can specify the alias (eg. `textbox`) rather than the full URL to the view (eg. `/umbraco/Views/propertyeditors/textbox/textbox.html`).
 
-You can see a list of all the built-in property editors in the [propertyeditors folder on GitHub](https://github.com/umbraco/Umbraco-CMS/tree/v11/contrib/src/Umbraco.Web.UI.Client/src/views/propertyeditors).
+You can see a list of all the built-in property editors in the [propertyeditors folder on GitHub](https://github.com/umbraco/Umbraco-CMS/tree/v13/main/src/Umbraco.Web.UI.Client/src/views/propertyeditors).

--- a/10/umbraco-cms/reference/angular/directives/umbproperty.md
+++ b/10/umbraco-cms/reference/angular/directives/umbproperty.md
@@ -30,4 +30,4 @@ var property = {
 
 The `view` property specifies the URL to the property editor that should be used for this property. To use one of the built-in property editors in Umbraco, you can specify the alias (eg. `textbox`) rather than the full URL to the view (eg. `/umbraco/Views/propertyeditors/textbox/textbox.html`).
 
-You can see a list of all the built-in property editors in the [propertyeditors folder on GitHub](https://github.com/umbraco/Umbraco-CMS/tree/v13/main/src/Umbraco.Web.UI.Client/src/views/propertyeditors).
+You can see a list of all the built-in property editors in the [propertyeditors folder on GitHub](https://github.com/umbraco/Umbraco-CMS/tree/83107bb31a7fe98f6c5b0a601c0e8ee898cd274b/src/Umbraco.Web.UI.Client/src/views/propertyeditors).

--- a/10/umbraco-cms/reference/cache/README.md
+++ b/10/umbraco-cms/reference/cache/README.md
@@ -13,7 +13,7 @@ Although caching is a pretty standard concept it is very important to make sure 
 
 In normal environments caching seems to be a pretty standard concept. If you are a package developer or developer who is going to publish a codebase to a load balanced environment then you need to be aware of how to invalidate your cache properly, so that it works in load balanced environments. If it is not done correctly then your package and/or codebase will not work the way that you would expect in a load balanced scenario.
 
-**If you are caching business logic data that changes based on a user's action in the backoffice and you are not using an **_**ICacheRefresher**_** then you will need to review your code and update it based on the below documentation.**
+**If you're caching business logic based on backoffice user actions without using an _ICacheRefresher_, review and update your code using the documentation below.**
 {% endhint %}
 
 ## Retrieving and Adding items in the cache

--- a/10/umbraco-cms/reference/cache/README.md
+++ b/10/umbraco-cms/reference/cache/README.md
@@ -48,7 +48,7 @@ There are 2 other base types of `ICacheRefresher` which are:
 * `ICacheRefresher<T>` - this inherits from `ICacheRefresher` and provides a set of strongly typed methods for cache invalidation. This is useful when executing the method to invoke the cache refresher, when you have the instance of the object already since this avoids the overhead of retrieving the object again.
   * `void Refresh(T instance);` - this would invalidate/refresh a single cache for the specified object.
   * `void Remove(T instance);` - this would invalidate a single cache for the specified object.
-* `IJsonCacheRefresher` - this inherits from `ICacheRefresher` but provides more flexibility if you need to invalidate cache based on more complex scenarios (e.g. the [MemberGroupCacheRefresher](https://github.com/umbraco/Umbraco-CMS/blob/v13/main/src/Umbraco.Core/Cache/MemberGroupCacheRefresher.cs)).
+* `IJsonCacheRefresher` - this inherits from `ICacheRefresher` but provides more flexibility if you need to invalidate cache based on more complex scenarios (for example, the [MemberGroupCacheRefresher](https://github.com/umbraco/Umbraco-CMS/blob/v13/main/src/Umbraco.Core/Cache/MemberGroupCacheRefresher.cs)).
   * `void Refresh(string jsonPayload)` - Invalidates/refreshes any cache based on the information provided in the JSON. The JSON value is any value that is used when executing the method to invoke the cache refresher.
 
 There are several examples of `ICacheRefresher`'s in the core: https://github.com/umbraco/Umbraco-CMS/tree/v13/main/src/Umbraco.Core/Cache

--- a/10/umbraco-cms/reference/cache/README.md
+++ b/10/umbraco-cms/reference/cache/README.md
@@ -51,7 +51,7 @@ There are 2 other base types of `ICacheRefresher` which are:
 * `IJsonCacheRefresher` - this inherits from `ICacheRefresher` but provides more flexibility if you need to invalidate cache based on more complex scenarios (for example, the [MemberGroupCacheRefresher](https://github.com/umbraco/Umbraco-CMS/blob/v13/main/src/Umbraco.Core/Cache/MemberGroupCacheRefresher.cs)).
   * `void Refresh(string jsonPayload)` - Invalidates/refreshes any cache based on the information provided in the JSON. The JSON value is any value that is used when executing the method to invoke the cache refresher.
 
-There are several examples of `ICacheRefresher`'s in the core: https://github.com/umbraco/Umbraco-CMS/tree/v13/main/src/Umbraco.Core/Cache
+There are a couple of examples of `ICacheRefresher's` in the [core](https://github.com/umbraco/Umbraco-CMS/tree/v13/main/src/Umbraco.Core/Cache).
 
 ### Executing an ICacheRefresher
 

--- a/10/umbraco-cms/reference/cache/README.md
+++ b/10/umbraco-cms/reference/cache/README.md
@@ -13,7 +13,7 @@ Although caching is a pretty standard concept it is very important to make sure 
 
 In normal environments caching seems to be a pretty standard concept. If you are a package developer or developer who is going to publish a codebase to a load balanced environment then you need to be aware of how to invalidate your cache properly, so that it works in load balanced environments. If it is not done correctly then your package and/or codebase will not work the way that you would expect in a load balanced scenario.
 
-**If you are caching business logic data that changes based on a user's action in the backoffice and you are not using an **_**ICacheRefresher**_** then you will need to review your code and update it based on the below documentation.** 
+**If you are caching business logic data that changes based on a user's action in the backoffice and you are not using an **_**ICacheRefresher**_** then you will need to review your code and update it based on the below documentation.**
 {% endhint %}
 
 ## Retrieving and Adding items in the cache
@@ -48,10 +48,10 @@ There are 2 other base types of `ICacheRefresher` which are:
 * `ICacheRefresher<T>` - this inherits from `ICacheRefresher` and provides a set of strongly typed methods for cache invalidation. This is useful when executing the method to invoke the cache refresher, when you have the instance of the object already since this avoids the overhead of retrieving the object again.
   * `void Refresh(T instance);` - this would invalidate/refresh a single cache for the specified object.
   * `void Remove(T instance);` - this would invalidate a single cache for the specified object.
-* `IJsonCacheRefresher` - this inherits from `ICacheRefresher` but provides more flexibility if you need to invalidate cache based on more complex scenarios (e.g. the [MemberGroupCacheRefresher](https://github.com/umbraco/Umbraco-CMS/blob/v11/contrib/src/Umbraco.Core/Cache/MemberGroupCacheRefresher.cs)).
+* `IJsonCacheRefresher` - this inherits from `ICacheRefresher` but provides more flexibility if you need to invalidate cache based on more complex scenarios (e.g. the [MemberGroupCacheRefresher](https://github.com/umbraco/Umbraco-CMS/blob/v13/main/src/Umbraco.Core/Cache/MemberGroupCacheRefresher.cs)).
   * `void Refresh(string jsonPayload)` - Invalidates/refreshes any cache based on the information provided in the JSON. The JSON value is any value that is used when executing the method to invoke the cache refresher.
 
-There are several examples of `ICacheRefresher`'s in the core: https://github.com/umbraco/Umbraco-CMS/tree/v11/contrib/src/Umbraco.Core/Cache
+There are several examples of `ICacheRefresher`'s in the core: https://github.com/umbraco/Umbraco-CMS/tree/v13/main/src/Umbraco.Core/Cache
 
 ### Executing an ICacheRefresher
 

--- a/10/umbraco-cms/reference/cache/README.md
+++ b/10/umbraco-cms/reference/cache/README.md
@@ -48,10 +48,10 @@ There are 2 other base types of `ICacheRefresher` which are:
 * `ICacheRefresher<T>` - this inherits from `ICacheRefresher` and provides a set of strongly typed methods for cache invalidation. This is useful when executing the method to invoke the cache refresher, when you have the instance of the object already since this avoids the overhead of retrieving the object again.
   * `void Refresh(T instance);` - this would invalidate/refresh a single cache for the specified object.
   * `void Remove(T instance);` - this would invalidate a single cache for the specified object.
-* `IJsonCacheRefresher` - this inherits from `ICacheRefresher` but provides more flexibility if you need to invalidate cache based on more complex scenarios (for example, the [MemberGroupCacheRefresher](https://github.com/umbraco/Umbraco-CMS/blob/v13/main/src/Umbraco.Core/Cache/MemberGroupCacheRefresher.cs)).
+* `IJsonCacheRefresher` - this inherits from `ICacheRefresher` but provides more flexibility if you need to invalidate cache based on more complex scenarios (for example, the [MemberGroupCacheRefresher](https://github.com/umbraco/Umbraco-CMS/blob/9f912aea0e4759a1fcea43d7469d3d4756b6fbe1/src/Umbraco.Core/Cache/MemberGroupCacheRefresher.cs)).
   * `void Refresh(string jsonPayload)` - Invalidates/refreshes any cache based on the information provided in the JSON. The JSON value is any value that is used when executing the method to invoke the cache refresher.
 
-There are a couple of examples of `ICacheRefresher's` in the [core](https://github.com/umbraco/Umbraco-CMS/tree/v13/main/src/Umbraco.Core/Cache).
+There are a couple of examples of `ICacheRefresher's` in the [core](https://github.com/umbraco/Umbraco-CMS/tree/9f912aea0e4759a1fcea43d7469d3d4756b6fbe1/src/Umbraco.Core/Cache).
 
 ### Executing an ICacheRefresher
 

--- a/10/umbraco-cms/reference/searching/examine/indexing.md
+++ b/10/umbraco-cms/reference/searching/examine/indexing.md
@@ -329,7 +329,7 @@ The index will only update its content when you manually trigger an index rebuil
 To update your index when content changes, you can use notification handlers.
 
 {% hint style="info" %}
-The following handler class does not automatically update the descendant items of the modified content nodes, such as removing descendants of deleted content. If changes to the parent content item can affect its children or descendant items in your setup, please refer to the [UmbracoContentIndex.PerformDeleteFromIndex() in Umbraco](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs#L124-L153). Such logic should be applied when both removing and reindexing content items of type _product_.
+The following handler class does not automatically update the descendant items of the modified content nodes, such as removing descendants of deleted content. If changes to the parent content item can affect its children or descendant items in your setup, please refer to the [UmbracoContentIndex.PerformDeleteFromIndex() in Umbraco](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs#L124-L153). Such logic should be applied when both removing and reindexing content items of type _product_.
 {% endhint %}
 
 ```csharp

--- a/10/umbraco-cms/reference/security/cookies.md
+++ b/10/umbraco-cms/reference/security/cookies.md
@@ -28,4 +28,4 @@ services.AddSession(options =>
     });
 ```
 
-For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/Constants-Web.cs) file on GitHub.
+For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Core/Constants-Web.cs) file on GitHub.

--- a/13/umbraco-cms/extending/language-files.md
+++ b/13/umbraco-cms/extending/language-files.md
@@ -234,4 +234,4 @@ In the above example of a missing translation for "assignDomain", locate this st
 </language>
 ```
 
-If you modify core language files or introduce a new language, you can assist the community by sharing your updates. This can be done by [submitting a pull request](https://github.com/umbraco/Umbraco-CMS/blob/contrib/.github/CONTRIBUTING.md) so that your changes are merged into the core.
+If you modify core language files or introduce a new language, you can assist the community by sharing your updates. This can be done by [submitting a pull request](https://github.com/umbraco/Umbraco-CMS/blob/main/.github/CONTRIBUTING.md) so that your changes are merged into the core.

--- a/13/umbraco-cms/fundamentals/backoffice/login.md
+++ b/13/umbraco-cms/fundamentals/backoffice/login.md
@@ -39,7 +39,7 @@ The login screen features a greeting which you can personalize by overriding the
 
 * Before the changes takes place you will need to restart the site.
 
-You can customize other text on the login screen as well. First, grab the default values and keys from the [en\_us.xml](https://github.com/umbraco/Umbraco-CMS/blob/v13/main/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml) in the Umbraco CMS GitHub repository. Thereafter copy the ones you want to translate into `~/config/lang/en_us.user.xml` file.
+You can customize other text on the login screen as well. First, grab the default values and keys from the [en_us.xml](https://github.com/umbraco/Umbraco-CMS/blob/v13/main/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml) in the Umbraco CMS GitHub repository. Thereafter, copy the ones you want to translate into the `~/config/lang/en_us.user.xml` file.
 
 ## Password reset
 

--- a/13/umbraco-cms/fundamentals/backoffice/login.md
+++ b/13/umbraco-cms/fundamentals/backoffice/login.md
@@ -39,7 +39,7 @@ The login screen features a greeting which you can personalize by overriding the
 
 * Before the changes takes place you will need to restart the site.
 
-You can customize other text on the login screen as well. First, grab the default values and keys from the [en_us.xml](https://github.com/umbraco/Umbraco-CMS/blob/v13/main/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml) in the Umbraco CMS GitHub repository. Thereafter, copy the ones you want to translate into the `~/config/lang/en_us.user.xml` file.
+You can customize other text on the login screen as well. First, grab the default values and keys from the [en_us.xml](https://github.com/umbraco/Umbraco-CMS/blob/5ba40c65fc45f0effb0153bb69ac435e40ed605c/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml) in the Umbraco CMS GitHub repository. Thereafter, copy the ones you want to translate into the `~/config/lang/en_us.user.xml` file.
 
 ## Password reset
 
@@ -155,4 +155,4 @@ The following CSS properties are available for customization:
 | `--umb-login-curves-color`               | The color of the curves                        | `#f5c1bc`                                                                                  |
 | `--umb-login-curves-display`             | The display of the curves                      | `inline`                                                                                   |
 
-The CSS custom properties may change in future versions of Umbraco. You can always find the latest values in the [login layout element](https://github.com/umbraco/Umbraco-CMS/blob/v13/main/src/Umbraco.Web.UI.Login/src/components/layouts/auth-layout.element.ts) in the Umbraco CMS GitHub repository.
+The CSS custom properties may change in future versions of Umbraco. You can always find the latest values in the [login layout element](https://github.com/umbraco/Umbraco-CMS/blob/v13/dev/src/Umbraco.Web.UI.Login/src/components/layouts/auth-layout.element.ts) in the Umbraco CMS GitHub repository.

--- a/13/umbraco-cms/fundamentals/backoffice/login.md
+++ b/13/umbraco-cms/fundamentals/backoffice/login.md
@@ -18,7 +18,7 @@ Below, you will find instructions on how to customize the login screen.
 
 ## Greeting
 
-The login screen features a greeting which you can personalize by overriding the existing language translation keys. To do this, create a 'user' translation file for the default language of your Umbraco site, (usually en-US) to override the greetings. For en-US, you'd create a file called: `en_us.user.xml` in the directory `~/config/lang/`. Then take the relevant keys (listed below) and add them to your `~/config/lang/en_us.user.xml` file, and update the greetings as necessary. 
+The login screen features a greeting which you can personalize by overriding the existing language translation keys. To do this, create a 'user' translation file for the default language of your Umbraco site, (usually en-US) to override the greetings. For en-US, you'd create a file called: `en_us.user.xml` in the directory `~/config/lang/`. Then take the relevant keys (listed below) and add them to your `~/config/lang/en_us.user.xml` file, and update the greetings as necessary.
 
 **Note:** the `config` directory needs to be in the root of your project (_not_ the `wwwroot`).
 
@@ -39,7 +39,7 @@ The login screen features a greeting which you can personalize by overriding the
 
 * Before the changes takes place you will need to restart the site.
 
-You can customize other text on the login screen as well. First, grab the default values and keys from the [en\_us.xml](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/EmbeddedResources/Lang/en\_us.xml) in the Umbraco CMS GitHub repository. Thereafter copy the ones you want to translate into `~/config/lang/en_us.user.xml` file.
+You can customize other text on the login screen as well. First, grab the default values and keys from the [en\_us.xml](https://github.com/umbraco/Umbraco-CMS/blob/v13/main/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml) in the Umbraco CMS GitHub repository. Thereafter copy the ones you want to translate into `~/config/lang/en_us.user.xml` file.
 
 ## Password reset
 
@@ -155,4 +155,4 @@ The following CSS properties are available for customization:
 | `--umb-login-curves-color`               | The color of the curves                        | `#f5c1bc`                                                                                  |
 | `--umb-login-curves-display`             | The display of the curves                      | `inline`                                                                                   |
 
-The CSS custom properties may change in future versions of Umbraco. You can always find the latest values in the [login layout element](https://github.com/umbraco/Umbraco-CMS/blob/v13/dev/src/Umbraco.Web.UI.Login/src/components/layouts/auth-layout.element.ts) in the Umbraco CMS GitHub repository.
+The CSS custom properties may change in future versions of Umbraco. You can always find the latest values in the [login layout element](https://github.com/umbraco/Umbraco-CMS/blob/v13/main/src/Umbraco.Web.UI.Login/src/components/layouts/auth-layout.element.ts) in the Umbraco CMS GitHub repository.

--- a/13/umbraco-cms/implementation/integration-testing.md
+++ b/13/umbraco-cms/implementation/integration-testing.md
@@ -4,7 +4,7 @@ description: A guide to getting started with integration testing in Umbraco
 
 # Integration Testing
 
-These examples are for Umbraco 10. They use [NUnit](https://nunit.org/) as the testing framework. Leveraging [Umbraco.Cms.Tests.Integration](https://github.com/umbraco/Umbraco-CMS/tree/contrib/tests/Umbraco.Tests.Integration) providing base classes. Beware that the Nuget package has an issue fixed in v10.3.1. So it is recommended to use this version.
+These examples are for Umbraco 10. They use [NUnit](https://nunit.org/) as the testing framework. Leveraging [Umbraco.Cms.Tests.Integration](https://github.com/umbraco/Umbraco-CMS/tree/main/tests/Umbraco.Tests.Integration) providing base classes. Beware that the Nuget package has an issue fixed in v10.3.1. So it is recommended to use this version.
 
 ## Getting started
 

--- a/13/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api.md
+++ b/13/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api.md
@@ -334,7 +334,7 @@ Different client libraries have different ways of declaring the `identity_provid
 
 We can also add the external identity providers to the member authentication login screen. This way the end user can decide whether to log in as a registered member, or use an external identity provider.
 
-The [Login partial view](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/EmbeddedResources/Snippets/Login.cshtml) features an implementation of this combined login experience.
+The [Login partial view](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Core/EmbeddedResources/Snippets/Login.cshtml) features an implementation of this combined login experience.
 
 ## Accessing protected content
 

--- a/13/umbraco-cms/reference/searching/examine/indexing.md
+++ b/13/umbraco-cms/reference/searching/examine/indexing.md
@@ -329,7 +329,7 @@ The index will only update its content when you manually trigger an index rebuil
 To update your index when content changes, you can use notification handlers.
 
 {% hint style="info" %}
-The following handler class does not automatically update the descendant items of the modified content nodes, such as removing descendants of deleted content. If changes to the parent content item can affect its children or descendant items in your setup, please refer to the [UmbracoContentIndex.PerformDeleteFromIndex() in Umbraco](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs#L124-L153). Such logic should be applied when both removing and reindexing content items of type _product_.
+The following handler class does not automatically update the descendant items of the modified content nodes, such as removing descendants of deleted content. If changes to the parent content item can affect its children or descendant items in your setup, please refer to the [UmbracoContentIndex.PerformDeleteFromIndex() in Umbraco](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs#L124-L153). Such logic should be applied when both removing and reindexing content items of type _product_.
 {% endhint %}
 
 ```csharp

--- a/13/umbraco-cms/reference/security/cookies.md
+++ b/13/umbraco-cms/reference/security/cookies.md
@@ -28,4 +28,4 @@ builder.Services.AddSession(options =>
     });
 ```
 
-For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/Constants-Web.cs) file on GitHub.
+For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Core/Constants-Web.cs) file on GitHub.

--- a/14/umbraco-cms/extending/language-files/README.md
+++ b/14/umbraco-cms/extending/language-files/README.md
@@ -29,7 +29,7 @@ You can use localization files for Document and Media Types as well. You can fin
 
 ## Supported Languages
 
-Current [languages](https://github.com/umbraco/Umbraco-CMS/tree/contrib/src/Umbraco.Core/EmbeddedResources/Lang) with their ISO codes that are included in new Umbraco installations are:
+Current [languages](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Core/EmbeddedResources/Lang) with their ISO codes that are included in new Umbraco installations are:
 
 * `bs-BS` - Bosnian (Bosnia and Herzegovina)
 * `cs-CZ` - Czech (Czech Republic)

--- a/14/umbraco-cms/extending/language-files/net-localization.md
+++ b/14/umbraco-cms/extending/language-files/net-localization.md
@@ -20,7 +20,7 @@ In other words, .NET localization is only applied server-side with no accompanyi
 
 ### Where to find the core localization files
 
-The core Umbraco localization files are found at the following location within the [Umbraco source](https://github.com/umbraco/Umbraco-CMS/tree/contrib/src/Umbraco.Core/EmbeddedResources/Lang):
+The core Umbraco localization files are found at the following location within the [Umbraco source](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Core/EmbeddedResources/Lang):
 
 ```xml
 Umbraco-CMS/src/Umbraco.Core/EmbeddedResources/Lang/

--- a/14/umbraco-cms/extending/language-files/net-localization.md
+++ b/14/umbraco-cms/extending/language-files/net-localization.md
@@ -115,4 +115,4 @@ In the above example of a missing translation for "**assignDomain**", locate thi
 </language>
 ```
 
-If you modify core language files or introduce a new language, you can assist the community by sharing your updates. This can be done by [submitting a pull request](https://github.com/umbraco/Umbraco-CMS/blob/contrib/.github/CONTRIBUTING.md) so that your changes are merged into the core.
+If you modify core language files or introduce a new language, you can assist the community by sharing your updates. This can be done by [submitting a pull request](https://github.com/umbraco/Umbraco-CMS/blob/main/.github/CONTRIBUTING.md) so that your changes are merged into the core.

--- a/14/umbraco-cms/fundamentals/backoffice/login.md
+++ b/14/umbraco-cms/fundamentals/backoffice/login.md
@@ -71,7 +71,7 @@ This will override the default greetings with the ones you provide. The login sc
 The login screen has its own set of localization files independent of the rest of the Backoffice. You can read more about Backoffice localization in the [UI Localization](../../customizing/foundation/localization.md) article.
 {% endhint %}
 
-You can customize other text on the login screen as well. First, grab the default values and keys from the [en.ts](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Web.UI.Login/src/localization/lang/en.ts) in the Umbraco CMS GitHub repository. Thereafter copy the ones you want to translate into `~/App_Plugins/Login/umbraco-package.json` file.
+You can customize other text on the login screen as well. First, grab the default values and keys from the [en.ts](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Web.UI.Login/src/localization/lang/en.ts) in the Umbraco CMS GitHub repository. Thereafter copy the ones you want to translate into `~/App_Plugins/Login/umbraco-package.json` file.
 
 ## Password reset
 

--- a/14/umbraco-cms/implementation/integration-testing.md
+++ b/14/umbraco-cms/implementation/integration-testing.md
@@ -4,7 +4,7 @@ description: A guide to getting started with integration testing in Umbraco
 
 # Integration Testing
 
-These examples are for Umbraco 14. They use [NUnit](https://nunit.org/) as the testing framework. Leveraging [Umbraco.Cms.Tests.Integration](https://github.com/umbraco/Umbraco-CMS/tree/contrib/tests/Umbraco.Tests.Integration) providing base classes. 
+These examples are for Umbraco 14. They use [NUnit](https://nunit.org/) as the testing framework. Leveraging [Umbraco.Cms.Tests.Integration](https://github.com/umbraco/Umbraco-CMS/tree/main/tests/Umbraco.Tests.Integration) providing base classes.
 
 {% hint style="info" %}
 The Umbraco.Tests.Integration project uses version `3.14.0` of the NUnit NuGet package. It is essential to use this version to ensure compatibility. You can check the current package versions used by the Umbraco.Tests.Integration project [here](https://github.com/umbraco/Umbraco-CMS/blob/v14/dev/tests/Directory.Packages.props).
@@ -48,7 +48,7 @@ public class CustomGlobalSetupTeardown
 }
 ```
 
-{% hint style="info" %} 
+{% hint style="info" %}
 The class should not have a namespace.
 {% endhint %}
 

--- a/14/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api.md
+++ b/14/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api.md
@@ -334,7 +334,7 @@ Different client libraries have different ways of declaring the `identity_provid
 
 We can also add the external identity providers to the member authentication login screen. This way the end user can decide whether to log in as a registered member, or use an external identity provider.
 
-The [Login partial view](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/EmbeddedResources/Snippets/Login.cshtml) features an implementation of this combined login experience.
+The [Login partial view](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Core/EmbeddedResources/Snippets/Login.cshtml) features an implementation of this combined login experience.
 
 ## Accessing protected content
 

--- a/14/umbraco-cms/reference/searching/examine/indexing.md
+++ b/14/umbraco-cms/reference/searching/examine/indexing.md
@@ -329,7 +329,7 @@ The index will only update its content when you manually trigger an index rebuil
 To update your index when content changes, you can use notification handlers.
 
 {% hint style="info" %}
-The following handler class does not automatically update the descendant items of the modified content nodes, such as removing descendants of deleted content. If changes to the parent content item can affect its children or descendant items in your setup, please refer to the [UmbracoContentIndex.PerformDeleteFromIndex() in Umbraco](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs#L124-L153). Such logic should be applied when both removing and reindexing content items of type _product_.
+The following handler class does not automatically update the descendant items of the modified content nodes, such as removing descendants of deleted content. If changes to the parent content item can affect its children or descendant items in your setup, please refer to the [UmbracoContentIndex.PerformDeleteFromIndex() in Umbraco](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs#L124-L153). Such logic should be applied when both removing and reindexing content items of type _product_.
 {% endhint %}
 
 ```csharp

--- a/14/umbraco-cms/reference/security/cookies.md
+++ b/14/umbraco-cms/reference/security/cookies.md
@@ -31,4 +31,4 @@ builder.Services.AddSession(options =>
     });
 ```
 
-For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/Constants-Web.cs) file on GitHub.
+For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Core/Constants-Web.cs) file on GitHub.

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/adding-server-side-validation.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/adding-server-side-validation.md
@@ -149,7 +149,7 @@ While it is beyond the scope of this article to discuss these in depth, a few of
 
 We can control how property data is indexed by overriding the `PropertyIndexValueFactory` property of the `DataEditor` base class.
 
-The [Tags Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs) contains an example of how this is done. The Property Editor stores a CSV value, which is split and indexes as individual tags for search.
+The [Tags Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs) contains an example of how this is done. The Property Editor stores a CSV value, which is split and indexes as individual tags for search.
 
 ### Server-side data conversion to and from the client
 
@@ -163,4 +163,4 @@ These operations can be performed in the `DataValueEditor` implementation:
 - Override `ToEditor()` to perform outbound conversion.
 - Override `FromEditor()` to perform inbound conversion.
 
-The [Markdown Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/PropertyEditors/MarkDownPropertyValueEditor.cs) contains an example of data conversion. It sanitizes the property data before storing the data in the database.
+The [Markdown Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Core/PropertyEditors/MarkDownPropertyValueEditor.cs) contains an example of data conversion. It sanitizes the property data before storing the data in the database.

--- a/14/umbraco-cms/tutorials/creating-a-property-editor/adding-server-side-validation.md
+++ b/14/umbraco-cms/tutorials/creating-a-property-editor/adding-server-side-validation.md
@@ -149,7 +149,7 @@ While it is beyond the scope of this article to discuss these in depth, a few of
 
 We can control how property data is indexed by overriding the `PropertyIndexValueFactory` property of the `DataEditor` base class.
 
-The [Tags Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs) contains an example of how this is done. The Property Editor stores a CSV value, which is split and indexes as individual tags for search.
+The [Tags Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs) contains an example of how this is done. The Property Editor stores a Comma-Separated Value (CSV) value, which is split and indexed as individual tags for search.
 
 ### Server-side data conversion to and from the client
 

--- a/15/umbraco-cms/extending/language-files/README.md
+++ b/15/umbraco-cms/extending/language-files/README.md
@@ -29,7 +29,7 @@ You can use localization files for Document and Media Types as well. You can fin
 
 ## Supported Languages
 
-Current [languages](https://github.com/umbraco/Umbraco-CMS/tree/contrib/src/Umbraco.Core/EmbeddedResources/Lang) with their ISO codes that are included in new Umbraco installations are:
+Current [languages](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Core/EmbeddedResources/Lang) with their ISO codes that are included in new Umbraco installations are:
 
 * `bs-BS` - Bosnian (Bosnia and Herzegovina)
 * `cs-CZ` - Czech (Czech Republic)

--- a/15/umbraco-cms/extending/language-files/net-localization.md
+++ b/15/umbraco-cms/extending/language-files/net-localization.md
@@ -18,7 +18,7 @@ In other words, .NET localization is only applied server-side with no accompanyi
 
 ## Where to find the core localization files
 
-The core Umbraco localization files are found at the following location within the [Umbraco source](https://github.com/umbraco/Umbraco-CMS/tree/contrib/src/Umbraco.Core/EmbeddedResources/Lang):
+The core Umbraco localization files are found at the following location within the [Umbraco source](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Core/EmbeddedResources/Lang):
 
 ```xml
 Umbraco-CMS/src/Umbraco.Core/EmbeddedResources/Lang/

--- a/15/umbraco-cms/extending/language-files/net-localization.md
+++ b/15/umbraco-cms/extending/language-files/net-localization.md
@@ -113,4 +113,4 @@ In the above example of a missing translation for "**assignDomain**", locate thi
 </language>
 ```
 
-If you modify core language files or introduce a new language, you can assist the community by sharing your updates. This can be done by [submitting a pull request](https://github.com/umbraco/Umbraco-CMS/blob/contrib/.github/CONTRIBUTING.md) so that your changes are merged into the core.
+If you modify core language files or introduce a new language, you can assist the community by sharing your updates. This can be done by [submitting a pull request](https://github.com/umbraco/Umbraco-CMS/blob/main/.github/CONTRIBUTING.md) so that your changes are merged into the core.

--- a/15/umbraco-cms/fundamentals/backoffice/login.md
+++ b/15/umbraco-cms/fundamentals/backoffice/login.md
@@ -71,7 +71,7 @@ This will override the default greetings with the ones you provide. The login sc
 The login screen has its own set of localization files independent of the rest of the Backoffice. You can read more about Backoffice localization in the [UI Localization](../../customizing/foundation/localization.md) article.
 {% endhint %}
 
-You can customize other text on the login screen as well. First, grab the default values and keys from the [en.ts](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Web.UI.Login/src/localization/lang/en.ts) in the Umbraco CMS GitHub repository. Thereafter copy the ones you want to translate into `~/App_Plugins/Login/umbraco-package.json` file.
+You can customize other text on the login screen as well. First, grab the default values and keys from the [en.ts](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Web.UI.Login/src/localization/lang/en.ts) in the Umbraco CMS GitHub repository. Thereafter copy the ones you want to translate into `~/App_Plugins/Login/umbraco-package.json` file.
 
 ## Password reset
 

--- a/15/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/block-grid-editor.md
+++ b/15/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/block-grid-editor.md
@@ -282,7 +282,7 @@ To use the Default Layout Stylesheet, copy the stylesheet to your frontend. You 
 {% hint style="info" %}
 A set of built-in Partial Views are responsible for rendering the Blocks and Areas in a Block Grid. If you want to tweak or change the way the Block Grid is rendered, you can use the built-in Partial Views as a template:
 
-1. Clone the views from [GitHub](https://github.com/umbraco/Umbraco-CMS/tree/contrib/src/Umbraco.Web.UI/Views/Partials/blockgrid). They can be found in `src/Umbraco.Web.UI/Views/Partials/blockgrid` .
+1. Clone the views from [GitHub](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Web.UI/Views/Partials/blockgrid). They can be found in `src/Umbraco.Web.UI/Views/Partials/blockgrid` .
 2. Copy the cloned views to the local folder `Views/Partials/blockgrid/` .
 3. Make changes to your copied views. The entry point for `GetBlockGridHtmlAsync()` is the view `default.cshtml` .
 {% endhint %}

--- a/15/umbraco-cms/fundamentals/setup/upgrading/version-specific/migrate-content-to-umbraco-15.md
+++ b/15/umbraco-cms/fundamentals/setup/upgrading/version-specific/migrate-content-to-umbraco-15.md
@@ -83,9 +83,9 @@ Subsequently, you are responsible for performing the content migration yourself.
 
 Custom code is required to perform the content migration. You can find inspiration in the core migrations:
 
-- [`ConvertBlockListEditorProperties`](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockListEditorProperties.cs) for Block List properties.
-- [`ConvertBlockGridEditorProperties`](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockGridEditorProperties.cs) for Block Grid properties.
-- [`ConvertRichTextEditorProperties`](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertRichTextEditorProperties.cs) for Rich Text Editor properties.
+- [`ConvertBlockListEditorProperties`](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockListEditorProperties.cs) for Block List properties.
+- [`ConvertBlockGridEditorProperties`](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockGridEditorProperties.cs) for Block Grid properties.
+- [`ConvertRichTextEditorProperties`](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertRichTextEditorProperties.cs) for Rich Text Editor properties.
 
 {% hint style="warning" %}
 This custom code should not run while editors are working in the Umbraco backoffice.

--- a/15/umbraco-cms/implementation/integration-testing.md
+++ b/15/umbraco-cms/implementation/integration-testing.md
@@ -4,7 +4,7 @@ description: A guide to getting started with integration testing in Umbraco
 
 # Integration Testing
 
-These examples are for Umbraco 14. They use [NUnit](https://nunit.org/) as the testing framework. Leveraging [Umbraco.Cms.Tests.Integration](https://github.com/umbraco/Umbraco-CMS/tree/contrib/tests/Umbraco.Tests.Integration) providing base classes. 
+These examples are for Umbraco 14. They use [NUnit](https://nunit.org/) as the testing framework. Leveraging [Umbraco.Cms.Tests.Integration](https://github.com/umbraco/Umbraco-CMS/tree/main/tests/Umbraco.Tests.Integration) providing base classes.
 
 {% hint style="info" %}
 The Umbraco.Tests.Integration project uses version `3.14.0` of the NUnit NuGet package. It is essential to use this version to ensure compatibility. You can check the current package versions used by the Umbraco.Tests.Integration project [here](https://github.com/umbraco/Umbraco-CMS/blob/v14/dev/tests/Directory.Packages.props).
@@ -48,7 +48,7 @@ public class CustomGlobalSetupTeardown
 }
 ```
 
-{% hint style="info" %} 
+{% hint style="info" %}
 The class should not have a namespace.
 {% endhint %}
 

--- a/15/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api/README.md
+++ b/15/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api/README.md
@@ -317,7 +317,7 @@ Different client libraries have different ways of declaring the `identity_provid
 
 We can also add the external identity providers to the member authentication login screen. This way the end user can decide whether to log in as a registered member, or use an external identity provider.
 
-The [Login partial view](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/EmbeddedResources/Snippets/Login.cshtml) features an implementation of this combined login experience.
+The [Login partial view](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Core/EmbeddedResources/Snippets/Login.cshtml) features an implementation of this combined login experience.
 
 ## Accessing protected content
 

--- a/15/umbraco-cms/reference/searching/examine/indexing.md
+++ b/15/umbraco-cms/reference/searching/examine/indexing.md
@@ -329,7 +329,7 @@ The index will only update its content when you manually trigger an index rebuil
 To update your index when content changes, you can use notification handlers.
 
 {% hint style="info" %}
-The following handler class does not automatically update the descendant items of the modified content nodes, such as removing descendants of deleted content. If changes to the parent content item can affect its children or descendant items in your setup, please refer to the [UmbracoContentIndex.PerformDeleteFromIndex() in Umbraco](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs#L124-L153). Such logic should be applied when both removing and reindexing content items of type _product_.
+The following handler class does not automatically update the descendant items of the modified content nodes, such as removing descendants of deleted content. If changes to the parent content item can affect its children or descendant items in your setup, please refer to the [UmbracoContentIndex.PerformDeleteFromIndex() in Umbraco](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs#L124-L153). Such logic should be applied when both removing and reindexing content items of type _product_.
 {% endhint %}
 
 ```csharp

--- a/15/umbraco-cms/reference/security/cookies.md
+++ b/15/umbraco-cms/reference/security/cookies.md
@@ -31,4 +31,4 @@ builder.Services.AddSession(options =>
     });
 ```
 
-For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/Constants-Web.cs) file on GitHub.
+For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Core/Constants-Web.cs) file on GitHub.

--- a/15/umbraco-cms/tutorials/creating-a-property-editor/adding-server-side-validation.md
+++ b/15/umbraco-cms/tutorials/creating-a-property-editor/adding-server-side-validation.md
@@ -149,7 +149,7 @@ While it is beyond the scope of this article to discuss these in depth, a few of
 
 We can control how property data is indexed by overriding the `PropertyIndexValueFactory` property of the `DataEditor` base class.
 
-The [Tags Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs) contains an example of how this is done. The Property Editor stores a CSV value, which is split and indexes as individual tags for search.
+The [Tags Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs) contains an example of how this is done. The Property Editor stores a CSV value, which is split and indexes as individual tags for search.
 
 ### Server-side data conversion to and from the client
 
@@ -163,4 +163,4 @@ These operations can be performed in the `DataValueEditor` implementation:
 - Override `ToEditor()` to perform outbound conversion.
 - Override `FromEditor()` to perform inbound conversion.
 
-The [Markdown Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/PropertyEditors/MarkDownPropertyValueEditor.cs) contains an example of data conversion. It sanitizes the property data before storing the data in the database.
+The [Markdown Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Core/PropertyEditors/MarkDownPropertyValueEditor.cs) contains an example of data conversion. It sanitizes the property data before storing the data in the database.

--- a/15/umbraco-cms/tutorials/creating-a-property-editor/adding-server-side-validation.md
+++ b/15/umbraco-cms/tutorials/creating-a-property-editor/adding-server-side-validation.md
@@ -149,7 +149,7 @@ While it is beyond the scope of this article to discuss these in depth, a few of
 
 We can control how property data is indexed by overriding the `PropertyIndexValueFactory` property of the `DataEditor` base class.
 
-The [Tags Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs) contains an example of how this is done. The Property Editor stores a CSV value, which is split and indexes as individual tags for search.
+The [Tags Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs) contains an example of how this is done. The Property Editor stores a Comma-Separated Value (CSV) value, which is split and indexed as individual tags for search.
 
 ### Server-side data conversion to and from the client
 

--- a/16/umbraco-cms/extending/language-files/README.md
+++ b/16/umbraco-cms/extending/language-files/README.md
@@ -29,7 +29,7 @@ You can use localization files for Document and Media Types as well. You can fin
 
 ## Supported Languages
 
-Current [languages](https://github.com/umbraco/Umbraco-CMS/tree/contrib/src/Umbraco.Core/EmbeddedResources/Lang) with their ISO codes that are included in new Umbraco installations are:
+Current [languages](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Core/EmbeddedResources/Lang) with their ISO codes that are included in new Umbraco installations are:
 
 * `bs-BS` - Bosnian (Bosnia and Herzegovina)
 * `cs-CZ` - Czech (Czech Republic)

--- a/16/umbraco-cms/extending/language-files/net-localization.md
+++ b/16/umbraco-cms/extending/language-files/net-localization.md
@@ -18,7 +18,7 @@ In other words, .NET localization is only applied server-side with no accompanyi
 
 ## Where to find the core localization files
 
-The core Umbraco localization files are found at the following location within the [Umbraco source](https://github.com/umbraco/Umbraco-CMS/tree/contrib/src/Umbraco.Core/EmbeddedResources/Lang):
+The core Umbraco localization files are found at the following location within the [Umbraco source](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Core/EmbeddedResources/Lang):
 
 ```xml
 Umbraco-CMS/src/Umbraco.Core/EmbeddedResources/Lang/

--- a/16/umbraco-cms/extending/language-files/net-localization.md
+++ b/16/umbraco-cms/extending/language-files/net-localization.md
@@ -113,4 +113,4 @@ In the above example of a missing translation for "**assignDomain**", locate thi
 </language>
 ```
 
-If you modify core language files or introduce a new language, you can assist the community by sharing your updates. This can be done by [submitting a pull request](https://github.com/umbraco/Umbraco-CMS/blob/contrib/.github/CONTRIBUTING.md) so that your changes are merged into the core.
+If you modify core language files or introduce a new language, you can assist the community by sharing your updates. This can be done by [submitting a pull request](https://github.com/umbraco/Umbraco-CMS/blob/main/.github/CONTRIBUTING.md) so that your changes are merged into the core.

--- a/16/umbraco-cms/fundamentals/backoffice/login.md
+++ b/16/umbraco-cms/fundamentals/backoffice/login.md
@@ -71,7 +71,7 @@ This will override the default greetings with the ones you provide. The login sc
 The login screen has its own set of localization files independent of the rest of the Backoffice. You can read more about Backoffice localization in the [UI Localization](../../customizing/foundation/localization.md) article.
 {% endhint %}
 
-You can customize other text on the login screen as well. First, grab the default values and keys from the [en.ts](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Web.UI.Login/src/localization/lang/en.ts) in the Umbraco CMS GitHub repository. Thereafter copy the ones you want to translate into `~/App_Plugins/Login/umbraco-package.json` file.
+You can customize other text on the login screen as well. First, grab the default values and keys from the [en.ts](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Web.UI.Login/src/localization/lang/en.ts) in the Umbraco CMS GitHub repository. Thereafter copy the ones you want to translate into `~/App_Plugins/Login/umbraco-package.json` file.
 
 ## Password reset
 

--- a/16/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/block-grid-editor.md
+++ b/16/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/block-grid-editor.md
@@ -282,7 +282,7 @@ To use the Default Layout Stylesheet, copy the stylesheet to your frontend. You 
 {% hint style="info" %}
 A set of built-in Partial Views are responsible for rendering the Blocks and Areas in a Block Grid. If you want to tweak or change the way the Block Grid is rendered, you can use the built-in Partial Views as a template:
 
-1. Clone the views from [GitHub](https://github.com/umbraco/Umbraco-CMS/tree/contrib/src/Umbraco.Web.UI/Views/Partials/blockgrid). They can be found in `src/Umbraco.Web.UI/Views/Partials/blockgrid` .
+1. Clone the views from [GitHub](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Web.UI/Views/Partials/blockgrid). They can be found in `src/Umbraco.Web.UI/Views/Partials/blockgrid` .
 2. Copy the cloned views to the local folder `Views/Partials/blockgrid/` .
 3. Make changes to your copied views. The entry point for `GetBlockGridHtmlAsync()` is the view `default.cshtml` .
 {% endhint %}

--- a/16/umbraco-cms/fundamentals/setup/upgrading/version-specific/migrate-content-to-umbraco-15.md
+++ b/16/umbraco-cms/fundamentals/setup/upgrading/version-specific/migrate-content-to-umbraco-15.md
@@ -83,9 +83,9 @@ Subsequently, you are responsible for performing the content migration yourself.
 
 Custom code is required to perform the content migration. You can find inspiration in the core migrations:
 
-- [`ConvertBlockListEditorProperties`](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockListEditorProperties.cs) for Block List properties.
-- [`ConvertBlockGridEditorProperties`](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockGridEditorProperties.cs) for Block Grid properties.
-- [`ConvertRichTextEditorProperties`](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertRichTextEditorProperties.cs) for Rich Text Editor properties.
+- [`ConvertBlockListEditorProperties`](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockListEditorProperties.cs) for Block List properties.
+- [`ConvertBlockGridEditorProperties`](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockGridEditorProperties.cs) for Block Grid properties.
+- [`ConvertRichTextEditorProperties`](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertRichTextEditorProperties.cs) for Rich Text Editor properties.
 
 {% hint style="warning" %}
 This custom code should not run while editors are working in the Umbraco backoffice.

--- a/16/umbraco-cms/implementation/integration-testing.md
+++ b/16/umbraco-cms/implementation/integration-testing.md
@@ -4,7 +4,7 @@ description: A guide to getting started with integration testing in Umbraco
 
 # Integration Testing
 
-These examples are for Umbraco 14. They use [NUnit](https://nunit.org/) as the testing framework. Leveraging [Umbraco.Cms.Tests.Integration](https://github.com/umbraco/Umbraco-CMS/tree/contrib/tests/Umbraco.Tests.Integration) providing base classes. 
+These examples are for Umbraco 14. They use [NUnit](https://nunit.org/) as the testing framework. Leveraging [Umbraco.Cms.Tests.Integration](https://github.com/umbraco/Umbraco-CMS/tree/main/tests/Umbraco.Tests.Integration) providing base classes.
 
 {% hint style="info" %}
 The Umbraco.Tests.Integration project uses version `3.14.0` of the NUnit NuGet package. It is essential to use this version to ensure compatibility. You can check the current package versions used by the Umbraco.Tests.Integration project [here](https://github.com/umbraco/Umbraco-CMS/blob/v14/dev/tests/Directory.Packages.props).
@@ -48,7 +48,7 @@ public class CustomGlobalSetupTeardown
 }
 ```
 
-{% hint style="info" %} 
+{% hint style="info" %}
 The class should not have a namespace.
 {% endhint %}
 

--- a/16/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api/README.md
+++ b/16/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api/README.md
@@ -317,7 +317,7 @@ Different client libraries have different ways of declaring the `identity_provid
 
 We can also add the external identity providers to the member authentication login screen. This way the end user can decide whether to log in as a registered member, or use an external identity provider.
 
-The [Login partial view](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/EmbeddedResources/Snippets/Login.cshtml) features an implementation of this combined login experience.
+The [Login partial view](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Core/EmbeddedResources/Snippets/Login.cshtml) features an implementation of this combined login experience.
 
 ## Accessing protected content
 

--- a/16/umbraco-cms/reference/searching/examine/indexing.md
+++ b/16/umbraco-cms/reference/searching/examine/indexing.md
@@ -329,7 +329,7 @@ The index will only update its content when you manually trigger an index rebuil
 To update your index when content changes, you can use notification handlers.
 
 {% hint style="info" %}
-The following handler class does not automatically update the descendant items of the modified content nodes, such as removing descendants of deleted content. If changes to the parent content item can affect its children or descendant items in your setup, please refer to the [UmbracoContentIndex.PerformDeleteFromIndex() in Umbraco](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs#L124-L153). Such logic should be applied when both removing and reindexing content items of type _product_.
+The following handler class does not automatically update the descendant items of the modified content nodes, such as removing descendants of deleted content. If changes to the parent content item can affect its children or descendant items in your setup, please refer to the [UmbracoContentIndex.PerformDeleteFromIndex() in Umbraco](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Examine.Lucene/UmbracoContentIndex.cs#L124-L153). Such logic should be applied when both removing and reindexing content items of type _product_.
 {% endhint %}
 
 ```csharp

--- a/16/umbraco-cms/reference/security/cookies.md
+++ b/16/umbraco-cms/reference/security/cookies.md
@@ -31,4 +31,4 @@ builder.Services.AddSession(options =>
     });
 ```
 
-For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/Constants-Web.cs) file on GitHub.
+For information on the rest of the cookies, see the [Constants-Web.cs](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Core/Constants-Web.cs) file on GitHub.

--- a/16/umbraco-cms/tutorials/creating-a-property-editor/adding-server-side-validation.md
+++ b/16/umbraco-cms/tutorials/creating-a-property-editor/adding-server-side-validation.md
@@ -149,7 +149,7 @@ While it is beyond the scope of this article to discuss these in depth, a few of
 
 We can control how property data is indexed by overriding the `PropertyIndexValueFactory` property of the `DataEditor` base class.
 
-The [Tags Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs) contains an example of how this is done. The Property Editor stores a CSV value, which is split and indexes as individual tags for search.
+The [Tags Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs) contains an example of how this is done. The Property Editor stores a CSV value, which is split and indexes as individual tags for search.
 
 ### Server-side data conversion to and from the client
 
@@ -163,4 +163,4 @@ These operations can be performed in the `DataValueEditor` implementation:
 - Override `ToEditor()` to perform outbound conversion.
 - Override `FromEditor()` to perform inbound conversion.
 
-The [Markdown Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Core/PropertyEditors/MarkDownPropertyValueEditor.cs) contains an example of data conversion. It sanitizes the property data before storing the data in the database.
+The [Markdown Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Core/PropertyEditors/MarkDownPropertyValueEditor.cs) contains an example of data conversion. It sanitizes the property data before storing the data in the database.

--- a/16/umbraco-cms/tutorials/creating-a-property-editor/adding-server-side-validation.md
+++ b/16/umbraco-cms/tutorials/creating-a-property-editor/adding-server-side-validation.md
@@ -149,7 +149,7 @@ While it is beyond the scope of this article to discuss these in depth, a few of
 
 We can control how property data is indexed by overriding the `PropertyIndexValueFactory` property of the `DataEditor` base class.
 
-The [Tags Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs) contains an example of how this is done. The Property Editor stores a CSV value, which is split and indexes as individual tags for search.
+The [Tags Property Editor](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs) contains an example of how this is done. The Property Editor stores a Comma-Separated Value (CSV) value, which is split and indexed as individual tags for search.
 
 ### Server-side data conversion to and from the client
 

--- a/contributing/backoffice-project/contributing.md
+++ b/contributing/backoffice-project/contributing.md
@@ -4,12 +4,12 @@
 
 In the high probability that you are porting something from angular JS then here are a few helpful tips for using Lit:
 
-Here is the LIT documentation and playground: [https://lit.dev](https://lit.dev)
+Here is the Lit documentation and playground: [https://lit.dev](https://lit.dev)
 
 ### How best to find what needs converting from the old backoffice?
 
 1. Navigate to [https://github.com/umbraco/Umbraco-CMS](https://github.com/umbraco/Umbraco-CMS)
-2. Make sure you are on the `contrib` branch
+2. Make sure you are on the `main` branch
 
 ### What is the process of contribution?
 
@@ -34,11 +34,11 @@ The frontend has an API formatter that takes the OpenAPI schema file and convert
 
 ### Caveats
 
-The backoffice can be ran and tested against a real Umbraco instance by cloning down the Umbraco-CMS `contrib` branch, but there are no guarantees about how well it works yet.
+The backoffice can be ran and tested against a real Umbraco instance by cloning down the Umbraco-CMS `main` branch, but there are no guarantees about how well it works yet.
 
 **Current schema for API:**
 
-[OpenApi.json](https://raw.githubusercontent.com/umbraco/Umbraco-CMS/contrib/src/Umbraco.Cms.Api.Management/OpenApi.json)
+[OpenApi.json](https://raw.githubusercontent.com/umbraco/Umbraco-CMS/main/src/Umbraco.Cms.Api.Management/OpenApi.json)
 
 **How to convert it:**
 

--- a/contributing/backoffice-project/contributing.md
+++ b/contributing/backoffice-project/contributing.md
@@ -34,7 +34,7 @@ The frontend has an API formatter that takes the OpenAPI schema file and convert
 
 ### Caveats
 
-The backoffice can be ran and tested against a real Umbraco instance by cloning down the Umbraco-CMS `main` branch, but there are no guarantees about how well it works yet.
+You can test the backoffice against a real Umbraco instance by cloning down the Umbraco-CMS `main` branch, but functionality is not guaranteed.
 
 **Current schema for API:**
 

--- a/contributing/umbraco-cms/contributing.md
+++ b/contributing/umbraco-cms/contributing.md
@@ -30,7 +30,7 @@ The following steps are a quick-start guide:
 {% embed url="https://youtu.be/LPmyTcIXzAs" %}
 
 3. **Switch to the correct branch**\
-   Switch to the `contrib` branch
+   Switch to the `main` branch
 4.  **Build**
 
     Build your fork of Umbraco locally as shown in the video below. You can build with any IDE that supports dotnet or the command line.
@@ -42,7 +42,7 @@ The following steps are a quick-start guide:
 {% embed url="https://youtu.be/sWetLj4PGQI" %}
 
 5. **Branch**\
-   Create a new branch now and name it after the issue you're fixing, we usually follow the format: `temp/12345`. This means it's a temporary branch for the particular issue you're working on, in this case issue number `12345`. Don't commit to `contrib`, create a new branch first.
+   Create a new branch now and name it after the issue you're fixing, we usually follow the format: `temp/12345`. This means it's a temporary branch for the particular issue you're working on, in this case issue number `12345`. Don't commit to `main`, create a new branch first.
 6.  **Change**
 
     Make your changes, experiment, have fun, explore and learn, and don't be afraid. We welcome all contributions and will [happily give feedback](first-issue.md#questions).
@@ -50,7 +50,7 @@ The following steps are a quick-start guide:
 
     Done? Yay! 🎉
 
-    Remember to commit to your new `temp` branch, and don't commit to `contrib`. Then you can push the changes up to your fork on GitHub.
+    Remember to commit to your new `temp` branch, and don't commit to `main`. Then you can push the changes up to your fork on GitHub.
 8.  **Create pull request**
 
     On GitHub, in your forked repository (`https://github.com/[YourUsername]/Umbraco-CMS`) you will see a banner saying that you pushed a new branch and a button to make a pull request. Tap the button and follow the instructions.

--- a/contributing/umbraco-cms/creating-a-pr.md
+++ b/contributing/umbraco-cms/creating-a-pr.md
@@ -7,10 +7,10 @@ We recommend you to [sync with our repository][sync fork] before you submit your
 GitHub will have picked up on the new branch you've pushed and will offer to create a Pull Request. Click that green button and away you go.
 ![Create a pull request](img/createpullrequest.png)
 
-We like to use [git flow][git flow] as much as possible, but don't worry if you are not familiar with it. The most important thing you need to know is that when you fork the Umbraco repository, the default branch is set to `contrib`. This is the branch you should be targeting.
+We like to use [git flow][git flow] as much as possible, but don't worry if you are not familiar with it. The most important thing you need to know is that when you fork the Umbraco repository, the default branch is set to `main`. This is the branch you should be targeting.
 
 Please note: we are no longer accepting features for v8 and below but will continue to merge security fixes as and when they arise.
-  
+
 ## The review process
 [review process]: #the-review-process
 
@@ -35,9 +35,9 @@ If you make the corrections we ask for in the same branch and push them to your 
 
 We understand you have other things to do and can't just drop everything to help us out.
 
-So if we’re asking for your help to improve the PR we’ll wait for two weeks to give you a fair chance to make changes. We’ll ask for an update if we don’t hear back from you after that time.  
+So if we’re asking for your help to improve the PR we’ll wait for two weeks to give you a fair chance to make changes. We’ll ask for an update if we don’t hear back from you after that time.
 
-If we don’t hear back from you for 4 weeks, we’ll close the PR so that it doesn’t just hang around forever. You’re very welcome to re-open it once you have some more time to spend on it.  
+If we don’t hear back from you for 4 weeks, we’ll close the PR so that it doesn’t just hang around forever. You’re very welcome to re-open it once you have some more time to spend on it.
 
 There will be times that we really like your proposed changes and we’ll finish the final improvements we’d like to see ourselves. You still get the credits and your commits will live on in the git repository.
 

--- a/contributing/umbraco-cms/creating-a-pr.md
+++ b/contributing/umbraco-cms/creating-a-pr.md
@@ -37,7 +37,7 @@ We understand you have other things to do and can't just drop everything to help
 
 If we’re asking for your help to improve the PR, we’ll wait for two weeks to give you a fair chance to make changes. We’ll ask for an update if we don’t hear back from you after that time.
 
-If we don’t hear back from you for 4 weeks, we’ll close the PR so that it doesn’t just hang around forever. You’re very welcome to re-open it once you have some more time to spend on it.
+If we don’t hear back from you for 4 weeks, we’ll close the PR so that it doesn’t hang around forever. You’re welcome to reopen it once you have some more time to spend on it.
 
 There will be times that we really like your proposed changes and we’ll finish the final improvements we’d like to see ourselves. You still get the credits and your commits will live on in the git repository.
 

--- a/contributing/umbraco-cms/creating-a-pr.md
+++ b/contributing/umbraco-cms/creating-a-pr.md
@@ -35,7 +35,7 @@ If you make the corrections we ask for in the same branch and push them to your 
 
 We understand you have other things to do and can't just drop everything to help us out.
 
-So if we’re asking for your help to improve the PR we’ll wait for two weeks to give you a fair chance to make changes. We’ll ask for an update if we don’t hear back from you after that time.
+If we’re asking for your help to improve the PR, we’ll wait for two weeks to give you a fair chance to make changes. We’ll ask for an update if we don’t hear back from you after that time.
 
 If we don’t hear back from you for 4 weeks, we’ll close the PR so that it doesn’t just hang around forever. You’re very welcome to re-open it once you have some more time to spend on it.
 

--- a/contributing/umbraco-cms/first-issue.md
+++ b/contributing/umbraco-cms/first-issue.md
@@ -11,18 +11,18 @@ Great question! The short version goes like this:
 1. **Fork**
 
     Create a fork of [`Umbraco-CMS` on GitHub][Umbraco CMS repo]
-    
+
     ![Fork the repository](img/forkrepository.png)
-    
+
 1. **Clone**
 
     When GitHub has created your fork, you can clone it in your favorite Git tool
-    
-    ![Clone the fork](img/clonefork.png) 
-    
+
+    ![Clone the fork](img/clonefork.png)
+
 1. **Switch to the correct branch**
 
-    Switch to the `contrib` branch
+    Switch to the `main` branch
 
 1. **Build**
 
@@ -30,7 +30,7 @@ Great question! The short version goes like this:
 
 1. **Branch**
 
-    Create a new branch now and name it after the issue you're fixing, we usually follow the format: `temp-12345`. This means it's a temporary branch for the particular issue you're working on, in this case issue number `12345`.  Don't commit to `contrib`, create a new branch first.
+    Create a new branch now and name it after the issue you're fixing, we usually follow the format: `temp-12345`. This means it's a temporary branch for the particular issue you're working on, in this case issue number `12345`.  Don't commit to `main`, create a new branch first.
 
 1. **Change**
 
@@ -40,7 +40,7 @@ Great question! The short version goes like this:
 
     Done? Yay! 🎉
 
-    Remember to commit to your new `temp` branch, and don't commit to `contrib`. Then you can push the changes up to your fork on GitHub.
+    Remember to commit to your new `temp` branch, and don't commit to `main`. Then you can push the changes up to your fork on GitHub.
 
 #### Keeping your Umbraco fork in sync with the main repository
 [sync fork]: #keeping-your-umbraco-fork-in-sync-with-the-main-repository
@@ -57,10 +57,10 @@ Then when you want to get the changes from the main repository:
 
 ```
 git fetch upstream
-git rebase upstream/contrib
+git rebase upstream/main
 ```
 
-In this command we're syncing with the `contrib` branch, but you can of course choose another one if needed.
+In this command we're syncing with the `main` branch, but you can choose another one if needed.
 
 [More information on how this works can be found on the thoughtbot blog.][sync fork ext]
 
@@ -88,6 +88,6 @@ You can get in touch with [the core contributors team][core collabs] in multiple
 
 [sync fork ext]: http://robots.thoughtbot.com/post/5133345960/keeping-a-git-fork-updated	"Details on keeping a git fork updated"
 [draft prs]: https://github.blog/2019-02-14-introducing-draft-pull-requests/	"GitHub's blog post providing details on draft pull requests"
-[contrib forum]: https://our.umbraco.com/forum/contributing-to-umbraco-cms/
+[contrib forum]: https://forum.umbraco.com/
 [Umbraco CMS repo]: https://github.com/umbraco/Umbraco-CMS
 [up for grabs issues]: https://github.com/umbraco/Umbraco-CMS/issues?q=is%3Aissue+is%3Aopen+label%3Acommunity%2Fup-for-grabs


### PR DESCRIPTION
## Description
Following a recent change on the main Umbraco-CMS repository, the default branch is now named **main**. This pull request aims to fix all links and mentions of the old _contrib_ name to **main**.

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
All


## Deadline (if relevant)

ASAP