### PR TITLE
Correct an internal link in IoC page

### DIFF
--- a/13/umbraco-cms/reference/using-ioc.md
+++ b/13/umbraco-cms/reference/using-ioc.md
@@ -18,7 +18,7 @@ There are different strategies for registering your dependencies and not one str
 
 In this article, we will cover the following three strategies:
 
-* [Registering dependencies in the `Program.cs` file](#registering-dependencies-in-the-programcs-file)
+* [Registering dependencies in the `Program.cs` file](#registering-dependencies-in-the-program.cs-file)
 * [Registering dependencies in a composer](#registering-dependencies-in-a-composer)
 * [Registering dependencies in bundles](#registering-dependencies-in-bundles)
 

--- a/14/umbraco-cms/reference/using-ioc.md
+++ b/14/umbraco-cms/reference/using-ioc.md
@@ -18,7 +18,7 @@ There are different strategies for registering your dependencies and not one str
 
 In this article, we will cover the following three strategies:
 
-* [Registering dependencies in the `Program.cs` file](#registering-dependencies-in-the-programcs-file)
+* [Registering dependencies in the `Program.cs` file](#registering-dependencies-in-the-program.cs-file)
 * [Registering dependencies in a composer](#registering-dependencies-in-a-composer)
 * [Registering dependencies in bundles](#registering-dependencies-in-bundles)
 

--- a/15/umbraco-cms/reference/using-ioc.md
+++ b/15/umbraco-cms/reference/using-ioc.md
@@ -18,7 +18,7 @@ There are different strategies for registering your dependencies and not one str
 
 In this article, we will cover the following three strategies:
 
-* [Registering dependencies in the `Program.cs` file](#registering-dependencies-in-the-programcs-file)
+* [Registering dependencies in the `Program.cs` file](#registering-dependencies-in-the-program.cs-file)
 * [Registering dependencies in a composer](#registering-dependencies-in-a-composer)
 * [Registering dependencies in bundles](#registering-dependencies-in-bundles)
 

--- a/16/umbraco-cms/reference/using-ioc.md
+++ b/16/umbraco-cms/reference/using-ioc.md
@@ -18,7 +18,7 @@ There are different strategies for registering your dependencies and not one str
 
 In this article, we will cover the following three strategies:
 
-* [Registering dependencies in the `Program.cs` file](#registering-dependencies-in-the-programcs-file)
+* [Registering dependencies in the `Program.cs` file](#registering-dependencies-in-the-program.cs-file)
 * [Registering dependencies in a composer](#registering-dependencies-in-a-composer)
 * [Registering dependencies in bundles](#registering-dependencies-in-bundles)
 


### PR DESCRIPTION
## 📋 Description

Updates an internal link in https://docs.umbraco.com/umbraco-cms/reference/using-ioc .

```bash
Before:
https://docs.umbraco.com/umbraco-cms/reference/using-ioc#registering-dependencies-in-the-programcs-file

After:
https://docs.umbraco.com/umbraco-cms/reference/using-ioc#registering-dependencies-in-the-program.cs-file
```

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ✅ ] Code blocks are correctly formatted.
* [ ✅ ] Sentences are short and clear (preferably under 25 words).
* [ ✅ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ✅ ] Relevant pages are linked.
* [ ✅ ] All links work and point to the correct resources.
* [ ✅ ] Screenshots or diagrams are included if useful.
* [ ✅ ] Any code examples or instructions have been tested.
* [ ✅ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

13, 14, 15, 16

## Deadline (if relevant)

N/A

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
