### PR TITLE
Add mention of extended IProductSnapshot interfaces

### DIFF
--- a/17/umbraco-commerce/key-concepts/product-adapters.md
+++ b/17/umbraco-commerce/key-concepts/product-adapters.md
@@ -72,7 +72,7 @@ public interface IProductSnapshot
 ```
 
 {% hint style="info" %}
-`IProductSnapshot` is the base model for what Umbraco Commerce needs. If you want to include images or measurements (for example, if you need weight-based shipping), then there are other interfaces you can return.
+`IProductSnapshot` is the base model for enriching the Umbraco Commerce product model. To include images or custom measurements, such as weight-based shipping, more specific interfaces are available.
 `IProductSnapshotWithImage`, `IProductSnapshotWithCategories` & `IProductSnapshotWithMeasurements` are all valid return types that allows you to enrich the product model.
 {% endhint %}
 


### PR DESCRIPTION
## 📋 Description

I've recently spent way more time than I'd like to admit on figuring out how to add a weight onto a product in Umbraco Commerce when fetching products through a Product Adapter.
This PR adds a note on the other extended IProductSnapshot interfaces that add additional data to your product that may be useful.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Any code examples or instructions have been tested.

## Product & Version (if relevant)

I've been working on Umbraco Commerce 16.4.1, but I'd assume it to be the same for all other versions.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
