### PR TITLE
Restore flag providers naming

### DIFF
--- a/16/umbraco-cms/extending/flag-providers.md
+++ b/16/umbraco-cms/extending/flag-providers.md
@@ -74,7 +74,7 @@ internal class MyDocumentFlagProvider : IFlagProvider
 The flag provider needs to be registered with Umbraco in a composer or application startup with:
 
 ```csharp
-  builder.FlagProviders()
+  builder.SignProviders()
     .Append<MyDocumentFlagProvider>();
 ```
 

--- a/17/umbraco-cms/extending/flag-providers.md
+++ b/17/umbraco-cms/extending/flag-providers.md
@@ -78,7 +78,7 @@ internal class MyDocumentFlagProvider : IFlagProvider
 The flag provider needs to be registered with Umbraco in a composer or application startup with:
 
 ```csharp
-  builder.SignProviders()
+  builder.FlagProviders()
     .Append<MyDocumentFlagProvider>();
 ```
 


### PR DESCRIPTION
## 📋 Description

https://github.com/umbraco/UmbracoDocs/pull/7588 revealed a problem in code where we hadn't be complete with a rename refactoring.  That's done now and will be corrected in 17.0.0-rc2.  Hence this PR updates back some of what was in the linked PR, to use the corrected naming.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [X] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17.0.0-rc2

## Deadline (if relevant)

November 13