### PR TITLE
Updated article to refer only to second-person (you)

### DIFF
--- a/17/umbraco-cms/tutorials/creating-custom-views-for-blocklist.md
+++ b/17/umbraco-cms/tutorials/creating-custom-views-for-blocklist.md
@@ -208,7 +208,7 @@ To add a Settings model:
    * Click **Add Group** and **Enter a Name**: _Settings_.
    * Click **Add Property** and **Enter a Name**: _Block Alignment_. The `blockAlignment` alias is automatically generated.
    * Select **Dropdown List** as the editor.
-   * In the Add options field, add **left**, **center** and **right** as values.
+   * Add **left**, **center** and **right** as values to the Dropdown List.
    * Click **Submit**.
 
 <figure><img src="../.gitbook/assets/prevalue-options-1 (1).png" alt=""><figcaption></figcaption></figure>


### PR DESCRIPTION
## 📋 Description

The article used both 1st, 2nd and 3rd person. I've updated the article to use only 2nd person.
Also resolved some formatting issues.

## Product & Version (if relevant)

CMS (all versions)
