### PR TITLE
Add Forms Deploy 13.1.2 and 16.0.1 release notes

### DIFF
--- a/13/umbraco-forms/release-notes.md
+++ b/13/umbraco-forms/release-notes.md
@@ -297,6 +297,10 @@ And there are a couple of further additions to improve the performance and acces
 
 ## Umbraco.Forms.Deploy
 
+### 13.1.2 (September 24th 2025)
+
+* Fix `FolderConnector.GetRange()` using root string throwing `ArgumentException`
+
 ### 13.1.1 (May 20th 2025)
 
 * Remove null entries in field prevalues [#260](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/260)

--- a/16/umbraco-forms/release-notes.md
+++ b/16/umbraco-forms/release-notes.md
@@ -83,6 +83,10 @@ By enabling the [`UseViewEngineFormThemeResolver` setting](./developer/configura
 
 This Deploy add-on adds support for transferring, restoring, exporting and importing (including migrating between major versions) of Umbraco Forms data.
 
+### 16.0.1 (September 24th 2025)
+
+* Fix `FolderConnector.GetRange()` using root string throwing `ArgumentException`
+
 ### 16.0.0 (June 12th 2025)
 
 * Update Forms and Deploy dependencies to 16.0.0


### PR DESCRIPTION
## 📋 Description

Add Forms Deploy 13.1.2 and 16.0.1 release notes.

## Product & Version (if relevant)

Forms Deploy 13.1.2
Forms Deploy 16.0.1

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
