### PR TITLE
Updated extension-types location

### DIFF
--- a/15/umbraco-cms/customizing/development-flow/typescript-setup.md
+++ b/15/umbraco-cms/customizing/development-flow/typescript-setup.md
@@ -2,14 +2,14 @@
 
 Make sure to configure your TypeScript compiler so it includes the Global Types from the Backoffice. This enables you to utilize the declared Extension Types. If your project is using other Packages that provides their Extension Types then please list these as well.
 
-In your `tsconfig.json` file. Add the array `types` inside `compilerOptions`, with the entry of `@umbraco-cms/backoffice/extension-types`:
+In your `tsconfig.json` file. Add the array `types` inside `compilerOptions`, with the entry of `@umbraco-cms/backoffice/dist-cms/packages/extension-types`:
 
 ```json
 {
     "compilerOptions": {
         ...
         "types": [
-            "@umbraco-cms/backoffice/extension-types"
+            "@umbraco-cms/backoffice/dist-cms/packages/extension-types"
         ]
     }
 }

--- a/15/umbraco-cms/customizing/development-flow/vite-package-setup.md
+++ b/15/umbraco-cms/customizing/development-flow/vite-package-setup.md
@@ -82,14 +82,14 @@ npm install --legacy-peer-deps -D @umbraco-cms/backoffice
 This disables IntelliSense for external references but keeps the install lean.
 
 7. Open the `tsconfig.json` file.
-8. Add the array `types` inside `compilerOptions`, with the entry of `@umbraco-cms/backoffice/extension-types`:
+8. Add the array `types` inside `compilerOptions`, with the entry of `@umbraco-cms/backoffice/dist-cms/packages/extension-types`:
 
 ```json
 {
     "compilerOptions": {
         ...
         "types": [
-            "@umbraco-cms/backoffice/extension-types"
+            "@umbraco-cms/backoffice/dist-cms/packages/extension-types"
         ]
     }
 }

--- a/15/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
+++ b/15/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
@@ -51,7 +51,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 {% endcode %}
 
 {% hint style="info" %}
-Ensure you have set up your `tsconfig.json` to include the extension-types as global types. Like this:
+Ensure you have set up your `tsconfig.json` to include the `extension-types` as global types. Like this:
 
 ```json
 {

--- a/15/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
+++ b/15/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
@@ -58,7 +58,7 @@ Ensure you have set up your `tsconfig.json` to include the extension-types as gl
     "compilerOptions": {
         ...
         "types": [
-            "@umbraco-cms/backoffice/extension-types"
+            "@umbraco-cms/backoffice/dist-cms/packages/extension-types"
         ]
     }
 }

--- a/16/umbraco-cms/customizing/development-flow/README.md
+++ b/16/umbraco-cms/customizing/development-flow/README.md
@@ -82,14 +82,14 @@ This will add a package to your devDependencies containing the TypeScript defini
 
 Make sure to configure your TypeScript compiler so it includes the Global Types from the Backoffice. This enables you to utilize the declared Extension Types. If your project is using other Packages that provide their Extension Types, list these as well.
 
-In your `tsconfig.json` file, add the array `types` inside `compilerOptions`, with the entry of `@umbraco-cms/backoffice/extension-types`:
+In your `tsconfig.json` file, add the array `types` inside `compilerOptions`, with the entry of `@umbraco-cms/backoffice/dist-cms/packages/extension-types`:
 
 ```json
 {
     "compilerOptions": {
         ...
         "types": [
-            "@umbraco-cms/backoffice/extension-types"
+            "@umbraco-cms/backoffice/dist-cms/packages/extension-types"
         ]
     }
 }

--- a/16/umbraco-cms/customizing/development-flow/vite-package-setup.md
+++ b/16/umbraco-cms/customizing/development-flow/vite-package-setup.md
@@ -74,14 +74,14 @@ npm install --legacy-peer-deps -D @umbraco-cms/backoffice@x.x.x
 This disables IntelliSense for external references but keeps the install lean.
 
 7. Open the `tsconfig.json` file.
-8. Add the array `types` inside `compilerOptions`, with the entry of `@umbraco-cms/backoffice/extension-types`:
+8. Add the array `types` inside `compilerOptions`, with the entry of `@umbraco-cms/backoffice/dist-cms/packages/extension-types`:
 
 ```json
 {
     "compilerOptions": {
         ...
         "types": [
-            "@umbraco-cms/backoffice/extension-types"
+            "@umbraco-cms/backoffice/dist-cms/packages/extension-types"
         ]
     }
 }

--- a/16/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
+++ b/16/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
@@ -51,7 +51,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 {% endcode %}
 
 {% hint style="info" %}
-Ensure you have set up your `tsconfig.json` to include the extension-types as global types. Like this:
+Ensure you have set up your `tsconfig.json` to include the `extension-types` as global types. Like this:
 
 ```json
 {

--- a/16/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
+++ b/16/umbraco-cms/customizing/extending-overview/extension-types/bundle.md
@@ -58,7 +58,7 @@ Ensure you have set up your `tsconfig.json` to include the extension-types as gl
     "compilerOptions": {
         ...
         "types": [
-            "@umbraco-cms/backoffice/extension-types"
+            "@umbraco-cms/backoffice/dist-cms/packages/extension-types"
         ]
     }
 }


### PR DESCRIPTION
## Description

Updated `extension-types` location as per folder in the project

![image](https://github.com/user-attachments/assets/76125866-cfbf-4f61-840b-dfa41efc9ef4)

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)

CMS v15 and v16


## Deadline (if relevant)

Anytime
