### PR TITLE
Added more information about DOTNET_ENVIRONMENT value and precedence

### DIFF
--- a/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/README.md
+++ b/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/README.md
@@ -133,9 +133,9 @@ Changing the .NET framework runtime or the `DOTNET_ENVIRONMENT` environment vari
 {% endhint %}
 
 {% hint style="info" %}
-When using `WebApplication`, `DOTNET_ENVIRONMENT` takes precedence over `ASPNETCORE_ENVIRONMENT`. When using the legacy `WebHost`, `ASPNETCORE_ENVIRONMENT` takes precedence instead. 
+When using `WebApplication`, `DOTNET_ENVIRONMENT` takes precedence over `ASPNETCORE_ENVIRONMENT`. When using the legacy `WebHost`, `ASPNETCORE_ENVIRONMENT` takes precedence instead.
 
-The environment value can be overridden by setting the `ASPNETCORE_ENVIRONMENT` variable in `web.config`.
+You can also override the environment value by setting the `ASPNETCORE_ENVIRONMENT` variable in your `web.config` file.
 {% endhint %}
 
 ![Advanced Settings](images/advanced-settings.png)


### PR DESCRIPTION
## 📋 Description

Some customers are overriding the environment value through `web.config` which means that we don't see the expected runtime environment value set through Umbraco Cloud Portal being retrieved in executed code. 
It would be really nice to give a bit more information on the precedence rules.


## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Cloud

## Deadline (if relevant)

No deadline

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
