### PR TITLE
Correct contact team for resource expansion inquiries

### DIFF
--- a/umbraco-cloud/release-notes/archive/overview-2023/2023-09-releasenotes.md
+++ b/umbraco-cloud/release-notes/archive/overview-2023/2023-09-releasenotes.md
@@ -29,6 +29,6 @@ We've specifically updated the "Usage" page for those who have added extra bandw
 
 ![Extra usage 2](../../images/UsageExtra2.png)
 
-If you are considering expanding your resources, you can contact our support team to add even more bandwidth or storage to your existing plan. You can also switch to a plan with dedicated resources for greater flexibility.
+If you are considering expanding your resources, you can contact our Sales team to add even more bandwidth or storage to your existing plan. You can also switch to a plan with dedicated resources for greater flexibility.
 
 Feel free to reach out for any further assistance or clarification.


### PR DESCRIPTION
Updated the contact team reference from 'support' to 'Sales' for resource expansion inquiries, since it's them and not support who handles this request. 
