### PR TITLE
Update rewrites-on-cloud.md with baseline feature note

### DIFF
--- a/umbraco-cloud/go-live/manage-hostnames/rewrites-on-cloud.md
+++ b/umbraco-cloud/go-live/manage-hostnames/rewrites-on-cloud.md
@@ -25,6 +25,7 @@ When setting up rewrite rules on Umbraco Cloud, there are a few important things
 * Always include a condition to exclude the Umbraco backoffice path (`/umbraco`). Failing to do so may prevent you from deploying to and from the environment.
 * To continue working locally with your Umbraco Cloud project, you should also add a condition to exclude `localhost`.
 * To serve verification files from the `.well-known` directory (for example, Apple Pay or Google), follow the [Rewrite rule workaround in the CMS documentation](https://docs.umbraco.com/umbraco-cms/reference/routing/iisrewriterules#example-serving-files-from-the-well-known-path).
+* If the Umbraco Cloud baseline feature is used, only apply the rewrites to the child project and not the baseline itself.
 
 ## Hiding the default `umbraco.io` URL
 


### PR DESCRIPTION
## 📋 Description

Added a note about applying rewrites only to child projects when using the Umbraco Cloud baseline feature. Some rewrites (the hiding umbraco.io i.e) can block child projects from being created if they are made directly on the baseline/parent.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Cloud