### PR TITLE
Add Content Security Policy check to built in health check list

### DIFF
--- a/16/umbraco-cms/extending/health-check/README.md
+++ b/16/umbraco-cms/extending/health-check/README.md
@@ -27,7 +27,7 @@ Umbraco comes with the following checks by default:
   * **Content/MIME Sniffing Protection (id: `1CF27DB3-EFC0-41D7-A1BB-EA912064E071`)** - checks that your site contains a header used to protect against Multipurpose Internet Mail Extensions (MIME) sniffing vulnerabilities
   * **Cookie hijacking and protocol downgrade attacks Protection (HSTS) (id: `E2048C48-21C5-4BE1-A80B-8062162DF124`)** - checks if your HTTPS site contains the Strict-Transport-Security Header (HSTS). If not - adds with a default of 18 weeks
   * **Cross-site scripting Protection (id: `F4D2B02E-28C5-4999-8463-05759FA15C3A`)** - checks for the presence of the X-XSS-Protection-header
-  * **Content Content Security Policy (CSP) (id: `10BEBF47-C128-4C5E-9680-5059BEAFBBDF`)** - checks that your site has a Content Security Policy (CSP) header to defend against Cross-Site Scripting (XSS) and data injection attacks.
+  * **Content Security Policy (CSP) (id: `10BEBF47-C128-4C5E-9680-5059BEAFBBDF`)** - checks that your site has a CSP header to defend against Cross-Site Scripting (XSS) and data injection attacks.
   * **Excessive Headers (id: `92ABBAA2-0586-4089-8AE2-9A843439D577`)** - checks to ensure that various headers that can provide details about the technology used to build and host the website have been removed
   * **HTTPS Configuration (id: `EB66BB3B-1BCD-4314-9531-9DA2C1D6D9A7`)** - to determine if the current site is running on a secure connection
   * **UseHttps check** - when the site is running on HTTPS, `Umbraco.Cms.Core.Configuration.Models.GlobalSettings.UseHttps` needs to be enabled to secure the backoffice. The setting can be found under `Umbraco:CMS:Global` in the `appsettings.json` file

--- a/16/umbraco-cms/extending/health-check/README.md
+++ b/16/umbraco-cms/extending/health-check/README.md
@@ -27,7 +27,7 @@ Umbraco comes with the following checks by default:
   * **Content/MIME Sniffing Protection (id: `1CF27DB3-EFC0-41D7-A1BB-EA912064E071`)** - checks that your site contains a header used to protect against Multipurpose Internet Mail Extensions (MIME) sniffing vulnerabilities
   * **Cookie hijacking and protocol downgrade attacks Protection (HSTS) (id: `E2048C48-21C5-4BE1-A80B-8062162DF124`)** - checks if your HTTPS site contains the Strict-Transport-Security Header (HSTS). If not - adds with a default of 18 weeks
   * **Cross-site scripting Protection (id: `F4D2B02E-28C5-4999-8463-05759FA15C3A`)** - checks for the presence of the X-XSS-Protection-header
-  * **Content Content Security Policy (CSP) (id: `10BEBF47-C128-4C5E-9680-5059BEAFBBDF`)** - checks if your site has a Content Security Policy (CSP) header to defend against Cross-Site Scripting (XSS) and data injection attacks.
+  * **Content Content Security Policy (CSP) (id: `10BEBF47-C128-4C5E-9680-5059BEAFBBDF`)** - checks that your site has a Content Security Policy (CSP) header to defend against Cross-Site Scripting (XSS) and data injection attacks.
   * **Excessive Headers (id: `92ABBAA2-0586-4089-8AE2-9A843439D577`)** - checks to ensure that various headers that can provide details about the technology used to build and host the website have been removed
   * **HTTPS Configuration (id: `EB66BB3B-1BCD-4314-9531-9DA2C1D6D9A7`)** - to determine if the current site is running on a secure connection
   * **UseHttps check** - when the site is running on HTTPS, `Umbraco.Cms.Core.Configuration.Models.GlobalSettings.UseHttps` needs to be enabled to secure the backoffice. The setting can be found under `Umbraco:CMS:Global` in the `appsettings.json` file

--- a/16/umbraco-cms/extending/health-check/README.md
+++ b/16/umbraco-cms/extending/health-check/README.md
@@ -27,6 +27,7 @@ Umbraco comes with the following checks by default:
   * **Content/MIME Sniffing Protection (id: `1CF27DB3-EFC0-41D7-A1BB-EA912064E071`)** - checks that your site contains a header used to protect against Multipurpose Internet Mail Extensions (MIME) sniffing vulnerabilities
   * **Cookie hijacking and protocol downgrade attacks Protection (HSTS) (id: `E2048C48-21C5-4BE1-A80B-8062162DF124`)** - checks if your HTTPS site contains the Strict-Transport-Security Header (HSTS). If not - adds with a default of 18 weeks
   * **Cross-site scripting Protection (id: `F4D2B02E-28C5-4999-8463-05759FA15C3A`)** - checks for the presence of the X-XSS-Protection-header
+  * **Content Content Security Policy (CSP) (id: `10BEBF47-C128-4C5E-9680-5059BEAFBBDF`)** - checks if your site has a Content Security Policy (CSP) header to defend against Cross-Site Scripting (XSS) and data injection attacks.
   * **Excessive Headers (id: `92ABBAA2-0586-4089-8AE2-9A843439D577`)** - checks to ensure that various headers that can provide details about the technology used to build and host the website have been removed
   * **HTTPS Configuration (id: `EB66BB3B-1BCD-4314-9531-9DA2C1D6D9A7`)** - to determine if the current site is running on a secure connection
   * **UseHttps check** - when the site is running on HTTPS, `Umbraco.Cms.Core.Configuration.Models.GlobalSettings.UseHttps` needs to be enabled to secure the backoffice. The setting can be found under `Umbraco:CMS:Global` in the `appsettings.json` file


### PR DESCRIPTION
## 📋 Description

Adds info about the CSP health check to the [health check](https://docs.umbraco.com/umbraco-cms/extending/health-check) page.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [X] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [X] Relevant pages are linked.
* [X] All links work and point to the correct resources.
* [X] Screenshots or diagrams are included if useful.
* [X] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

The CSP check was added in 14.3, not sure how that works for the docs though.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
