### PR TITLE
Add proper path for config

### DIFF
--- a/marketplace-and-integrations/integrations/dynamics.md
+++ b/marketplace-and-integrations/integrations/dynamics.md
@@ -31,7 +31,8 @@ To connect to your Dynamics 365 instance, the following configuration is require
 {% code title="appsettings.json" %}
 ```json
 "Umbraco": {
-  "Integrations": {
+  "CMS": {
+    "Integrations": {
       "Crm": {
         "Dynamics": {
           "Settings": {
@@ -42,6 +43,7 @@ To connect to your Dynamics 365 instance, the following configuration is require
       }
     }
   }
+}
 ```
 {% endcode %}
 {% endtab %}


### PR DESCRIPTION
## 📋 Description

The CMS part was missing in one of the examples

## Product & Version (if relevant)

Umbraco.Cms.Integrations.Crm.Dynamics

Can see the path it uses within the code has CMS in its path:
https://github.com/umbraco/Umbraco.Cms.Integrations/blob/main/src/Umbraco.Cms.Integrations.Crm.Dynamics/Constants.cs#L40
