### PR TITLE
Update README.md to correct details of Writers permissions and approval process

### DIFF
--- a/17/umbraco-cms/fundamentals/data/users/README.md
+++ b/17/umbraco-cms/fundamentals/data/users/README.md
@@ -77,7 +77,11 @@ By default, the User Groups available to new users are **Administrators**, **Edi
 * **Editors**: Allowed to create and publish content items or nodes on the website without approval from others or restrictions (has permissions to **Public Access**, **Rollback**, **Browse Node**, **Create Content Template**, **Delete**, **Create**, **Publish**, **Unpublish**, **Update**, **Copy**, **Move** and **Sort**).
 * **Sensitive data**: Any users added to this User group will have access to view any data marked as sensitive. Learn more about this feature in the [Sensitive Data](../../../reference/security/sensitive-data-on-members.md) article.
 * **Translators**: These are used for translating your website. Translators are allowed to browse and update nodes as well as grant dashboard access. Translations of site pages must be reviewed by others before publication (has permissions to **Browse Node** and **Update**).
-* **Writers**: Allowed to browse nodes, create nodes and save content. Not allowed to publish directly (has permissions to **Browse Node**, **Create** and **Update**). In previous versions of Umbraco there was a "Send to publish" permission enabled for Writers but now approval processes can be configured using the official [Workflow package](https://umbraco.com/products/add-ons/workflow/). Umbraco Workflow is available for free or on a yearly licence with an extra set of features.
+* **Writers**: Allowed to browse nodes, create nodes, and save content. Not allowed to publish directly but has permissions to **Browse Node**, **Create**, and **Update**.
+
+{% hint style="info" %}
+In previous versions of Umbraco, "Send to publish" was enabled for Writers. Since Umbraco 16, approval processes can be configured using the official [Umbraco Workflow package](https://umbraco.com/products/add-ons/workflow/).
+{% endhint %}
 
 ## Creating a User Group
 


### PR DESCRIPTION
The documentation incorrectly mentions "Send to publish" permission for the Writers group which is no longer available from Umbraco 16 onwards. The process of requesting approval can now be configured by using the Umbraco Workflow product so the docs needs an update to reflect this.

## 📋 Description

This Pull Request updates the paragraph discussing the Writers User Group permission set which previously indicated a "Send to Publish" permission but that permission is no longer available as part of the core CMS offering. This was discussed in this forum post - https://forum.umbraco.com/t/send-to-publish-in-v16-v17/7249 and had previously confused us when trying to replicate a setup from an Umbraco 13 build as the documentation was out of date.

## 📎 Related Issues (if applicable)

Not applicable.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

- [x] Sentences are short and clear (preferably under 25 words).
- [x] Passive voice and first-person language (“we”, “I”) are avoided.
- [x] Relevant pages are linked.
- [x] All links work and point to the correct resources.
- [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

v16 & v17

## Deadline (if relevant)

No deadline.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
