### PR TITLE
Fix yaml files

### DIFF
--- a/14/umbraco-ui-builder/.gitbook.yaml
+++ b/14/umbraco-ui-builder/.gitbook.yaml
@@ -3,5 +3,3 @@ root: ./
 ​structure:
     readme: README.md
     summary: SUMMARY.md
-
-redirects:

--- a/15/umbraco-ui-builder/.gitbook.yaml
+++ b/15/umbraco-ui-builder/.gitbook.yaml
@@ -3,5 +3,3 @@ root: ./
 ​structure:
     readme: README.md
     summary: SUMMARY.md
-
-redirects:

--- a/16/umbraco-commerce/.gitbook.yaml
+++ b/16/umbraco-commerce/.gitbook.yaml
@@ -2,7 +2,4 @@ root: ./
 
 ​structure:
     readme: README.md
-    summary: SUMMARY.md
-
-redirects:
-    
+    summary: SUMMARY.md   

--- a/16/umbraco-deploy/.gitbook.yaml
+++ b/16/umbraco-deploy/.gitbook.yaml
@@ -3,6 +3,3 @@ root: ./
 ​structure:
     readme: README.md
     summary: SUMMARY.md
-
-redirects:
-    

--- a/16/umbraco-forms/.gitbook.yaml
+++ b/16/umbraco-forms/.gitbook.yaml
@@ -3,6 +3,3 @@ root: ./
 ​structure:
     readme: README.md
     summary: SUMMARY.md
-
-redirects:
-    

--- a/16/umbraco-ui-builder/.gitbook.yaml
+++ b/16/umbraco-ui-builder/.gitbook.yaml
@@ -3,5 +3,3 @@ root: ./
 ​structure:
     readme: README.md
     summary: SUMMARY.md
-
-redirects:

--- a/16/umbraco-workflow/.gitbook.yaml
+++ b/16/umbraco-workflow/.gitbook.yaml
@@ -3,6 +3,3 @@ root: ./
 ​structure:
     readme: README.md
     summary: SUMMARY.md
-
-redirects:
-    

--- a/commerce-add-ons/packages/.gitbook.yaml
+++ b/commerce-add-ons/packages/.gitbook.yaml
@@ -3,6 +3,3 @@ root: ./
 ​structure:  
     readme: README.md
     summary: SUMMARY.md
-
-redirects:
-    

--- a/commerce-add-ons/payment-providers/.gitbook.yaml
+++ b/commerce-add-ons/payment-providers/.gitbook.yaml
@@ -2,7 +2,4 @@ root: ./
 
 ​structure:  
     readme: README.md
-    summary: SUMMARY.md
-
-redirects:
-    
+    summary: SUMMARY.md   

--- a/commerce-add-ons/shipping-providers/.gitbook.yaml
+++ b/commerce-add-ons/shipping-providers/.gitbook.yaml
@@ -3,6 +3,3 @@ root: ./
 ​structure:  
     readme: README.md
     summary: SUMMARY.md
-
-redirects:
-    


### PR DESCRIPTION
## 📋 Description

The redirects section can't be empty in the .gitbook.yaml files.
This PR removed all empty redirects sections from our docs sites.
