### PR TITLE
Fix installation command for MCP server

### DIFF
--- a/17/umbraco-cms/reference/developer-mcp/README.md
+++ b/17/umbraco-cms/reference/developer-mcp/README.md
@@ -163,7 +163,7 @@ If you prefer, you can also install it globally with:
 
 ``` bash
 
-npm install -g @umbraco/mcp-server
+@umbraco-cms/mcp-dev@17
 
 ```
 


### PR DESCRIPTION
This pull request makes a minor update to the installation instructions in the `README.md` for the MCP developer reference. The change updates the global install command to reference the correct package.

- Updated the global installation example to use `@umbraco-cms/mcp-dev@17` instead of `@umbraco/mcp-server` in the `README.md` documentation.Updated installation command for MCP server to use the correct package name.



## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [X] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

