### PR TITLE
Added `ComposeAfter` attribute to composer used in Examine sample

### DIFF
--- a/16/umbraco-cms/reference/searching/examine/indexing.md
+++ b/16/umbraco-cms/reference/searching/examine/indexing.md
@@ -64,7 +64,9 @@ public class ExamineComposer : IComposer
 }
 ```
 
-Note the use of the `ComposeAfter` attribute. Adding this guarantees that the composer will run after the core composer responsible for setting up the default index details.
+{% hint style="info" %}
+The use of the `ComposeAfter` attribute guarantees that the composer will run after the core composer responsible for setting up the default index details.
+{% endhint %}
 
 ### Changing field value types
 


### PR DESCRIPTION
## 📋 Description

Updated the code sample for Examine index customization to include a `ComposeAfter` attribute, which will guarantee that the composer will run after the core setup of Examine indexes.

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/issues/20267
https://github.com/umbraco/Umbraco-CMS/issues/20284

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [X] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [X] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 16

## Deadline (if relevant)

Can be reviewed and published at any time.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
