### PR TITLE
Remove SendingAllowedChildrenNotification

### DIFF
--- a/16/umbraco-cms/.gitbook.yaml
+++ b/16/umbraco-cms/.gitbook.yaml
@@ -113,6 +113,7 @@ redirects:
     reference/configuration/runtimeminificationsettings: reference/configuration/README.md
     reference/routing/umbraco-api-controllers/authorization: reference/routing/umbraco-api-controllers/README.md
     reference/routing/umbraco-api-controllers/routing: reference/routing/umbraco-api-controllers/README.md
+    reference/notifications/sendingallowedchildrennotifications: reference/content-type-filters.md
     extending/property-editors/package-manifest: customizing/umbraco-package.md
     fundamentals/backoffice/infinite-editing: fundamentals/backoffice/sidebar.md
     extending/backoffice-tours: extending/build-on-umbraco-functionality.md

--- a/16/umbraco-cms/SUMMARY.md
+++ b/16/umbraco-cms/SUMMARY.md
@@ -369,7 +369,6 @@
   * [Determining if an entity is new](reference/notifications/determining-new-entity.md)
   * [MediaService Notifications Example](reference/notifications/mediaservice-notifications.md)
   * [MemberService Notifications Example](reference/notifications/memberservice-notifications.md)
-  * [Sending Allowed Children Notification](reference/notifications/sendingallowedchildrennotifications.md)
   * [Umbraco Application Lifetime Notifications](reference/notifications/umbracoapplicationlifetime-notifications.md)
   * [EditorModel Notifications](reference/notifications/editormodel-notifications/README.md)
   * [Hot vs. cold restarts](reference/notifications/hot-vs-cold-restarts.md)

--- a/16/umbraco-cms/reference/content-type-filters.md
+++ b/16/umbraco-cms/reference/content-type-filters.md
@@ -1,6 +1,9 @@
 ---
 description: Describes how to use Content Type Filters to restrict the allowed content options available to editors.
 ---
+{% hint style="info" %}
+The use cases supported here are similar to those where the `SendingAllowedChildrenNotification` would be used in Umbraco 13 or earlier.
+{% endhint %}
 
 # Filtering Allowed Content Types
 
@@ -9,10 +12,6 @@ When content editors add new content they are presented with a dialog where they
 Implementors and package creators can add additional logic to determine which options are available to the editors.
 
 This is possible using Content Type Filters.
-
-{% hint style="info" %}
-The use cases supported here are similar to those where the `SendingAllowedChildrenNotification` would be used in Umbraco 13 or earlier.
-{% endhint %}
 
 ## Implementing a Content Type Filter
 

--- a/16/umbraco-cms/reference/notifications/README.md
+++ b/16/umbraco-cms/reference/notifications/README.md
@@ -285,5 +285,4 @@ Below you can find some articles with some examples using Notifications.
 * [Hot vs. cold restarts](hot-vs-cold-restarts.md)
 * [MediaService Notifications](mediaservice-notifications.md)
 * [MemberService Notifications](memberservice-notifications.md)
-* [Sending Allowed Children Notification](sendingallowedchildrennotifications.md)
 * [Umbraco Application Lifetime Notifications](umbracoapplicationlifetime-notifications.md)

--- a/16/umbraco-cms/reference/notifications/sendingallowedchildrennotifications.md
+++ b/16/umbraco-cms/reference/notifications/sendingallowedchildrennotifications.md
@@ -1,9 +1,0 @@
----
-description: Example of how to use a SendingAllowedChildren Notification
----
-
-# Sending Allowed Children Notification
-
-The `SendingAllowedChildrenNotification` is no longer available in Umbraco 15.
-
-Please see [content type filters](../content-type-filters.md) as the supported alternative for use cases that previously relied on this notification.


### PR DESCRIPTION
## 📋 Description
In Umbraco 16 (and 14 and 15) the SendingAllowedChildrenNotification no longer exists. Although the content of that page was updated to reflect the fact that it's no longer supported in Umbraco 16, after a conversion with Sofie it was decided that pages should be removed when a feature is no longer present in the CMS.

So this PR deleted this page and adds a redirect to it's replacement: content filters.

## 📎 Related Issues (if applicable)
Fixes [#7332](https://github.com/umbraco/UmbracoDocs/issues/7332)

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)
Umbraco 16

## Deadline (if relevant)
-

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
