### PR TITLE
Add warnings against exposing auth tokens in web apps

### DIFF
--- a/13/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api.md
+++ b/13/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api.md
@@ -17,9 +17,9 @@ If you are not familiar with members in Umbraco, please read the [Members](https
 {% endhint %}
 
 {% hint style="warning" %}
-It is no longer recommended to use public OpenID Connect (OAuth) clients for web applications. If you want to use protected content from the Delivery API in a web application, please consider adding additional layers of security.
+It is no longer recommended to use public OpenID Connect (OAuth) clients for web applications. If you want to use protected content from the Delivery API in a web application, consider adding additional layers of security.
 
-You'll find more details in [this article](https://learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-oidc-web-authentication) from Microsoft.
+For more details, see [Microsoft’s guide on configuring OpenID Connect for web authentication](https://learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-oidc-web-authentication).
 {% endhint %}
 
 ## Member authorization

--- a/15/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api/README.md
+++ b/15/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api/README.md
@@ -19,9 +19,9 @@ If you are looking to achieve server-to-server access to protected content, plea
 {% endhint %}
 
 {% hint style="warning" %}
-It is no longer recommended to use public OpenID Connect (OAuth) clients for web applications. If you want to use protected content from the Delivery API in a web application, please consider adding additional layers of security.
+It is no longer recommended to use public OpenID Connect (OAuth) clients for web applications. If you want to use protected content from the Delivery API in a web application, consider adding additional layers of security.
 
-You'll find more details in [this article](https://learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-oidc-web-authentication) from Microsoft.
+For more details, see [Microsoft’s guide on configuring OpenID Connect for web authentication](https://learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-oidc-web-authentication).
 {% endhint %}
 
 ## Member authorization

--- a/16/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api/README.md
+++ b/16/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api/README.md
@@ -19,9 +19,9 @@ If you are looking to achieve server-to-server access to protected content, plea
 {% endhint %}
 
 {% hint style="warning" %}
-It is no longer recommended to use public OpenID Connect (OAuth) clients for web applications. If you want to use protected content from the Delivery API in a web application, please consider adding additional layers of security.
+It is no longer recommended to use public OpenID Connect (OAuth) clients for web applications. If you want to use protected content from the Delivery API in a web application, consider adding additional layers of security.
 
-You'll find more details in [this article](https://learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-oidc-web-authentication) from Microsoft.
+For more details, see [Microsoft’s guide on configuring OpenID Connect for web authentication](https://learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-oidc-web-authentication).
 {% endhint %}
 
 ## Member authorization

--- a/17/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api/README.md
+++ b/17/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api/README.md
@@ -24,9 +24,9 @@ Member authentication and authorization in the Delivery API is performed using t
 Most programming languages have OpenId Connect client libraries to handle the complexity for us. [`AppAuth`](https://appauth.io/) is a great example of such a library. In ASP.NET Core, OpenId Connect support is built into the framework.
 
 {% hint style="warning" %}
-It is no longer recommended to use public OpenID Connect (OAuth) clients for web applications. If you want to use protected content from the Delivery API in a web application, please consider adding additional layers of security.
+It is no longer recommended to use public OpenID Connect (OAuth) clients for web applications. If you want to use protected content from the Delivery API in a web application, consider adding additional layers of security.
 
-You'll find more details in [this article](https://learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-oidc-web-authentication) from Microsoft.
+For more details, see [Microsoft’s guide on configuring OpenID Connect for web authentication](https://learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-oidc-web-authentication).
 {% endhint %}
 
 ### Enabling member authorization


### PR DESCRIPTION
## 📋 Description

Following [these recommendations](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps) from IETF (also mirrored by [this article](https://learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-oidc-web-authentication) from Microsoft), it seems prudent to add explicit warnings to our documentation, discouraging site implementers from exposing auth tokens to web applications.

## 📎 Related Issues (if applicable)

None.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

All active versions.

## Deadline (if relevant)

Anytime 😄 

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
