### PR TITLE
Add Forms 13.6.0 and 16.1.0 release notes and update licensing model page

### DIFF
--- a/10/umbraco-forms/installation/the-licensing-model.md
+++ b/10/umbraco-forms/installation/the-licensing-model.md
@@ -7,7 +7,7 @@ Umbraco Forms is a commercial product. You have a 14-day free trial to try out t
 Licenses are sold per domain and will also work on all subdomains. With every license, you will be able to configure two development/testing domains.
 
 {% hint style="info" %}
-The licenses are not bound to a specific product version. They will work for all versions of the related product.
+The licenses are not bound to a specific product version. They will work for all versions of the related product, but version 17+ will only be available through a subscription based license (see [announcement](https://github.com/umbraco/Announcements/issues/25)).
 {% endhint %}
 
 ### Example

--- a/13/umbraco-forms/developer/configuration/README.md
+++ b/13/umbraco-forms/developer/configuration/README.md
@@ -244,7 +244,7 @@ If you want to ensure form creators always have to provide a caption, you can se
 
 ### UseViewEngineFormThemeResolver
 
-Forms introduced an alternative `IFormThemeResolver` in 13.6 that uses the View Engine (`ICompositeViewEngine`) to resolve theme views, instead of relying on physical files to exist (and doing I/O lookups via the Partial Views file system abstraction). To take advantage of this new resolver, you can set the value of this setting to `true`.
+Switches the `IFormThemeResolver` to use the View Engine (`ICompositeViewEngine`) to resolve theme views. This is done instead of relying on physical files to exist and doing I/O lookups via the `PartialViews` file system abstraction. To take advantage of this new resolver (available since 13.6), you can set the value of this setting to `true`.
 
 ### Form default settings configuration
 

--- a/13/umbraco-forms/developer/configuration/README.md
+++ b/13/umbraco-forms/developer/configuration/README.md
@@ -73,7 +73,8 @@ For illustration purposes, the following structure represents the full set of op
         "PrevalueSourceTypes": {},
         "WorkflowTypes": {},
       },
-      "MandatoryFieldsetLegends": false
+      "MandatoryFieldsetLegends": false,
+      "UseViewEngineFormThemeResolver": false
     },
     "Options": {
       "IgnoreWorkFlowsOnEdit": "True",
@@ -240,6 +241,10 @@ The default value and read-only settings apply to most setting types. There is a
 When creating a form with Umbraco Forms, adding captions to the groups for fields is optional. To follow accessibility best practices, these fields should be completed. When they are, the group of fields are presented within a `<fieldset>` element that has a populated `<legend>`.
 
 If you want to ensure form creators always have to provide a caption, you can set the value of this setting to `true`.
+
+### UseViewEngineFormThemeResolver
+
+Forms introduced an alternative `IFormThemeResolver` in 13.6 that uses the View Engine (`ICompositeViewEngine`) to resolve theme views, instead of relying on physical files to exist (and doing I/O lookups via the Partial Views file system abstraction). To take advantage of this new resolver, you can set the value of this setting to `true`.
 
 ### Form default settings configuration
 

--- a/13/umbraco-forms/installation/the-licensing-model.md
+++ b/13/umbraco-forms/installation/the-licensing-model.md
@@ -69,7 +69,7 @@ You can configure either the one-off purchase license file or when using version
 
 Once you've configured your license with the correct domains, you are ready to install the license on your Umbraco installation.
 
-1. Obtain the license from the sales team, they will send you a `.lic` file
+1. Obtain the license (a `.lic` file) from the sales team
 2. Place the file in the `/umbraco/Licenses` directory in your Umbraco installation
 
 The `.lic` file must be placed in the `/umbraco/Licenses` directory to be registered by Umbraco Forms. If the file isn't placed correctly, the application will automatically switch to trial mode.
@@ -153,7 +153,7 @@ You can verify that your license is successfully installed by logging into your 
 
 If you are running on a single domain for both your frontend and backend environments, it's not necessary to configure a `UmbracoApplicationUrl`.
 
-If you have different domains for your frontend and backend, then it's advised that you configure an `UmbracoApplicationUrl` set to your backoffice URL. This helps the licensing engine know which URL should be used for validation checks. Without this configuration setting, the licensing engine will try and work out the domain to validate from the HTTP request object. This can lead to errors when switching between domains.
+If you have different domains for your frontend and backend, it's advised to configure an `UmbracoApplicationUrl` set to your backoffice URL. This helps the licensing engine know which domain should be used for validation checks. Without this configuration setting, the licensing engine will use the domain from the HTTP request object. This can lead to errors when switching between domains.
 
 An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file like so:
 

--- a/13/umbraco-forms/installation/the-licensing-model.md
+++ b/13/umbraco-forms/installation/the-licensing-model.md
@@ -9,7 +9,7 @@ Version 13 supports both the one-off purchase and (in 13.6+) subscription licens
 Licenses are sold per domain and will also work on all subdomains. With every license, you will be able to configure two development/testing domains.
 
 {% hint style="info" %}
-The licenses are not bound to a specific product version. They will work for all versions of the related product, but version 17+ will only be available through a subscription based license (see [announcement](https://github.com/umbraco/Announcements/issues/25)).
+The licenses are not bound to a specific product version. They will work for all versions of the related product, but version 17+ will only be available through a subscription-based license (see [announcement](https://github.com/umbraco/Announcements/issues/25)).
 {% endhint %}
 
 Let's say that you have a license configured for your domain, `mysite.com`, and you've configured two development domains, `devdomain.com` and `devdomain2.com`.
@@ -173,11 +173,12 @@ See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/h
 
 #### Configuring `UmbracoApplicationUrl` on Umbraco Cloud
 
-If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). This overrides what is set via the `appsettings.json` file.
+If you are hosting on Umbraco Cloud, you can find that the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). This overrides what is set via the `appsettings.json` file.
 
 There are two options in this case:
+
 - Either the domains for each of your Cloud environments can be added to your license.
-- Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
+- Or, you can apply the configuration via code for more control and to ensure this value is set correctly for other reasons.
 
 For example, in your `Program.cs`:
 
@@ -185,23 +186,26 @@ For example, in your `Program.cs`:
 services.Configure<WebRoutingSettings>(o => o.UmbracoApplicationUrl = "<your application URL>");
 ```
 
-In practice, you will probably want to make this a bit more sophisticated. You can read the value from another configuration key, removing the need to hard-code it and have it set as appropriate in different environments. You can also move this code into a composer or an extension method if you prefer not to clutter up the `Program.cs` file.
+In practice, make this more sophisticated. You can read the value from another configuration key, removing the need to hard-code it and have it set as appropriate in different environments. You can also move this code into a composer or an extension method if you prefer.
 
 #### Validating a license without an outgoing Internet connection
 
-Some Umbraco installations will have a highly locked down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
+Some Umbraco installations will have a highly locked-down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
 
-On start-up, and periodically whilst Umbraco is running, the license component used by Umbraco Forms will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
+On start-up, and periodically whilst Umbraco is running, the license component will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
 
-If it's possible to do so, the firewall rules should be adjusted to allow this request.
+The firewall rules should be adjusted to allow this request.
 
-If such a change is not feasible, there is another approach you can use.
+If such a change is not feasible, there is another approach, which is outlined below.
 
-You will need to have a server, or serverless function, that is running and can make a request to the online license validation service. That needs to run on a daily schedule, making a request and relaying it onto the restricted Umbraco environment.
+You will need to have a server, or serverless function, that is running and can request the online license validation service. That needs to run on a daily schedule, making a request and relaying it to the restricted Umbraco environment.
 
-To set this up, firstly ensure you have a reference to `Umbraco.Licenses` version 13.1 or higher. If the version of Forms you are using depends on an earlier version, you can add a direct package reference for `Umbraco.Licenses`.
+To set this up, follow these steps:
 
-Then configure a random string as an authorization key in configuration. This is used as protection to ensure only valid requests are handled. You can also disable the normal regular license checks - as there is no point in these running if they will be blocked:
+1. Ensure you have a reference to `Umbraco.Licenses` version 13.1 or higher. If the version of Forms you are using depends on an earlier version, add a direct package reference for `Umbraco.Licenses`.
+2. Configure a random string as an authorization key in the configuration. This is used as protection to ensure only valid requests are handled.
+
+Alternatively, you can also disable the normal regular license checks, as there is no point in these running if they will be blocked:
 
 ```json
   "Umbraco": {
@@ -214,7 +218,7 @@ Then configure a random string as an authorization key in configuration. This is
     }
 ```
 
-Your Internet-enabled server should make a request of the following form to the online license validation service:
+Your Internet-enabled server requests the following form from the online license validation service:
 
 ```
 POST https://license-validation.umbraco.com/api/ValidateLicense
@@ -225,12 +229,12 @@ POST https://license-validation.umbraco.com/api/ValidateLicense
 }
 ```
 
-The response should be relayed exactly via an HTTP request to your restricted Umbraco environment:
+The response is relayed exactly via an HTTP request to your restricted Umbraco environment:
 
 ```
 POST http://<your umbraco environment>/umbraco/licenses/validatedLicense/relay?productId=<product id>&licenseKey=<license key>
 ```
 
-A header with a key of `X-AUTH-KEY` and the value of the authorization key you have configured should be provided.
+A header with a key of `X-AUTH-KEY` and the value of the authorization key you have configured is provided.
 
-This will trigger the same processes that occur when the normal scheduled validation completes ensuring your product is considered licensed.
+This triggers the same processes that occur when the normal scheduled validation completes, ensuring your product is licensed.

--- a/13/umbraco-forms/installation/the-licensing-model.md
+++ b/13/umbraco-forms/installation/the-licensing-model.md
@@ -1,13 +1,15 @@
 # Licensing
 
-Umbraco Forms is a commercial product. You have a 14-day free trial to try out the product. After your trial expires, you'll need to have a **valid license** to keep using the product on your site.
+Umbraco Forms is a commercial product. You can run Umbraco Forms unrestricted locally without the need for a license. Running Umbraco Forms in the public domain will require a valid license.
+
+Version 13 supports both the one-off purchase and (in 13.6+) subscription license.
 
 ## How does it work?
 
 Licenses are sold per domain and will also work on all subdomains. With every license, you will be able to configure two development/testing domains.
 
 {% hint style="info" %}
-The licenses are not bound to a specific product version. They will work for all versions of the related product.
+The licenses are not bound to a specific product version. They will work for all versions of the related product, but version 17+ will only be available through a subscription based license (see [announcement](https://github.com/umbraco/Announcements/issues/25)).
 {% endhint %}
 
 Let's say that you have a license configured for your domain, `mysite.com`, and you've configured two development domains, `devdomain.com` and `devdomain2.com`.
@@ -49,50 +51,38 @@ This is an add-on domain for existing licenses. Refunds will not be given for th
 
 You can look at the pricing, features, and purchase the license on the [Umbraco Forms](https://umbraco.com/products/add-ons/forms/) page.
 
-When you've bought a license you need to configure it with your domains. You can either configure your license right away or you can do it later by visiting your account on Umbraco.com.
-
-1. Login to your account at [shop.umbraco.com](https://shop.umbraco.com).
-2. Navigate to the **Manage Licenses** section.
-3. Locate your unconfigured Forms license and choose **Configure / Add domain**.
-4. Define the primary as well as up to two development domains for which the license will be used.
-
 ### Add additional domains
 
-Once you have a configured Umbraco Forms license, you can add additional domains. This is relevant if you need your forms to be available on multiple public domains.
-
-1. Login to your account at [shop.umbraco.com](https://shop.umbraco.com).
-2. Navigate to the **Manage Licenses** section.
-3. Locate your configured Forms license.
-4. Choose **Configure / Add domain**.
-
-<figure><img src="./images/image.png" alt=""><figcaption></figcaption></figure>
-
-5. Select **Click here to buy** at the bottom of the configuration page.
-6. Configure the additional domain after completing the purchase, or do it later via your account.
+If you require to add addition domains to the license, [reach out the sales team](https://umbraco.com/products/add-ons/forms/) with your request and they will manage this process.
 
 ### Reconfiguration of domains
 
 Once a license has been configured with the domains, it is not possible to reconfigure them. An exception is when there is a mistake in the domain URL.
+
 As reconfiguration is not possible, you will either need to purchase an additional domain or a [new license](https://umbraco.com/products/umbraco-forms/).
 
 ## Installing your license
 
+You can configure either the one-off purchase license file or when using version 13.6+ the subscription license product key. We do not recommend having both a license file and product key configured, but if you have, the product key is checked first.
+
+### Installing one-off purchase license file
+
 Once you've configured your license with the correct domains, you are ready to install the license on your Umbraco installation.
 
-1. Download your license from your Umbraco.com account - this will give you a `.lic` file
+1. Obtain the license from the sales team, they will send you a `.lic` file
 2. Place the file in the `/umbraco/Licenses` directory in your Umbraco installation
 
 The `.lic` file must be placed in the `/umbraco/Licenses` directory to be registered by Umbraco Forms. If the file isn't placed correctly, the application will automatically switch to trial mode.
 
-### Multiple license files
+#### Multiple license files
 
 You can install multiple Umbraco Forms license files without merging them. Place each license file in the `/umbraco/Licenses` directory (or an alternative location). Each file should begin with `umbracoForms`, for example, `umbracoForms.example1.lic` and `umbracoForms.example2.lic`. This setup allows your installation to recognize multiple licensed domains.
 
-### Alternative license location
+#### Alternative license location
 
 If you can't include the license file in the `/umbraco/Licenses` directory for any reason, it is possible to configure an alternative location for the file.
 
-It can be configured in the Umbraco installation's `appSettings.json` file by adding the following configuration:
+It can be configured in the Umbraco installation's `appsettings.json` file by adding the following configuration:
 
 ```json
 {
@@ -110,7 +100,7 @@ The value contains the path of your custom license directory relative to the roo
 This will also change the location for other Umbraco-related licenses in this project.
 {% endhint %}
 
-## Federal Information Processing Standards (FIPS) Compliant Environments
+#### Federal Information Processing Standards (FIPS) Compliant Environments
 
 The algorithm used to decrypt Forms licenses is not supported on locked down FIPS compliant environments, such as those used in the defense industry.
 
@@ -129,4 +119,118 @@ Apply the following configuration with the appropriate algorithm - `DES` (the de
     "Licensing": {
       "LicenseEncodeAndDecodeAlgorithm": "DES|TripleDES|AES"
     },
-``````
+```
+
+### Installing subscription license product key
+
+Once you have received your license code it needs to be installed on your site.
+
+1. Open the root directory for your project files.
+2. Locate and open the `appsettings.json` file.
+3. Add your Umbraco Forms license key to `Umbraco:Licenses:Umbraco.Forms`:
+
+```json
+"Umbraco": {
+  "Licenses": {
+    "Umbraco.Forms": "YOUR_LICENSE_KEY"
+  }
+}
+```
+
+{% hint style="info" %}
+You might run into issues when using a period in the product name when using environment variables. Use an underscore in the product name instead, to avoid problems.
+
+```json
+"Umbraco_Forms": "YOUR_LICENSE_KEY"
+```
+{% endhint %}
+
+#### Verify the license installation
+
+You can verify that your license is successfully installed by logging into your project's backoffice and navigating to the settings section. Here you will see a license dashboard which should display the status of your license.
+
+### When and how to configure an `UmbracoApplicationUrl`
+
+If you are running on a single domain for both your frontend and backend environments, it's not necessary to configure a `UmbracoApplicationUrl`.
+
+If you have different domains for your frontend and backend, then it's advised that you configure an `UmbracoApplicationUrl` set to your backoffice URL. This helps the licensing engine know which URL should be used for validation checks. Without this configuration setting, the licensing engine will try and work out the domain to validate from the HTTP request object. This can lead to errors when switching between domains.
+
+An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file like so:
+
+```json
+{
+    "Umbraco": {
+        "CMS": {
+            "WebRouting": {
+                "UmbracoApplicationUrl": "https://admin.my-custom-domain.com/"
+            }
+        }
+    }
+}
+```
+
+See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) documentation for more details about this setting.
+
+#### Configuring `UmbracoApplicationUrl` on Umbraco Cloud
+
+If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). This overrides what is set via the `appsettings.json` file.
+
+There are two options in this case:
+- Either the domains for each of your Cloud environments can be added to your license.
+- Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
+
+For example, in your `Program.cs`:
+
+```csharp
+services.Configure<WebRoutingSettings>(o => o.UmbracoApplicationUrl = "<your application URL>");
+```
+
+In practice, you will probably want to make this a bit more sophisticated. You can read the value from another configuration key, removing the need to hard-code it and have it set as appropriate in different environments. You can also move this code into a composer or an extension method if you prefer not to clutter up the `Program.cs` file.
+
+#### Validating a license without an outgoing Internet connection
+
+Some Umbraco installations will have a highly locked down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
+
+On start-up, and periodically whilst Umbraco is running, the license component used by Umbraco Forms will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
+
+If it's possible to do so, the firewall rules should be adjusted to allow this request.
+
+If such a change is not feasible, there is another approach you can use.
+
+You will need to have a server, or serverless function, that is running and can make a request to the online license validation service. That needs to run on a daily schedule, making a request and relaying it onto the restricted Umbraco environment.
+
+To set this up, firstly ensure you have a reference to `Umbraco.Licenses` version 13.1 or higher. If the version of Forms you are using depends on an earlier version, you can add a direct package reference for `Umbraco.Licenses`.
+
+Then configure a random string as an authorization key in configuration. This is used as protection to ensure only valid requests are handled. You can also disable the normal regular license checks - as there is no point in these running if they will be blocked:
+
+```json
+  "Umbraco": {
+    "Licenses": {
+      "Umbraco.Forms": "<your license key>"
+    },
+    "LicensesOptions": {
+      "EnableScheduledValidation": false,
+      "ValidatedLicenseRelayAuthKey": "<your authorization key>"
+    }
+```
+
+Your Internet-enabled server should make a request of the following form to the online license validation service:
+
+```
+POST https://license-validation.umbraco.com/api/ValidateLicense
+{
+    "ProductId": "Umbraco.Forms",
+    "LicenseKey": "<your license key>",
+    "Domain": "<your licensed domain>"
+}
+```
+
+The response should be relayed exactly via an HTTP request to your restricted Umbraco environment:
+
+```
+POST http://<your umbraco environment>/umbraco/licenses/validatedLicense/relay?productId=<product id>&licenseKey=<license key>
+```
+
+A header with a key of `X-AUTH-KEY` and the value of the authorization key you have configured should be provided.
+
+This will trigger the same processes that occur when the normal scheduled validation completes ensuring your product is considered licensed.

--- a/13/umbraco-forms/release-notes.md
+++ b/13/umbraco-forms/release-notes.md
@@ -20,15 +20,15 @@ This section contains the release notes for Umbraco Forms 13 including all chang
 
 #### Add support for subscription licensing using product key
 
-In addition to the existing one-off license using the `umbracoForms.lic` file, support for configuring a subscription license using a product key is added. As [announced](https://github.com/umbraco/Announcements/issues/25), Forms 17 will only be available through a subscription-based license. To make the transition to this upcoming major easier, you can already purchase a new subscription (avoiding the one-off purchase) or convert your recently purchased one-off license into a subscription.
+In addition to the existing one-off license using the `umbracoForms.lic` file, support for configuring a subscription license using a product key is added. As [announced](https://github.com/umbraco/Announcements/issues/25), Forms 17 will only be available through a subscription-based license. You can already purchase a new subscription (avoiding the one-off purchase) or convert your recently purchased one-off license into a subscription.
 
-The 14-day trail license isn't generated anymore on install, but you can still fully test Forms on localhost. Configuring the license from the backoffice is also removed due to the direct integration with the legacy license infrastructure and to align the license management to the Licenses dashboard in the Settings section.
+The 14-day trial license is no longer generated on install. You can still fully test Forms on `localhost`. The option to configure the license from the backoffice is removed. This is due to the direct integration with the legacy license infrastructure and to align the license management to the Licenses dashboard.
 
 Read more about [the licensing model](./installation/the-licensing-model.md).
 
 #### Only show reCAPTCHA v2 or v3 fields when settings are configured
 
-Forms provides reCAPTCHA v2 and v3 fields out-of-the-box, but both were always shown to editors in the backoffice. These fields are now only shown when their respective settings are configured. This avoids editors adding a reCAPTCHA field that doesn't work due to missing configuration and/or mixing up the v2 and v3 versions.
+Forms provides reCAPTCHA v2 and v3 fields out of the box, but both were always shown to editors in the backoffice. These fields are now only shown when their respective settings are configured. This avoids editors adding a reCAPTCHA field that doesn't work due to missing configuration and/or mixing up the v2 and v3 versions.
 
 If the settings aren't configured in `appsettings.json` or environment variables (and thus available through `IConfiguration`), the required field needs to be manually added. This can be the case when manually configuring the `Recaptcha2Settings` or `Recaptcha3Settings` object in code:
 

--- a/13/umbraco-forms/release-notes.md
+++ b/13/umbraco-forms/release-notes.md
@@ -16,6 +16,39 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 13 including all changes for this version.
 
+### [13.6.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.6.0) (August 28th 2025)
+
+#### Add support for subscription licensing using product key
+
+In addition to the existing one-off license using the `umbracoForms.lic` file, support for configuring a subscription license using a product key is added. As [announced](https://github.com/umbraco/Announcements/issues/25), Forms 17 will only be available through a subscription-based license. To make the transition to this upcoming major easier, you can already purchase a new subscription (avoiding the one-off purchase) or convert your recently purchased one-off license into a subscription.
+
+The 14-day trail license isn't generated anymore on install, but you can still fully test Forms on localhost. Configuring the license from the backoffice is also removed due to the direct integration with the legacy license infrastructure and to align the license management to the Licenses dashboard in the Settings section.
+
+Read more about [the licensing model](./installation/the-licensing-model.md).
+
+#### Only show reCAPTCHA v2 or v3 fields when settings are configured
+
+Forms provides reCAPTCHA v2 and v3 fields out-of-the-box, but both were always shown to editors in the backoffice. These fields are now only shown when their respective settings are configured. This avoids editors adding a reCAPTCHA field that doesn't work due to missing configuration and/or mixing up the v2 and v3 versions.
+
+If the settings aren't configured in `appsettings.json` or environment variables (and thus available through `IConfiguration`), the required field needs to be manually added. This can be the case when manually configuring the `Recaptcha2Settings` or `Recaptcha3Settings` object in code:
+
+```csharp
+builder.Services.Configure<Recaptcha3Settings>(options =>
+{
+    options.SiteKey = "...";
+    options.PrivateKey = "...";
+});
+
+// Ensure the field is added and available
+builder.FormsFields().Add<Recaptcha3>();
+```
+
+#### Allow using ViewEngine to resolve theme views
+
+The default theme views are resolved using the [Partial Views file system](../umbraco-cms/extending/filesystemproviders/README.md#other-ifilesystems) (an abstraction over the `/Views/Partials` directory). This requires I/O lookups to determine whether specific theme views exist and manually specifying all files when using a [Razor Class Library](./developer/themes.md#shipping-themes-in-a-razor-class-library).
+
+By enabling the [`UseViewEngineFormThemeResolver` setting](./developer/configuration/README.md#useviewengineformthemeresolver), theme vies are resolved using the `ICompositeViewEngine`, which will include compiled views (including those shipped in RCLs).
+
 ### [13.5.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.5.0) (June 12th 2025)
 
 * All items detailed under 13.5.0-rc

--- a/14/umbraco-forms/installation/the-licensing-model.md
+++ b/14/umbraco-forms/installation/the-licensing-model.md
@@ -7,7 +7,7 @@ Umbraco Forms is a commercial product. You have a 14-day free trial to try out t
 Licenses are sold per domain and will also work on all subdomains. With every license, you will be able to configure two development/testing domains.
 
 {% hint style="info" %}
-The licenses are not bound to a specific product version. They will work for all versions of the related product.
+The licenses are not bound to a specific product version. They will work for all versions of the related product, but version 17+ will only be available through a subscription based license (see [announcement](https://github.com/umbraco/Announcements/issues/25)).
 {% endhint %}
 
 Let's say that you have a license configured for your domain, `mysite.com`, and you've configured two development domains, `devdomain.com` and `devdomain2.com`.

--- a/15/umbraco-forms/installation/the-licensing-model.md
+++ b/15/umbraco-forms/installation/the-licensing-model.md
@@ -7,7 +7,7 @@ Umbraco Forms is a commercial product. You have a 14-day free trial to try out t
 Licenses are sold per domain and will also work on all subdomains. With every license, you will be able to configure two development/testing domains.
 
 {% hint style="info" %}
-The licenses are not bound to a specific product version. They will work for all versions of the related product.
+The licenses are not bound to a specific product version. They will work for all versions of the related product, but version 17+ will only be available through a subscription based license (see [announcement](https://github.com/umbraco/Announcements/issues/25)).
 {% endhint %}
 
 Let's say that you have a license configured for your domain, `mysite.com`, and you've configured two development domains, `devdomain.com` and `devdomain2.com`.

--- a/16/umbraco-forms/developer/configuration/README.md
+++ b/16/umbraco-forms/developer/configuration/README.md
@@ -10,7 +10,7 @@ With Umbraco Forms it's possible to customize the functionality with various con
 
 ## Editing configuration values
 
-All configuration for Umbraco Forms is held in the `appSettings.json` file found at the root of your Umbraco website. If the configuration has been customized to use another source, then the same keys and values discussed in this article can be applied there.
+All configuration for Umbraco Forms is held in the `appsettings.json` file found at the root of your Umbraco website. If the configuration has been customized to use another source, then the same keys and values discussed in this article can be applied there.
 
 The convention for Umbraco configuration is to have package based options stored as a child structure below the `Umbraco` element, and as a sibling of `CMS`. Forms configuration follows this pattern, i.e.:
 
@@ -72,7 +72,8 @@ For illustration purposes, the following structure represents the full set of op
         "PrevalueSourceTypes": {},
         "WorkflowTypes": {},
       },
-      "MandatoryFieldsetLegends": false
+      "MandatoryFieldsetLegends": false,
+      "UseViewEngineFormThemeResolver": false
     },
     "Options": {
       "IgnoreWorkFlowsOnEdit": "True",
@@ -235,6 +236,10 @@ The default value and read-only settings apply to most setting types. There is a
 When creating a form with Umbraco Forms, adding captions to the groups for fields is optional. To follow accessibility best practices, these fields should be completed. When they are, the group of fields are presented within a `<fieldset>` element that has a populated `<legend>`.
 
 If you want to ensure form creators always have to provide a caption, you can set the value of this setting to `true`.
+
+### UseViewEngineFormThemeResolver
+
+Forms introduced an alternative `IFormThemeResolver` in 16.1 that uses the View Engine (`ICompositeViewEngine`) to resolve theme views, instead of relying on physical files to exist (and doing I/O lookups via the Partial Views file system abstraction). To take advantage of this new resolver, you can set the value of this setting to `true`.
 
 ### Form default settings configuration
 
@@ -428,7 +433,7 @@ Forms will by default track relations between forms and the content pages they a
 
 If you would like to disable this feature, you can set the value of this setting to `true`.
 
-## TrackRenderedFormsStorageMethod
+### TrackRenderedFormsStorageMethod
 
 Forms tracks the forms rendered on a page in order that the associated scripts can be placed in a different location within the HTML. Usually this is used to [render the scripts](../rendering-scripts.md) at the bottom of the page.
 
@@ -436,20 +441,19 @@ By default, `HttpContext.Items` is used as the storage mechanism for this tracki
 
 You can optionally revert to the legacy behavior of using `TempData` by changing this setting from the default of `HttpContextItems` to `TempData`.
 
-## EnableMultiPageFormSettings
+### EnableMultiPageFormSettings
 
 This setting determines whether [multi-page form settings](../../editor/creating-a-form/form-settings.md#multi-page-forms) are available to editors.
 
 By default the value is `true`. To disable the feature, set the value to `false`.
 
-## EnableAdvancedValidationRules
+### EnableAdvancedValidationRules
 
 This setting determines whether [advanced form validation rules](../../editor/creating-a-form/form-advanced.md) are available to editors.
 
 By default, the value is `false`.  This is partly because the feature is only considered for "power users", comfortable with crafting rules using the required JSON syntax. And partly as validating the rules on the client requires an additional front-end dependency.
 
 To make the feature available to editors and include the dependency when using `@Html.RenderUmbracoFormDependencies(Url)`, set the value to `true`.
-
 
 ## Security configuration
 

--- a/16/umbraco-forms/developer/configuration/README.md
+++ b/16/umbraco-forms/developer/configuration/README.md
@@ -239,7 +239,7 @@ If you want to ensure form creators always have to provide a caption, you can se
 
 ### UseViewEngineFormThemeResolver
 
-Forms introduced an alternative `IFormThemeResolver` in 16.1 that uses the View Engine (`ICompositeViewEngine`) to resolve theme views, instead of relying on physical files to exist (and doing I/O lookups via the Partial Views file system abstraction). To take advantage of this new resolver, you can set the value of this setting to `true`.
+Switches the `IFormThemeResolver` to use the View Engine (`ICompositeViewEngine`) to resolve theme views. This is done instead of relying on physical files to exist and doing I/O lookups via the `PartialViews` file system abstraction. To take advantage of this new resolver (available since 16.1), you can set the value of this setting to `true`.
 
 ### Form default settings configuration
 

--- a/16/umbraco-forms/installation/the-licensing-model.md
+++ b/16/umbraco-forms/installation/the-licensing-model.md
@@ -9,7 +9,7 @@ Version 16 supports both the one-off purchase and (in 16.1+) subscription licens
 Licenses are sold per domain and will also work on all subdomains. With every license, you will be able to configure two development/testing domains.
 
 {% hint style="info" %}
-The licenses are not bound to a specific product version. They will work for all versions of the related product, but version 17+ will only be available through a subscription based license (see [announcement](https://github.com/umbraco/Announcements/issues/25)).
+The licenses are not bound to a specific product version. They will work for all versions of the related product, but version 17+ will only be available through a subscription-based license (see [announcement](https://github.com/umbraco/Announcements/issues/25)).
 {% endhint %}
 
 Let's say that you have a license configured for your domain, `mysite.com`, and you've configured two development domains, `devdomain.com` and `devdomain2.com`.
@@ -69,7 +69,7 @@ You can configure either the one-off purchase license file or when using version
 
 Once you've configured your license with the correct domains, you are ready to install the license on your Umbraco installation.
 
-1. Obtain the license from the sales team, they will send you a `.lic` file
+1. Obtain the license (a `.lic` file) from the sales team
 2. Place the file in the `/umbraco/Licenses` directory in your Umbraco installation
 
 The `.lic` file must be placed in the `/umbraco/Licenses` directory to be registered by Umbraco Forms. If the file isn't placed correctly, the application will automatically switch to trial mode.
@@ -149,7 +149,7 @@ You can verify that your license is successfully installed by logging into your 
 
 If you are running on a single domain for both your frontend and backend environments, it's not necessary to configure a `UmbracoApplicationUrl`.
 
-If you have different domains for your frontend and backend, then it's advised that you configure an `UmbracoApplicationUrl` set to your backoffice URL. This helps the licensing engine know which URL should be used for validation checks. Without this configuration setting, the licensing engine will try and work out the domain to validate from the HTTP request object. This can lead to errors when switching between domains.
+If you have different domains for your frontend and backend, it's advised to configure an `UmbracoApplicationUrl` set to your backoffice URL. This helps the licensing engine know which domain should be used for validation checks. Without this configuration setting, the licensing engine will use the domain from the HTTP request object. This can lead to errors when switching between domains.
 
 An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file like so:
 
@@ -169,11 +169,12 @@ See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/h
 
 #### Configuring `UmbracoApplicationUrl` on Umbraco Cloud
 
-If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). This overrides what is set via the `appsettings.json` file.
+If you are hosting on Umbraco Cloud, you can find that the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). This overrides what is set via the `appsettings.json` file.
 
 There are two options in this case:
+
 - Either the domains for each of your Cloud environments can be added to your license.
-- Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
+- Or, you can apply the configuration via code for more control and to ensure this value is set correctly for other reasons.
 
 For example, in your `Program.cs`:
 
@@ -181,21 +182,23 @@ For example, in your `Program.cs`:
 services.Configure<WebRoutingSettings>(o => o.UmbracoApplicationUrl = "<your application URL>");
 ```
 
-In practice, you will probably want to make this a bit more sophisticated. You can read the value from another configuration key, removing the need to hard-code it and have it set as appropriate in different environments. You can also move this code into a composer or an extension method if you prefer not to clutter up the `Program.cs` file.
+In practice, make this more sophisticated. You can read the value from another configuration key, removing the need to hard-code it and have it set as appropriate in different environments. You can also move this code into a composer or an extension method if you prefer.
 
 #### Validating a license without an outgoing Internet connection
 
-Some Umbraco installations will have a highly locked down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
+Some Umbraco installations will have a highly locked-down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
 
-On start-up, and periodically whilst Umbraco is running, the license component used by Umbraco Forms will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
+On start-up, and periodically whilst Umbraco is running, the license component will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
 
-If it's possible to do so, the firewall rules should be adjusted to allow this request.
+The firewall rules should be adjusted to allow this request.
 
-If such a change is not feasible, there is another approach you can use.
+If such a change is not feasible, there is another approach, which is outlined below.
 
-You will need to have a server, or serverless function, that is running and can make a request to the online license validation service. That needs to run on a daily schedule, making a request and relaying it onto the restricted Umbraco environment.
+You will need to have a server, or serverless function, that is running and can request the online license validation service. That needs to run on a daily schedule, making a request and relaying it to the restricted Umbraco environment.
 
-Then configure a random string as an authorization key in configuration. This is used as protection to ensure only valid requests are handled. You can also disable the normal regular license checks - as there is no point in these running if they will be blocked:
+Then configure a random string as an authorization key in the configuration. This is used as protection to ensure only valid requests are handled.
+
+Alternatively, you can also disable the normal regular license checks, as there is no point in these running if they will be blocked:
 
 ```json
   "Umbraco": {
@@ -208,7 +211,7 @@ Then configure a random string as an authorization key in configuration. This is
     }
 ```
 
-Your Internet-enabled server should make a request of the following form to the online license validation service:
+Your Internet-enabled server requests the following form from the online license validation service:
 
 ```
 POST https://license-validation.umbraco.com/api/ValidateLicense
@@ -219,12 +222,12 @@ POST https://license-validation.umbraco.com/api/ValidateLicense
 }
 ```
 
-The response should be relayed exactly via an HTTP request to your restricted Umbraco environment:
+The response is relayed exactly via an HTTP request to your restricted Umbraco environment:
 
 ```
 POST http://<your umbraco environment>/umbraco/licenses/validatedLicense/relay?productId=<product id>&licenseKey=<license key>
 ```
 
-A header with a key of `X-AUTH-KEY` and the value of the authorization key you have configured should be provided.
+A header with a key of `X-AUTH-KEY` and the value of the authorization key you have configured is provided.
 
-This will trigger the same processes that occur when the normal scheduled validation completes ensuring your product is considered licensed.
+This triggers the same processes that occur when the normal scheduled validation completes, ensuring your product is licensed.

--- a/16/umbraco-forms/installation/the-licensing-model.md
+++ b/16/umbraco-forms/installation/the-licensing-model.md
@@ -1,13 +1,15 @@
 # Licensing
 
-Umbraco Forms is a commercial product. You have a 14-day free trial to try out the product. After your trial expires, you'll need to have a **valid license** to keep using the product on your site.
+Umbraco Forms is a commercial product. You can run Umbraco Forms unrestricted locally without the need for a license. Running Umbraco Forms in the public domain will require a valid license.
+
+Version 16 supports both the one-off purchase and (in 16.1+) subscription license.
 
 ## How does it work?
 
 Licenses are sold per domain and will also work on all subdomains. With every license, you will be able to configure two development/testing domains.
 
 {% hint style="info" %}
-The licenses are not bound to a specific product version. They will work for all versions of the related product.
+The licenses are not bound to a specific product version. They will work for all versions of the related product, but version 17+ will only be available through a subscription based license (see [announcement](https://github.com/umbraco/Announcements/issues/25)).
 {% endhint %}
 
 Let's say that you have a license configured for your domain, `mysite.com`, and you've configured two development domains, `devdomain.com` and `devdomain2.com`.
@@ -49,50 +51,38 @@ This is an add-on domain for existing licenses. Refunds will not be given for th
 
 You can look at the pricing, features, and purchase the license on the [Umbraco Forms](https://umbraco.com/products/add-ons/forms/) page.
 
-When you've bought a license you need to configure it with your domains. You can either configure your license right away or you can do it later by visiting your account on Umbraco.com.
-
-1. Login to your account at [shop.umbraco.com](https://shop.umbraco.com).
-2. Navigate to the **Manage Licenses** section.
-3. Locate your unconfigured Forms license and choose **Configure / Add domain**.
-4. Define the primary as well as up to two development domains for which the license will be used.
-
 ### Add additional domains
 
-Once you have a configured Umbraco Forms license, you can add additional domains. This is relevant if you need your forms to be available on multiple public domains.
-
-1. Login to your account at [shop.umbraco.com](https://shop.umbraco.com).
-2. Navigate to the **Manage Licenses** section.
-3. Locate your configured Forms license.
-4. Choose **Configure / Add domain**.
-
-<figure><img src="./images/image.png" alt=""><figcaption></figcaption></figure>
-
-5. Select **Click here to buy** at the bottom of the configuration page.
-6. Configure the additional domain after completing the purchase, or do it later via your account.
+If you require to add addition domains to the license, [reach out the sales team](https://umbraco.com/products/add-ons/forms/) with your request and they will manage this process.
 
 ### Reconfiguration of domains
 
 Once a license has been configured with the domains, it is not possible to reconfigure them. An exception is when there is a mistake in the domain URL.
+
 As reconfiguration is not possible, you will either need to purchase an additional domain or a [new license](https://umbraco.com/products/umbraco-forms/).
 
 ## Installing your license
 
+You can configure either the one-off purchase license file or when using version 16.1+ the subscription license product key. We do not recommend having both a license file and product key configured, but if you have, the product key is checked first.
+
+### Installing one-off purchase license file
+
 Once you've configured your license with the correct domains, you are ready to install the license on your Umbraco installation.
 
-1. Download your license from your Umbraco.com account - this will give you a `.lic` file
+1. Obtain the license from the sales team, they will send you a `.lic` file
 2. Place the file in the `/umbraco/Licenses` directory in your Umbraco installation
 
-The `.lic` file must be placed in the `/umbraco/Licenses` directory to be registered by Umbraco Forms. If the file isn't placed correctly, the application will automatically switch to trial mode. It is also recommended to restart your site after you have added the license file.
+The `.lic` file must be placed in the `/umbraco/Licenses` directory to be registered by Umbraco Forms. If the file isn't placed correctly, the application will automatically switch to trial mode.
 
-### Multiple license files
+#### Multiple license files
 
 You can install multiple Umbraco Forms license files without merging them. Place each license file in the `/umbraco/Licenses` directory (or an alternative location). Each file should begin with `umbracoForms`, for example, `umbracoForms.example1.lic` and `umbracoForms.example2.lic`. This setup allows your installation to recognize multiple licensed domains.
 
-### Alternative license location
+#### Alternative license location
 
 If you can't include the license file in the `/umbraco/Licenses` directory for any reason, it is possible to configure an alternative location for the file.
 
-It can be configured in the Umbraco installation's `appSettings.json` file by adding the following configuration:
+It can be configured in the Umbraco installation's `appsettings.json` file by adding the following configuration:
 
 ```json
 {
@@ -110,17 +100,13 @@ The value contains the path of your custom license directory relative to the roo
 This will also change the location for other Umbraco-related licenses in this project.
 {% endhint %}
 
-## Federal Information Processing Standards (FIPS) Compliant Environments
+#### Federal Information Processing Standards (FIPS) Compliant Environments
 
 The algorithm used to decrypt Forms licenses is not supported on locked down FIPS compliant environments, such as those used in the defense industry.
 
 If you are in this situation and unable to resolve it via configuration of the environment, please reach out to Umbraco support.
 
 We have the possibility of generating and providing Forms licenses using alternate algorithms.
-
-{% hint style="info" %}
-You can use this configuration if you reference `Umbraco.Licensing` version `13.0.1` or higher.
-{% endhint %}
 
 Apply the following configuration with the appropriate algorithm - `DES` (the default), `TripleDES`, or `AES`:
 
@@ -129,4 +115,116 @@ Apply the following configuration with the appropriate algorithm - `DES` (the de
     "Licensing": {
       "LicenseEncodeAndDecodeAlgorithm": "DES|TripleDES|AES"
     },
-``````
+```
+
+### Installing subscription license product key
+
+Once you have received your license code it needs to be installed on your site.
+
+1. Open the root directory for your project files.
+2. Locate and open the `appsettings.json` file.
+3. Add your Umbraco Forms license key to `Umbraco:Licenses:Umbraco.Forms`:
+
+```json
+"Umbraco": {
+  "Licenses": {
+    "Umbraco.Forms": "YOUR_LICENSE_KEY"
+  }
+}
+```
+
+{% hint style="info" %}
+You might run into issues when using a period in the product name when using environment variables. Use an underscore in the product name instead, to avoid problems.
+
+```json
+"Umbraco_Forms": "YOUR_LICENSE_KEY"
+```
+{% endhint %}
+
+#### Verify the license installation
+
+You can verify that your license is successfully installed by logging into your project's backoffice and navigating to the settings section. Here you will see a license dashboard which should display the status of your license.
+
+### When and how to configure an `UmbracoApplicationUrl`
+
+If you are running on a single domain for both your frontend and backend environments, it's not necessary to configure a `UmbracoApplicationUrl`.
+
+If you have different domains for your frontend and backend, then it's advised that you configure an `UmbracoApplicationUrl` set to your backoffice URL. This helps the licensing engine know which URL should be used for validation checks. Without this configuration setting, the licensing engine will try and work out the domain to validate from the HTTP request object. This can lead to errors when switching between domains.
+
+An `UmbracoApplicationUrl` can be configured in your `appSettings.json` file like so:
+
+```json
+{
+    "Umbraco": {
+        "CMS": {
+            "WebRouting": {
+                "UmbracoApplicationUrl": "https://admin.my-custom-domain.com/"
+            }
+        }
+    }
+}
+```
+
+See the [Fixed Application URL](https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/fixedapplicationurl) documentation for more details about this setting.
+
+#### Configuring `UmbracoApplicationUrl` on Umbraco Cloud
+
+If you are hosting on Umbraco Cloud you will find the configuration described above won't be reflected in your environment. The reason for this is that Umbraco Cloud sets this value as an environment variable set to the Cloud project domain (`<your project>.umbraco.io`). This overrides what is set via the `appsettings.json` file.
+
+There are two options in this case:
+- Either the domains for each of your Cloud environments can be added to your license.
+- Or, for more control and to ensure this value is set correctly for other reasons, you can apply the configuration via code.
+
+For example, in your `Program.cs`:
+
+```csharp
+services.Configure<WebRoutingSettings>(o => o.UmbracoApplicationUrl = "<your application URL>");
+```
+
+In practice, you will probably want to make this a bit more sophisticated. You can read the value from another configuration key, removing the need to hard-code it and have it set as appropriate in different environments. You can also move this code into a composer or an extension method if you prefer not to clutter up the `Program.cs` file.
+
+#### Validating a license without an outgoing Internet connection
+
+Some Umbraco installations will have a highly locked down production environment, with firewall rules that prevent outgoing HTTP requests. This will interfere with the normal process of license validation.
+
+On start-up, and periodically whilst Umbraco is running, the license component used by Umbraco Forms will make an HTTP POST request to `https://license-validation.umbraco.com/api/ValidateLicense`.
+
+If it's possible to do so, the firewall rules should be adjusted to allow this request.
+
+If such a change is not feasible, there is another approach you can use.
+
+You will need to have a server, or serverless function, that is running and can make a request to the online license validation service. That needs to run on a daily schedule, making a request and relaying it onto the restricted Umbraco environment.
+
+Then configure a random string as an authorization key in configuration. This is used as protection to ensure only valid requests are handled. You can also disable the normal regular license checks - as there is no point in these running if they will be blocked:
+
+```json
+  "Umbraco": {
+    "Licenses": {
+      "Umbraco.Forms": "<your license key>"
+    },
+    "LicensesOptions": {
+      "EnableScheduledValidation": false,
+      "ValidatedLicenseRelayAuthKey": "<your authorization key>"
+    }
+```
+
+Your Internet-enabled server should make a request of the following form to the online license validation service:
+
+```
+POST https://license-validation.umbraco.com/api/ValidateLicense
+{
+    "ProductId": "Umbraco.Forms",
+    "LicenseKey": "<your license key>",
+    "Domain": "<your licensed domain>"
+}
+```
+
+The response should be relayed exactly via an HTTP request to your restricted Umbraco environment:
+
+```
+POST http://<your umbraco environment>/umbraco/licenses/validatedLicense/relay?productId=<product id>&licenseKey=<license key>
+```
+
+A header with a key of `X-AUTH-KEY` and the value of the authorization key you have configured should be provided.
+
+This will trigger the same processes that occur when the normal scheduled validation completes ensuring your product is considered licensed.

--- a/16/umbraco-forms/release-notes.md
+++ b/16/umbraco-forms/release-notes.md
@@ -20,9 +20,9 @@ This section contains the release notes for Umbraco Forms 16 including all chang
 
 #### Add support for subscription licensing using product key
 
-In addition to the existing one-off license using the `umbracoForms.lic` file, support for configuring a subscription license using a product key is added. As [announced](https://github.com/umbraco/Announcements/issues/25), Forms 17 will only be available through a subscription-based license. To make the transition to this upcoming major easier, you can already purchase a new subscription (avoiding the one-off purchase) or convert your recently purchased one-off license into a subscription.
+In addition to the existing one-off license using the `umbracoForms.lic` file, support for configuring a subscription license using a product key is added. As [announced](https://github.com/umbraco/Announcements/issues/25), Forms 17 will only be available through a subscription-based license. You can already purchase a new subscription (avoiding the one-off purchase) or convert your recently purchased one-off license into a subscription.
 
-The 14-day trail license isn't generated anymore on install, but you can still fully test Forms on localhost. Configuring the license from the backoffice is also removed due to the direct integration with the legacy license infrastructure and to align the license management to the Licenses dashboard in the Settings section.
+The 14-day trial license is no longer generated on install. You can still fully test Forms on `localhost`. The option to configure the license from the backoffice is removed. This is due to the direct integration with the legacy license infrastructure and to align the license management to the Licenses dashboard.
 
 Read more about [the licensing model](./installation/the-licensing-model.md).
 

--- a/16/umbraco-forms/release-notes.md
+++ b/16/umbraco-forms/release-notes.md
@@ -16,6 +16,39 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 16 including all changes for this version.
 
+### [16.1.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F16.1.0) (August 28th 2025)
+
+#### Add support for subscription licensing using product key
+
+In addition to the existing one-off license using the `umbracoForms.lic` file, support for configuring a subscription license using a product key is added. As [announced](https://github.com/umbraco/Announcements/issues/25), Forms 17 will only be available through a subscription-based license. To make the transition to this upcoming major easier, you can already purchase a new subscription (avoiding the one-off purchase) or convert your recently purchased one-off license into a subscription.
+
+The 14-day trail license isn't generated anymore on install, but you can still fully test Forms on localhost. Configuring the license from the backoffice is also removed due to the direct integration with the legacy license infrastructure and to align the license management to the Licenses dashboard in the Settings section.
+
+Read more about [the licensing model](./installation/the-licensing-model.md).
+
+#### Only show reCAPTCHA v2 or v3 fields when settings are configured
+
+Forms provides reCAPTCHA v2 and v3 fields out-of-the-box, but both were always shown to editors in the backoffice. These fields are now only shown when their respective settings are configured. This avoids editors adding a reCAPTCHA field that doesn't work due to missing configuration and/or mixing up the v2 and v3 versions.
+
+If the settings aren't configured in `appsettings.json` or environment variables (and thus available through `IConfiguration`), the required field needs to be manually added. This can be the case when manually configuring the `Recaptcha2Settings` or `Recaptcha3Settings` object in code:
+
+```csharp
+builder.Services.Configure<Recaptcha3Settings>(options =>
+{
+    options.SiteKey = "...";
+    options.PrivateKey = "...";
+});
+
+// Ensure the field is added and available
+builder.FormsFields().Add<Recaptcha3>();
+```
+
+#### Allow using ViewEngine to resolve theme views
+
+The default theme views are resolved using the [Partial Views file system](../umbraco-cms/extending/filesystemproviders/README.md#other-ifilesystems) (an abstraction over the `/Views/Partials` directory). This requires I/O lookups to determine whether specific theme views exist and manually specifying all files when using a [Razor Class Library](./developer/themes.md#shipping-themes-in-a-razor-class-library).
+
+By enabling the [`UseViewEngineFormThemeResolver` setting](./developer/configuration/README.md#useviewengineformthemeresolver), theme vies are resolved using the `ICompositeViewEngine`, which will include compiled views (including those shipped in RCLs).
+
 ### [16.0.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F16.0.0) (June 12th 2025)
 
 * Compatibility with Umbraco 16.0.0


### PR DESCRIPTION
## 📋 Description

This adds the release notes for Forms 13.6.0 and 16.1.0 and updates the licensing model pages with information and instructions on how to install the subscription-based license.

## 📎 Related Issues (if applicable)

n/a

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Forms 13.6 and 16.1

## Deadline (if relevant)

These versions will be released today, but the license changes are applicable from September 1st, 2025.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
