### PR TITLE
Clarified usage of NuCacheSerializerType setting

### DIFF
--- a/15/umbraco-cms/reference/configuration/cache-settings.md
+++ b/15/umbraco-cms/reference/configuration/cache-settings.md
@@ -184,29 +184,12 @@ Specifying the `SqlPageSize` will change the size of the paged SQL queries. The 
 
 ## NuCacheSerializerType
 
-The `NuCacheSerializerType` setting allows developers to specify the serialization format for NuCache content. This setting is particularly relevant for projects migrating from older versions of Umbraco that relied on JSON formats.
+The `NuCacheSerializerType` setting allows developers to specify the serialization format for cached content.
 
-To use JSON serialization instead of the default MessagePack:
+The fastest and most compact format `MessagePack` option is used by default.
 
-### Using 'Program.cs'
+An alternate `JSON` option was provided for backward compatibility for the Umbraco cache implementation used from Umbraco 8 to 14 (NuCache).
 
-```csharp
-builder.Services.Configure<NuCacheSettings>(options =>
-{
-    options.NuCacheSerializerType = NuCacheSerializerType.JSON;
-});
-```
+It is no longer supported with the cache implementation from Umbraco 15+ based on .NET's Hybrid cache.
 
-### Using 'appsettings.json'
-
-```csharp
-{
-  "Umbraco": {
-    "CMS": {
-      "NuCache": {
-        "NuCacheSerializerType": "JSON"
-      }
-    }
-  }
-}
-```
+The option is kept available only for a more readable format suitable for testing purposes.

--- a/15/umbraco-cms/reference/configuration/cache-settings.md
+++ b/15/umbraco-cms/reference/configuration/cache-settings.md
@@ -186,7 +186,7 @@ Specifying the `SqlPageSize` will change the size of the paged SQL queries. The 
 
 The `NuCacheSerializerType` setting allows developers to specify the serialization format for cached content.
 
-The fastest and most compact format `MessagePack` option is used by default.
+The fastest and most compact format `MessagePack` is used by default.
 
 An alternate `JSON` option was provided for backward compatibility for the Umbraco cache implementation used from Umbraco 8 to 14 (NuCache).
 

--- a/16/umbraco-cms/reference/configuration/cache-settings.md
+++ b/16/umbraco-cms/reference/configuration/cache-settings.md
@@ -1,5 +1,5 @@
 ---
-description: Information on the Cache settings section 
+description: Information on the Cache settings section
 ---
 
 # Cache Settings
@@ -186,29 +186,12 @@ Specifying the `SqlPageSize` will change the size of the paged SQL queries. The 
 
 ## NuCacheSerializerType
 
-The `NuCacheSerializerType` setting allows developers to specify the serialization format for NuCache content. This setting is particularly relevant for projects migrating from older versions of Umbraco that relied on JSON formats.
+The `NuCacheSerializerType` setting allows developers to specify the serialization format for cached content.
 
-To use JSON serialization instead of the default MessagePack:
+The fastest and most compact format `MessagePack` option is used by default.
 
-### Using 'Program.cs'
+An alternate `JSON` option was provided for backward compatibility for the Umbraco cache implementation used from Umbraco 8 to 14 (NuCache).
 
-```csharp
-builder.Services.Configure<NuCacheSettings>(options =>
-{
-    options.NuCacheSerializerType = NuCacheSerializerType.JSON;
-});
-```
+It is no longer supported with the cache implementation from Umbraco 15+ based on .NET's Hybrid cache.
 
-### Using 'appsettings.json'
-
-```csharp
-{
-  "Umbraco": {
-    "CMS": {
-      "NuCache": {
-        "NuCacheSerializerType": "JSON"
-      }
-    }
-  }
-}
-```
+The option is kept available only for a more readable format suitable for testing purposes.

--- a/16/umbraco-cms/reference/configuration/cache-settings.md
+++ b/16/umbraco-cms/reference/configuration/cache-settings.md
@@ -188,7 +188,7 @@ Specifying the `SqlPageSize` will change the size of the paged SQL queries. The 
 
 The `NuCacheSerializerType` setting allows developers to specify the serialization format for cached content.
 
-The fastest and most compact format `MessagePack` option is used by default.
+The fastest and most compact format `MessagePack` is used by default.
 
 An alternate `JSON` option was provided for backward compatibility for the Umbraco cache implementation used from Umbraco 8 to 14 (NuCache).
 


### PR DESCRIPTION
## 📋 Description

Applied source code documentation on the usage of the `NuCacheSerializerType` to the published documentation.

## 📎 Related Issues (if applicable)

See PR: https://github.com/umbraco/Umbraco-CMS/pull/19555 and issue https://github.com/umbraco/Umbraco-CMS/issues/19544

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [X] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [X] Relevant pages are linked.
* [X] All links work and point to the correct resources.
* [X] Screenshots or diagrams are included if useful.
* [X] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco CMS 15+ 

## Deadline (if relevant)

Any time