### PR TITLE
Update Forms documentation to correct order of email workflow senders

### DIFF
--- a/13/umbraco-forms/editor/attaching-workflows/workflow-types.md
+++ b/13/umbraco-forms/editor/attaching-workflows/workflow-types.md
@@ -95,7 +95,7 @@ person@umbraco.dk; person@umbraco.com, person@umbraco.de
 
 If the _Sender Email_ field is not populated, the address used will be read from CMS configuration.
 
-The [Global Settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/globalsettings) value configured at `Umbraco:CMS:Global:Smtp` will be used if provided.
+The [Global Settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/globalsettings) value configured at `Umbraco:CMS:Global:Smtp:From` will be used if provided.
 
 ```json
     "Umbraco": {

--- a/16/umbraco-forms/editor/attaching-workflows/workflow-types.md
+++ b/16/umbraco-forms/editor/attaching-workflows/workflow-types.md
@@ -95,7 +95,7 @@ person@umbraco.dk; person@umbraco.com, person@umbraco.de
 
 If the _Sender Email_ field is not populated, the address used will be read from CMS configuration.
 
-The [Global Settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/globalsettings) value configured at `Umbraco:CMS:Global:Smtp` will be used if provided.
+The [Global Settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/globalsettings) value configured at `Umbraco:CMS:Global:Smtp:From` will be used if provided.
 
 ```json
     "Umbraco": {

--- a/17/umbraco-forms/editor/attaching-workflows/workflow-types.md
+++ b/17/umbraco-forms/editor/attaching-workflows/workflow-types.md
@@ -95,7 +95,7 @@ person@umbraco.dk; person@umbraco.com, person@umbraco.de
 
 If the _Sender Email_ field is not populated, the address used will be read from CMS configuration.
 
-The [Global Settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/globalsettings) value configured at `Umbraco:CMS:Global:Smtp` will be used if provided.
+The [Global Settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/globalsettings) value configured at `Umbraco:CMS:Global:Smtp:From` will be used if provided.
 
 ```json
     "Umbraco": {


### PR DESCRIPTION
This pull request updates the documentation for how the sender email address is determined in Umbraco Forms workflows when the _Sender Email_ field is not populated. The main change is that the order of precedence between the Global and Content configuration settings has been swapped, and the example JSON configuration has been updated to reflect this.

Resolves an issue raised in https://github.com/umbraco/Umbraco.Forms.Issues/issues/1417#issuecomment-3714040498