### PR TITLE
Fix UFM filter syntax in markdown documentation

### DIFF
--- a/17/umbraco-cms/reference/umbraco-flavored-markdown.md
+++ b/17/umbraco-cms/reference/umbraco-flavored-markdown.md
@@ -52,7 +52,7 @@ The syntax for UFM filters uses a pipe character `|` (Vertical Line). Multiple f
 To display a rich text value, stripping out the HTML markup and limiting it to the first 15 words could use the following filters:
 
 ```markdown
-{umbValue: bodyText | strip-html | word-limit:15}
+{umbValue: bodyText | stripHtml | wordLimit:15}
 ```
 
 The following UFM filters are available to use.
@@ -62,11 +62,11 @@ The following UFM filters are available to use.
 | Bytes      | `bytes`      | `{umbValue: umbracoBytes \| bytes}`    |
 | Fallback   | `fallback`   | `{umbValue: headline \| fallback:N/A}` |
 | Lowercase  | `lowercase`  | `{umbValue: headline \| lowercase}`    |
-| Strip HTML | `strip-html` | `{umbValue: bodyText \| strip-html}`   |
-| Title Case | `title-case` | `{umbValue: headline \| title-case}`   |
+| Strip HTML | `stripHtml` | `{umbValue: bodyText \| stripHtml}`   |
+| Title Case | `titleCase` | `{umbValue: headline \| titleCase}`   |
 | Truncate   | `truncate`   | `{umbValue: intro \| truncate:30:...}` |
 | Uppercase  | `uppercase`  | `{umbValue: headline \| uppercase}`    |
-| Word Limit | `word-limit` | `{umbValue: intro \| word-limit:15}`   |
+| Word Limit | `wordLimit` | `{umbValue: intro \| wordLimit:15}`   |
 
 
 ## UFM Expressions (JavaScript-like syntax)


### PR DESCRIPTION
## 📋 Description

Fix the UFM filter syntax for v17 ([it should also apply to v16.4](https://github.com/umbraco/UmbracoDocs/pull/7552#issuecomment-3480190669)).

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->
https://github.com/umbraco/Umbraco-CMS/pull/20501
https://github.com/umbraco/UmbracoDocs/pull/7533

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

v16.4+ and v17

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
