### PR TITLE
Update LinkTextClarity.yml

### DIFF
--- a/.github/styles/UmbracoDocs/LinkTextClarity.yml
+++ b/.github/styles/UmbracoDocs/LinkTextClarity.yml
@@ -2,10 +2,8 @@
 extends: existence
 message: "Avoid generic link text like '%s'. Use descriptive link text instead."
 description: >
-  Descriptive link text improves accessibility and SEO.
+  Descriptive link text improves accessibility and SEO by clearly indicating
+  where the link leads, rather than using vague terms.
 level: warning
-tokens:
-  - 'click here'
-  - 'read more'
-  - 'more info'
-  - '\bhere\b'
+raw:
+  - '(?i)\[(?:click here|here)\]\([^)]*\)'


### PR DESCRIPTION
Changed `tokens` to `raw`. The goal of this rule is to check for terms like "here" and "click here" in the link text because these are vague terms. The rule should flag these terms in the link text and not in sentences/paragraphs.

## 📋 Description

<!-- A clear and concise description of what this PR changes or adds. Include context if necessary. -->

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
