### PR TITLE
V16 CMS: Tell the developer to set `MaxRequestLength` regardless of hosting platform

### DIFF
--- a/16/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
+++ b/16/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
@@ -12,6 +12,10 @@ Learn how to change the upload size limit for your Umbraco site depending on you
 
 By default, Umbraco does not restrict upload size. The limits are controlled by the hosting platform.
 
+{% hint style="info" %}
+It is advisable that you tell Umbraco what the maximum upload size is by setting the `Umbraco:CMS:Runtime:MaxRequestLength` in the `appsettings.json` file. The Backoffice will use this value to help guide the users.
+{% endhint %}
+
 ## Using IIS
 
 The default upload limit in IIS is 30000000 bytes (~28.6 MB). The maximum value allowed is 4 GB.

--- a/16/umbraco-cms/reference/configuration/runtimesettings.md
+++ b/16/umbraco-cms/reference/configuration/runtimesettings.md
@@ -24,7 +24,7 @@ An example of a configuration could look something like:
 }
 ```
 
-- `MaxRequestLength` is specified in kilobytes. Setting this limits the request size, including the size of uploaded files. This only has an effect when hosting with Kestrel. See the [Maximum Upload Size Settings
+- `MaxRequestLength` is specified in kilobytes. Setting this limits the request size, including the size of uploaded files. This only has an effect on the server when hosting with Kestrel. But it is also used by the Backoffice to advise the users. See the [Maximum Upload Size Settings
 ](./maximumuploadsizesettings.md) article for more information.
 - `Mode` can have three values: `BackofficeDevelopment` (default), `Development`, and `Production`. For more information, see the [Runtime modes](../../fundamentals/setup/server-setup/runtime-modes.md) article.
 - `TemporaryFileLifeTime` is specified as a timespan. The default value is one day - `1.00:00:00`.

--- a/16/umbraco-cms/reference/configuration/runtimesettings.md
+++ b/16/umbraco-cms/reference/configuration/runtimesettings.md
@@ -24,7 +24,7 @@ An example of a configuration could look something like:
 }
 ```
 
-- `MaxRequestLength` is specified in kilobytes. Setting this limits the request size, including the size of uploaded files. This only has an effect on the server when hosting with Kestrel. But it is also used by the Backoffice to advise the users. See the [Maximum Upload Size Settings
+- `MaxRequestLength` is specified in kilobytes. Setting this limits the request size, including the size of uploaded files. This only has an effect on the server when hosting with Kestrel, but is also used by the Backoffice to advise users. See the [Maximum Upload Size Settings
 ](./maximumuploadsizesettings.md) article for more information.
 - `Mode` can have three values: `BackofficeDevelopment` (default), `Development`, and `Production`. For more information, see the [Runtime modes](../../fundamentals/setup/server-setup/runtime-modes.md) article.
 - `TemporaryFileLifeTime` is specified as a timespan. The default value is one day - `1.00:00:00`.


### PR DESCRIPTION
## 📋 Description

The intention of this pull request is to inform the reader, that it is advisable to set the `MaxRequestLength` in appsettings.json regardless of hosting platform, as Umbraco 16 uses this value to evaluate the validation for file uploads. (So instead of guessing the maximum file size, it will actively guide/advise the user that they are exceeding the file size).

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

16

## Deadline (if relevant)

ASAP

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
