### PR TITLE
Correct FilterAllowedChildrenAsync method signature in content type filter example

### DIFF
--- a/17/umbraco-cms/reference/content-type-filters.md
+++ b/17/umbraco-cms/reference/content-type-filters.md
@@ -56,7 +56,10 @@ internal class OneHomePageOnlyContentTypeFilter : IContentTypeFilter
             .Where(x => docTypeAliasesToExclude.Contains(x.Alias) is false));
     }
 
-    public Task<IEnumerable<ContentTypeSort>> FilterAllowedChildrenAsync(IEnumerable<ContentTypeSort> contentTypes, Guid parentKey)
+    public Task<IEnumerable<ContentTypeSort>> FilterAllowedChildrenAsync(
+        IEnumerable<ContentTypeSort> contentTypes,
+        Guid parentContentTypeKey,
+        Guid? parentContentKey)
         => Task.FromResult(contentTypes);
 }
 ```


### PR DESCRIPTION
## 📋 Description

Corrects the `FilterAllowedChildrenAsync` method signature in the provided content type filter example.

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/issues/21691

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [X] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [X] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17

## Deadline (if relevant)

Any time