### PR TITLE
Remove duplicate nodeName field from indexing

### DIFF
--- a/16/umbraco-cms/reference/searching/examine/indexing.md
+++ b/16/umbraco-cms/reference/searching/examine/indexing.md
@@ -259,7 +259,6 @@ public class ProductIndexValueSetBuilder : IValueSetBuilder<IContent>
                 [UmbracoExamineFieldNames.NodeNameFieldName] = content.Name!,
                 ["name"] = content.Name!,
                 // add the fields you want in the index
-                ["nodeName"] = content.Name!,
                 ["id"] = content.Id,
             };
 


### PR DESCRIPTION
Removed duplicate 'nodeName' field from index values.

## 📋 Description

The `UmbracoExamineFieldNames.NodeNameFieldName` constant equals to `nodeName`, so no reason to add the same field twice.

As the example uses the indexer property of the dictionary, this doesn't actually cause any errors, but I thought I might as well fix it.

As I'm removing code, I haven't checked any of the boxes in the checkbox below.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
