### PR TITLE
Update attributes from DiscountRuleProviderSetting to DiscountRewardProviderSetting

### DIFF
--- a/16/umbraco-commerce/key-concepts/discount-rules-and-rewards.md
+++ b/16/umbraco-commerce/key-concepts/discount-rules-and-rewards.md
@@ -131,19 +131,19 @@ public class TieredPercentageRewardProvider : DiscountRewardProviderBase<TieredP
 
 public class TieredPercentageSettings
 {
-    [DiscountRuleProviderSetting(Key = "baseTierPercentage")]
+    [DiscountRewardProviderSetting(Key = "baseTierPercentage")]
     public decimal BaseTierPercentage { get; set; }
 
-    [DiscountRuleProviderSetting(Key = "midTierThreshold")]
+    [DiscountRewardProviderSetting(Key = "midTierThreshold")]
     public decimal MidTierThreshold { get; set; }
 
-    [DiscountRuleProviderSetting(Key = "midTierPercentage")]
+    [DiscountRewardProviderSetting(Key = "midTierPercentage")]
     public decimal MidTierPercentage { get; set; }
 
-    [DiscountRuleProviderSetting(Key = "highTierThreshold")]
+    [DiscountRewardProviderSetting(Key = "highTierThreshold")]
     public decimal HighTierThreshold { get; set; }
 
-    [DiscountRuleProviderSetting(Key = "highTierPercentage")]
+    [DiscountRewardProviderSetting(Key = "highTierPercentage")]
     public decimal HighTierPercentage { get; set; }
 }
 ```


### PR DESCRIPTION
## 📋 Description

In the example code for custom discount reward provider, the attributes used on the properties of the TieredPercentageSettings class are wrong. They are of type DiscountRuleProviderSetting, but they should be DiscountRewardProviderSetting.

## 📎 Related Issues 

Fixes #7513

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [✅] Code blocks are correctly formatted.
* [✅] Sentences are short and clear (preferably under 25 words).
* [✅] Passive voice and first-person language (“we”, “I”) are avoided.
* [✅] Relevant pages are linked.
* [✅] All links work and point to the correct resources.
* [✅] Screenshots or diagrams are included if useful.
* [✅] Any code examples or instructions have been tested.
* [✅] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

16

