### PR TITLE
Update reCAPTCHA V3 documentation with link to config options

### DIFF
--- a/17/umbraco-forms/editor/creating-a-form/fieldtypes/recaptcha3.md
+++ b/17/umbraco-forms/editor/creating-a-form/fieldtypes/recaptcha3.md
@@ -31,4 +31,4 @@ You can create your keys by logging into your [reCAPTCHA account](https://www.go
 
 ## Additional Configuration Options
 
-Refer to [Configuration](https://docs.umbraco.com/umbraco-forms/developer/configuration#recaptcha-v3-field-type-configuration) to see additional options that can be set in the `appSettings.json` for reCAPTCHA v3.
+Refer to [Configuration](../../../developer/configuration#recaptcha-v3-field-type-configuration) to see additional options that can be set in the `appSettings.json` for reCAPTCHA v3.


### PR DESCRIPTION
Added link to relevant section in Configuration doc which contains relevant configuration options for reCAPTCHA V3.

## 📋 Description

Adds information to the reCAPTCHA V3 doc to point readers to the relevant section in the Configuration doc containing additional reCAPTCHA V3 options. 

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
