### PR TITLE
Add note about .lic for third-party add-ons

### DIFF
--- a/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
+++ b/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
@@ -115,7 +115,10 @@ Delete the `<PackageReference>` entries for these packages.
   * `Umbraco.Cloud.Cms`
   * `Umbraco.Cloud.StorageProviders.AzureBlob`
 
-* Delete the `Licenses` folder and all `.lic` files within it. Please note that `.lic` files may exist for third-party add-ons. In such cases, these files should generally be preserved, and the `Licenses` folder should not be removed.
+* Open the `Licenses` folder and delete all Umbraco-related `.lic` files.
+* Keep any `.lic` files needed for your third-party tools.
+
+If the folder is empty after deleting the files, you can safely remove the entire `Licenses` folder as well.
 
 * _[Optional]_ If using Deploy and Forms on Umbraco Cloud:
   1. Locate and open the `appsettings.json` file (and any environment-specific variants).


### PR DESCRIPTION
## 📋 Description

<!-- A clear and concise description of what this PR changes or adds. Include context if necessary. -->
For Umbraco Cloud prorject licenses can be registered via the following in appsettings.json.

```
"Licenses": {
  "Products": {
    "Umbraco.Deploy": "UMBRACO-CLOUD",
    "Umbraco.Forms": "UMBRACO-CLOUD"
  }
}
```

However some third-party add-on, e.g. MediaProtect still use the file-based `.lic` in `Licenses` folder in which case this shouldn't be deleted.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
