### PR TITLE
Update MCP package references from beta to version 16

### DIFF
--- a/16/umbraco-cms/reference/developer-mcp/README.md
+++ b/16/umbraco-cms/reference/developer-mcp/README.md
@@ -104,7 +104,7 @@ Although the details vary slightly, the general pattern is the same across all h
 {
   "umbraco-mcp": {
     "command": "npx",
-    "args": ["@umbraco-cms/mcp-dev@beta"],
+    "args": ["@umbraco-cms/mcp-dev"],
     "env": {
       "NODE_TLS_REJECT_UNAUTHORIZED": "0",
       "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",
@@ -184,7 +184,7 @@ The Umbraco MCP Server is designed to work with specific major versions of Umbra
 | MCP Server Version | Compatible Umbraco Version | NPM Package Name                     |
 |--------------------|----------------------------|--------------------------------------|
 | 15.x.x             | alpha                      | @umbraco-mcp/umbraco-mcp-cms@alpha   |
-| 16.x.x             | all betas, 16.x            | @umbraco-cms/mcp-dev@beta            |
+| 16.x.x             | all betas, 16.x            | @umbraco-cms/mcp-dev@16              |
 
 ### Version Checking
 

--- a/16/umbraco-cms/reference/developer-mcp/configuration.md
+++ b/16/umbraco-cms/reference/developer-mcp/configuration.md
@@ -100,7 +100,7 @@ The `.env` file is included in `.gitignore` by default to prevent sensitive cred
 You can also provide configuration values directly via CLI arguments, which override any `.env` or environment variable settings:
 
 ```bash
-npx @umbraco-cms/mcp-dev@beta \
+npx @umbraco-cms/mcp-dev \
   --umbraco-client-id="your-id" \
   --umbraco-client-secret="your-secret" \
   --umbraco-base-url="http://localhost:56472" \

--- a/16/umbraco-cms/reference/developer-mcp/host-setup/claude-code.md
+++ b/16/umbraco-cms/reference/developer-mcp/host-setup/claude-code.md
@@ -21,7 +21,7 @@ npm install -g @anthropic-ai/claude-code
 Add an MCP server using the Claude CLI:
 
 ```bash
-claude mcp add umbraco-mcp npx @umbraco-cms/mcp-dev@beta
+claude mcp add umbraco-mcp npx @umbraco-cms/mcp-dev@16
 ```
 
 **Define configuration values directly**
@@ -31,7 +31,7 @@ To define configuration values directly, use this pattern:
 ```bash
 
 # Add with environment variables
-claude mcp add umbraco-mcp --env UMBRACO_CLIENT_ID="your-id" --env UMBRACO_CLIENT_SECRET="your-secret" --env UMBRACO_BASE_URL="https://your-domain.com" --env NODE_TLS_REJECT_UNAUTHORIZED="0" --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type" -- npx @umbraco-cms/mcp-dev@beta
+claude mcp add umbraco-mcp --env UMBRACO_CLIENT_ID="your-id" --env UMBRACO_CLIENT_SECRET="your-secret" --env UMBRACO_BASE_URL="https://your-domain.com" --env NODE_TLS_REJECT_UNAUTHORIZED="0" --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type" -- npx @umbraco-cms/mcp-dev@16
 ```
 
 Replace the `UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, `UMBRACO_BASE_UR` and `UMBRACO_INCLUDE_TOOL_COLLECTIONS` values with your local connection details.
@@ -75,7 +75,7 @@ Example `.mcp.json` file
   "mcpServers": {
     "umbraco-mcp": {
       "command": "npx",
-      "args": ["@umbraco-cms/mcp-dev@beta"],
+      "args": ["@umbraco-cms/mcp-dev@16"],
     }
   }
 }

--- a/16/umbraco-cms/reference/developer-mcp/host-setup/cursor.md
+++ b/16/umbraco-cms/reference/developer-mcp/host-setup/cursor.md
@@ -19,7 +19,7 @@ description: "Host set up for Cursor"
   "mcpServers": {
     "umbraco-mcp": {
       "command": "npx", 
-      "args": ["@umbraco-cms/mcp-dev@beta"],
+      "args": ["@umbraco-cms/mcp-dev@16"],
       "env": {
         "NODE_TLS_REJECT_UNAUTHORIZED": "0",
         "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",


### PR DESCRIPTION
## 📋 Description

Changed all references from @umbraco-cms/mcp-dev@beta to @umbraco-cms/mcp-dev@16 across documentation files to reflect the proper version tagging for the v16 release.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS Developper MCP

## Deadline (if relevant)

Some time next week would be OK

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
