### PR TITLE
Update block-list-editor.md

### DIFF
--- a/16/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/block-list-editor.md
+++ b/16/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/block-list-editor.md
@@ -148,17 +148,17 @@ Example:
 @using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
 @{
     var content = (ContentModels.MyElementTypeAliasOfContent)Model.Content;
-    var settings = (ContentModels.MyElementTypeAliasOfSettings)Model.Settings;
+    var settings = Model.Settings as ContentModels.MyElementTypeAliasOfContent; // using as here, fixes CS8600 - Converting null literal or possible null value to non-nullable type. 
 }
 
-// Output the value of field with alias 'heading' from the Element Type selected as Content section
+@{ // Output the value of field with alias 'heading' from the Element Type selected as Content section }@
 <h1>@content.Value("heading")</h1>
 ```
 
 With ModelsBuilder:
 
 ```csharp
-// Output the value of field with alias 'heading' from the Element Type selected as Content section
+@{ // Output the value of field with alias 'heading' from the Element Type selected as Content section }@
 <h1>@content.Heading</h1>
 ```
 


### PR DESCRIPTION
using as here, fixes CS8600 - Converting null literal or possible null value to non-nullable type.

Razor renders C# // comments when they are not within code blocks!
