### PR TITLE
Moved Built-in Conditions Types info and added reference link

### DIFF
--- a/14/umbraco-cms/customizing/extending-overview/extension-conditions.md
+++ b/14/umbraco-cms/customizing/extending-overview/extension-conditions.md
@@ -33,6 +33,10 @@ The example above requires the nearest Workspaces Alias to be equal to `'Umb.Wor
 
 When declaring multiple conditions all of them must be permitted for the extension to be available.
 
+## Built-in Conditions Types
+
+For a list of available options, see the [Built-in Conditions Types](extension-types/condition.md#built-in-conditions-types) section.
+
 ## Condition Configuration
 
 The conditions are defined as an array of condition configurations. Each entry can contain the following properties:

--- a/14/umbraco-cms/customizing/extending-overview/extension-types/condition.md
+++ b/14/umbraco-cms/customizing/extending-overview/extension-types/condition.md
@@ -6,11 +6,11 @@ description: >-
 
 # Extension Conditions
 
-Extension Conditions declare requirements that should be permitted for the extension to be available. Many, but not all, Extension Types support Conditions.
+Extension Conditions let you define specific requirements that must be met for an extension to be available. While not all Extension Types support Conditions, many do.
 
-[Read about utilizing conditions in Manifests](../extension-conditions.md#utilizing-conditions-in-your-manifest).
+For information on how to utilize conditions in your Manifest, see the [Utilizing Conditions in your Manifest](../extension-conditions.md#utilizing-conditions-in-your-manifest) section.
 
-## Built-in conditions types <a href="#core-conditions-types" id="core-conditions-types"></a>
+## Built-in Conditions Types
 
 The following conditions are available out of the box, for all extension types that support Conditions.
 
@@ -27,7 +27,7 @@ The following conditions are available out of the box, for all extension types t
 * `Umb.Condition.SectionUserPermission` - Requires the current user to have permissions to the given Section Alias.
 * `Umb.Condition.UserPermission.Document` - Requires the current user to have specific Document permissions. Example: 'Umb.Document.Save'
 
-## Make your own conditions
+## Make your own Conditions
 
 ```html
 <a href="#make-your-own-conditions" id="make-your-own-conditions"></a>

--- a/15/umbraco-cms/customizing/extending-overview/extension-conditions.md
+++ b/15/umbraco-cms/customizing/extending-overview/extension-conditions.md
@@ -33,26 +33,9 @@ The example above requires the nearest Workspaces Alias to be equal to `'Umb.Wor
 
 When declaring multiple conditions all of them must be permitted for the extension to be available.
 
-## Built-in conditions types <a href="#core-conditions-types" id="core-conditions-types"></a>
+## Built-in Conditions Types
 
-The following conditions are available out of the box, for all extension types that support Conditions.
-
-* `Umb.Condition.Switch` - Toggles on and off based on the `frequency` set in seconds.
-* `Umb.Condition.MultipleAppLanguages` - Requires the app to have more than one language, such as a multi-language site.
-* `Umb.Condition.SectionAlias` - Requires the current Section Alias to match the one specified.
-* `Umb.Condition.MenuAlias` - Requires the current Menu Alias to match the one specified.
-* `Umb.Condition.WorkspaceAlias` - Requires the current Workspace Alias to match the one specified.
-* `Umb.Condition.WorkspaceEntityType` - Requires the current workspace to work on the given Entity Type. Examples: 'document', 'block' or 'user'.
-* `Umb.Condition.WorkspaceContentTypeAlias` - Requires the current workspace to be based on a Content Type which Alias matches the one specified.
-* `Umb.Condition.Workspace.ContentHasProperties` - Requires the Content Type of the current Workspace to have properties.
-* `Umb.Condition.WorkspaceHasCollection` - Requires the current Workspace to have a Collection.
-* `Umb.Condition.WorkspaceEntityIsNew` - Requires the current Workspace data to be new, not yet persisted on the server.
-* `Umb.Condition.EntityIsTrashed` - Requires the current entity to be trashed.
-* `Umb.Condition.EntityIsNotTrashed` - Requires the current entity to not be trashed.
-* `Umb.Condition.SectionUserPermission` - Requires the current user to have permissions to the given Section Alias.
-* `Umb.Condition.UserPermission.Document` - Requires the current user to have specific Document permissions. Example: 'Umb.Document.Save'.
-* `Umb.Condition.CurrentUser.GroupId` - Requires the current user to belong to a specific group by GUID. Accepts `match` (GUID), `oneOf` (array), `allOf` (array), and `noneOf` (array). Example: '8d2b3c4d-4f1f-4b1f-8e3d-4a6b7b8c4f1e'.
-* `Umb.Condition.CurrentUser.IsAdmin` - Requires the current user to be an admin as defined by the backend, for example, that they belong to the Administrator group.
+For a list of available options, see the [Built-in Conditions Types](extension-types/condition.md#built-in-conditions-types) section.
 
 ## Condition Configuration
 

--- a/15/umbraco-cms/customizing/extending-overview/extension-types/condition.md
+++ b/15/umbraco-cms/customizing/extending-overview/extension-types/condition.md
@@ -6,11 +6,32 @@ description: >-
 
 # Extension Conditions
 
-Extension Conditions declare requirements that should be permitted for the extension to be available. Many, but not all, Extension Types support Conditions.
+Extension Conditions let you define specific requirements that must be met for an extension to be available. While not all Extension Types support Conditions, many do.
 
-[Read about utilizing conditions in Manifests](../extension-conditions.md#utilizing-conditions-in-your-manifest).
+For information on how to utilize conditions in your Manifest, see the [Utilizing Conditions in your Manifest](../extension-conditions.md#utilizing-conditions-in-your-manifest) section.
 
-## Make your own conditions
+## Built-in Conditions Types
+
+The following conditions are available out of the box, for all extension types that support Conditions.
+
+* `Umb.Condition.Switch` - Toggles on and off based on the `frequency` set in seconds.
+* `Umb.Condition.MultipleAppLanguages` - Requires the app to have more than one language, such as a multi-language site.
+* `Umb.Condition.SectionAlias` - Requires the current Section Alias to match the one specified.
+* `Umb.Condition.MenuAlias` - Requires the current Menu Alias to match the one specified.
+* `Umb.Condition.WorkspaceAlias` - Requires the current Workspace Alias to match the one specified.
+* `Umb.Condition.WorkspaceEntityType` - Requires the current workspace to work on the given Entity Type. Examples: 'document', 'block' or 'user'.
+* `Umb.Condition.WorkspaceContentTypeAlias` - Requires the current workspace to be based on a Content Type which Alias matches the one specified.
+* `Umb.Condition.Workspace.ContentHasProperties` - Requires the Content Type of the current Workspace to have properties.
+* `Umb.Condition.WorkspaceHasCollection` - Requires the current Workspace to have a Collection.
+* `Umb.Condition.WorkspaceEntityIsNew` - Requires the current Workspace data to be new, not yet persisted on the server.
+* `Umb.Condition.EntityIsTrashed` - Requires the current entity to be trashed.
+* `Umb.Condition.EntityIsNotTrashed` - Requires the current entity to not be trashed.
+* `Umb.Condition.SectionUserPermission` - Requires the current user to have permissions to the given Section Alias.
+* `Umb.Condition.UserPermission.Document` - Requires the current user to have specific Document permissions. Example: 'Umb.Document.Save'.
+* `Umb.Condition.CurrentUser.GroupId` - Requires the current user to belong to a specific group by GUID. Accepts `match` (GUID), `oneOf` (array), `allOf` (array), and `noneOf` (array). Example: '8d2b3c4d-4f1f-4b1f-8e3d-4a6b7b8c4f1e'.
+* `Umb.Condition.CurrentUser.IsAdmin` - Requires the current user to be an admin as defined by the backend, for example, that they belong to the Administrator group.
+
+## Make your own Conditions
 
 ```html
 <a href="#make-your-own-conditions" id="make-your-own-conditions"></a>

--- a/16/umbraco-cms/customizing/extending-overview/extension-conditions.md
+++ b/16/umbraco-cms/customizing/extending-overview/extension-conditions.md
@@ -33,26 +33,9 @@ The example above requires the nearest Workspaces Alias to be equal to `'Umb.Wor
 
 When declaring multiple conditions all of them must be permitted for the extension to be available.
 
-## Built-in conditions types <a href="#core-conditions-types" id="core-conditions-types"></a>
+## Built-in Conditions Types
 
-The following conditions are available out of the box, for all extension types that support Conditions.
-
-* `Umb.Condition.Switch` - Toggles on and off based on the `frequency` set in seconds.
-* `Umb.Condition.MultipleAppLanguages` - Requires the app to have more than one language, such as a multi-language site.
-* `Umb.Condition.SectionAlias` - Requires the current Section Alias to match the one specified.
-* `Umb.Condition.MenuAlias` - Requires the current Menu Alias to match the one specified.
-* `Umb.Condition.WorkspaceAlias` - Requires the current Workspace Alias to match the one specified.
-* `Umb.Condition.WorkspaceEntityType` - Requires the current workspace to work on the given Entity Type. Examples: 'document', 'block' or 'user'.
-* `Umb.Condition.WorkspaceContentTypeAlias` - Requires the current workspace to be based on a Content Type which Alias matches the one specified.
-* `Umb.Condition.Workspace.ContentHasProperties` - Requires the Content Type of the current Workspace to have properties.
-* `Umb.Condition.WorkspaceHasCollection` - Requires the current Workspace to have a Collection.
-* `Umb.Condition.WorkspaceEntityIsNew` - Requires the current Workspace data to be new, not yet persisted on the server.
-* `Umb.Condition.EntityIsTrashed` - Requires the current entity to be trashed.
-* `Umb.Condition.EntityIsNotTrashed` - Requires the current entity to not be trashed.
-* `Umb.Condition.SectionUserPermission` - Requires the current user to have permissions to the given Section Alias.
-* `Umb.Condition.UserPermission.Document` - Requires the current user to have specific Document permissions. Example: 'Umb.Document.Save'.
-* `Umb.Condition.CurrentUser.GroupId` - Requires the current user to belong to a specific group by GUID. Accepts `match` (GUID), `oneOf` (array), `allOf` (array), and `noneOf` (array). Example: '8d2b3c4d-4f1f-4b1f-8e3d-4a6b7b8c4f1e'.
-* `Umb.Condition.CurrentUser.IsAdmin` - Requires the current user to be an admin as defined by the backend, for example, that they belong to the Administrator group.
+For a list of available options, see the [Built-in Conditions Types](extension-types/condition.md#built-in-conditions-types) section.
 
 ## Condition Configuration
 

--- a/16/umbraco-cms/customizing/extending-overview/extension-types/condition.md
+++ b/16/umbraco-cms/customizing/extending-overview/extension-types/condition.md
@@ -6,11 +6,32 @@ description: >-
 
 # Extension Conditions
 
-Extension Conditions declare requirements that should be permitted for the extension to be available. Many, but not all, Extension Types support Conditions.
+Extension Conditions let you define specific requirements that must be met for an extension to be available. While not all Extension Types support Conditions, many do.
 
-[Read about utilizing conditions in Manifests](../extension-conditions.md#utilizing-conditions-in-your-manifest).
+For information on how to utilize conditions in your Manifest, see the [Utilizing Conditions in your Manifest](../extension-conditions.md#utilizing-conditions-in-your-manifest) section.
 
-## Make your own conditions
+## Built-in Conditions Types
+
+The following conditions are available out of the box, for all extension types that support Conditions.
+
+* `Umb.Condition.Switch` - Toggles on and off based on the `frequency` set in seconds.
+* `Umb.Condition.MultipleAppLanguages` - Requires the app to have more than one language, such as a multi-language site.
+* `Umb.Condition.SectionAlias` - Requires the current Section Alias to match the one specified.
+* `Umb.Condition.MenuAlias` - Requires the current Menu Alias to match the one specified.
+* `Umb.Condition.WorkspaceAlias` - Requires the current Workspace Alias to match the one specified.
+* `Umb.Condition.WorkspaceEntityType` - Requires the current workspace to work on the given Entity Type. Examples: 'document', 'block' or 'user'.
+* `Umb.Condition.WorkspaceContentTypeAlias` - Requires the current workspace to be based on a Content Type which Alias matches the one specified.
+* `Umb.Condition.Workspace.ContentHasProperties` - Requires the Content Type of the current Workspace to have properties.
+* `Umb.Condition.WorkspaceHasCollection` - Requires the current Workspace to have a Collection.
+* `Umb.Condition.WorkspaceEntityIsNew` - Requires the current Workspace data to be new, not yet persisted on the server.
+* `Umb.Condition.EntityIsTrashed` - Requires the current entity to be trashed.
+* `Umb.Condition.EntityIsNotTrashed` - Requires the current entity to not be trashed.
+* `Umb.Condition.SectionUserPermission` - Requires the current user to have permissions to the given Section Alias.
+* `Umb.Condition.UserPermission.Document` - Requires the current user to have specific Document permissions. Example: 'Umb.Document.Save'.
+* `Umb.Condition.CurrentUser.GroupId` - Requires the current user to belong to a specific group by GUID. Accepts `match` (GUID), `oneOf` (array), `allOf` (array), and `noneOf` (array). Example: '8d2b3c4d-4f1f-4b1f-8e3d-4a6b7b8c4f1e'.
+* `Umb.Condition.CurrentUser.IsAdmin` - Requires the current user to be an admin as defined by the backend, for example, that they belong to the Administrator group.
+
+## Make your own Conditions
 
 ```html
 <a href="#make-your-own-conditions" id="make-your-own-conditions"></a>


### PR DESCRIPTION
## Description

In v14, the Built-in Conditions Types section is in the Extension Conditions article, where it also talks about how to make your own conditions. For v15 and v16, that info was moved into the high-level overview Extension Conditions article, where it was kinda lost. 

For consistency and ease of finding stuff, I moved the info back in the original article, where it makes more sense, and added a link in the high-level overview article.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

CMS v14, v15, and v16

## Deadline (if relevant)

Anytime
