### PR TITLE
Increase documented Kestrel MaxRequestLength to 50MB to match product behaviour

### DIFF
--- a/10/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
+++ b/10/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
@@ -35,7 +35,7 @@ Umbraco Cloud uses IIS for hosting. This means you need to add the setting in a 
 
 ## Using Kestrel
 
-Runtime settings allow you to configure the `MaxRequestLength` and `MaxQueryStringLength` for kestrel. If you want to upload files larger than 28.6MB, then you have to configure these settings. If nothing is configured requests and query strings can only be the default size and smaller.
+Runtime settings allow you to configure the `MaxRequestLength` and `MaxQueryStringLength` for kestrel. If you want to upload files larger than 50MB, then you have to configure these settings. If nothing is configured requests and query strings can only be the default size and smaller.
 
 An example of a configuration could look something like this:
 

--- a/13/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
+++ b/13/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
@@ -34,7 +34,7 @@ The upload size limit is 500mb on Umbraco Cloud.
 
 # Using Kestrel
 
-Runtime settings allow you to configure the `MaxRequestLength` and `MaxQueryStringLength` for kestrel. If you want to upload files larger than 28.6MB, then you have to configure these settings. If nothing is configured requests and query strings can only be the default size and smaller.
+Runtime settings allow you to configure the `MaxRequestLength` and `MaxQueryStringLength` for kestrel. If you want to upload files larger than 50MB, then you have to configure these settings. If nothing is configured requests and query strings can only be the default size and smaller.
 
 An example of a configuration could look something like this:
 

--- a/15/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
+++ b/15/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
@@ -49,7 +49,7 @@ To customize this limit, adjust the `maxAllowedContentLength` value in your `web
 
 ## Using Kestrel
 
-Kestrel’s runtime settings allow you to configure `MaxRequestLength` and `MaxQueryStringLength`. If you want to upload files larger than 28.6MB, update these values in the `appsettings.json` file.
+Kestrel’s runtime settings allow you to configure `MaxRequestLength`. If you want to upload files larger than 50MB, or amend this default, update this value in the `appsettings.json` file.
 
 Example configuration:
 

--- a/16/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
+++ b/16/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
@@ -53,7 +53,7 @@ To customize this limit, adjust the `maxAllowedContentLength` value in your `web
 
 ## Using Kestrel
 
-Kestrel’s runtime settings allow you to configure `MaxRequestLength`. If you want to upload files larger than 28.6MB, update this value in the `appsettings.json` file.
+Kestrel’s runtime settings allow you to configure `MaxRequestLength`. If you want to upload files larger than 50MB, or amend this default value, update this value in the `appsettings.json` file.
 
 Example configuration:
 

--- a/16/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
+++ b/16/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
@@ -53,7 +53,7 @@ To customize this limit, adjust the `maxAllowedContentLength` value in your `web
 
 ## Using Kestrel
 
-Kestrel’s runtime settings allow you to configure `MaxRequestLength`. If you want to upload files larger than 50MB, or amend this default value, update this value in the `appsettings.json` file.
+Kestrel’s runtime settings allow you to configure `MaxRequestLength`. If you want to upload files larger than 50MB, or amend this default, update this value in the `appsettings.json` file.
 
 Example configuration:
 

--- a/17/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
+++ b/17/umbraco-cms/reference/configuration/maximumuploadsizesettings.md
@@ -53,7 +53,7 @@ To customize this limit, adjust the `maxAllowedContentLength` value in your `web
 
 ## Using Kestrel
 
-Kestrel’s runtime settings allow you to configure `MaxRequestLength`. If you want to upload files larger than 28.6MB, update this value in the `appsettings.json` file.
+Kestrel’s runtime settings allow you to configure `MaxRequestLength`. If you want to upload files larger than 50MB, or amend this default, update this value in the `appsettings.json` file.
 
 Example configuration:
 


### PR DESCRIPTION
Updated Kestrel's MaxRequestLength limit to 50MB.

## 📋 Description

Increases the  documented Kestrel MaxRequestLength to 50MB to match product behaviour.

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/issues/20353

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 13+

## Deadline (if relevant)

Any time.
