### PR TITLE
docs: add context to the two methods for form scripts

### DIFF
--- a/17/umbraco-forms/developer/rendering-scripts.md
+++ b/17/umbraco-forms/developer/rendering-scripts.md
@@ -56,7 +56,7 @@ This will use the appropriate storage method that you have configured.
 
 ## Using Form Scripts Alongside Validation Dependencies
 
-When setting up templates for Umbraco Forms, two separate script-rendering methods are involved and both are required for forms to work correctly.
+When setting up templates for Umbraco Forms, two separate script-rendering methods are involved, and both are required for forms to work correctly.
 
 `@Html.RenderUmbracoFormDependencies(Url)`, covered in the [Preparing Your Frontend](/umbraco-forms/developer/prepping-frontend) article, renders client-side validation scripts such as jQuery Validate and unobtrusive validation. This goes in the `<head>` of your template.
 


### PR DESCRIPTION
## 📋 Description

I was having a bit of a battle recently with AI-assisted development tools telling me not to include two scripts for forms and it repeatedly informing me to use only one.

This PR adds a documentation section to help AI understand why two might be required.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
