### PR TITLE
Adds definitions to block custom view tutorial

### DIFF
--- a/16/umbraco-cms/tutorials/creating-custom-views-for-blocklist.md
+++ b/16/umbraco-cms/tutorials/creating-custom-views-for-blocklist.md
@@ -133,11 +133,18 @@ Now that we have created our Web Component, let us register it to show up on our
 }
 ```
 
-While the `forContentTypeAlias` and `forBlockEditor` parameters are optional, they also accept arrays. They can therefore be used to declare a custom view for multiple blocks. The code snippet below shows an example of such an array:
+While the `forContentTypeAlias` and `forBlockEditor` parameters are optional, they also accept arrays. They can therefore be used to declare a custom view for multiple blocks and block editors. The code snippet below shows an example of such an array:
 
 ```typescript
     forContentTypeAlias: ['product', 'anotherContentTypeAlias'],
+    forBlockEditor: ['block-list', 'block-grid', 'block-rte'],
 ```
+
+Depending on the values, the custom view is applied to the following data types:
+
+- **block-list** - The [Block List editor](../fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/block-list-editor.md)
+- **block-grid** - The [Block Grid editor](../fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/block-editor/block-grid-editor.md)
+- **block-rte** - Blocks used inline in the [Rich Text editor](../fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/blocks.md)
 
 Read about [extension-manifest](../customizing/extending-overview/extension-registry/extension-manifest.md) to learn how to register an Extension Manifest.
 


### PR DESCRIPTION
## 📋 Description

Adds definitions to the block custom view tutorial on what the different block types are: block-rte, block-list, and block-grid.

## 📎 Related Issues (if applicable)



## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 16

## Deadline (if relevant)

ASAP

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
