### PR TITLE
Add Forms 13.4.2 and 15.1.2 release notes

### DIFF
--- a/13/umbraco-forms/release-notes.md
+++ b/13/umbraco-forms/release-notes.md
@@ -16,6 +16,10 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 13 including all changes for this version.
 
+### [13.4.2](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.4.2) (May 15th 2025)
+
+* HTML encode submitted values in 'Send Email' workflow [GHSA-2qrj-g9hq-chph](https://github.com/umbraco/Umbraco.Forms.Issues/security/advisories/GHSA-2qrj-g9hq-chph)
+
 ### [13.4.1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.4.1) (March 7th 2025)
 
 * Parse magic string placeholders in advanced validation rule error message

--- a/15/umbraco-forms/release-notes.md
+++ b/15/umbraco-forms/release-notes.md
@@ -16,6 +16,13 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 15 including all changes for this version.
 
+### [15.1.2](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.1.2) (May 15th 2025)
+
+* HTML encode submitted values in 'Send Email' workflow [GHSA-2qrj-g9hq-chph](https://github.com/umbraco/Umbraco.Forms.Issues/security/advisories/GHSA-2qrj-g9hq-chph)
+* Omit file path from export endpoint result
+* Fix selectable items in dialogs [#1377](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1377)
+* Fix API error in security condition [#1389](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1389)
+
 ### [15.1.1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F15.1.1) (March 7th 2025)
 
 * Ignore existing corrupt record data and ensure proper JSON serialization when storing entries with forged data


### PR DESCRIPTION
## Description

Added release notes for Forms 13.4.2 and 15.1.2.

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [x] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

Forms 13.4.2 and 15.1.2

## Deadline (if relevant)

These patches are already released.
