### PR TITLE
Remove warning on `Microsoft.EntityFrameworkCore.Design` dependency conflicts

### DIFF
--- a/13/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
+++ b/13/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
@@ -31,18 +31,6 @@ Data stored in custom tables are not supported by default by add-ons such as Umb
 * EFCore CLI tool
   * Can be installed by running `dotnet tool install --global dotnet-ef` in the terminal
 
-<details>
-
-<summary>If you are using EF Core, and have installed the <code>Microsoft.EntityFrameworkCore.Design 8.0.0</code> package</summary>
-
-You need to be aware of some things if you are using EF Core, and have installed the `Microsoft.EntityFrameworkCore.Design 8.0.0` package:
-
-* This package has a transient dependency to `Microsoft.CodeAnalysis.Common` which clashes with the same transient dependency from `Umbraco.Cms 13.0.0`. This happens because `Microsoft.EntityFrameworkCore.Design 8.0.0` requires `Microsoft.CodeAnalysis.CSharp.Workspaces` in v4.5.0 or higher.
-* If there are no other dependencies that need that package then it installs it in the lowest allowed version (4.5.0). That package then has a strict dependency on `Microsoft.CodeAnalysis.Common` version 4.5.0. The problem is `Umbraco.Cms` through its own transient dependencies that require the version of `Microsoft.CodeAnalysis.Common` to be >= 4.8.0.
-* This can be fixed by installing `Microsoft.CodeAnalysis.CSharp.Workspaces` version 4.8.0 as a specific package instead of leaving it as a transient dependency. This is because it will then have a strict transient dependency on `Microsoft.CodeAnalysis.Common` version 4.8.0, which is the same that Umbraco has.
-
-</details>
-
 The tutorial will show how to create custom database tables using a composer and a notification handler. With this pattern, you create and run a similar migration but trigger it in response to a [notification handler](https://docs.umbraco.com/umbraco-cms/fundamentals/code/subscribing-to-notifications).
 
 ## Step 1: Create Model Class


### PR DESCRIPTION
## 📋 Description

This issue has been fixed in the CMS and will be released in 13.12, so the mentioned workaround will no longer be needed.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS - 13.12

## Deadline (if relevant)

13.12-RC release on November 6th