### PR TITLE
Modernize Custom Property Editors/Delivery API away from IPublishedSnapshotAccessor 

### DIFF
--- a/15/umbraco-cms/reference/content-delivery-api/custom-property-editors-support.md
+++ b/15/umbraco-cms/reference/content-delivery-api/custom-property-editors-support.md
@@ -91,7 +91,7 @@ public class MyCustomPickerValueConverter(
 {% endcode %}
 
 {% hint style="info" %}
-Umbraco developers will need to inject `IPublishedContentCache`, `IPublishedMediaCache`, `IPublishedMemberCache` and `IPublishedContentTypeCache` dependencies individually, instead of injecting the `IPublishedSnapshotAccessor` as would have been done previously.
+Umbraco developers need to inject `IPublishedContentCache`, `IPublishedMediaCache`, `IPublishedMemberCache`, and `IPublishedContentTypeCache` individually, instead of injecting the `IPublishedSnapshotAccessor` as in previous versions.
 {% endhint %}
 
 The Implementation of the `IDeliveryApiPropertyValueConverter` interface can be found in the following methods:

--- a/16/umbraco-cms/reference/content-delivery-api/custom-property-editors-support.md
+++ b/16/umbraco-cms/reference/content-delivery-api/custom-property-editors-support.md
@@ -91,7 +91,7 @@ public class MyCustomPickerValueConverter(
 {% endcode %}
 
 {% hint style="info" %}
-Umbraco developers will need to inject `IPublishedContentCache`, `IPublishedMediaCache`, `IPublishedMemberCache` and `IPublishedContentTypeCache` dependencies individually, instead of injecting the `IPublishedSnapshotAccessor` as would have been done previously.
+Umbraco developers need to inject `IPublishedContentCache`, `IPublishedMediaCache`, `IPublishedMemberCache`, and `IPublishedContentTypeCache` individually, instead of injecting the `IPublishedSnapshotAccessor` as in previous versions.
 {% endhint %}
 
 The Implementation of the `IDeliveryApiPropertyValueConverter` interface can be found in the following methods:

--- a/17/umbraco-cms/reference/content-delivery-api/custom-property-editors-support.md
+++ b/17/umbraco-cms/reference/content-delivery-api/custom-property-editors-support.md
@@ -91,7 +91,7 @@ public class MyCustomPickerValueConverter(
 {% endcode %}
 
 {% hint style="info" %}
-Umbraco developers will need to inject `IPublishedContentCache`, `IPublishedMediaCache`, `IPublishedMemberCache` and `IPublishedContentTypeCache` dependencies individually, instead of injecting the `IPublishedSnapshotAccessor` as would have been done previously.
+Umbraco developers need to inject `IPublishedContentCache`, `IPublishedMediaCache`, `IPublishedMemberCache`, and `IPublishedContentTypeCache` individually, instead of injecting the `IPublishedSnapshotAccessor` as in previous versions.
 {% endhint %}
 
 The Implementation of the `IDeliveryApiPropertyValueConverter` interface can be found in the following methods:


### PR DESCRIPTION
## 📋 Description

Rewriting code samples for custom property editor support in headless for a modern approach that replaces `IPublishedSnapshotAccessor`.

## 📎 Related Issues (if applicable)

https://github.com/umbraco/UmbracoDocs/issues/7572

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

v15, v16

## Deadline (if relevant)

N/A

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
