### PR TITLE
Detailed removal of URLs population in document and media models

### DIFF
--- a/16/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
+++ b/16/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
@@ -53,6 +53,8 @@ Client-side there are a few things to look out for if you've built extensions to
 
 - When making calls to retrieve data from the server, if you used either of Umbraco's helper methods `tryExecute` or `tryExecuteAndNotify`, then you need to adjust your code slightly. `tryExecuteAndNotify` is obsolete, and `tryExecute` takes the 'host' as the first argument. See [PR 18939](https://github.com/umbraco/Umbraco-CMS/pull/18939) for more information.
 
+- The `urls` property is no longer populated on the document and media detail response models. This was removed to alleviate performance concerns. Dedicated repositories and management API endpoints exist for retrieving URLs for documents and media. See [PR #19030](https://github.com/umbraco/Umbraco-CMS/pull/19030) and [PR 19130](https://github.com/umbraco/Umbraco-CMS/pull/19130).
+
 The full details of breaking changes can be found from [this list of labelled PRs](https://github.com/umbraco/Umbraco-CMS/pulls?q=is:pr+label:category/breaking+is:closed+label:release/16.0.0).
 
 </details>


### PR DESCRIPTION
## 📋 Description

Added further details to the information about breaking changes for 16 relating to the removal of URLs population in document and media models

## 📎 Related Issues (if applicable)

[Relates to https://github.com/umbraco/Umbraco-CMS/issues/19543](https://github.com/umbraco/Umbraco-CMS/issues/19558)

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [X] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [X] Relevant pages are linked.
* [X] All links work and point to the correct resources.
* [X] Screenshots or diagrams are included if useful.
* [X] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 16

## Deadline (if relevant)

Any time
