### PR TITLE
Code block fix for 'language-files-for-packages.md'

### DIFF
--- a/16/umbraco-cms/extending/packages/language-files-for-packages.md
+++ b/16/umbraco-cms/extending/packages/language-files-for-packages.md
@@ -11,10 +11,6 @@ If you want your package to be available in different languages, you can use the
 To register localizations to a language, you must add a new manifest to the Extension API. The manifest can be added through the `umbraco-package.json` file like this:
 
 {% code title="umbraco-package.json" lineNumbers="true" %}
-```
-```
-{% endcode %}
-
 ```json
 {
   ...
@@ -32,5 +28,6 @@ To register localizations to a language, you must add a new manifest to the Exte
   ]
 }
 ```
+{% endcode %}
 
 Read the [UI Localization documentation](../../customizing/foundation/localization.md) to learn in-depth on how you can use languages in your packages and Umbraco in general.

--- a/17/umbraco-cms/extending/packages/language-files-for-packages.md
+++ b/17/umbraco-cms/extending/packages/language-files-for-packages.md
@@ -11,10 +11,6 @@ If you want your package to be available in different languages, you can use the
 To register localizations to a language, you must add a new manifest to the Extension API. The manifest can be added through the `umbraco-package.json` file like this:
 
 {% code title="umbraco-package.json" lineNumbers="true" %}
-```
-```
-{% endcode %}
-
 ```json
 {
   ...
@@ -32,5 +28,6 @@ To register localizations to a language, you must add a new manifest to the Exte
   ]
 }
 ```
+{% endcode %}
 
 Read the [UI Localization documentation](../../customizing/foundation/localization.md) to learn in-depth on how you can use languages in your packages and Umbraco in general.


### PR DESCRIPTION
## 📋 Description

Fix for issue with code block formatting on Language file for packages page. v16 and v17 https://docs.umbraco.com/umbraco-cms/extending/packages/language-files-for-packages  (See example in image below)

<img width="797" height="443" alt="image" src="https://github.com/user-attachments/assets/10f1d5a7-2ed4-4b67-a939-3526e018d636" />



## 📎 Related Issues (if applicable)


## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
