### PR TITLE
Added information about default groups when auto-linking backoffice accounts from external login providers

### DIFF
--- a/13/umbraco-cms/reference/security/external-login-providers.md
+++ b/13/umbraco-cms/reference/security/external-login-providers.md
@@ -151,6 +151,8 @@ In those cases, it would mean that anyone who has a Google or Facebook account c
 
 If auto-linking for public providers such as these was needed you would need to limit the access. This can be done by domain or other information provided in the claims using the options/callbacks specified in those provider's authentication options.
 
+When auto-linking for the backoffice you will want to define what user groups the user will be part of. This is done via the `defaultUserGroups` parameter provided to the constructor of `ExternalSignInAutoLinkOptions` (see example below). If the value is not set the user will by default be added to the Editors group.
+
 ### Auto-linking on Member authentication
 
 Auto-linking on Member authentication only makes sense if you have a public member registration already or the provider does not have public account creation.

--- a/14/umbraco-cms/reference/security/external-login-providers.md
+++ b/14/umbraco-cms/reference/security/external-login-providers.md
@@ -155,6 +155,8 @@ In those cases, it would mean that anyone who has a Google or Facebook account c
 
 If auto-linking for public providers such as these was needed you would need to limit the access. This can be done by domain or other information provided in the claims using the options/callbacks specified in those provider's authentication options.
 
+When auto-linking for the backoffice you will want to define what user groups the user will be part of. This is done via the `defaultUserGroups` parameter provided to the constructor of `ExternalSignInAutoLinkOptions` (see example below). If the value is not set the user will by default be added to the Editors group.
+
 #### Is your project hosted on Umbraco Cloud?
 
 Umbraco Cloud uses Umbraco ID for all authentication, including access to the Umbraco Backoffice.

--- a/15/umbraco-cms/reference/security/external-login-providers.md
+++ b/15/umbraco-cms/reference/security/external-login-providers.md
@@ -155,6 +155,8 @@ In those cases, it would mean that anyone who has a Google or Facebook account c
 
 If auto-linking for public providers such as these was needed you would need to limit the access. This can be done by domain or other information provided in the claims using the options/callbacks specified in those provider's authentication options.
 
+When auto-linking for the backoffice you will want to define what user groups the user will be part of. This is done via the `defaultUserGroups` parameter provided to the constructor of `ExternalSignInAutoLinkOptions` (see example below). If the value is not set the user will by default be added to the Editors group.
+
 #### Is your project hosted on Umbraco Cloud?
 
 Umbraco Cloud uses Umbraco ID for all authentication, including access to the Umbraco Backoffice.

--- a/16/umbraco-cms/reference/security/external-login-providers.md
+++ b/16/umbraco-cms/reference/security/external-login-providers.md
@@ -155,6 +155,8 @@ In those cases, it would mean that anyone who has a Google or Facebook account c
 
 If auto-linking for public providers such as these was needed you would need to limit the access. This can be done by domain or other information provided in the claims using the options/callbacks specified in those provider's authentication options.
 
+When auto-linking for the backoffice you will want to define what user groups the user will be part of. This is done via the `defaultUserGroups` parameter provided to the constructor of `ExternalSignInAutoLinkOptions` (see example below). You will need to explicitly assign these. If the value is not set the user will be part of no groups.
+
 #### Is your project hosted on Umbraco Cloud?
 
 Umbraco Cloud uses Umbraco ID for all authentication, including access to the Umbraco Backoffice.


### PR DESCRIPTION
## 📋 Description

Added information about default groups when auto-linking backoffice accounts from external login providers.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS

## Deadline (if relevant)

Any time