### PR TITLE
Link the Style Menu article to the Umbraco Package article.

### DIFF
--- a/15/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/style-menu.md
+++ b/15/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/style-menu.md
@@ -24,7 +24,7 @@ Alternatively, while configuring an editor on a Document Type, you can drag **St
 
 ## Creating a Style Select Menu
 
-In this article, you can find an example of how to set up a Style Select Menu using the package manifest file.
+In this article, you can find an example of how to set up a Style Select Menu using an [Umbraco Package Manifest](../../../../../customizing/umbraco-package.md) file.
 
 {% code title="umbraco-package.json" %}
 ```json

--- a/16/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/style-menu.md
+++ b/16/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/style-menu.md
@@ -24,7 +24,7 @@ Alternatively, while configuring an editor on a Document Type, you can drag **St
 
 ## Creating a Style Select Menu
 
-In this article, you can find an example of how to set up a Style Select Menu using the package manifest file.
+In this article, you can find an example of how to set up a Style Select Menu using an [Umbraco Package Manifest](../../../../../customizing/umbraco-package.md) file.
 
 {% code title="umbraco-package.json" %}
 ```json

--- a/17/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/style-menu.md
+++ b/17/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/style-menu.md
@@ -24,7 +24,7 @@ Alternatively, while configuring an editor on a Document Type, you can drag **St
 
 ## Creating a Style Select Menu
 
-In this article, you can find an example of how to set up a Style Select Menu using the package manifest file.
+In this article, you can find an example of how to set up a Style Select Menu using an [Umbraco Package Manifest](../../../../../customizing/umbraco-package.md) file.
 
 {% code title="umbraco-package.json" %}
 ```json


### PR DESCRIPTION
## 📋 Description

While setting up a test site using a custom RTE Style Select Menu, I stumbled upon the mention of a "package manifest" file.

It sounded a lot like something from the V13 days - the `package.manifest` file. However, after a bit of digging, I realized that a lot of articles speak of the "Umbraco Package Manifest" file, which refers to the `umbraco-package.json` file explained in [this article](https://docs.umbraco.com/umbraco-cms/customizing/umbraco-package).

All the same, I figured it made sense to update the RTE Style Select Menu article, so it mentions "Umbraco Package Manifest" instead of "package manifest", and also links to the explanatory article.

## 📎 Related Issues (if applicable)

None

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

V15+

## Deadline (if relevant)

No deadline.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
