### PR TITLE
Update openapi-ts command to use correct paramaters

### DIFF
--- a/16/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
+++ b/16/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
@@ -25,7 +25,7 @@ npm install @hey-api/openapi-ts
 Then, use the `openapi-ts` command to generate a client from your OpenAPI specification:
 
 ```bash
-npx openapi-ts generate --url https://example.com/openapi.json --output ./my-client
+npx openapi-ts --input https://example.com/openapi.json --output ./my-client
 ```
 
 This will generate a TypeScript client in the `./my-client` folder. Import the generated client into your project to make requests to the Management API.


### PR DESCRIPTION
## 📋 Description

The parameters for openapi-ts should be `--input` not `--url`

`generate` isn't a command as far as I can tell it gives the following error `error: too many arguments. Expected 0 arguments but got 1.` so that needed removing. Then this command works as supplied
## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

v16+