### PR TITLE
Adds details of main domain acquisition timeout setting

### DIFF
--- a/17/umbraco-cms/reference/configuration/globalsettings.md
+++ b/17/umbraco-cms/reference/configuration/globalsettings.md
@@ -55,6 +55,7 @@ The following snippet contains all the available options, with default values, a
       "DistributedLockingMechanism": "",
       "DistributedLockingReadLockDefaultTimeout": "00:01:00",
       "DistributedLockingWriteLockDefaultTimeout": "00:00:05",
+      "MainDomAcquisitionTimeout": "00:00:40"
     }
   }
 }
@@ -371,3 +372,12 @@ Type: `string` (default: `00:00:05`)
 Gets or sets a value representing the maximum time to wait whilst attempting to obtain a distributed write lock.
 
 The default value is 5 seconds.
+
+### Main Domain Acquisition Timeout
+
+Key: `MainDomAcquisitionTimeout`
+Type: `string` (default: `00:00:40`)
+
+Gets or sets a value representing the maximum time to wait whilst attempting to acquire MainDom status on startup.
+
+The default value is 40 seconds.


### PR DESCRIPTION
## 📋 Description

Adds details of main domain acquisition timeout setting.  This has always been a hardcoded value, but for flexibility we have made it configurable now.

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/pull/22013

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17.3

## Deadline (if relevant)

Should be published along with the release of the RC for 17.3, which is scheduled for 19th March.
