### PR TITLE
Adding allow list data type configuration for 17

### DIFF
--- a/17/umbraco-cms/reference/content-delivery-api/README.md
+++ b/17/umbraco-cms/reference/content-delivery-api/README.md
@@ -116,7 +116,7 @@ Find a description of each of the configuration keys in the table below.
         </tr>
         <tr>
             <td><code>AllowedContentTypeAliases</code></td>
-            <td>Contains the aliases of the content types that should be exposed through the Delivery API, this configuration takes precedence over the <code>DisallowedContentTypeAliases</code> so if there are any duplicates, they will be allowed regardless. Note that if this configuration contains any aliases, all other aliases will not be exposed through the Delivery API, if the configuration is empty, all aliases will be exposed, unless they are included in the <code>DisallowedContentTypeAliases</code></td>
+            <td>Contains the aliases of the content types that should be exposed through the Delivery API. This configuration takes precedence over the <code>DisallowedContentTypeAliases</code> so if there are any duplicates, they will be allowed regardless. If this configuration contains any aliases, all other aliases will not be exposed through the Delivery API. If the configuration is empty, all aliases will be exposed, unless they are included in <code>DisallowedContentTypeAliases</code></td>
         </tr>
         <tr>
             <td><code>RichTextOutputAsJson</code></td>


### PR DESCRIPTION
## 📋 Description
A new allow list will be added to the Delivery API settings, where developers can configure which content types will be exposed through the API.

This PR aims to clearly explain the functionality of this new allow list.

## 📎 Related Issues (if applicable)
No related issue, but a discussion and a PR.

https://github.com/umbraco/Umbraco-CMS/discussions/15806
https://github.com/umbraco/Umbraco-CMS/pull/21111

## Product & Version (if relevant)
Umbraco 17.1

## Release
This should be reviewed for publication on December 23rd, aligning with the 17.1 release candidate.