### PR TITLE
Fixed vale errors in Cloud articles - Part 2

### DIFF
--- a/.github/styles/UmbracoDocs/Acronyms.yml
+++ b/.github/styles/UmbracoDocs/Acronyms.yml
@@ -91,3 +91,4 @@ exceptions:
     - ASCII
     - CMD
     - NGINX
+    - SMTP

--- a/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/README.md
+++ b/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/README.md
@@ -91,9 +91,9 @@ From this page, you can manage whether your site is automatically upgraded to th
 
 ![Automatic Upgrades](images/automatic-upgrades.png)
 
-### [CDN & Caching](../../../optimize-and-maintain-your-site/optimize-performance/manage-cdn-caching.md)
+### [Content Delivery Network (CDN) and Caching](../../../optimize-and-maintain-your-site/optimize-performance/manage-cdn-caching.md)
 
-The CDN & Caching section lets you manage CDN Caching and Optimization settings for your project. You can:
+The CDN and Caching section lets you manage CDN Caching and Optimization settings for your project. You can:
 
 * Modify the default settings that apply to all hostnames added to the project.
 * Set specific caching settings per hostname if different configurations are required for certain hostnames.
@@ -205,7 +205,9 @@ You can upgrade your project to a **Standard** or a **Professional** plan from t
 You can rename your Umbraco Cloud project from the **Management** menu.
 
 {% hint style="info" %}
+
 If you are working locally, you need to update the origin of your local git repository to point to the new clone URL. Alternatively, you can make a fresh local clone of the project once you’ve changed your project name.
+
 {% endhint %}
 
 ![Rename Project](images/rename-project.png)

--- a/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/application-settings.md
+++ b/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/application-settings.md
@@ -14,7 +14,7 @@ You can find this option in **Settings** -> **Advanced** -> **Custom Application
 
 ## Enable client certificate loaded from file system Explained
 
-If your cloud project needs to load a client certificate (such as an X.509 certificate) at runtime, you can turn on this feature for one or more environments. By turning this feature on for an environment, you will be able to load a client certificate as a file during the run-time of your cloud project.
+To load a client certificate (such as an X.509 certificate) at runtime, enable this feature for one or more environments. Enabling this feature for an environment allows you to load a client certificate file during your cloud project's runtime.
 
 For more information on loading a certificate from a file, see the [Load certificate from file](https://docs.microsoft.com/en-us/azure/app-service/configure-ssl-certificate-in-code#load-certificate-from-file) article in the Microsoft documentation.
 

--- a/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/config-transforms.md
+++ b/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/config-transforms.md
@@ -22,7 +22,7 @@ To transform a config file, you need to create a new file in your project with t
 If your project is on Umbraco 7 and 8 the naming convention is the following: `{config-file name}.{environment}.xdt.config.` Find more details on this in the [Legacy Documentation](https://github.com/umbraco/UmbracoDocs/blob/legacy-cloud/Umbraco-Cloud/Set-Up/Config-Transforms/index.md).
 {% endhint %}
 
-If you want to do a transform on your `Web.config` file for the Live environment of your project, the config transform you need to create will look like this:
+To transform your `Web.config` file for the Live environment, create a config transform that looks like this:
 
 `Web.Production.config`
 
@@ -32,7 +32,7 @@ The `{environment}` part needs to be replaced with the target environment, for w
 2. `Staging`
 3. `Development`
 
-This file needs to be created on a local clone of your project, as this will ensure that the file is added to the project repository.
+Create this file in your local project clone to ensure it's added to the repository.
 
 When the file is deployed to the Live environment, the transforms will be applied to the `Web.config` file in the `Root` of your project. In the case that you have mutliple mainline environments, the `Web.Production.config` will **only** transform the `Web.config` on the Live environment.
 
@@ -88,7 +88,7 @@ Here is an example of how that config transform would look:
 ```
 
 {% hint style="info" %}
-The above snippet requires your project to have a web.config file with a matching structure, otherwise, the config transform (and subsequently, the deployment) might fail.
+The snippet requires a `web.config` file with a matching structure; otherwise, the config transform (and subsequently, the deployment) may fail.
 {% endhint %}
 
 This config transform will add a `<rule>` to `<system.webServer><rewrite><rules>`. The `xdt:Transform` attribute is used to tell the system what to transform. In this case, the value is `Insert`, which means it will add the section if it's not already in the config file.

--- a/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/smtp-settings.md
+++ b/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/smtp-settings.md
@@ -1,10 +1,10 @@
 ---
 description: >-
-  Learn how to configure SMTP settings for your Umbraco Cloud project to enable
+  Learn how to configure Simple Mail Transfer Protocol (SMTP= settings for your Umbraco Cloud project to enable
   email functionality  for workflows, user invitations, and password resets.
 ---
 
-# Simple Mail Transfer Protocol (SMTP) Settings
+# SMTP Settings
 
 In many cases, you might want to send emails from your Umbraco Cloud project. This could be for inviting users to the Backoffice or as part of an Umbraco Forms Workflow. To do so, you need a SMTP server and must configure it in your `appsettings.json` file.
 

--- a/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/smtp-settings.md
+++ b/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/smtp-settings.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Learn how to configure Simple Mail Transfer Protocol (SMTP= settings for your Umbraco Cloud project to enable
+  Learn how to configure SMTP settings for your Umbraco Cloud project to enable
   email functionality  for workflows, user invitations, and password resets.
 ---
 

--- a/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/smtp-settings.md
+++ b/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/smtp-settings.md
@@ -4,9 +4,9 @@ description: >-
   email functionality  for workflows, user invitations, and password resets.
 ---
 
-# SMTP Settings
+# Simple Mail Transfer Protocol (SMTP) Settings
 
-In many cases, you might want to send emails from your Umbraco Cloud project. This could be for inviting users to the Backoffice or as part of an Umbraco Forms Workflow. To do so, you need a Simple Mail Transfer Protocol (SMTP) server and must configure it in your `appsettings.json` file.
+In many cases, you might want to send emails from your Umbraco Cloud project. This could be for inviting users to the Backoffice or as part of an Umbraco Forms Workflow. To do so, you need a SMTP server and must configure it in your `appsettings.json` file.
 
 SMTP servers are not included with Umbraco Cloud projects. You will need to set up your own SMTP server elsewhere and configure it with your Umbraco Cloud project.
 

--- a/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/upgrade-your-plan.md
+++ b/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/upgrade-your-plan.md
@@ -1,6 +1,6 @@
 # Upgrade your Plan
 
-In this article, you can read about how you can upgrade your Umbraco Cloud plan and what you need to be aware of before you do so.
+This article discusses how to upgrade your Umbraco Cloud plan and important considerations to keep in mind.
 
 ## Before you upgrade your plan
 
@@ -12,9 +12,11 @@ Before you decide to upgrade your Umbraco Cloud plan, you need to consider a few
 * Before upgrading, make sure to check the [price difference](https://umbraco.com/umbraco-cloud-pricing) and the features you get on the new plan.
 
 {% hint style="warning" %}
+
 When upgrading your plan (for example, from Starter to Standard), log files such as trace logs will not be transferred to the new environment.
 
 If you need to retain log history, make sure to download and back up the log files before upgrading. For more information on accessing the logs, see the [Log files](../../../optimize-and-maintain-your-site/monitor-and-troubleshoot/resolve-issues-quickly-and-efficiently/log-files.md) article.
+
 {% endhint %}
 
 ## How to upgrade your plan
@@ -41,10 +43,10 @@ In the menu, you can find a tab called _"Upgrade plan"_.
 Follow the below steps to upgrade your plan:
 
 1. Click on the **Select Plan** button to choose the plan you want to upgrade to.
-2.  _\[Optional]_ Choose to upgrade to a **dedicated option** in the next step.
+2. _[Optional]_ Choose to upgrade to a **dedicated option** in the next step.
 
     <div align="left"><figure><img src="images/dedicated-option.png" alt=""><figcaption><p>Dedicated option on Cloud</p></figcaption></figure></div>
-3.  Review the **Summary** to make sure that everything selected is correct in the last step.
+3. Review the **Summary** to make sure that everything selected is correct in the last step.
 
     <figure><img src="images/upgrade-summary.png" alt=""><figcaption><p>Summary of project upgrade.</p></figcaption></figure>
 
@@ -62,16 +64,16 @@ When upgrading or downgrading the plan, the ID of your project will be appended 
 
 ## Automatic plan upgrades
 
-If your project/website exceeds any of the usage limits, you will automatically get upgraded to a plan that fits your actual usage to ensure your website keeps running smoothly.
+If your project exceeds usage limits, you'll be automatically upgraded to a suitable plan to keep your website running smoothly.
 
-We will send an email to the project owner and the technical contact(s) of the project to let you know that this has happened. The upgrade to a new plan will be reflected in your next bill and will count from the day of the upgrade.
+We will send an email to the project owner and the technical contact(s) to inform them about this update. The upgrade to a new plan will be reflected in your next bill and will take effect from the date of the upgrade.
 
-When you get upgraded to a new plan, you also get access to all the features that are included in this plan. [Check out the list of features for the various Umbraco Cloud plans](https://umbraco.com/umbraco-cloud-pricing/).
+Once you are upgraded to a new plan, you also get access to all the features that are included in that plan. [Check out the list of features for the Umbraco Cloud plans](https://umbraco.com/umbraco-cloud-pricing/).
 
 ## Downgrade your plan
 
-If you’d like to downgrade, this is possible if you make sure to lower your limit to fit the desired plan.
+If you would like to downgrade your plan, you can do so by first lowering your data usage limit to match the desired plan.
 
-When you’ve lowered the required data usage, reach out to Umbraco Support and they’ll be able to help downgrade your plan. When downgrading to a lower plan, this will come to effect immediately, meaning that your usage limits will be reduced and any extra features related to your previous plan will be deactivated. You will pay for the old plan until the next scheduled bill.
+Once you have adjusted your data usage, contact Umbraco Support for assistance with the downgrade. Keep in mind that when you downgrade to a lower plan, the changes will take effect immediately. This means your usage limits will be reduced, and any extra features associated with your previous plan will be deactivated. You will continue to be billed for the old plan until your next scheduled billing date.
 
-If you have any questions regarding this, feel free to reach out to [Umbraco Support](mailto:contact@umbraco.com).
+If you have any questions regarding this process, feel free to reach out to [Umbraco Support](mailto:contact@umbraco.com).

--- a/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
+++ b/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
@@ -13,7 +13,9 @@ For projects on a Standard, Professional, and Enterprise plan you can enable sta
 On the **Advanced** page of your project, you can turn on the static outbound IP address feature to ensure persistent communication. This opt-in feature can be switched on for **Standard**, **Professional**, and **Enterprise** Cloud projects.
 
 {% hint style="info" %}
+
 The enabling of static outbound IP addresses will have the effect that port 25 will be blocked. Port 25 is the default port for Simple Mail Transfer Protocol (SMTP) relays and is commonly abused to send spam from compromised parties. Accordingly, this port is often blocked by ISPs and cloud providers such as Microsoft and Google. For SMTP submissions, we advise you to use port 587 or port 2525.
+
 {% endhint %}
 
 ![StaticOutboundIps](https://user-images.githubusercontent.com/93588665/158338313-c433c994-71a5-40f5-a947-4947df23a0cf.gif)

--- a/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
+++ b/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
@@ -14,7 +14,7 @@ On the **Advanced** page of your project, you can turn on the static outbound IP
 
 {% hint style="info" %}
 
-The enabling of static outbound IP addresses will have the effect that port 25 will be blocked. Port 25 is the default port for Simple Mail Transfer Protocol (SMTP) relays and is commonly abused to send spam from compromised parties. Accordingly, this port is often blocked by ISPs and cloud providers such as Microsoft and Google. For SMTP submissions, we advise you to use port 587 or port 2525.
+The enabling of static outbound IP addresses will have the effect that port 25 will be blocked. Port 25 is the default port for SMTP relays and is commonly abused to send spam from compromised parties. Accordingly, this port is often blocked by ISPs and cloud providers such as Microsoft and Google. For SMTP submissions, we advise you to use port 587 or port 2525.
 
 {% endhint %}
 

--- a/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
+++ b/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
@@ -1,10 +1,10 @@
 # External Services
 
-In some cases, Umbraco Cloud might not be the only service you are working with. You might need to work with other services as well - this could be either internal or third-party services. In either case, it will be serviced externally to Umbraco Cloud.
+In some cases, Umbraco Cloud might not be the only service you are working with. You might need to work with other services as well. This could be either internal or third-party services. In either case, it will be serviced externally to Umbraco Cloud.
 
-When you are working with an external service that is behind a firewall and that service needs to communicate with your Umbraco Cloud project, you need to make sure the Umbraco Cloud Server IPs are allowed to bypass the firewall.
+If an external service behind a firewall needs to communicate with your Umbraco Cloud project, allow Umbraco Cloud Server IPs to bypass the firewall.
 
-An example could be, that you're fetching some information from an external service that is behind a firewall. To give your Umbraco Cloud project access to the external service you need to add the IPs used by the Umbraco Cloud servers to an allow list (other services may refer to it as a "whitelist").
+For example, to retrieve information from an external service that is located behind a firewall, you must grant access to your Umbraco Cloud project. To do this, add the IP addresses used by Umbraco Cloud servers to an allowlist.
 
 ## Enabling static outbound IP addresses
 
@@ -13,12 +13,12 @@ For projects on a Standard, Professional, and Enterprise plan you can enable sta
 On the **Advanced** page of your project, you can turn on the static outbound IP address feature to ensure persistent communication. This opt-in feature can be switched on for **Standard**, **Professional**, and **Enterprise** Cloud projects.
 
 {% hint style="info" %}
-The enabling of static outbound IP addresses will have the effect that port 25 will be blocked. Port 25 is the default port for SMTP relays and is commonly abused to send spam from compromised parties. Accordingly, this port is often blocked by ISPs and cloud providers such as Microsoft and Google. For SMTP submissions, we advise you to use port 587 or port 2525.
+The enabling of static outbound IP addresses will have the effect that port 25 will be blocked. Port 25 is the default port for Simple Mail Transfer Protocol (SMTP) relays and is commonly abused to send spam from compromised parties. Accordingly, this port is often blocked by ISPs and cloud providers such as Microsoft and Google. For SMTP submissions, we advise you to use port 587 or port 2525.
 {% endhint %}
 
 ![StaticOutboundIps](https://user-images.githubusercontent.com/93588665/158338313-c433c994-71a5-40f5-a947-4947df23a0cf.gif)
 
-The static outbound IP ranges vary per region. Below are the values per region in a [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) (Classless Inter-Domain Routing) notation. The expanded IP ranges can be calculated by using [online tooling](https://www.ipaddressguide.com/cidr).
+The static outbound IP ranges vary per region. Below are the values per region in a [Classless Inter-Domain Routing (CIDR)](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) notation. The expanded IP ranges can be calculated by using [online tooling](https://www.ipaddressguide.com/cidr).
 
 **West Europe**
 
@@ -44,8 +44,8 @@ The static outbound IP ranges vary per region. Below are the values per region i
 4.147.161.240/28
 ```
 
-If you need to use a CIDR (Classless Inter-Domain Routing) Range for the IPs: `40.113.173.32/28`
+If you need to use a CIDR Range for the IPs: `40.113.173.32/28`
 
 {% hint style="info" %}
-For projects on a Starter plan, you can see the current dynamic outbound IP addresses. The IP addresses shown for starter projects are dynamic and are likely to change at some point due to either Azure or Umbraco optimizing hosting resources.
+For projects on a Starter plan, you can see the current dynamic outbound IP addresses. The IP addresses for starter projects are dynamic and may change due to Azure or Umbraco optimizing resources.
 {% endhint %}

--- a/umbraco-cloud/expand-your-projects-capabilities/external-services/application-insights.md
+++ b/umbraco-cloud/expand-your-projects-capabilities/external-services/application-insights.md
@@ -13,13 +13,11 @@ To install Application Insight on your Umbraco Cloud project read the[ Applicati
 ## Limitations on Umbraco Cloud
 
 {% hint style="warning" %}
-As projects on Umbraco Cloud are hosted on a shared infrastructure, the information that&#x20;
+Be aware that projects hosted on Umbraco Cloud operate on a shared infrastructure, which may lead to misleading information when using Application Insights.
 
-you gather through Application Insight can be a misrepresentation.
+Since multiple projects utilize the same resources, Application Insights will provide data based on the overall resource usage across these projects.
 
-Since several projects share the same resources Application Insight will gather information based on the overall resources used.
-
-To gather accurate information using Application Insight, you must move your project to a [dedicated server](../../build-and-customize-your-solution/set-up-your-project/project-settings/dedicated-resources.md).
+To obtain accurate information with Application Insights, you  must move your project to a [dedicated server](../../build-and-customize-your-solution/set-up-your-project/project-settings/dedicated-resources.md).
 {% endhint %}
 
 ## Microsoft Documentation

--- a/umbraco-cloud/explore-umbraco-cloud/what-is-umbraco-cloud/README.md
+++ b/umbraco-cloud/explore-umbraco-cloud/what-is-umbraco-cloud/README.md
@@ -32,10 +32,8 @@ Learn more about the [quotas put in place](umbraco-cloud-plans.md) to ensure the
 
 ### What’s Included?
 
-*
-  Umbraco CMS: The core editor-friendly, open-source CMS.
-*
-  Cloud Portal: A user-friendly dashboard for managing projects, environments, users, and settings.
+* Umbraco CMS: The core editor-friendly, open-source CMS.
+* Cloud Portal: A user-friendly dashboard for managing projects, environments, users, and settings.
 * Umbraco Deploy: Effortlessly synchronize content and structure across environments, ensuring smooth collaboration between development and live environments.
 * Umbraco Forms: Build and manage forms seamlessly, enhancing user engagement and collecting valuable insights without additional costs.
 * Umbraco UI Builder (In selected plans): Accelerate content creation and management by building intuitive, customized interfaces that enhance editorial workflows.

--- a/umbraco-cloud/explore-umbraco-cloud/what-is-umbraco-cloud/README.md
+++ b/umbraco-cloud/explore-umbraco-cloud/what-is-umbraco-cloud/README.md
@@ -6,7 +6,7 @@ description: >-
 
 # What is Umbraco Cloud?
 
-Umbraco Cloud is the fully managed, flexible, and scalable way to build and host Umbraco websites, all in one place. Built on top of the open-source Umbraco CMS and hosted on Microsoft Azure, it gives developers, editors, and teams everything they need to deliver fast, secure, and future-proof digital experiences.
+Umbraco Cloud is a fully managed, flexible, and scalable way to build and host Umbraco websites, all in one place. Built on the open-source Umbraco CMS and hosted on Microsoft Azure, it provides everything developers and teams need for fast, secure digital experiences.
 
 Umbraco Cloud takes care of installation, infrastructure, and security. You will also get the tools to work with your project in the Cloud or locally. Local development starts with cloning the project down to your PC or Linux/macOS.
 
@@ -14,10 +14,10 @@ When you are ready to show your work to the world, Umbraco Cloud provides a safe
 
 ## Why Use Umbraco Cloud?
 
-*  Fully managed hosting: Hosted on Microsoft Azure with automatic backups, global CDN, HTTPS, and scaling built in.
+* Fully managed hosting: Hosted on Microsoft Azure with automatic backups, global Content Delivery Network (CDN), HTTPS, and scaling built in.
 * Out-of-the-box DevOps: Use Git-based workflows, built-in CI/CD, and structured environments (Development, Staging, Live) to deliver with confidence.
-* Easy collaboration: Invite team members, manage access, and deploy content and code with ease, all from the Cloud Portal.&#x20;
-* Security and reliability: Backed by secure infrastructure, automated TLS, point-in-time restores, and Cloudflare protection for performance and safety.
+* Seamless collaboration: Invite team members, manage access, and deploy content and code with ease, all from Cloud Portal.
+* Security and reliability: Backed by secure infrastructure, automated Transport Layer Security (TLS), point-in-time restores, and Cloudflare protection for performance and safety.
 * Built for growth: Start small and scale as needed, with flexible environments, external integrations, and support for custom workflows and packages.
 
 ### Umbraco Cloud Plans
@@ -32,8 +32,10 @@ Learn more about the [quotas put in place](umbraco-cloud-plans.md) to ensure the
 
 ### What’s Included?
 
-*  Umbraco CMS: The core editor-friendly, open-source CMS.
-*  Cloud Portal: A user-friendly dashboard for managing projects, environments, users, and settings.
+*
+  Umbraco CMS: The core editor-friendly, open-source CMS.
+*
+  Cloud Portal: A user-friendly dashboard for managing projects, environments, users, and settings.
 * Umbraco Deploy: Effortlessly synchronize content and structure across environments, ensuring smooth collaboration between development and live environments.
 * Umbraco Forms: Build and manage forms seamlessly, enhancing user engagement and collecting valuable insights without additional costs.
 * Umbraco UI Builder (In selected plans): Accelerate content creation and management by building intuitive, customized interfaces that enhance editorial workflows.

--- a/umbraco-cloud/explore-umbraco-cloud/what-is-umbraco-cloud/hosting-with-umbraco-cloud-cloud-vs.-self-hosted.md
+++ b/umbraco-cloud/explore-umbraco-cloud/what-is-umbraco-cloud/hosting-with-umbraco-cloud-cloud-vs.-self-hosted.md
@@ -8,18 +8,18 @@ description: >-
 
 Umbraco Cloud offers fully managed hosting for your Umbraco projects, leveraging Microsoft Azure. This means you don’t have to worry about setting up infrastructure, servers, or deployment pipelines. Everything is included and optimized for running Umbraco projects at scale.
 
-Whether you're launching a new site or migrating an existing one, choosing between **Umbraco Cloud** and **self-hosted Umbraco** depends on your project's requirements, team setup, and compliance needs. Here's a breakdown to help you make a decision.
+Choosing between **Umbraco Cloud** and **self-hosted Umbraco** depends on your project's requirements, team setup, and compliance needs. Here's a breakdown to help you make a decision:
 
 | Feature                     | Umbraco Cloud                          | Self-Hosted Umbraco                                   |
 | --------------------------- | -------------------------------------- | ----------------------------------------------------- |
-| **Hosting infrastructure**  | Managed by Umbraco on Azure            | Managed by you (Azure, AWS, on-prem, etc.)            |
+| **Hosting infrastructure**  | Managed by Umbraco on Azure            | Managed by you (Azure, Amazon Web Services (AWS), on-prem, etc.) |
 | **Setup Time**              | Minimal, creates a project in minutes  | Manual configuration is required                      |
 | **Upgrades (CMS + Deploy)** | Automated and guided                   | Manual updates needed                                 |
 | **Deployments**             | Built-in workflows via Umbraco Deploy  | Custom pipeline setup needed                          |
 | **Upgrades and Backups**    | Automatic and included                 | Manual or via custom setup                            |
 | **CI/CD Support**           | Built-in automated deployments         | Custom pipelines (e.g., Azure DevOps, GitHub Actions) |
 | **Monitoring and logging**  | Integrated dashboards and logs         | Must integrate with external tools                    |
-| **Security and Compliance** | WAF, HTTPS, MFA, ISO-certified hosting | Your responsibility                                   |
+| **Security and Compliance** | Web Application Firewall (WAF), HTTPS, Multi-Factor Authentication (MFA), ISO-certified hosting | Your responsibility                                   |
 | **Support**                 | Included with selected plans           | Community or third-party support                      |
 
 ## Shared vs. Dedicated Hosting

--- a/umbraco-cloud/explore-umbraco-cloud/what-is-umbraco-cloud/hosting-with-umbraco-cloud-cloud-vs.-self-hosted.md
+++ b/umbraco-cloud/explore-umbraco-cloud/what-is-umbraco-cloud/hosting-with-umbraco-cloud-cloud-vs.-self-hosted.md
@@ -19,7 +19,7 @@ Choosing between **Umbraco Cloud** and **self-hosted Umbraco** depends on your p
 | **Upgrades and Backups**    | Automatic and included                 | Manual or via custom setup                            |
 | **CI/CD Support**           | Built-in automated deployments         | Custom pipelines (e.g., Azure DevOps, GitHub Actions) |
 | **Monitoring and logging**  | Integrated dashboards and logs         | Must integrate with external tools                    |
-| **Security and Compliance** | Web Application Firewall (WAF), HTTPS, Multi-Factor Authentication (MFA), ISO-certified hosting | Your responsibility                                   |
+| **Security and Compliance** | Web Application Firewall (WAF), HTTPS, Multi-Factor Authentication (MFA), ISO-certified hosting | Your responsibility |
 | **Support**                 | Included with selected plans           | Community or third-party support                      |
 
 ## Shared vs. Dedicated Hosting

--- a/umbraco-cloud/explore-umbraco-cloud/what-is-umbraco-cloud/key-features-and-benefits-of-using-umbraco-cloud.md
+++ b/umbraco-cloud/explore-umbraco-cloud/what-is-umbraco-cloud/key-features-and-benefits-of-using-umbraco-cloud.md
@@ -4,13 +4,13 @@ description: Discover some of the features of Umbraco Cloud.
 
 # Key Features and Benefits of Using Umbraco Cloud
 
-Umbraco Cloud is a fully managed, scalable platform built to simplify and enhance the experience of building, deploying, and maintaining Umbraco websites.&#x20;
+Umbraco Cloud is a fully managed, scalable platform built to simplify and enhance the experience of building, deploying, and maintaining Umbraco websites.
 
-Whether you're a developer, digital agency, or enterprise team, Umbraco Cloud empowers you to move faster, collaborate seamlessly, and stay secure by default while running on modern best practices.
+Umbraco Cloud enables developers, agencies, and enterprise teams to work faster, collaborate easily, and maintain security using modern best practices.
 
 This article highlights the most valuable features and benefits of Umbraco Cloud.
 
-### Fully Managed Hosting on Microsoft Azure
+## Fully Managed Hosting on Microsoft Azure
 
 Umbraco Cloud hosts your projects on trusted Microsoft Azure infrastructure, ensuring:
 
@@ -18,7 +18,7 @@ Umbraco Cloud hosts your projects on trusted Microsoft Azure infrastructure, ens
 * Data privacy and security
 * Azure-backed reliability and global scalability
 
-### Smooth Deployments & Built-In CI/CD Workflows
+## Smooth Deployments & Built-In CI/CD Workflows
 
 Deploy faster and safer with a modern, built-in developer experience:
 
@@ -28,11 +28,11 @@ Deploy faster and safer with a modern, built-in developer experience:
 
 For more information, see the [Deployment](../../build-and-customize-your-solution/handle-deployments-and-environments/deployment/), [CI/CD on Umbraco Cloud](../../build-and-customize-your-solution/handle-deployments-and-environments/umbraco-cicd/), and [GitHub Actions](../../build-and-customize-your-solution/handle-deployments-and-environments/umbraco-cicd/samplecicdpipeline/github-actions.md) articles.
 
-### Faster Project Setup with Baselines
+## Faster Project Setup with Baselines
 
 Umbraco Baselines allows you to use a base project as a template for creating more projects. This is ideal if you're planning on building multiple similar websites. For more information, see the [Baselines](../../begin-your-cloud-journey/creating-a-cloud-project/baselines.md) articles.
 
-### Automated Upgrades and Hotfixes
+## Automated Upgrades and Hotfixes
 
 Stay secure and up to date with automated CMS upgrades, including:
 
@@ -42,7 +42,7 @@ Stay secure and up to date with automated CMS upgrades, including:
 
 For more information, see the [Product Upgrades](../../optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/) article.
 
-### Security by Default
+## Security by Default
 
 Umbraco Cloud includes multiple layers of security so your team doesn’t have to manage patches or infrastructure hardening manually:
 
@@ -54,7 +54,7 @@ Umbraco Cloud includes multiple layers of security so your team doesn’t have t
 
 For more information, see the [Security](../../build-and-customize-your-solution/set-up-your-project/security/) article.
 
-### Multi-Environment Workflow
+## Multi-Environment Workflow
 
 Every project comes with mainline and flexible environments (based on the plan), so you can:
 
@@ -63,7 +63,7 @@ Every project comes with mainline and flexible environments (based on the plan),
 
 For more information, read the [Environments](../../begin-your-cloud-journey/project-features/environments.md) and [Flexible Environments](../../begin-your-cloud-journey/project-features/flexible-environments.md) articles.
 
-### Insights and Performance Monitoring
+## Insights and Performance Monitoring
 
 Get visibility into site health and performance:
 
@@ -73,7 +73,7 @@ Get visibility into site health and performance:
 
 For more information, see the [Application Insights](../../expand-your-projects-capabilities/external-services/application-insights.md) article.
 
-### Unlimited Team Collaboration
+## Unlimited Team Collaboration
 
 Umbraco Cloud is designed for modern teams and agencies:
 
@@ -83,4 +83,4 @@ Umbraco Cloud is designed for modern teams and agencies:
 
 For more information, see the [Managing Team Members](../../begin-your-cloud-journey/project-features/team-members/) article.
 
-And that’s just the beginning. Explore even more features, benefits, and capabilities on the [Umbraco Cloud Product Page](https://umbraco.com/products/umbraco-cloud/) and the [Umbraco Cloud Pricing](https://umbraco.com/products/umbraco-cloud/pricing/) page.
+And that’s only the beginning. Explore even more features, benefits, and capabilities on the [Umbraco Cloud Product Page](https://umbraco.com/products/umbraco-cloud/) and the [Umbraco Cloud Pricing](https://umbraco.com/products/umbraco-cloud/pricing/) page.

--- a/umbraco-cloud/explore-umbraco-cloud/what-is-umbraco-cloud/key-features-and-benefits-of-using-umbraco-cloud.md
+++ b/umbraco-cloud/explore-umbraco-cloud/what-is-umbraco-cloud/key-features-and-benefits-of-using-umbraco-cloud.md
@@ -6,7 +6,7 @@ description: Discover some of the features of Umbraco Cloud.
 
 Umbraco Cloud is a fully managed, scalable platform built to simplify and enhance the experience of building, deploying, and maintaining Umbraco websites.
 
-Umbraco Cloud enables developers, agencies, and enterprise teams to work faster, collaborate easily, and maintain security using modern best practices.
+Umbraco Cloud enables developers, agencies, and enterprise teams to work faster, collaborate seamlessly, and maintain security using modern best practices.
 
 This article highlights the most valuable features and benefits of Umbraco Cloud.
 


### PR DESCRIPTION
## 📋 Description

- Fixed Vale errors, like writing short sentences, defining acronyms, and removing editorializing words.
- Added SMTP to the list of exceptions in the Acronyms file. It has been defined multiple times in the docs in various articles still keeps throwing an error every time it´s mentioned in a different article. Also, SMTP is a widely known term in software.

## 📎 Related Issues (if applicable)

NA

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Cloud

## Deadline (if relevant)

Anytime

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
