### PR TITLE
Updated the extension registry subpages order

### DIFF
--- a/16/umbraco-cms/SUMMARY.md
+++ b/16/umbraco-cms/SUMMARY.md
@@ -153,7 +153,7 @@
   * [Vite Package Setup](customizing/development-flow/vite-package-setup.md)
 * [Extensions Overview](customizing/extending-overview/README.md)
   * [Extension Registry](customizing/extending-overview/extension-registry/README.md)
-    * [Extension Manifest introduction](customizing/extending-overview/extension-registry/extension-manifest.md)
+    * [Extension Manifest Introduction](customizing/extending-overview/extension-registry/extension-manifest.md)
     * [Register an Extension](customizing/extending-overview/extension-registry/register-extensions.md)
     * [Replace, Exclude or Unregister](customizing/extending-overview/extension-registry/replace-exclude-or-unregister.md)
   * [Extension Types](customizing/extending-overview/extension-types/README.md)


### PR DESCRIPTION
## 📋 Description
I recently updated the extension registry pages and I noticed that I forgot to change the order of the pages in the menu. The idea is to read them in this order:

Introduction > Register an extension > replace, exclude or Unregister. This is clear if you check the content of the overview page:

<img width="784" height="396" alt="afbeelding" src="https://github.com/user-attachments/assets/13e87e54-d3ed-493e-91c0-579a9f61f6c2" />

(https://docs.umbraco.com/umbraco-cms/customizing/extending-overview/extension-registry)

However, I did not update the menu:

<img width="307" height="221" alt="afbeelding" src="https://github.com/user-attachments/assets/25d1712d-69b6-46c1-b650-0119ca447d8a" />

This PR fixes this.

## 📎 Related Issues (if applicable)
N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)
N/A

## Deadline (if relevant)
N/A

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
