### PR TITLE
Update details on using conditions with Forms DatePicker

### DIFF
--- a/16/umbraco-forms/editor/creating-a-form/conditional-logic.md
+++ b/16/umbraco-forms/editor/creating-a-form/conditional-logic.md
@@ -61,7 +61,7 @@ When applying a condition to a page, effectively you are controlling the display
 
 ## Conditions for Dates
 
-In order to use less than and greater than conditions on dates, you must change the date format.
+To use less-than or greater-than conditions on dates, you must change the date format.
 
 By default, date is shown like `September 5, 2025`. This needs to change to a format only containing numbers: `09/05/2025`.
 

--- a/16/umbraco-forms/editor/creating-a-form/conditional-logic.md
+++ b/16/umbraco-forms/editor/creating-a-form/conditional-logic.md
@@ -61,10 +61,14 @@ When applying a condition to a page, effectively you are controlling the display
 
 ## Conditions for Dates
 
-In order to use less than and greater than conditions on dates, you must first change the date format. 
+In order to use less than and greater than conditions on dates, you must change the date format.
+
+By default, date is shown like `September 5, 2025`. This needs to change to a format only containing numbers: `09/05/2025`.
+
+To change the default format setting for dates, follow the steps below:
 
 1. Open the `appSettings.json` file.
-2. Add the following, below the CMS section within the Umbraco section.
+2. Change the `DatePickerFormat` value to `L` (the default is `LL`):
 
 ´´´json
 "Forms": {
@@ -75,6 +79,3 @@ In order to use less than and greater than conditions on dates, you must first c
   }
 }
 ´´´
-You can apply conditions to dates as well as strings. 
-
-When you use the date picker field, you can set a condition if a submitted date is greater/less than a specific date.

--- a/16/umbraco-forms/editor/creating-a-form/conditional-logic.md
+++ b/16/umbraco-forms/editor/creating-a-form/conditional-logic.md
@@ -61,4 +61,20 @@ When applying a condition to a page, effectively you are controlling the display
 
 ## Conditions for Dates
 
-You can apply conditions to dates as well as strings. When you use the date picker field, you can set a condition if a submitted date is greater/less than a specific date.
+In order to use less than and greater than conditions on dates, you must first change the date format. 
+
+1. Open the `appSettings.json` file.
+2. Add the following, below the CMS section within the Umbraco section.
+
+´´´json
+"Forms": {
+  "FieldTypes": {
+    "DatePicker": {
+      "DatePickerFormat": "L"
+    }
+  }
+}
+´´´
+You can apply conditions to dates as well as strings. 
+
+When you use the date picker field, you can set a condition if a submitted date is greater/less than a specific date.

--- a/16/umbraco-forms/editor/creating-a-form/conditional-logic.md
+++ b/16/umbraco-forms/editor/creating-a-form/conditional-logic.md
@@ -70,7 +70,7 @@ To change the default format setting for dates, follow the steps below:
 1. Open the `appSettings.json` file.
 2. Change the `DatePickerFormat` value to `L` (the default is `LL`):
 
-´´´json
+```json
 "Forms": {
   "FieldTypes": {
     "DatePicker": {
@@ -78,4 +78,4 @@ To change the default format setting for dates, follow the steps below:
     }
   }
 }
-´´´
+```


### PR DESCRIPTION
## 📋 Description

It wasnt possible to set a less than / greater than condition on a Date Picker field, as the default format is not a correct date.
I've updated the Conditions article to include steps on how to change the config of the Date Picker format so it's possible to use conditions again.

## 📎 Related Issues (if applicable)

Task related to feedback from the GitBook feedback feature.