### PR TITLE
Update icon registry links in documentation

### DIFF
--- a/14/umbraco-cms/customizing/foundation/icons.md
+++ b/14/umbraco-cms/customizing/foundation/icons.md
@@ -1,3 +1,3 @@
 # Icons
 
-The icons from the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for getting the icons starts with`icon-`. You can find the list of all icons in the [Icon registry list on GitHub](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icons).
+The icons in the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for using an icon starts with `icon-`. You can find the full list of available icons in the [Icon registry list on GitHub](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icons).

--- a/14/umbraco-cms/customizing/foundation/icons.md
+++ b/14/umbraco-cms/customizing/foundation/icons.md
@@ -1,3 +1,3 @@
 # Icons
 
-The icons from the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for getting the icons starts with`icon-`. You can find the list of all icons in the [Icon registry list on GitHub](https://github.com/umbraco/Umbraco.CMS.Backoffice/tree/762e43b2f49ca483df9cfe28de20f31ca07bb22b/src/packages/core/icon-registry/icons).
+The icons from the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for getting the icons starts with`icon-`. You can find the list of all icons in the [Icon registry list on GitHub](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icons).

--- a/15/umbraco-cms/customizing/foundation/icons.md
+++ b/15/umbraco-cms/customizing/foundation/icons.md
@@ -1,3 +1,3 @@
 # Icons
 
-The icons from the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for getting the icons starts with`icon-`. You can find the list of all icons in the [Icon registry list on GitHub](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icons).
+The icons in the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for using an icon starts with `icon-`. You can find the full list of available icons in the [Icon registry list on GitHub](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icons).

--- a/15/umbraco-cms/customizing/foundation/icons.md
+++ b/15/umbraco-cms/customizing/foundation/icons.md
@@ -1,3 +1,3 @@
 # Icons
 
-The icons from the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for getting the icons starts with`icon-`. You can find the list of all icons in the [Icon registry list on GitHub](https://github.com/umbraco/Umbraco.CMS.Backoffice/tree/762e43b2f49ca483df9cfe28de20f31ca07bb22b/src/packages/core/icon-registry/icons).
+The icons from the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for getting the icons starts with`icon-`. You can find the list of all icons in the [Icon registry list on GitHub](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icons).

--- a/16/umbraco-cms/customizing/foundation/icons.md
+++ b/16/umbraco-cms/customizing/foundation/icons.md
@@ -1,3 +1,3 @@
 # Icons
 
-The icons from the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for getting the icons starts with`icon-`. You can find the list of all icons in the [Icon registry list on GitHub](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icons).
+The icons in the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for using an icon starts with `icon-`. You can find the full list of available icons in the [Icon registry list on GitHub](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icons).

--- a/16/umbraco-cms/customizing/foundation/icons.md
+++ b/16/umbraco-cms/customizing/foundation/icons.md
@@ -1,3 +1,3 @@
 # Icons
 
-The icons from the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for getting the icons starts with`icon-`. You can find the list of all icons in the [Icon registry list on GitHub](https://github.com/umbraco/Umbraco.CMS.Backoffice/tree/762e43b2f49ca483df9cfe28de20f31ca07bb22b/src/packages/core/icon-registry/icons).
+The icons from the Umbraco backoffice are based on [Lucide Icons](https://lucide.dev/). The syntax for getting the icons starts with`icon-`. You can find the list of all icons in the [Icon registry list on GitHub](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icons).


### PR DESCRIPTION
## 📋 Description

Moved path for icon registry to the cms repo because these files have been moved.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] All links work and point to the correct resources.

## Product & Version (if relevant)

CMS

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
