### PR TITLE
Update vite-package-setup.md

### DIFF
--- a/15/umbraco-cms/customizing/development-flow/vite-package-setup.md
+++ b/15/umbraco-cms/customizing/development-flow/vite-package-setup.md
@@ -89,7 +89,7 @@ This disables IntelliSense for external references but keeps the install lean.
     "compilerOptions": {
         ...
         "types": [
-            "@umbraco-cms/backoffice/dist-cms/packages/extension-types"
+            "@umbraco-cms/backoffice/extension-types"
         ]
     }
 }


### PR DESCRIPTION
The type declaration has changed in v15, but the documentation still has the old reference from v14.

## 📋 Description

The type declaration has changed in v15, but the documentation still has the old reference from v14.


