### PR TITLE
Update import for extension registry in property actions

### DIFF
--- a/16/umbraco-cms/customizing/property-editors/property-actions.md
+++ b/16/umbraco-cms/customizing/property-editors/property-actions.md
@@ -23,8 +23,8 @@ Before creating a Property Action, make sure you are familiar with the [Extensio
 
 Here is how you can register a new Property Action:
 ```
-import { extensionRegistry } from '@umbraco-cms/extension-registry';
-import { MyEntityAction } from './my-property-action.api';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+
 const manifest =
   {
     type: 'propertyAction',
@@ -40,7 +40,7 @@ const manifest =
     }
   };
 
-extensionRegistry.register(manifest);
+umbExtensionsRegistry.register(manifest);
 ```
 ### Creating the Property Action Class
 


### PR DESCRIPTION
## 📋 Description

Fixes the extension registry import, it used the wrong path. Updated to reflect your working docs over here:
https://docs.umbraco.com/umbraco-cms/customizing/extending-overview/extension-registry/register-extensions#registration-with-javascript

In addition, the import of `MyEntityAction` was not used so removed. The import was done already at this line:

```js
api: () => import('./my-property-action.api.js'),
```