### PR TITLE
Add Deploy 16.0.5, 16.0.6 and 17.0.2 release notes

### DIFF
--- a/16/umbraco-deploy/release-notes.md
+++ b/16/umbraco-deploy/release-notes.md
@@ -14,7 +14,20 @@ If you are upgrading to a new major version you can find the details about the b
 
 ## Release history
 
-This section contains the release notes for Umbraco Deploy 15 including all changes for this version.
+This section contains the release notes for Umbraco Deploy 16 including all changes for this version.
+
+### [16.0.6](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F16.0.6) (March 5th 2026)
+
+* Set create date on new documents/media/members [#259](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/259)
+* Request children/structure reload and entity update after import or restore [#286](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/286)
+* Fix `InvalidOperationException` when getting value from `JsonValue` [#324](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/324)
+* Ensure all blocks are exposed during migration [#325](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/325)
+* Maintain reverse UDI order when cleaning entities [#327](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/327)
+
+### [16.0.5](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F16.0.5) (January 8th 2026)
+
+* Register all supported entity types on back-end and front-end [#273](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/273)
+* Set environment URL when fetching remote items and close dropdown after changing environment [#300](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/300)
 
 ### [16.0.4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F16.0.4) (October 9th 2025)
 

--- a/17/umbraco-deploy/release-notes.md
+++ b/17/umbraco-deploy/release-notes.md
@@ -16,6 +16,14 @@ If you are upgrading to a new major version, you can find the details about the 
 
 This section contains the release notes for Umbraco Deploy 17, including all changes for this version.
 
+### [17.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.0.2) (March 5th 2026)
+
+* Set create date on new documents/media/members [#259](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/259)
+* Request children/structure reload and entity update after import or restore [#286](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/286)
+* Fix `InvalidOperationException` when getting value from `JsonValue` [#324](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/324)
+* Ensure all blocks are exposed during migration [#325](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/325)
+* Maintain reverse UDI order when cleaning entities [#327](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/327)
+
 ### [17.0.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.0.1) (January 8th 2026)
 
 * Set environment URL when fetching remote items and close dropdown after changing environment: [#300](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/300).


### PR DESCRIPTION
## 📋 Description

Add Deploy 16.0.5, 16.0.6 and 17.0.2 release notes.

## Product & Version (if relevant)

Deploy 16 and 17.

## Deadline (if relevant)

These are already released to NuGet, so this can get merged without delay.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
