### PR TITLE
Fix wrong link to `backofficeEntryPoint` article

### DIFF
--- a/16/umbraco-cms/customizing/extending-overview/extension-registry/extension-manifest.md
+++ b/16/umbraco-cms/customizing/extending-overview/extension-registry/extension-manifest.md
@@ -74,7 +74,7 @@ There are many use cases. To name a few, it could be to load external libraries 
 
 The entry point declares a single JavaScript file that will be loaded and run when the Backoffice starts.
 
-Read more about the `backofficeEntryPoint` extension type in the [Entry Point](extension-manifest.md#the-backofficeentrypoint-extension-type) article.
+Read more about the `backofficeEntryPoint` extension type in the [Backoffice Entry Point](../extension-types/backoffice-entry-point.md) article.
 
 ### The `appEntryPoint` extension type
 


### PR DESCRIPTION
## 📋 Description

While going through the Extension Overview documentation, I noticed that the article link in `backofficeEntryPoint` was pointing to its own page, instead of the actual article, like the `appEntryPoint`.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
