### PR TITLE
Fix typo in example-package-repository.md

### DIFF
--- a/13/umbraco-cms/extending/packages/example-package-repository.md
+++ b/13/umbraco-cms/extending/packages/example-package-repository.md
@@ -30,7 +30,7 @@ When the next major version of Umbraco is released, we'll test and either extend
 
 ### Tests Project
 
-We have a [project for unit tests](https://github.com/umbraco/Umbraco.AuthorizedServices/tree/main/tests/Umbraco.AuthorizedServices.Tests) in `tests/<ProjectName>.Tests`.  It contains references to `Umbraco.Cms.Tets` and a project reference to the package:
+We have a [project for unit tests](https://github.com/umbraco/Umbraco.AuthorizedServices/tree/main/tests/Umbraco.AuthorizedServices.Tests) in `tests/<ProjectName>.Tests`.  It contains references to `Umbraco.Cms.Tests` and a project reference to the package:
 
 ```xml
 <ProjectReference Include="..\..\src\Umbraco.AuthorizedServices\Umbraco.AuthorizedServices.csproj" />


### PR DESCRIPTION
## 📋 Description

Minor typo correction, changed `Umbraco.Cms.Tets` to `Umbraco.Cms.Tests`