### PR TITLE
Changed Umbraco.Cms.Web.BackOffice to Umbraco.Cms.Api.Management for api tutorial

### DIFF
--- a/16/umbraco-cms/tutorials/creating-a-backoffice-api/README.md
+++ b/16/umbraco-cms/tutorials/creating-a-backoffice-api/README.md
@@ -10,7 +10,7 @@ The Umbraco Backoffice API is also known as the Management API. Thus, a Backoffi
 
 ## Creating the class
 
-To create a custom API, you need to create a class that inherits from `Umbraco.Cms.Web.BackOffice.Controllers.ManagementApiControllerBase`.
+To create a custom API, you need to create a class that inherits from `Umbraco.Cms.Api.Management.Controllers.ManagementApiControllerBase`.
 
 The `ManagementApiControllerBase` serves as the foundation for your custom API class. It provides essential functionalities and utilities required for managing APIs within the Umbraco backoffice environment.
 


### PR DESCRIPTION
It seems like

`Umbraco.Cms.Web.BackOffice`

 has been removed in favor of:

`Umbraco.Cms.Api.Management`

Just updating for the tutorial so it doesn't confuse the user with outdated namespaces