### PR TITLE
Add how to make a whole custom view for a block clickable to edit the block

### DIFF
--- a/17/umbraco-cms/tutorials/creating-custom-views-for-blocklist.md
+++ b/17/umbraco-cms/tutorials/creating-custom-views-for-blocklist.md
@@ -166,7 +166,7 @@ To add content to the blocks:
 
 ## Creating `Settings` section for Blocks
 
-Now, we have overwritten the default view for the content editor's block presentation by using our own view. Let's create a **Settings** section to control the data alignment of the block. To do this, we need to add a **Settings** model to our block configuration.
+Now, we have overwritten the default view for the block presentation by using our own view. Let's create a **Settings** section to control the data alignment of the block. To do this, we need to add a **Settings** model to our block configuration.
 
 To add a Settings model:
 


### PR DESCRIPTION
## 📋 Description

In Umbraco 13.x when you have a custom backoffice view for a block you can include `ng-click=“block.edit()”` to make the entire block clickable, where a click opens the edit content pane. The equivalent for Umbraco 17 exists but is not documented.

This PR adds to the documentation the solution shared in https://forum.umbraco.com/t/custom-backoffice-views-for-blocks-in-umbraco-17-click-to-edit/6616

I also removed an obsolete reference to AngularJS.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided. (I've used "We" but only to match the rest of the document.)
* [x] Relevant pages are linked. (I would've linked to documentation of `UMB_BLOCK_ENTRY_CONTEXT` but there isn't any.)
* [x] Any code examples or instructions have been tested. (I copied the existing example and added lines of code that I have many working examples of)
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco CMS v17.x

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
