### PR TITLE
V16: Adds `pt` as an accepted language

### DIFF
--- a/16/umbraco-cms/extending/language-files/README.md
+++ b/16/umbraco-cms/extending/language-files/README.md
@@ -48,6 +48,7 @@ Current [languages](https://github.com/umbraco/Umbraco-CMS/tree/main/src/Umbraco
 * `nb-NO` - Norwegian Bokmål (Norway)
 * `nl-NL` - Dutch (Netherlands)
 * `pl-PL` - Polish (Poland)
+* `pt`    - Portuguese (Portugal)
 * `pt-BR` - Portuguese (Brazil)
 * `ro-RO` - Romanian (Romania)
 * `ru-RU` - Russian (Russia)


### PR DESCRIPTION
This documents `pt` as an accepted Backoffice language

## 📋 Description

Since 16.0, the code `pt` has been accepted as a language and `pt-BR` has been made to fallback to `pt` for unknown variables.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

16.0

## Deadline (if relevant)

ASAP

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
