### PR TITLE
Update links to Umbraco documentation

### DIFF
--- a/17/umbraco-forms/developer/extending/adding-a-fieldtype.md
+++ b/17/umbraco-forms/developer/extending/adding-a-fieldtype.md
@@ -204,7 +204,7 @@ npm install -D @umbraco-forms/backoffice@x.x.x
 
 This will add a package to your devDependencies containing the TypeScript definitions for Umbraco Forms.
 
-To display a name and description on a custom field, you need to register a JavaScript file as shown in the [Localization](https://docs.umbraco.com/umbraco-cms/tutorials/creating-your-first-extension) article.
+To display a name and description on a custom field, you need to register a JavaScript file as shown in the [Localization](https://docs.umbraco.com/umbraco-cms/customizing/foundation/localization) article.
 
 ### Field Preview
 


### PR DESCRIPTION
Fixing links that were broken and pointing to Gitbook

## 📋 Description

This pull request updates documentation links in the custom field type extension guide for Umbraco Forms 14+ to point to the official Umbraco documentation site instead of an external GitBook resource. This ensures that users are directed to the most current and authoritative information.

Documentation link updates:

* Updated the "Extension with Vite, TypeScript, and Lit" article link to use the official Umbraco documentation site.
* Updated the "Localization" article link to use the official Umbraco documentation site.


## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.
