### PR TITLE
Update PropertyValueConverter examples to Umbraco 15+

### DIFF
--- a/15/umbraco-cms/customizing/property-editors/property-value-converters.md
+++ b/15/umbraco-cms/customizing/property-editors/property-value-converters.md
@@ -21,7 +21,7 @@ public class ContentPickerValueConverter : IPropertyValueConverter
 ```
 
 {% hint style="info" %}
-Consider using the `PropertyValueConverterBase` class as the base of your PropertyValueConverter instead of the `IPropertyValueConverter` interface. The `PropertyValueConverterBase` class comes with a default implementation of `IPropertyValueConverter`, so you only need to override the functions you need to change. In contrast, if you use the `IPropertyValueConverter`, you are responsible for implementing all functions yourself. In this document, we'll assume that you are using the `IPropertyValueConverter`, so we cover all functions.
+Consider using the `PropertyValueConverterBase` class as the base of your PropertyValueConverter instead of the `IPropertyValueConverter` interface. The `PropertyValueConverterBase` class comes with a default implementation of `IPropertyValueConverter`, so you only need to override the functions you need to change. In contrast, if you use the `IPropertyValueConverter`, you are responsible for implementing all functions yourself. In this document, it is assumed that you are using the `IPropertyValueConverter`, so functions are covered.
 {% endhint %}
 
 The `IPropertyValueConverter` interface exposes the following functions you need to implement:
@@ -126,7 +126,7 @@ A property value can be cached at the following levels:
 
 #### `PropertyCacheLevel.Unknown`
 
-Do not use this cache level unless you know exactly what you're doing. We recommend using the `PropertyCacheLevel.Element` level.
+Do not use this cache level unless you know exactly what you're doing. It is recommend using the `PropertyCacheLevel.Element` level.
 
 #### `PropertyCacheLevel.Element`
 
@@ -162,7 +162,7 @@ public PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyT
 Implement the functions that perform the conversion from a raw database value to an intermediate value and then to the final type. Conversions happen in two steps.
 
 ### ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
-This method converts the raw data value into an appropriate intermediate type that is needed for the final conversion step to an object. For example, for a node picker the node identifier's raw value is saved as a `string`, but to get to an `IPublishedContent` in the final conversion step, we need a `Udi` instead of a `string`. So in the intermediate step, we check if the string value is a valid `Udi` and convert the string to a `Udi` as the intermediate value.
+This method converts the raw data value into an appropriate intermediate type that is needed for the final conversion step to an object. For example, for a node picker the node identifier's raw value is saved as a `string`, but to get to an `IPublishedContent` in the final conversion step, we need a `Udi` instead of a `string`. So in the intermediate step, check if the string value is a valid `Udi` and convert the string to a `Udi` as the intermediate value.
 
 Include `using Umbraco.Extensions` to be able to use the `TryConvertTo` extension method.
 

--- a/15/umbraco-cms/customizing/property-editors/property-value-converters.md
+++ b/15/umbraco-cms/customizing/property-editors/property-value-converters.md
@@ -4,61 +4,37 @@ description: A guide to creating a custom property value converter in Umbraco
 
 # Property Value Converters
 
-A Property Value Converter converts a property editor's database-stored value to another type. The converted value can be accessed from MVC Razor or any other Published Content API.
+A Property Value Converter converts a property editor's database-stored value into another type that is stored in the Umbraco cache. This way, the database stores only the most essential data, while Razor views, the Published Content API, and the Content Delivery API can work with strongly typed and cleaner models.
 
-Published property values have four "Values":
+For example, a Document picker typically only stores the Key of the picked node in the database, but when working with the published data, an IPublishedContent object is returned instead of just the key. This conversion is done by a Property Value Converter.
 
-* **Source** - The raw data stored in the database, this is generally a `String`
-* **Intermediate** - An object of a type that is appropriate to the property, for example a nodeId should be an `Int` or a collection of nodeIds would be an integer array, `Int[]`
-* **Object** - The object to be used when accessing the property using a Published Content API, for example UmbracoHelper's `GetPropertyValue<T>` method
+A PropertyValueConverter has three conversion levels:
+* **Source** - The raw data stored in the database; this is generally a `string`.
+* **Intermediate** - An object of a type that is appropriate to the property. For example, a node key should be a `Guid`, or a collection of node keys would be a `Guid[]` array.
+* **Object** - The object to be used when accessing the property using the Published Content API; for example, UmbracoHelper's `GetPropertyValue<T>` method. Also, the Models Builder generates a property of the type of the object.
 
-## Registering PropertyValueConverters
-
-PropertyValueConverters are automatically registered when implementing the interface. Any given PropertyEditor can only utilize a single PropertyValueConverter.
-
-If you are implementing a PropertyValueConverter for a PropertyEditor that doesn't already have one, creating the PropertyValueConverter will automatically enable it. No further actions are needed.
-
-If you aim to override an existing PropertyValueConverter, possibly from Umbraco or a package, additional steps are necessary. Deregister the existing one to prevent conflicts in this scenario.
-
-```csharp
-using System.Linq;
-using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Core.DependencyInjection;
-
-public class MyComposer : IComposer
-{
-    public void Compose(IUmbracoBuilder builder)
-    {
-        //If the type is accessible (not internal) you can deregister it by the type:
-        builder.PropertyValueConverters().Remove<MyCustom.StandardValueConnector>();
-
-        //If the type is not accessible you will need to locate the instance and then remove it:
-        var contentPickerValueConverter = builder.PropertyValueConverters().GetTypes().FirstOrDefault(x => x.Name == "ContentPickerValueConverter");
-        if (contentPickerValueConverter != null)
-        {
-            builder.PropertyValueConverters().Remove(contentPickerValueConverter);
-        }
-    }
-}
-```
-
-The built-in PropertyValueConverters included with Umbraco, are currently marked as internal. This means you will not be able to remove them by type since the type isn't accessible outside of the namespace. In order to remove such PropertyValueConverters, you will need to look up the instance by name and then deregister it by the instance. This could be the case for other PropertyValueConverters included by packages as well, depending on the implementation details.
-
-## Implementing the Interface
-
-Implement `IPropertyValueConverter` from the `Umbraco.Cms.Core.PropertyEditors` namespace on your class
+## Create a PropertyValueConverter
+A class becomes a PropertyValueConverter when it implements the `IPropertyValueConverter` interface from the `Umbraco.Cms.Core.PropertyEditors` namespace. PropertyValueConverters are automatically registered when implementing the interface. Any given PropertyEditor can only utilize a single PropertyValueConverter.
 
 ```csharp
 public class ContentPickerValueConverter : IPropertyValueConverter
 ```
 
-## Methods - Information
+{% hint style="info" %}
+Consider using the `PropertyValueConverterBase` class as the base of your PropertyValueConverter instead of the `IPropertyValueConverter` interface. The `PropertyValueConverterBase` class comes with a default implementation of `IPropertyValueConverter`, so you only need to override the functions you need to change. In contrast, if you use the `IPropertyValueConverter`, you are responsible for implementing all functions yourself. In this document, we'll assume that you are using the `IPropertyValueConverter`, so we cover all functions.
+{% endhint %}
+
+The `IPropertyValueConverter` interface exposes the following functions you need to implement:
+
+## Implement information functions
+Implement the following functions, which provide Umbraco with context about the PropertyValueConverter.
 
 ### IsConverter(IPublishedPropertyType propertyType)
 
-This method is called for each PublishedPropertyType (Document Type Property) at application startup. By returning `True` your value converter will be registered for that property type and your conversion methods will be executed whenever that value is requested.
+This method is called for each PublishedPropertyType (Document Type Property) at Umbraco startup. By returning `true`, your value converter will be registered for that property type and your conversion methods will be executed whenever that value is requested.
 
-Example: Checking if the IPublishedPropertyType EditorAlias property is equal to the alias of the core content editor. This check is a string comparison but we recommend creating a constant for it to avoid spelling errors:
+Example: Checking if the IPublishedPropertyType EditorAlias property is equal to the alias of the core content editor.\
+This check is a string comparison but we recommend creating a constant for it to avoid spelling errors:
 
 ```csharp
 public bool IsConverter(IPublishedPropertyType propertyType)
@@ -68,12 +44,70 @@ public bool IsConverter(IPublishedPropertyType propertyType)
 ```
 
 ### IsValue(object value, PropertyValueLevel level)
+The IsValue function determines whether a property contains a meaningful value or should be considered "empty" at different stages of the value conversion process. This function is essentially an advanced 'HasValue' function and is essential for Umbraco's property.HasValue() method.
 
-This method is called to determine if the passed-in value is a value, and is of the level specified. There's a basic implementation of this in `PropertyValueConverterBase`.
+{% hint style="info" %}
+There's a basic implementation of this function in `PropertyValueConverterBase` that's good enough for most scenarios.
+{% endhint %}
+
+When Umbraco needs to check if a property has a valid value, it calls IsValue progressively through three conversion levels until one returns true. They are called in the order of Source > Inter > Object. This allows you to choose at what stage of the conversion you need to perform the validation to get the best results. Consider these scenarios:
+
+```csharp
+//If value is a simple string, it's enough to just check if string is null or empty
+//This is the default implementation in PropertyValueConverterBase
+public bool? IsValue(object? value, PropertyValueLevel level)
+{
+    switch (level)
+    {
+        case PropertyValueLevel.Source:
+            return value != null && (!(value is string stringValue) || !string.IsNullOrWhiteSpace(stringValue));
+        case PropertyValueLevel.Inter:
+            return null;
+        case PropertyValueLevel.Object:
+            return null;
+        default:
+            throw new NotSupportedException($"Invalid level: {level}.");
+    }
+}
+
+//If the value is numeric, it's usually not enough to check if the raw string value is null
+//or empty, but also to check if the value is a valid int and if it doesn't contain the default value
+public bool? IsValue(object? value, PropertyValueLevel level)
+{
+    switch (level)
+    {
+        case PropertyValueLevel.Source:
+            return null;
+        case PropertyValueLevel.Inter:
+            return value is int intValue && intValue > 0;
+        case PropertyValueLevel.Object:
+            return null;
+        default:
+            throw new NotSupportedException($"Invalid level: {level}.");
+    }
+}
+
+//If the value is a complex object, you can consider checking
+//the object level
+public bool? IsValue(object? value, PropertyValueLevel level)
+{
+        switch (level)
+    {
+        case PropertyValueLevel.Source:
+            return null;
+        case PropertyValueLevel.Inter:
+            return null;
+        case PropertyValueLevel.Object:
+            return value is ComplexObject objectValue && objectValue.SomeProperty == "value";
+        default:
+            throw new NotSupportedException($"Invalid level: {level}.");
+    }
+}
+```
 
 ### GetPropertyValueType(IPublishedPropertyType propertyType)
 
-This is where you can specify the type returned by this Converter. This type will be used by ModelsBuilder to return data from properties using this Converter in the proper type.
+This is where you can specify the type returned by this converter. This type will be used by Models Builder to return data from properties using this converter in the proper type.
 
 Example: Content Picker data is being converted to `IPublishedContent`.
 
@@ -109,23 +143,13 @@ The property value will be cached until _any_ element (see above) is changed. Th
 
 This is particularly useful for property values that contain references to other content or elements. For example, this cache level is utilized by the Content Picker to clear its property values from the cache upon content updates.
 
-#### `PropertyCacheLevel.Snapshot`
-
-{% hint style="warning" %}
-`PropertyCacheLevel.Snapshot` is obsolete in Umbraco 15 and will be removed in a future version.
-{% endhint %}
-
-The property value will only be cached for the duration of the current _snapshot_.
-
-A snapshot represents a point in time. For example, a snapshot is created for every content request from the frontend. When accessing a property in a snapshot using this cache level, it gets converted, cached throughout the snapshot, and later cleared.
-
-For all intents and purposes, think of this cache level as "per request". If your property value should _only_ be cached per request, this is the cache level you should use. Use it with caution, as the added property conversions incur a performance penalty.
-
 #### `PropertyCacheLevel.None`
 
 The property value will _never_ be cached. Every time a property value is accessed (even within the same snapshot) property conversion is performed explicitly.
 
+{% hint style="danger" %}
 Use this cache level with extreme caution, as it incurs a massive performance penalty.
+{% endhint %}
 
 ```csharp
 public PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
@@ -134,17 +158,16 @@ public PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyT
 }
 ```
 
-## Methods - Conversion
-
-There are a few different levels of conversion which can occur.
+## Implement conversion functions
+Implement the functions that perform the conversion from a raw database value to an intermediate value and then to the final type. Conversions happen in two steps.
 
 ### ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
+This method converts the raw data value into an appropriate intermediate type that is needed for the final conversion step to an object. For example, for a node picker the node identifier's raw value is saved as a `string`, but to get to an `IPublishedContent` in the final conversion step, we need a `Udi` instead of a `string`. So in the intermediate step, we check if the string value is a valid `Udi` and convert the string to a `Udi` as the intermediate value.
 
-This method should convert the raw data value into an appropriate type. For example, a node identifier stored as a `String` should be converted to an `Int` or `Udi`.
-
-Include a `using Umbraco.Extensions;` to be able to use the `TryConvertTo` extension method.
+Include `using Umbraco.Extensions` to be able to use the `TryConvertTo` extension method.
 
 ```csharp
+//Example of a conversion to an int or Guid for a node identifier
 public object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
 {
     if (source == null) return null;
@@ -159,46 +182,78 @@ public object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPro
 
     return null;
 }
+
+//For simple property editors, like a textbox, that only store a text string,
+//you can just return the raw value since the intermediate and raw values are the same
+public object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
+{
+    return source as string;
+}
 ```
 
 ### ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
 
-This method converts the Intermediate to an Object. The returned value is used by the `GetPropertyValue<T>` method of `IPublishedContent`.
+This method converts the intermediate value to an object of the type specified in the `GetPropertyValueType()` function of the PropertyValueConverter. The returned value is used by the `GetPropertyValue<T>` method of `IPublishedContent`.
 
-{% include "../../.gitbook/includes/obsolete-warning-ipublishedsnapshotaccessor.md" %}
-
-The below example converts the nodeId (converted to `Int` or `Udi` by _ConvertSourceToIntermediate_) into an 'IPublishedContent' object.
+The example below converts the node ID (converted to `int` or `Udi` by _ConvertSourceToIntermediate_) into an `IPublishedContent` object.
 
 ```csharp
+// In this example _contentCache is an instance of IPublishedContentCache that is injected
 public object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
 {
     if (inter == null)
         return null;
 
-    if ((propertyType.Alias != null && PropertiesToExclude.Contains(propertyType.Alias.ToLower(CultureInfo.InvariantCulture))) == false)
+    if (inter is int id)
     {
-        IPublishedContent content;
-        if (inter is int id)
-        {
-            content = _publishedSnapshotAccessor.PublishedSnapshot.Content.GetById(id);
-            if (content != null)
-                return content;
-        }
-        else
-        {
-            var udi = inter as GuidUdi;
-            if (udi == null)
-                return null;
-            content = _publishedSnapshotAccessor.PublishedSnapshot.Content.GetById(udi.Guid);
-            if (content != null && content.ContentType.ItemType == PublishedItemType.Content)
-                return content;
-        }
+        var content = _contentCache.GetById(id);
+        if (content != null)
+            return content;
+    }
+    else if (inter is GuidUdi udi)
+    {
+        var content = _contentCache.GetById(udi.Guid);
+        if (content != null && content.ContentType.ItemType == PublishedItemType.Content)
+            return content;
     }
 
     return inter;
 }
 ```
 
-## Sample
+## Override existing PropertyValueConverters
+If you are implementing a PropertyValueConverter for a PropertyEditor that doesn't already have one, creating the PropertyValueConverter will automatically enable it. No further actions are needed.
+
+If you aim to override an existing PropertyValueConverter, possibly from Umbraco or a package, additional steps are necessary. Deregister the existing one to prevent conflicts.
+
+{% hint style="info" %}
+The built-in PropertyValueConverters included with Umbraco are currently marked as internal. This means you will not be able to remove them by type since the type isn't accessible outside of its namespace. In order to remove such PropertyValueConverters, you will need to look up the instance by name and then deregister it by the instance. This could be the case for other PropertyValueConverters included by packages as well, depending on the implementation details.
+{% endhint %}
+
+```csharp
+using System.Linq;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+
+public class MyComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        //If the type is accessible (not internal) you can deregister it by the type:
+        builder.PropertyValueConverters().Remove<MyCustom.StandardValueConnector>();
+
+        //If the type is not accessible you will need to locate the instance and then remove it:
+        var contentPickerValueConverter = builder.PropertyValueConverters().GetTypes()
+            .FirstOrDefault(converter => converter.Name == "ContentPickerValueConverter");
+
+        if (contentPickerValueConverter != null)
+        {
+            builder.PropertyValueConverters().Remove(contentPickerValueConverter);
+        }
+    }
+}
+```
+
+## Full example
 
 [Content Picker to `IPublishedContent` using `IPropertyValueConverter` interface](full-examples-value-converters.md)

--- a/16/umbraco-cms/.gitbook.yaml
+++ b/16/umbraco-cms/.gitbook.yaml
@@ -113,6 +113,7 @@ redirects:
     reference/configuration/runtimeminificationsettings: reference/configuration/README.md
     reference/routing/umbraco-api-controllers/authorization: reference/routing/umbraco-api-controllers/README.md
     reference/routing/umbraco-api-controllers/routing: reference/routing/umbraco-api-controllers/README.md
+    reference/notifications/sendingallowedchildrennotifications: reference/content-type-filters.md
     extending/property-editors/package-manifest: customizing/umbraco-package.md
     fundamentals/backoffice/infinite-editing: fundamentals/backoffice/sidebar.md
     extending/backoffice-tours: extending/build-on-umbraco-functionality.md

--- a/16/umbraco-cms/SUMMARY.md
+++ b/16/umbraco-cms/SUMMARY.md
@@ -369,7 +369,6 @@
   * [Determining if an entity is new](reference/notifications/determining-new-entity.md)
   * [MediaService Notifications Example](reference/notifications/mediaservice-notifications.md)
   * [MemberService Notifications Example](reference/notifications/memberservice-notifications.md)
-  * [Sending Allowed Children Notification](reference/notifications/sendingallowedchildrennotifications.md)
   * [Umbraco Application Lifetime Notifications](reference/notifications/umbracoapplicationlifetime-notifications.md)
   * [EditorModel Notifications](reference/notifications/editormodel-notifications/README.md)
   * [Hot vs. cold restarts](reference/notifications/hot-vs-cold-restarts.md)

--- a/16/umbraco-cms/customizing/property-editors/property-value-converters.md
+++ b/16/umbraco-cms/customizing/property-editors/property-value-converters.md
@@ -4,14 +4,14 @@ description: A guide to creating a custom property value converter in Umbraco
 
 # Property Value Converters
 
-A Property Value Converter converts a property editor's database-stored value into another type that is stored in the Umbraco cache. This way, the database stores only the most essential data, while Razor views, the Published Content API and the Content Delivery API can work with strong typed and cleaner models.
+A Property Value Converter converts a property editor's database-stored value into another type that is stored in the Umbraco cache. This way, the database stores only the most essential data, while Razor views, the Published Content API, and the Content Delivery API can work with strongly typed and cleaner models.
 
 For example, a Document picker typically only stores the Key of the picked node in the database, but when working with the published data, an IPublishedContent object is returned instead of just the key. This conversion is done by a Property Value Converter.
 
 A PropertyValueConverter has three conversion levels:
-* **Source** - The raw data stored in the database, this is generally a `String`
-* **Intermediate** - An object of a type that is appropriate to the property, for example a node key should be a `Guid` or a collection of node keys would be an Guid array `Guid[]`
-* **Object** - The object to be used when accessing the property using a Published Content API, for example UmbracoHelper's `GetPropertyValue<T>` method. Also, te models builder generates a property of the type of the object.
+* **Source** - The raw data stored in the database; this is generally a `string`.
+* **Intermediate** - An object of a type that is appropriate to the property. For example, a node key should be a `Guid`, or a collection of node keys would be a `Guid[]` array.
+* **Object** - The object to be used when accessing the property using the Published Content API; for example, UmbracoHelper's `GetPropertyValue<T>` method. Also, the Models Builder generates a property of the type of the object.
 
 ## Create a PropertyValueConverter
 A class becomes a PropertyValueConverter when it implements the `IPropertyValueConverter` interface from the `Umbraco.Cms.Core.PropertyEditors` namespace. PropertyValueConverters are automatically registered when implementing the interface. Any given PropertyEditor can only utilize a single PropertyValueConverter.
@@ -21,7 +21,7 @@ public class ContentPickerValueConverter : IPropertyValueConverter
 ```
 
 {% hint style="info" %}
-Consider using the `PropertyValueConverterBase` class as the base of your PropertyValueConverter instead of the `IPropertyValueConverter` interface. The `PropertyValueConverterBase` class comes with a default implementation of `IPropertyValueConverter`, so you only need to override the functions you need to change. In contrast, if you use the `IPropertyValueConverter` you are responsible for implementing all functions yourself. In this document we'll assume that you are using the `IPropertyValueConverter` so we cover all functions.
+Consider using the `PropertyValueConverterBase` class as the base of your PropertyValueConverter instead of the `IPropertyValueConverter` interface. The `PropertyValueConverterBase` class comes with a default implementation of `IPropertyValueConverter`, so you only need to override the functions you need to change. In contrast, if you use the `IPropertyValueConverter`, you are responsible for implementing all functions yourself. In this document, we'll assume that you are using the `IPropertyValueConverter`, so we cover all functions.
 {% endhint %}
 
 The `IPropertyValueConverter` interface exposes the following functions you need to implement:
@@ -31,7 +31,7 @@ Implement the following functions, which provide Umbraco with context about the 
 
 ### IsConverter(IPublishedPropertyType propertyType)
 
-This method is called for each PublishedPropertyType (Document Type Property) at Umbraco startup. By returning `True` your value converter will be registered for that property type and your conversion methods will be executed whenever that value is requested.
+This method is called for each PublishedPropertyType (Document Type Property) at Umbraco startup. By returning `true`, your value converter will be registered for that property type and your conversion methods will be executed whenever that value is requested.
 
 Example: Checking if the IPublishedPropertyType EditorAlias property is equal to the alias of the core content editor.\
 This check is a string comparison but we recommend creating a constant for it to avoid spelling errors:
@@ -47,10 +47,10 @@ public bool IsConverter(IPublishedPropertyType propertyType)
 The IsValue function determines whether a property contains a meaningful value or should be considered "empty" at different stages of the value conversion process. This function is essentially an advanced 'HasValue' function and is essential for Umbraco's property.HasValue() method.
 
 {% hint style="info" %}
-There's a basic implementation of this function in `PropertyValueConverterBase` that's good enough for most scenario's.
+There's a basic implementation of this function in `PropertyValueConverterBase` that's good enough for most scenarios.
 {% endhint %}
 
-When Umbraco needs to check if a property has a valid value, it calls IsValue progressively through three conversion levels until one returns true. They are called in the order of Source > Inter > Object. This allows you to choose in what stage of the conversion you need to perform the validation to get the best results. Consider these scenario's:
+When Umbraco needs to check if a property has a valid value, it calls IsValue progressively through three conversion levels until one returns true. They are called in the order of Source > Inter > Object. This allows you to choose at what stage of the conversion you need to perform the validation to get the best results. Consider these scenarios:
 
 ```csharp
 //If value is a simple string, it's enough to just check if string is null or empty
@@ -71,7 +71,7 @@ public bool? IsValue(object? value, PropertyValueLevel level)
 }
 
 //If the value is numeric, it's usually not enough to check if the raw string value is null
-//or empty, but also to check if the value is a valid int and if doesn't contain the default value
+//or empty, but also to check if the value is a valid int and if it doesn't contain the default value
 public bool? IsValue(object? value, PropertyValueLevel level)
 {
     switch (level)
@@ -107,7 +107,7 @@ public bool? IsValue(object? value, PropertyValueLevel level)
 
 ### GetPropertyValueType(IPublishedPropertyType propertyType)
 
-This is where you can specify the type returned by this Converter. This type will be used by ModelsBuilder to return data from properties using this Converter in the proper type.
+This is where you can specify the type returned by this converter. This type will be used by Models Builder to return data from properties using this converter in the proper type.
 
 Example: Content Picker data is being converted to `IPublishedContent`.
 
@@ -162,7 +162,7 @@ public PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyT
 Implement the functions that perform the conversion from a raw database value to an intermediate value and then to the final type. Conversions happen in two steps.
 
 ### ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
-This method converts the raw data value into an appropriate intermediate type that is needed for the final conversion step to object. For example, for a node picker the node identifier's raw value is saved as a `String`, but to get to an `IPublishedContent` in the final conversion step, we need a `Udi` instead of a `String`. So in the intermediate step, we check if the string value is a valid `Uid` and convert the string to a `Uid` as intermediate value.
+This method converts the raw data value into an appropriate intermediate type that is needed for the final conversion step to an object. For example, for a node picker the node identifier's raw value is saved as a `string`, but to get to an `IPublishedContent` in the final conversion step, we need a `Udi` instead of a `string`. So in the intermediate step, we check if the string value is a valid `Udi` and convert the string to a `Udi` as the intermediate value.
 
 Include `using Umbraco.Extensions` to be able to use the `TryConvertTo` extension method.
 
@@ -183,7 +183,7 @@ public object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPro
     return null;
 }
 
-//For simple property editors, like a textbox, that only store a text string
+//For simple property editors, like a textbox, that only store a text string,
 //you can just return the raw value since the intermediate and raw values are the same
 public object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
 {
@@ -193,9 +193,9 @@ public object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPro
 
 ### ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
 
-This method converts the Intermediate to an Object of the type specified in the `GetPropertyValueType()` function of the PropertyValueConverter. The returned value is used by the `GetPropertyValue<T>` method of `IPublishedContent`.
+This method converts the intermediate value to an object of the type specified in the `GetPropertyValueType()` function of the PropertyValueConverter. The returned value is used by the `GetPropertyValue<T>` method of `IPublishedContent`.
 
-The below example converts the nodeId (converted to `Int` or `Udi` by _ConvertSourceToIntermediate_) into an 'IPublishedContent' object.
+The example below converts the node ID (converted to `int` or `Udi` by _ConvertSourceToIntermediate_) into an `IPublishedContent` object.
 
 ```csharp
 // In this example _contentCache is an instance of IPublishedContentCache that is injected
@@ -224,10 +224,10 @@ public object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPro
 ## Override existing PropertyValueConverters
 If you are implementing a PropertyValueConverter for a PropertyEditor that doesn't already have one, creating the PropertyValueConverter will automatically enable it. No further actions are needed.
 
-If you aim to override an existing PropertyValueConverter, possibly from Umbraco or a package, additional steps are necessary. Deregister the existing one to prevent conflicts in this scenario.
+If you aim to override an existing PropertyValueConverter, possibly from Umbraco or a package, additional steps are necessary. Deregister the existing one to prevent conflicts.
 
 {% hint style="info" %}
-The built-in PropertyValueConverters included with Umbraco, are currently marked as internal. This means you will not be able to remove them by type since the type isn't accessible outside of the namespace. In order to remove such PropertyValueConverters, you will need to look up the instance by name and then deregister it by the instance. This could be the case for other PropertyValueConverters included by packages as well, depending on the implementation details.
+The built-in PropertyValueConverters included with Umbraco are currently marked as internal. This means you will not be able to remove them by type since the type isn't accessible outside of its namespace. In order to remove such PropertyValueConverters, you will need to look up the instance by name and then deregister it by the instance. This could be the case for other PropertyValueConverters included by packages as well, depending on the implementation details.
 {% endhint %}
 
 ```csharp

--- a/16/umbraco-cms/customizing/property-editors/property-value-converters.md
+++ b/16/umbraco-cms/customizing/property-editors/property-value-converters.md
@@ -21,7 +21,7 @@ public class ContentPickerValueConverter : IPropertyValueConverter
 ```
 
 {% hint style="info" %}
-Consider using the `PropertyValueConverterBase` class as the base of your PropertyValueConverter instead of the `IPropertyValueConverter` interface. The `PropertyValueConverterBase` class comes with a default implementation of `IPropertyValueConverter`, so you only need to override the functions you need to change. In contrast, if you use the `IPropertyValueConverter`, you are responsible for implementing all functions yourself. In this document, we'll assume that you are using the `IPropertyValueConverter`, so we cover all functions.
+Consider using the `PropertyValueConverterBase` class as the base of your PropertyValueConverter instead of the `IPropertyValueConverter` interface. The `PropertyValueConverterBase` class comes with a default implementation of `IPropertyValueConverter`, so you only need to override the functions you need to change. In contrast, if you use the `IPropertyValueConverter`, you are responsible for implementing all functions yourself. In this document, it is assumed that you are using the `IPropertyValueConverter`, so functions are covered.
 {% endhint %}
 
 The `IPropertyValueConverter` interface exposes the following functions you need to implement:
@@ -126,7 +126,7 @@ A property value can be cached at the following levels:
 
 #### `PropertyCacheLevel.Unknown`
 
-Do not use this cache level unless you know exactly what you're doing. We recommend using the `PropertyCacheLevel.Element` level.
+Do not use this cache level unless you know exactly what you're doing. It is recommend using the `PropertyCacheLevel.Element` level.
 
 #### `PropertyCacheLevel.Element`
 
@@ -162,7 +162,7 @@ public PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyT
 Implement the functions that perform the conversion from a raw database value to an intermediate value and then to the final type. Conversions happen in two steps.
 
 ### ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
-This method converts the raw data value into an appropriate intermediate type that is needed for the final conversion step to an object. For example, for a node picker the node identifier's raw value is saved as a `string`, but to get to an `IPublishedContent` in the final conversion step, we need a `Udi` instead of a `string`. So in the intermediate step, we check if the string value is a valid `Udi` and convert the string to a `Udi` as the intermediate value.
+This method converts the raw data value into an appropriate intermediate type that is needed for the final conversion step to an object. For example, for a node picker the node identifier's raw value is saved as a `string`, but to get to an `IPublishedContent` in the final conversion step, we need a `Udi` instead of a `string`. So in the intermediate step, check if the string value is a valid `Udi` and convert the string to a `Udi` as the intermediate value.
 
 Include `using Umbraco.Extensions` to be able to use the `TryConvertTo` extension method.
 

--- a/16/umbraco-cms/customizing/property-editors/property-value-converters.md
+++ b/16/umbraco-cms/customizing/property-editors/property-value-converters.md
@@ -4,59 +4,34 @@ description: A guide to creating a custom property value converter in Umbraco
 
 # Property Value Converters
 
-A Property Value Converter converts a property editor's database-stored value to another type. The converted value can be accessed from MVC Razor or any other Published Content API.
+A Property Value Converter converts a property editor's database-stored value into another type that is stored in the Umbraco cache. This way, the database stores only the most essential data, while Razor views, the Published Content API and the Content Delivery API can work with strong typed and cleaner models.
 
-Published property values have four "Values":
+For example, a Document picker typically only stores the Key of the picked node in the database, but when working with the published data, an IPublishedContent object is returned instead of just the key. This conversion is done by a Property Value Converter.
 
+A PropertyValueConverter has three conversion levels:
 * **Source** - The raw data stored in the database, this is generally a `String`
-* **Intermediate** - An object of a type that is appropriate to the property, for example a nodeId should be an `Int` or a collection of nodeIds would be an integer array, `Int[]`
-* **Object** - The object to be used when accessing the property using a Published Content API, for example UmbracoHelper's `GetPropertyValue<T>` method
+* **Intermediate** - An object of a type that is appropriate to the property, for example a node key should be a `Guid` or a collection of node keys would be an Guid array `Guid[]`
+* **Object** - The object to be used when accessing the property using a Published Content API, for example UmbracoHelper's `GetPropertyValue<T>` method. Also, te models builder generates a property of the type of the object.
 
-## Registering PropertyValueConverters
-
-PropertyValueConverters are automatically registered when implementing the interface. Any given PropertyEditor can only utilize a single PropertyValueConverter.
-
-If you are implementing a PropertyValueConverter for a PropertyEditor that doesn't already have one, creating the PropertyValueConverter will automatically enable it. No further actions are needed.
-
-If you aim to override an existing PropertyValueConverter, possibly from Umbraco or a package, additional steps are necessary. Deregister the existing one to prevent conflicts in this scenario.
-
-```csharp
-using System.Linq;
-using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Core.DependencyInjection;
-
-public class MyComposer : IComposer
-{
-    public void Compose(IUmbracoBuilder builder)
-    {
-        //If the type is accessible (not internal) you can deregister it by the type:
-        builder.PropertyValueConverters().Remove<MyCustom.StandardValueConnector>();
-
-        //If the type is not accessible you will need to locate the instance and then remove it:
-        var contentPickerValueConverter = builder.PropertyValueConverters().GetTypes().FirstOrDefault(x => x.Name == "ContentPickerValueConverter");
-        if (contentPickerValueConverter != null)
-        {
-            builder.PropertyValueConverters().Remove(contentPickerValueConverter);
-        }
-    }
-}
-```
-
-The built-in PropertyValueConverters included with Umbraco, are currently marked as internal. This means you will not be able to remove them by type since the type isn't accessible outside of the namespace. In order to remove such PropertyValueConverters, you will need to look up the instance by name and then deregister it by the instance. This could be the case for other PropertyValueConverters included by packages as well, depending on the implementation details.
-
-## Implementing the Interface
-
-Implement `IPropertyValueConverter` from the `Umbraco.Cms.Core.PropertyEditors` namespace on your class
+## Create a PropertyValueConverter
+A class becomes a PropertyValueConverter when it implements the `IPropertyValueConverter` interface from the `Umbraco.Cms.Core.PropertyEditors` namespace. PropertyValueConverters are automatically registered when implementing the interface. Any given PropertyEditor can only utilize a single PropertyValueConverter.
 
 ```csharp
 public class ContentPickerValueConverter : IPropertyValueConverter
 ```
 
-## Methods - Information
+{% hint style="info" %}
+Consider using the `PropertyValueConverterBase` class as the base of your PropertyValueConverter instead of the `IPropertyValueConverter` interface. The `PropertyValueConverterBase` class comes with a default implementation of `IPropertyValueConverter`, so you only need to override the functions you need to change. In contrast, if you use the `IPropertyValueConverter` you are responsible for implementing all functions yourself. In this document we'll assume that you are using the `IPropertyValueConverter` so we cover all functions.
+{% endhint %}
+
+The `IPropertyValueConverter` interface exposes the following functions you need to implement:
+
+## Implement information functions
+Implement the following functions, which provide Umbraco with context about the PropertyValueConverter.
 
 ### IsConverter(IPublishedPropertyType propertyType)
 
-This method is called for each PublishedPropertyType (Document Type Property) at application startup. By returning `True` your value converter will be registered for that property type and your conversion methods will be executed whenever that value is requested.
+This method is called for each PublishedPropertyType (Document Type Property) at Umbraco startup. By returning `True` your value converter will be registered for that property type and your conversion methods will be executed whenever that value is requested.
 
 Example: Checking if the IPublishedPropertyType EditorAlias property is equal to the alias of the core content editor.\
 This check is a string comparison but we recommend creating a constant for it to avoid spelling errors:
@@ -69,8 +44,66 @@ public bool IsConverter(IPublishedPropertyType propertyType)
 ```
 
 ### IsValue(object value, PropertyValueLevel level)
+The IsValue function determines whether a property contains a meaningful value or should be considered "empty" at different stages of the value conversion process. This function is essentially an advanced 'HasValue' function and is essential for Umbraco's property.HasValue() method.
 
-This method is called to determine if the passed-in value is a value, and is of the level specified. There's a basic implementation of this in `PropertyValueConverterBase`.
+{% hint style="info" %}
+There's a basic implementation of this function in `PropertyValueConverterBase` that's good enough for most scenario's.
+{% endhint %}
+
+When Umbraco needs to check if a property has a valid value, it calls IsValue progressively through three conversion levels until one returns true. They are called in the order of Source > Inter > Object. This allows you to choose in what stage of the conversion you need to perform the validation to get the best results. Consider these scenario's:
+
+```csharp
+//If value is a simple string, it's enough to just check if string is null or empty
+//This is the default implementation in PropertyValueConverterBase
+public bool? IsValue(object? value, PropertyValueLevel level)
+{
+    switch (level)
+    {
+        case PropertyValueLevel.Source:
+            return value != null && (!(value is string stringValue) || !string.IsNullOrWhiteSpace(stringValue));
+        case PropertyValueLevel.Inter:
+            return null;
+        case PropertyValueLevel.Object:
+            return null;
+        default:
+            throw new NotSupportedException($"Invalid level: {level}.");
+    }
+}
+
+//If the value is numeric, it's usually not enough to check if the raw string value is null
+//or empty, but also to check if the value is a valid int and if doesn't contain the default value
+public bool? IsValue(object? value, PropertyValueLevel level)
+{
+    switch (level)
+    {
+        case PropertyValueLevel.Source:
+            return null;
+        case PropertyValueLevel.Inter:
+            return value is int intValue && intValue > 0;
+        case PropertyValueLevel.Object:
+            return null;
+        default:
+            throw new NotSupportedException($"Invalid level: {level}.");
+    }
+}
+
+//If the value is a complex object, you can consider checking
+//the object level
+public bool? IsValue(object? value, PropertyValueLevel level)
+{
+        switch (level)
+    {
+        case PropertyValueLevel.Source:
+            return null;
+        case PropertyValueLevel.Inter:
+            return null;
+        case PropertyValueLevel.Object:
+            return value is ComplexObject objectValue && objectValue.SomeProperty == "value";
+        default:
+            throw new NotSupportedException($"Invalid level: {level}.");
+    }
+}
+```
 
 ### GetPropertyValueType(IPublishedPropertyType propertyType)
 
@@ -110,23 +143,13 @@ The property value will be cached until _any_ element (see above) is changed. Th
 
 This is particularly useful for property values that contain references to other content or elements. For example, this cache level is utilized by the Content Picker to clear its property values from the cache upon content updates.
 
-#### `PropertyCacheLevel.Snapshot`
-
-{% hint style="warning" %}
-`PropertyCacheLevel.Snapshot` is obsolete in Umbraco 15 and will be removed in a future version.
-{% endhint %}
-
-The property value will only be cached for the duration of the current _snapshot_.
-
-A snapshot represents a point in time. For example, a snapshot is created for every content request from the frontend. When accessing a property in a snapshot using this cache level, it gets converted, cached throughout the snapshot, and later cleared.
-
-For all intents and purposes, think of this cache level as "per request". If your property value should _only_ be cached per request, this is the cache level you should use. Use it with caution, as the added property conversions incur a performance penalty.
-
 #### `PropertyCacheLevel.None`
 
 The property value will _never_ be cached. Every time a property value is accessed (even within the same snapshot) property conversion is performed explicitly.
 
+{% hint style="danger" %}
 Use this cache level with extreme caution, as it incurs a massive performance penalty.
+{% endhint %}
 
 ```csharp
 public PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
@@ -135,17 +158,16 @@ public PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyT
 }
 ```
 
-## Methods - Conversion
-
-There are a few different levels of conversion which can occur.
+## Implement conversion functions
+Implement the functions that perform the conversion from a raw database value to an intermediate value and then to the final type. Conversions happen in two steps.
 
 ### ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
+This method converts the raw data value into an appropriate intermediate type that is needed for the final conversion step to object. For example, for a node picker the node identifier's raw value is saved as a `String`, but to get to an `IPublishedContent` in the final conversion step, we need a `Udi` instead of a `String`. So in the intermediate step, we check if the string value is a valid `Uid` and convert the string to a `Uid` as intermediate value.
 
-This method should convert the raw data value into an appropriate type. For example, a node identifier stored as a `String` should be converted to an `Int` or `Udi`.
-
-Include a `using Umbraco.Extensions;` to be able to use the `TryConvertTo` extension method.
+Include `using Umbraco.Extensions` to be able to use the `TryConvertTo` extension method.
 
 ```csharp
+//Example of a conversion to an int or Guid for a node identifier
 public object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
 {
     if (source == null) return null;
@@ -160,46 +182,78 @@ public object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPro
 
     return null;
 }
+
+//For simple property editors, like a textbox, that only store a text string
+//you can just return the raw value since the intermediate and raw values are the same
+public object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
+{
+    return source as string;
+}
 ```
 
 ### ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
 
-This method converts the Intermediate to an Object. The returned value is used by the `GetPropertyValue<T>` method of `IPublishedContent`.
-
-{% include "../../.gitbook/includes/obsolete-warning-ipublishedsnapshotaccessor.md" %}
+This method converts the Intermediate to an Object of the type specified in the `GetPropertyValueType()` function of the PropertyValueConverter. The returned value is used by the `GetPropertyValue<T>` method of `IPublishedContent`.
 
 The below example converts the nodeId (converted to `Int` or `Udi` by _ConvertSourceToIntermediate_) into an 'IPublishedContent' object.
 
 ```csharp
+// In this example _contentCache is an instance of IPublishedContentCache that is injected
 public object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
 {
     if (inter == null)
         return null;
 
-    if ((propertyType.Alias != null && PropertiesToExclude.Contains(propertyType.Alias.ToLower(CultureInfo.InvariantCulture))) == false)
+    if (inter is int id)
     {
-        IPublishedContent content;
-        if (inter is int id)
-        {
-            content = _publishedSnapshotAccessor.PublishedSnapshot.Content.GetById(id);
-            if (content != null)
-                return content;
-        }
-        else
-        {
-            var udi = inter as GuidUdi;
-            if (udi == null)
-                return null;
-            content = _publishedSnapshotAccessor.PublishedSnapshot.Content.GetById(udi.Guid);
-            if (content != null && content.ContentType.ItemType == PublishedItemType.Content)
-                return content;
-        }
+        var content = _contentCache.GetById(id);
+        if (content != null)
+            return content;
+    }
+    else if (inter is GuidUdi udi)
+    {
+        var content = _contentCache.GetById(udi.Guid);
+        if (content != null && content.ContentType.ItemType == PublishedItemType.Content)
+            return content;
     }
 
     return inter;
 }
 ```
 
-## Sample
+## Override existing PropertyValueConverters
+If you are implementing a PropertyValueConverter for a PropertyEditor that doesn't already have one, creating the PropertyValueConverter will automatically enable it. No further actions are needed.
+
+If you aim to override an existing PropertyValueConverter, possibly from Umbraco or a package, additional steps are necessary. Deregister the existing one to prevent conflicts in this scenario.
+
+{% hint style="info" %}
+The built-in PropertyValueConverters included with Umbraco, are currently marked as internal. This means you will not be able to remove them by type since the type isn't accessible outside of the namespace. In order to remove such PropertyValueConverters, you will need to look up the instance by name and then deregister it by the instance. This could be the case for other PropertyValueConverters included by packages as well, depending on the implementation details.
+{% endhint %}
+
+```csharp
+using System.Linq;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+
+public class MyComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        //If the type is accessible (not internal) you can deregister it by the type:
+        builder.PropertyValueConverters().Remove<MyCustom.StandardValueConnector>();
+
+        //If the type is not accessible you will need to locate the instance and then remove it:
+        var contentPickerValueConverter = builder.PropertyValueConverters().GetTypes()
+            .FirstOrDefault(converter => converter.Name == "ContentPickerValueConverter");
+
+        if (contentPickerValueConverter != null)
+        {
+            builder.PropertyValueConverters().Remove(contentPickerValueConverter);
+        }
+    }
+}
+```
+
+## Full example
 
 [Content Picker to `IPublishedContent` using `IPropertyValueConverter` interface](full-examples-value-converters.md)

--- a/16/umbraco-cms/reference/content-type-filters.md
+++ b/16/umbraco-cms/reference/content-type-filters.md
@@ -1,6 +1,9 @@
 ---
 description: Describes how to use Content Type Filters to restrict the allowed content options available to editors.
 ---
+{% hint style="info" %}
+The use cases supported here are similar to those where the `SendingAllowedChildrenNotification` would be used in Umbraco 13 or earlier.
+{% endhint %}
 
 # Filtering Allowed Content Types
 
@@ -9,10 +12,6 @@ When content editors add new content they are presented with a dialog where they
 Implementors and package creators can add additional logic to determine which options are available to the editors.
 
 This is possible using Content Type Filters.
-
-{% hint style="info" %}
-The use cases supported here are similar to those where the `SendingAllowedChildrenNotification` would be used in Umbraco 13 or earlier.
-{% endhint %}
 
 ## Implementing a Content Type Filter
 

--- a/16/umbraco-cms/reference/notifications/README.md
+++ b/16/umbraco-cms/reference/notifications/README.md
@@ -285,5 +285,4 @@ Below you can find some articles with some examples using Notifications.
 * [Hot vs. cold restarts](hot-vs-cold-restarts.md)
 * [MediaService Notifications](mediaservice-notifications.md)
 * [MemberService Notifications](memberservice-notifications.md)
-* [Sending Allowed Children Notification](sendingallowedchildrennotifications.md)
 * [Umbraco Application Lifetime Notifications](umbracoapplicationlifetime-notifications.md)

--- a/16/umbraco-cms/reference/notifications/sendingallowedchildrennotifications.md
+++ b/16/umbraco-cms/reference/notifications/sendingallowedchildrennotifications.md
@@ -1,9 +1,0 @@
----
-description: Example of how to use a SendingAllowedChildren Notification
----
-
-# Sending Allowed Children Notification
-
-The `SendingAllowedChildrenNotification` is no longer available in Umbraco 15.
-
-Please see [content type filters](../content-type-filters.md) as the supported alternative for use cases that previously relied on this notification.


### PR DESCRIPTION
## 📋 Description
This PR updates the examples of PropertyValueConverters to Umbraco 15+. I updated both the Umbraco 15 and 16 documentation. And while I was at it, I also revised the pages thoroughly.

## 📎 Related Issues (if applicable)
Fixes [#7336](https://github.com/umbraco/UmbracoDocs/issues/7336)

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)
v15 and v16 (versions with the new cache)

## Deadline (if relevant)
-

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
