### PR TITLE
UFM: `umbValue` refinements

### DIFF
--- a/17/umbraco-cms/reference/umbraco-flavored-markdown.md
+++ b/17/umbraco-cms/reference/umbraco-flavored-markdown.md
@@ -57,7 +57,7 @@ To display a rich-text value, stripping out the HTML markup and limiting it to t
 
 {% hint style="info" %}
 Please note, using `umbValue` directly with a rich-text value will not display the contents. This is due to the complexity of the underlying data structure. The `stripHtml` filter has been designed to support the rich-text value.
-Alternatively, you may use the UFM Expression syntax to access the raw rich-text value, e.g. `${ bodyText.markup }`.
+Alternatively, you may use the UFM Expression syntax to access the raw rich-text value, like `${ bodyText.markup }`.
 {% endhint %}
 
 The following UFM filters are available to use.


### PR DESCRIPTION
## 📋 Description

Updates [Umbraco Flavored Markdown](https://docs.umbraco.com/umbraco-cms/reference/umbraco-flavored-markdown/) (UFM) documentation with a refinement and clarification on `umbValue` usage and rich-text editor values.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco CMS v17

## Deadline (if relevant)

As soon as convenient.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
