### PR TITLE
Update prepping-frontend.md

### DIFF
--- a/17/umbraco-forms/developer/prepping-frontend.md
+++ b/17/umbraco-forms/developer/prepping-frontend.md
@@ -42,7 +42,9 @@ If using `async`, please make sure to [disable the Forms client-side validation 
 
 ## Validation Using jQuery
 
-If you want to use jQuery as your validation framework for Umbraco Forms instead of the ASP.NET Client Validation library, you can manually add the following client dependencies:
+It is possible to use jQuery as your validation framework instead of the ASP.NET Client Validation library.
+
+To use jQuery validation, add the following client dependencies:
 
 - `jQuery` (JavaScript library)
 - `jQuery validate` (jQuery plugin that provides client-side Form validation)


### PR DESCRIPTION
Updating language to call out that the jQuery Validation is not required if your using the ASP.NET validation.

## 📋 Description

Page is unclear around what is needed for setup.  For validation i believe it's an either or setup, but the documentation is unclear and makes it look like you may need both for validation.    

## 📚 Helpful Resources

*🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)](https://umbraco.com/blog/umbraco-forms-86-release/)

## Other note

Also i think the jQuery validation script needs to be updated i the documentation as version 1.16 has several known vulnerabilities.  But I'm not sure what versions are supported by Umbraco forms..

https://ajax.aspnetcdn.com/ajax/jquery.validate/1.16.0/jquery.validate.min.js

CVE-2022-31147
CVE-2021-21252
CVE-2021-43306