### PR TITLE
Fix UFM filter syntax for markdown examples

### DIFF
--- a/16/umbraco-cms/reference/umbraco-flavored-markdown.md
+++ b/16/umbraco-cms/reference/umbraco-flavored-markdown.md
@@ -52,7 +52,7 @@ The syntax for UFM filters uses a pipe character `|` (Vertical Line). Multiple f
 To display a rich text value, stripping out the HTML markup and limiting it to the first 15 words could use the following filters:
 
 ```markdown
-{umbValue: bodyText | stripHtml | wordLimit:15}
+{umbValue: bodyText | strip-html | word-limit:15}
 ```
 
 The following UFM filters are available to use.
@@ -62,11 +62,11 @@ The following UFM filters are available to use.
 | Bytes      | `bytes`      | `{umbValue: umbracoBytes \| bytes}`    |
 | Fallback   | `fallback`   | `{umbValue: headline \| fallback:N/A}` |
 | Lowercase  | `lowercase`  | `{umbValue: headline \| lowercase}`    |
-| Strip HTML | `stripHtml` | `{umbValue: bodyText \| stripHtml}`   |
-| Title Case | `titleCase` | `{umbValue: headline \| titleCase}`   |
+| Strip HTML | `strip-html` | `{umbValue: bodyText \| strip-html}`   |
+| Title Case | `title-case` | `{umbValue: headline \| title-case}`   |
 | Truncate   | `truncate`   | `{umbValue: intro \| truncate:30:...}` |
 | Uppercase  | `uppercase`  | `{umbValue: headline \| uppercase}`    |
-| Word Limit | `wordLimit` | `{umbValue: intro \| wordLimit:15}`   |
+| Word Limit | `word-limit` | `{umbValue: intro \| word-limit:15}`   |
 
 
 ## UFM Expressions (JavaScript-like syntax)


### PR DESCRIPTION
The filters in Umbraco 16 are kebab-case ( with Hyphens ) and NOT camelCase

## 📋 Description

The examples incorrectly show camelCase for the filters, where they should be kebab-case

## 📎 Related Issues (if applicable)

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

U16

## Deadline (if relevant)

ASAP as currently it's misleading.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
