### PR TITLE
Remove RuntimeMinification section from runtime modes

### DIFF
--- a/16/umbraco-cms/fundamentals/setup/server-setup/runtime-modes.md
+++ b/16/umbraco-cms/fundamentals/setup/server-setup/runtime-modes.md
@@ -95,10 +95,6 @@ The recommended approach to enable `Production` mode is to update the `appsettin
       },
       "WebRouting": {
         "UmbracoApplicationUrl": "https://<REPLACE_WITH_YOUR_PRIMARY_DOMAIN>/"
-      },
-      "RuntimeMinification": {
-        "UseInMemoryCache": true,
-        "CacheBuster": "AppDomain"
       }
     }
   }


### PR DESCRIPTION
Removed RuntimeMinification configuration from the document.

## 📋 Description

Updating the (v16) documentation to match available settings

Runtime minification has been removed as part of version 14 
So I'm assuming what I'm submitting is correct [example?](https://github.com/umbraco/UmbracoDocs/pull/6029)

## 📎 Related Issues (if applicable)

[maybe](https://github.com/umbraco/UmbracoDocs/pull/6029)

## ✅ Contributor Checklist

I do not confirm. I do not conform. I am unanimous.

## 📚 Helpful Resources

* [Runtime minification settings (v13)](https://docs.umbraco.com/umbraco-cms/13.latest/reference/configuration/runtimeminificationsettings)
* [Runtime modes - Production - appsettings suggestion (v16)](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/server-setup/runtime-modes#production-mode)
