### PR TITLE
Update document-types.md

### DIFF
--- a/13/umbraco-cms/tutorials/creating-a-basic-website/document-types.md
+++ b/13/umbraco-cms/tutorials/creating-a-basic-website/document-types.md
@@ -46,7 +46,7 @@ To create a Document Type at the root of the **Content Tree**:
 1.  Go to the **Structure** tab.
 
     ![Allow Document Type as root](images/figure-9a-allow-document-type-as-root-v8.png)
-2. Toggle the **Allow as root** or **Allow at root** button.
+2. Toggle the **Allow at root** button.
    * If your **Document Types** do not have the **Allow as root** checked, you will not be able to create any content on your site.
 3. Click **Save**.
 


### PR DESCRIPTION
Update "Settings Permissions" instructions to show that "Allow at root" (Allow as root) can now be found under the "Structure" tab.
<img width="1911" height="785" alt="image" src="https://github.com/user-attachments/assets/1a8486ad-681e-40c7-a3b8-47c00092eaf1" />
