### PR TITLE
added missing rendering markup for UmbSorterController example

### DIFF
--- a/17/umbraco-cms/customizing/utilities/sorting.md
+++ b/17/umbraco-cms/customizing/utilities/sorting.md
@@ -82,15 +82,16 @@ Lit does provide a render helper method called `repeat` that does this for us. T
 
     render() {
 		return html`
-			
+			<div class="sorter-container">
 				${repeat(
 					this._items,
 					(item) => item.id,
 					(item) =>
-						html`${item.name}
+						html`
+                            <p class="sorter-item" data-sorter-id="${item.id}">${item.name}</p>
 						`,
 				)}
-			
+			</div>
 		`;
 	}
 ```


### PR DESCRIPTION
The example render code was missing the classes for the container and item, as well as the "data-sorter-id" attribute, so the sorter would throw an error when the sorter starts up when copying this example. I just changed the rendering markup to match up with the settings earlier in this document.

## Product & Version (if relevant)

Umbraco: 17.0.2
