### PR TITLE
Updated docs with fallback en

### DIFF
--- a/14/umbraco-cms/extending/packages/language-files-for-packages.md
+++ b/14/umbraco-cms/extending/packages/language-files-for-packages.md
@@ -22,10 +22,10 @@ To register localizations to a language, you must add a new manifest to the Exte
   "extensions": [
     {
       "type": "localization",
-      "alias": "MyPackage.Localize.EnUS",
-      "name": "English (United States)",
+      "alias": "MyPackage.Localize.En",
+      "name": "English",
       "meta": {
-        "culture": "en-us"
+        "culture": "en"
       },
       "js": "/App_Plugins/MyPackage/Localization/en-us.js"
     }

--- a/15/umbraco-cms/extending/packages/language-files-for-packages.md
+++ b/15/umbraco-cms/extending/packages/language-files-for-packages.md
@@ -22,10 +22,10 @@ To register localizations to a language, you must add a new manifest to the Exte
   "extensions": [
     {
       "type": "localization",
-      "alias": "MyPackage.Localize.EnUS",
-      "name": "English (United States)",
+      "alias": "MyPackage.Localize.En",
+      "name": "English",
       "meta": {
-        "culture": "en-us"
+        "culture": "en"
       },
       "js": "/App_Plugins/MyPackage/Localization/en-us.js"
     }

--- a/16/umbraco-cms/extending/packages/language-files-for-packages.md
+++ b/16/umbraco-cms/extending/packages/language-files-for-packages.md
@@ -22,10 +22,10 @@ To register localizations to a language, you must add a new manifest to the Exte
   "extensions": [
     {
       "type": "localization",
-      "alias": "MyPackage.Localize.EnUS",
-      "name": "English (United States)",
+      "alias": "MyPackage.Localize.En",
+      "name": "English",
       "meta": {
-        "culture": "en-us"
+        "culture": "en"
       },
       "js": "/App_Plugins/MyPackage/Localization/en-us.js"
     }


### PR DESCRIPTION
## Description

Updated the docs to use `en` for the culture in code samples for package developers as this is the default fallback.

See this for details: https://github.com/umbraco/Umbraco-CMS/issues/19227

## Type of suggestion

* [ ] Typo/grammar fix
* [x] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)
Umbraco CMS v14+

