### PR TITLE
Fix table of contents links in scenarios.md

### DIFF
--- a/16/umbraco-cms/reference/developer-mcp/scenarios.md
+++ b/16/umbraco-cms/reference/developer-mcp/scenarios.md
@@ -14,7 +14,7 @@ Each scenario includes example prompts that demonstrate how to accomplish real-w
 - [Site Structure & Configuration](#site-structure-and-configuration)
 - [Development & DevOps](#development-and-devops)
 - [Monitoring & Maintenance](#monitoring-and-maintenance)
-- [User & Permissions Management](#user-abd-permissions-management)
+- [User & Permissions Management](#user-and-permissions-management)
 - [Content Analysis & Reporting](#content-analysis-and-reporting)
 - [Multi-language & Localization](#multi-language-and-localization)
 - [Advanced Workflows](#advanced-workflows)


### PR DESCRIPTION
## 📋 Description

The in page table of contents had incorrect links to navigate down the page. Where ever there was an & in the name it was doing `--` instead of `-and-`.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] ~Code blocks are correctly formatted.~
* [ ] ~Sentences are short and clear (preferably under 25 words).~
* [ ] ~Passive voice and first-person language (“we”, “I”) are avoided.~
* [ ] ~Relevant pages are linked.~
* [x] All links work and point to the correct resources.
* [ ] ~Screenshots or diagrams are included if useful.~
* [ ] ~Any code examples or instructions have been tested.~
* [x] Typos, broken links, and broken images are fixed.

