### PR TITLE
Add missing import statement for "Tokens"

### DIFF
--- a/15/umbraco-cms/reference/umbraco-flavored-markdown.md
+++ b/15/umbraco-cms/reference/umbraco-flavored-markdown.md
@@ -127,6 +127,7 @@ If you wish to develop your own custom UFM component, you can use the `ufmCompon
 The corresponding JavaScript/TypeScript API would contain a method to render the custom label/markup.
 
 ```js
+import { Tokens } from '@umbraco-cms/backoffice/external/marked';
 import { UmbUfmComponentBase } from '@umbraco-cms/backoffice/ufm';
 
 export class MyCustomUfmComponentApi extends UmbUfmComponentBase {


### PR DESCRIPTION
When copy/pasting the displayed code sample my IDE tells me to import "Tokens" so I suggest that it's added to the docs as well :)

## Description

_What did you add/update/change?_

## Type of suggestion

* [x] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
