### PR TITLE
Clarified documentation on the AllowEditInvariantFromNonDefault setting

### DIFF
--- a/10/umbraco-cms/reference/configuration/contentsettings.md
+++ b/10/umbraco-cms/reference/configuration/contentsettings.md
@@ -13,7 +13,7 @@ The following snippet will give an overview of the keys and values in the conten
         "KeepAllVersionsNewerThanDays": 7,
         "KeepLatestVersionPerDayForDays": 90
       },
-      "AllowEditInvariantFromNonDefault": true,
+      "AllowEditInvariantFromNonDefault": false,
       "AllowedUploadFiles": [],
       "AllowedMediaHosts":  [],
       "DisableDeleteWhenReferenced": false,
@@ -60,9 +60,9 @@ In the root level section, that is those without a seperate sub section like Ima
 
 Invariant properties are properties on a multilingual site that are not varied by culture. This means that they share the same value across all languages added to the website.
 
-When the setting is set to `false` the invariant properties that are shared between all languages can only be edited from the default language. This means you need access to the default language, in order to edit the property.
+When the setting is set to `false` (default) the invariant properties that are shared between all languages can only be edited from the default language. This means you need access to the default language, in order to edit the property.
 
-When set to `true` (default) the invariant properties will need to be unlocked before they can be edited. The lock exists in order to make it clear that this change will affect more languages.
+When set to `true` the invariant properties will need to be unlocked before they can be edited. The lock exists in order to make it clear that this change will affect more languages.
 
 ### Allowed upload files
 

--- a/13/umbraco-cms/fundamentals/backoffice/variants.md
+++ b/13/umbraco-cms/fundamentals/backoffice/variants.md
@@ -66,8 +66,6 @@ Each Property Editor that does not allow variants (an Invariant Property) will b
 {% hint style="info" %}
 Whether or not the lock is enabled on the invariant properties depends on the `AllowEditInvariantFromNonDefault` setting in the `appsettings.json` file.
 
-For projects created on Umbraco version 10.2 or later, the setting is `true`, by default. If the project is upgraded to version 10.2 or later, the setting will by default be `false`.
-
 Learn more about the `AllowEditInvariantFromNonDefault` setting in the [Security Settings](../../reference/configuration/securitysettings.md) article.
 {% endhint %}
 

--- a/13/umbraco-cms/reference/configuration/contentsettings.md
+++ b/13/umbraco-cms/reference/configuration/contentsettings.md
@@ -17,7 +17,7 @@ The following snippet will give an overview of the keys and values in the conten
         "KeepAllVersionsNewerThanDays": 7,
         "KeepLatestVersionPerDayForDays": 90
       },
-      "AllowEditInvariantFromNonDefault": true,
+      "AllowEditInvariantFromNonDefault": false,
       "AllowedMediaHosts":  [],
       "AllowedUploadedFileExtensions": [],
       "DisableDeleteWhenReferenced": false,
@@ -62,9 +62,9 @@ In the root level section, that is those without a separate sub section like Ima
 
 Invariant properties are properties on a multilingual site that are not varied by culture. This means that they share the same value across all languages added to the website.
 
-When the setting is set to `false` the invariant properties that are shared between all languages can only be edited from the default language. This means you need access to the default language, in order to edit the property.
+When the setting is set to `false` (default) the invariant properties that are shared between all languages can only be edited from the default language. This means you need access to the default language, in order to edit the property.
 
-When set to `true` (default) the invariant properties will need to be unlocked before they can be edited. The lock exists in order to make it clear that this change will affect more languages.
+When set to `true` the invariant properties will need to be unlocked before they can be edited. The lock exists in order to make it clear that this change will affect more languages.
 
 ### Allowed upload file extensions
 

--- a/14/umbraco-cms/fundamentals/backoffice/variants.md
+++ b/14/umbraco-cms/fundamentals/backoffice/variants.md
@@ -59,18 +59,6 @@ When you return to your content node you will notice two things:
 
     ![Allowing Variance on properties](images/Allowing-Variance-on-properties.png)
 
-Each Property Editor that does not allow variants (an Invariant Property) will by default need to be unlocked in order to be edited. The lock exists to make it clear that this change will affect more languages. Since the value of the invariant properties are shared between all variants on the website.
-
-![How an invariant property looks when it is locked](../../../../10/umbraco-cms/fundamentals/backoffice/images/invariant-property-locked.png)
-
-{% hint style="info" %}
-Whether or not the lock is enabled on the invariant properties depends on the `AllowEditInvariantFromNonDefault` setting in the `appsettings.json` file.
-
-For projects created on Umbraco version 10.2 or later, the setting is `true`, by default. If the project is upgraded to version 10.2 or later, the setting will by default be `false`.
-
-Learn more about the `AllowEditInvariantFromNonDefault` setting in the [Security Settings](../../reference/configuration/securitysettings.md) article.
-{% endhint %}
-
 To read about how you render variant content in Templates, check out the [rendering content section](../design/rendering-content.md).
 
 ## Test your language variants

--- a/14/umbraco-cms/reference/configuration/contentsettings.md
+++ b/14/umbraco-cms/reference/configuration/contentsettings.md
@@ -17,7 +17,7 @@ The following snippet will give an overview of the keys and values in the conten
         "KeepAllVersionsNewerThanDays": 7,
         "KeepLatestVersionPerDayForDays": 90
       },
-      "AllowEditInvariantFromNonDefault": true,
+      "AllowEditInvariantFromNonDefault": false,
       "AllowedMediaHosts":  [],
       "AllowedUploadedFileExtensions": [],
       "DisableDeleteWhenReferenced": false,
@@ -61,9 +61,9 @@ In the root level section, that is those without a separate sub section like Ima
 
 Invariant properties are properties on a multilingual site that are not varied by culture. This means that they share the same value across all languages added to the website.
 
-When the setting is set to `false` the invariant properties that are shared between all languages can only be edited from the default language. This means you need access to the default language, in order to edit the property.
+When the setting is set to `false` (default) the invariant properties that are shared between all languages can only be edited from the default language. This means you need access to the default language, in order to edit the property.
 
-When set to `true` (default) the invariant properties will need to be unlocked before they can be edited. The lock exists in order to make it clear that this change will affect more languages.
+When set to `true` the invariant properties will need to be unlocked before they can be edited. The lock exists in order to make it clear that this change will affect more languages.
 
 ### Allowed upload file extensions
 

--- a/15/umbraco-cms/fundamentals/backoffice/variants.md
+++ b/15/umbraco-cms/fundamentals/backoffice/variants.md
@@ -59,18 +59,6 @@ When you return to your content node you will notice two things:
 
     ![Allowing Variance on properties](images/Allowing-Variance-on-properties.png)
 
-Each Property Editor that does not allow variants (an Invariant Property) will by default need to be unlocked in order to be edited. The lock exists to make it clear that this change will affect more languages. Since the value of the invariant properties are shared between all variants on the website.
-
-![How an invariant property looks when it is locked](../../../../10/umbraco-cms/fundamentals/backoffice/images/invariant-property-locked.png)
-
-{% hint style="info" %}
-Whether or not the lock is enabled on the invariant properties depends on the `AllowEditInvariantFromNonDefault` setting in the `appsettings.json` file.
-
-For projects created on Umbraco version 10.2 or later, the setting is `true`, by default. If the project is upgraded to version 10.2 or later, the setting will by default be `false`.
-
-Learn more about the `AllowEditInvariantFromNonDefault` setting in the [Security Settings](../../reference/configuration/securitysettings.md) article.
-{% endhint %}
-
 To read about how you render variant content in Templates, check out the [rendering content section](../design/rendering-content.md).
 
 ## Test your language variants

--- a/15/umbraco-cms/reference/configuration/contentsettings.md
+++ b/15/umbraco-cms/reference/configuration/contentsettings.md
@@ -17,7 +17,7 @@ The following snippet will give an overview of the keys and values in the conten
         "KeepAllVersionsNewerThanDays": 7,
         "KeepLatestVersionPerDayForDays": 90
       },
-      "AllowEditInvariantFromNonDefault": true,
+      "AllowEditInvariantFromNonDefault": false,
       "AllowedMediaHosts":  [],
       "AllowedUploadedFileExtensions": [],
       "DisableDeleteWhenReferenced": false,
@@ -63,9 +63,9 @@ In the root level section, that is those without a separate sub section like Ima
 
 Invariant properties are properties on a multilingual site that are not varied by culture. This means that they share the same value across all languages added to the website.
 
-When the setting is set to `false` the invariant properties that are shared between all languages can only be edited from the default language. This means you need access to the default language, in order to edit the property.
+When the `AllowEditInvariantFromNonDefault` setting is set to `false` (default) the invariant properties can only be edited and published from the default language. This means you need access to the default language in order to edit the property. You will also need to publish the default language to see changes in the invariant property on your website.
 
-When set to `true` (default) the invariant properties will need to be unlocked before they can be edited. The lock exists in order to make it clear that this change will affect more languages.
+When set to `true` the invariant properties can be edited and published from any language.
 
 ### Allowed upload file extensions
 

--- a/16/umbraco-cms/fundamentals/backoffice/variants.md
+++ b/16/umbraco-cms/fundamentals/backoffice/variants.md
@@ -59,18 +59,6 @@ When you return to your content node you will notice two things:
 
     ![Allowing Variance on properties](images/Allowing-Variance-on-properties.png)
 
-Each Property Editor that does not allow variants (an Invariant Property) will by default need to be unlocked in order to be edited. The lock exists to make it clear that this change will affect more languages. Since the value of the invariant properties are shared between all variants on the website.
-
-![How an invariant property looks when it is locked](../../../../10/umbraco-cms/fundamentals/backoffice/images/invariant-property-locked.png)
-
-{% hint style="info" %}
-Whether or not the lock is enabled on the invariant properties depends on the `AllowEditInvariantFromNonDefault` setting in the `appsettings.json` file.
-
-For projects created on Umbraco version 10.2 or later, the setting is `true`, by default. If the project is upgraded to version 10.2 or later, the setting will by default be `false`.
-
-Learn more about the `AllowEditInvariantFromNonDefault` setting in the [Security Settings](../../reference/configuration/securitysettings.md) article.
-{% endhint %}
-
 To read about how you render variant content in Templates, check out the [rendering content section](../design/rendering-content.md).
 
 ## Test your language variants

--- a/16/umbraco-cms/reference/configuration/contentsettings.md
+++ b/16/umbraco-cms/reference/configuration/contentsettings.md
@@ -17,7 +17,7 @@ The following snippet will give an overview of the keys and values in the conten
         "KeepAllVersionsNewerThanDays": 7,
         "KeepLatestVersionPerDayForDays": 90
       },
-      "AllowEditInvariantFromNonDefault": true,
+      "AllowEditInvariantFromNonDefault": false,
       "AllowedMediaHosts":  [],
       "AllowedUploadedFileExtensions": [],
       "DisableDeleteWhenReferenced": false,
@@ -63,9 +63,9 @@ In the root level section, that is those without a separate sub section like Ima
 
 Invariant properties are properties on a multilingual site that are not varied by culture. This means that they share the same value across all languages added to the website.
 
-When the setting is set to `false` the invariant properties that are shared between all languages can only be edited from the default language. This means you need access to the default language, in order to edit the property.
+When the `AllowEditInvariantFromNonDefault` setting is set to `false` (default) the invariant properties can only be edited and published from the default language. This means you need access to the default language in order to edit the property. You will also need to publish the default language to see changes in the invariant property on your website.
 
-When set to `true` (default) the invariant properties will need to be unlocked before they can be edited. The lock exists in order to make it clear that this change will affect more languages.
+When set to `true` the invariant properties can be edited and published from any language.
 
 ### Allowed upload file extensions
 


### PR DESCRIPTION
## 📋 Description

Having investigated a reported issue on the CMS, it was clear our documentation of this setting wasn't entirely correct and was missing some changes between versions.

I've corrected the details of the default value of the setting across all versions, and updated the copy for 15 and 16 to describe the current behaviour.

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/issues/19814

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 10+

## Deadline (if relevant)

Any time
