### PR TITLE
fix: replace deprecated `dotnet new --list` with `dotnet new list`

### DIFF
--- a/17/umbraco-cms/fundamentals/setup/install/install-umbraco-with-templates.md
+++ b/17/umbraco-cms/fundamentals/setup/install/install-umbraco-with-templates.md
@@ -14,7 +14,7 @@ Video Tutorial
 2. Run `dotnet new install Umbraco.Templates` to install the project templates.
 _The solution is packaged up into the NuGet package_ [_Umbraco.Templates_](https://www.nuget.org/packages/Umbraco.Templates) _and can be installed into the dotnet CLI_.
 
-> Once that is complete, you can see that Umbraco was added to the list of available projects types by running `dotnet new --list`:
+> Once that is complete, you can see that Umbraco was added to the list of available projects types by running `dotnet new list`:
 
 ```cli
 Templates                    Short Name               Language          Tags


### PR DESCRIPTION
## 📋 Description

Replace deprecated `dotnet new --list` with `dotnet new list`  to avoid deprecation warning

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
