### PR TITLE
Update dashboard.md - Add documentation for hiding and restricting dashboard access

### DIFF
--- a/16/umbraco-cms/customizing/extending-overview/extension-types/dashboard.md
+++ b/16/umbraco-cms/customizing/extending-overview/extension-types/dashboard.md
@@ -106,7 +106,7 @@ export const onInit = (host, extensionRegistry) => {
 
 You can find user group GUIDs in the **Users > User Groups** section of the backoffice.
 
-Read more about the many conditions available to you:
+Read more about the available conditions:
 
 {% content-ref url="condition.md" %}
 [condition.md](condition.md)


### PR DESCRIPTION
## 📋 Description

Adds a new section documenting how to hide dashboards or add conditional access rules using the extension registry.

This addresses a common gap in the documentation where developers need to:
- Hide default dashboards like the Getting Started dashboard
- Restrict dashboard access to specific user groups (e.g., admins only)
- Use extensionRegistry.exclude() and extensionRegistry.appendCondition()

Includes examples for:
- Removing dashboards completely
- Restricting to admin users only
- Restricting to multiple specific user groups using GUIDs

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ x ] Code blocks are correctly formatted.
* [ x ] Sentences are short and clear (preferably under 25 words).
* [ x ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ x ] Relevant pages are linked.
* [ x ] All links work and point to the correct resources.
* [ x ] Screenshots or diagrams are included if useful.
* [ x ] Any code examples or instructions have been tested.
* [ x ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

v16


