### PR TITLE
Reformat routing-properties.md

### DIFF
--- a/16/umbraco-cms/reference/routing/routing-properties.md
+++ b/16/umbraco-cms/reference/routing/routing-properties.md
@@ -24,9 +24,8 @@ If you enter a value for this property and save/publish the content node you wil
 
 ## umbracoUrlAlias
 
-This property when created as a text string lets you provide a comma separated\
-list of alternate full URL paths for the node. For example, if your URL was /some-category/some-page/content-node,\
-by adding an umbracoUrlAlias of "flowers", a user can navigate to the node by going to /flowers.\
+This property when created as a text string lets you provide a comma separated list of alternate full URL paths for the node.\ 
+For example, if your URL was /some-category/some-page/content-node, by adding an umbracoUrlAlias of "flowers", a user can navigate to the node by going to /flowers.\
 The URL alias remains in the browser address bar as a 'mask' over the real URL. You can also specify paths like "flowers/roses/red".
 
 ## Filtering


### PR DESCRIPTION
## 📋 Description

A small change to the formatting of the document. The line break was in a strange place and it broke up mid sentence. 


## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.


