### PR TITLE
Add one more limitation to Cloud/Database Backups

### DIFF
--- a/umbraco-cloud/databases/backups.md
+++ b/umbraco-cloud/databases/backups.md
@@ -17,6 +17,8 @@ When restoring a database backup on Umbraco Cloud, certain elements may cause is
 - **SQL Server logins** - Custom SQL Server logins (for example, admin, sysuser, etc.) may conflict with existing logins when restoring the database in the hosting platform.
 - **Complex Database Objects** - Custom complex database objects in SQL is an element with external dependencies or special server configurations, which may result in conflicts when restoring the database in our hosting platform.
 
+Also note: Restoring a database will switch the existing database with a fresh one with the restored content. Because the initial database is removed you will not be able to create database backups with a timestamp that lies before the restore. Any existing backups are still available though.
+
 ## Backup on Umbraco Cloud
 
 On Umbraco Cloud, you can utilize our 35-day point-in-time recovery to create and download a `bacpac` file from your project.

--- a/umbraco-cloud/databases/backups.md
+++ b/umbraco-cloud/databases/backups.md
@@ -17,7 +17,9 @@ When restoring a database backup on Umbraco Cloud, certain elements may cause is
 - **SQL Server logins** - Custom SQL Server logins (for example, admin, sysuser, etc.) may conflict with existing logins when restoring the database in the hosting platform.
 - **Complex Database Objects** - Custom complex database objects in SQL is an element with external dependencies or special server configurations, which may result in conflicts when restoring the database in our hosting platform.
 
-Also note: Restoring a database will switch the existing database with a fresh one with the restored content. Because the initial database is removed you will not be able to create database backups with a timestamp that lies before the restore. Any existing backups are still available though.
+{% hint style="info" %}
+Restoring a database replaces the existing database with a fresh one containing the restored content. Once a Restore has run, you cannot create database backups with a **Date and Time for snapshot (UTC)** earlier than the time of the Restore-operation. However, any existing backups are still available.
+{% endhint %}
 
 ## Backup on Umbraco Cloud
 


### PR DESCRIPTION
## 📋 Description

Add a note about how restoring a database will prevent you from being able to try and make a backup at an earlier time that when the restore happened.

## 📎 Related Issues (if applicable)


## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Cloud / Backups
## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
