### PR TITLE
Added Note in Workflow Licensing article about using underscore instead of period

### DIFF
--- a/10/umbraco-workflow/installation/licensing.md
+++ b/10/umbraco-workflow/installation/licensing.md
@@ -40,6 +40,14 @@ Once you have received your license code it needs to be installed on your site.
 }
 ```
 
+{% hint style="info" %}
+You might run into issues when using a period in the product name when using environment variables. Use an underscore in the product name instead, to avoid problems.
+
+```json
+"Umbraco_Workflow": "YOUR_LICENSE_KEY"
+```
+{% endhint %}
+
 ### Verify the license installation
 
 You can verify that your license is successfully installed by logging into your project's backoffice and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.

--- a/13/umbraco-workflow/installation/licensing.md
+++ b/13/umbraco-workflow/installation/licensing.md
@@ -38,6 +38,14 @@ Once you have received your license code it needs to be installed on your site.
 }
 ```
 
+{% hint style="info" %}
+You might run into issues when using a period in the product name when using environment variables. Use an underscore in the product name instead, to avoid problems.
+
+```json
+"Umbraco_Workflow": "YOUR_LICENSE_KEY"
+```
+{% endhint %}
+
 ### Verify the license installation
 
 You can verify that your license is successfully installed by logging into your project's backoffice and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.

--- a/14/umbraco-workflow/installation/licensing.md
+++ b/14/umbraco-workflow/installation/licensing.md
@@ -39,6 +39,14 @@ Once you have received your license code it needs to be installed on your site.
 }
 ```
 
+{% hint style="info" %}
+You might run into issues when using a period in the product name when using environment variables. Use an underscore in the product name instead, to avoid problems.
+
+```json
+"Umbraco_Workflow": "YOUR_LICENSE_KEY"
+```
+{% endhint %}
+
 ### Verify the license installation
 
 You can verify that your license is successfully installed by logging into your project's backoffice and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.

--- a/15/umbraco-workflow/installation/licensing.md
+++ b/15/umbraco-workflow/installation/licensing.md
@@ -39,6 +39,14 @@ Once you have received your license code it needs to be installed on your site.
 }
 ```
 
+{% hint style="info" %}
+You might run into issues when using a period in the product name when using environment variables. Use an underscore in the product name instead, to avoid problems.
+
+```json
+"Umbraco_Workflow": "YOUR_LICENSE_KEY"
+```
+{% endhint %}
+
 ### Verify the license installation
 
 You can verify that your license is successfully installed by logging into your project's backoffice and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.

--- a/16/umbraco-workflow/installation/licensing.md
+++ b/16/umbraco-workflow/installation/licensing.md
@@ -39,6 +39,14 @@ Once you have received your license code it needs to be installed on your site.
 }
 ```
 
+{% hint style="info" %}
+You might run into issues when using a period in the product name when using environment variables. Use an underscore in the product name instead, to avoid problems.
+
+```json
+"Umbraco_Workflow": "YOUR_LICENSE_KEY"
+```
+{% endhint %}
+
 ### Verify the license installation
 
 You can verify that your license is successfully installed by logging into your project's backoffice and navigating to the settings section. Here you will see a licenses dashboard which should display the status of your license.


### PR DESCRIPTION
## 📋 Description

A customer experienced validation issues with their Workflow license. According to their feedback:

"I changed the license value from **UMBRACO_LICENSES_UMBRACO_WORKFLOW** to **UMBRACO_LICENSES_Umbraco_Workflow** (case sensitive) and instead of using **Umbraco.Workflow** as the key, I used **Umbraco_Workflow** (underscore instead of period). The key change is not necessary but changed it for consistency (both ways work).
I'm providing this information in the hopes that the documentation is updated. This issue applies to Umbraco Engage as well. I experienced it when setting it up a couple of days/weeks ago."

Umbraco Engage v13 and v16 already have this Note. So no changes there.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Workflow v10, 13, 14, 15, 16

## Deadline (if relevant)

Anytime

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
