### PR TITLE
Add documentation for Setting attribute DefaultValue property

### DIFF
--- a/13/umbraco-forms/developer/configuration/README.md
+++ b/13/umbraco-forms/developer/configuration/README.md
@@ -187,7 +187,7 @@ For example, providing a value of `"f_"` will apply a prefix of "f\_" to each fi
 Forms allows you to configure default values and visibility for field, workflow, data source, and prevalue source settings. Default values can be set in two ways:
 
 1. **In code** - by using the `DefaultValue` property on the [`Setting` attribute](../extending/adding-a-fieldtype.md#field-settings), or a property initializer, when defining custom or extended provider types.
-2. **In configuration** - using this `SettingsCustomization` section, which takes precedence over code-based defaults.
+2. **In configuration** - by using the `SettingsCustomization` section, which takes precedence over code-based defaults.
 
 Without any configuration, the default behavior when a new field or workflow is added to a form is for each setting to be empty. The values are then completed by the editor. All settings defined on the type are displayed for entry.
 

--- a/13/umbraco-forms/developer/extending/adding-a-fieldtype.md
+++ b/13/umbraco-forms/developer/extending/adding-a-fieldtype.md
@@ -188,7 +188,7 @@ public virtual string MySetting { get; set; }
 
 `IsMandatory` if set to `true` will provide client-side validation in the backoffice to ensure the value is completed.
 
-Default values for settings can be defined in code using two approaches.
+Default values for settings can be defined in code using one of two approaches.
 
 Using a property initializer:
 

--- a/16/umbraco-forms/developer/configuration/README.md
+++ b/16/umbraco-forms/developer/configuration/README.md
@@ -182,7 +182,7 @@ For example, providing a value of `"f_"` will apply a prefix of "f\_" to each fi
 Forms allows you to configure default values and visibility for field, workflow, data source, and prevalue source settings. Default values can be set in two ways:
 
 1. **In code** - by using the `DefaultValue` property on the [`Setting` attribute](../extending/adding-a-fieldtype.md#field-settings), or a property initializer, when defining custom or extended provider types.
-2. **In configuration** - using this `SettingsCustomization` section, which takes precedence over code-based defaults.
+2. **In configuration** - by using the `SettingsCustomization` section, which takes precedence over code-based defaults.
 
 Without any configuration, the default behavior when a new field or workflow is added to a form is for each setting to be empty. The values are then completed by the editor. All settings defined on the type are displayed for entry.
 

--- a/16/umbraco-forms/developer/extending/adding-a-fieldtype.md
+++ b/16/umbraco-forms/developer/extending/adding-a-fieldtype.md
@@ -156,7 +156,7 @@ The `View` property indicates a property editor UI used for editing the setting 
 
 `IsMandatory` if set to `true` will provide client-side validation in the backoffice to ensure the value is completed.
 
-Default values for settings can be defined in code using two approaches.
+Default values for settings can be defined in code using one of two approaches.
 
 Using a property initializer:
 

--- a/17/umbraco-forms/developer/configuration/README.md
+++ b/17/umbraco-forms/developer/configuration/README.md
@@ -182,7 +182,7 @@ For example, providing a value of `"f_"` will apply a prefix of "f\_" to each fi
 Forms allows you to configure default values and visibility for field, workflow, data source, and prevalue source settings. Default values can be set in two ways:
 
 1. **In code** - by using the `DefaultValue` property on the [`Setting` attribute](../extending/adding-a-fieldtype.md#field-settings), or a property initializer, when defining custom or extended provider types.
-2. **In configuration** - using this `SettingsCustomization` section, which takes precedence over code-based defaults.
+2. **In configuration** - by using the `SettingsCustomization` section, which takes precedence over code-based defaults.
 
 Without any configuration, the default behavior when a new field or workflow is added to a form is for each setting to be empty. The values are then completed by the editor. All settings defined on the type are displayed for entry.
 

--- a/17/umbraco-forms/developer/extending/adding-a-fieldtype.md
+++ b/17/umbraco-forms/developer/extending/adding-a-fieldtype.md
@@ -156,7 +156,7 @@ The `View` property indicates a property editor UI used for editing the setting 
 
 `IsMandatory` if set to `true` will provide client-side validation in the backoffice to ensure the value is completed.
 
-Default values for settings can be defined in code using two approaches.
+Default values for settings can be defined in code using one of two approaches.
 
 Using a property initializer:
 


### PR DESCRIPTION
## 📋 Description

Documents the new `DefaultValue` property available on the `Setting` attribute for custom field types, workflows, data sources, and prevalue sources. Also clarifies how default values can be set both in code and via configuration, with configuration taking precedence.

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Forms: 13, 16, 17

## Deadline (if relevant)

Only to be merged on final release of 13.9.0, 16.4.0 and 17.1.0 (Thursday 22nd January)

🤖 Generated with [Claude Code](https://claude.com/claude-code)