### PR TITLE
CMS: Tiptap RTE: Adds link (`<a>` tag) to Style Menu config

### DIFF
--- a/17/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/style-menu.md
+++ b/17/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/style-menu.md
@@ -109,7 +109,7 @@ The `items` property defines the structure of the style select menu. Each menu i
 
 ### Supported HTML tags
 
-Due to Tiptap’s strict rich-text schema, only supported HTML tags are allowed in the style select menu, _(arbitrary markup will be excluded)._ The following HTML tag names are supported:
+Due to Tiptap’s strict rich-text schema, only supported HTML tags are allowed in the style select menu *(arbitrary markup will be excluded)*. The following HTML tag names are supported:
 
 * `h1`
 * `h2`


### PR DESCRIPTION
## 📋 Description

Updates the [Tiptap RTE Style Menu](https://docs.umbraco.com/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/style-menu) page with configuration to support link (`<a>` tags).

## 📎 Related Issues (if applicable)

- https://github.com/umbraco/Umbraco-CMS/pull/21494

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco CMS 17.2.0

## Deadline (if relevant)

Can be published once v17.2.0-RC has been released, on-or-after 5th February.
