### PR TITLE
Fixed broken link and minor fixes

### DIFF
--- a/17/umbraco-forms/editor/creating-a-form/fieldtypes/README.md
+++ b/17/umbraco-forms/editor/creating-a-form/fieldtypes/README.md
@@ -19,7 +19,7 @@ By default, the following Field Types are available:
 * [File Upload](fileupload.md): Allows the user to select and upload a local file.
 
     ![File upload](images/fileupload-v14.png)
-* **Password**: Allows to type a password. The input is not visible when typing.
+* **Password**: Allows typing a password. The input is not visible when typing.
 
     ![Password field](images/password-v14.png)
 * **Multiple Choice**: Displays a list of items with a checkbox for each item where the user can select multiple options.


### PR DESCRIPTION
## 📋 Description

[Recaptcha Enterprise with Score](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-forms/editor/creating-a-form/fieldtypes/recaptcha-enterprise.md) is a broken link in the published doc. However, the file path and link are correct. This PR fixes some minor stuff. The Preview shows the link fine. Not sure what exactly is happening here with the link.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Forms v17

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
