### PR TITLE
Adds mention of label and description in ucOrderProperty meta

### DIFF
--- a/16/umbraco-commerce/key-concepts/ui-extensions/order-properties.md
+++ b/16/umbraco-commerce/key-concepts/ui-extensions/order-properties.md
@@ -30,6 +30,8 @@ A `meta` entry provides configuration options for the property
 
 | Name | Description |  
 | -- | -- |
+| `label` | A fallback label for the property, if there is no localization available. If empty, or undefined, it will display the default localization fallback. |
+| `description` |  A fallback label for the property description, if there is no localization available. If empty, or undefined, it will display the default localization fallback. |
 | `propertyAlias` | The alias of the order line property to edit |
 | `group` | Defines a [group](#order-property-groups) in which to display the property |
 | `editorUiAlias` | The alias of the property editor to use to edit this property |


### PR DESCRIPTION
## 📋 Description

I noticed that it is possible to add fallback label and description to ucOrderProperty.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

16.0.0
