### PR TITLE
CMS: Update fetching-data for runtimeConfigPath, security scheme, and how security metadata works

### DIFF
--- a/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
+++ b/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
@@ -137,7 +137,7 @@ Register it in your SwaggerGen configuration:
 swaggerGenOptions.OperationFilter<MyExtensionSecurityRequirementsOperationFilter>();
 ```
 
-No `AddSecurityDefinition` call is needed — Umbraco already registers the `"Backoffice-User"` Bearer scheme globally, and the base filter references it automatically. Once in place, hey-api will generate SDK functions with the correct `security` metadata.
+No `AddSecurityDefinition` call is needed — Umbraco already registers the required Bearer security scheme globally, and the base filter references it automatically. Once in place, hey-api will generate SDK functions with the correct `security` metadata.
 
 For a full walkthrough of setting up a custom API, see [Creating a Backoffice API](../../../tutorials/creating-a-backoffice-api/README.md).
 

--- a/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
+++ b/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
@@ -107,11 +107,54 @@ if (data) {
 
 This uses the backoffice's HTTP client directly for that request instead of the generated client. The `umbHttpClient` already has authentication and the correct base URL configured.
 
-{% hint style="warning" %}
-The `auth` callback on `umbHttpClient` only fires for SDK functions that have `security` metadata. This metadata is generated automatically when your OpenAPI specification includes a security scheme (for example, Bearer authentication). If your spec does not include a security scheme, the generated functions will not send an `Authorization` header. For direct `.get()` / `.post()` calls (without a generated client), see [Umbraco HTTP Client](http-client.md).
-{% endhint %}
+## How security metadata works
 
-### Fetch API
+The `auth` callback on `umbHttpClient` only fires when a request carries `security` metadata. This metadata originates from the `security` field on each operation in your OpenAPI specification. When hey-api generates your client from the spec, it reads that field and includes `security: [{ type: 'http', scheme: 'bearer' }]` directly in each generated SDK function.
+
+### Management API (automatic)
+
+If your controllers are part of the Umbraco Management API — tagged with `[MapToApi("management")]` — Umbraco adds the `security` field to every non-anonymous endpoint automatically. This is done by `BackOfficeSecurityRequirementsOperationFilter`, a Swashbuckle operation filter registered as part of the Management API configuration. It inspects each operation at startup: if neither the controller class nor the action method carries `[AllowAnonymous]`, it writes the security requirement into the OpenAPI spec.
+
+When hey-api then generates your client from that spec, the `security` metadata is already in place. No extra setup needed.
+
+### Custom separate API
+
+If you expose a separate API with its own Swagger document, you need to add the security scheme to your OpenAPI specification yourself. Umbraco provides `BackOfficeSecurityRequirementsOperationFilterBase` as a public base class you can subclass:
+
+```csharp
+using Umbraco.Cms.Api.Management.OpenApi;
+
+internal sealed class MyExtensionSecurityRequirementsOperationFilter : BackOfficeSecurityRequirementsOperationFilterBase
+{
+    // Must match the [MapToApi("...")] attribute on your controllers
+    protected override string ApiName => "myextension";
+}
+```
+
+Register it in your SwaggerGen configuration:
+
+```csharp
+swaggerGenOptions.OperationFilter<MyExtensionSecurityRequirementsOperationFilter>();
+```
+
+No `AddSecurityDefinition` call is needed — Umbraco already registers the `"Backoffice-User"` Bearer scheme globally, and the base filter references it automatically. Once in place, hey-api will generate SDK functions with the correct `security` metadata.
+
+For a full walkthrough of setting up a custom API, see [Creating a Backoffice API](../../../tutorials/creating-a-backoffice-api/README.md).
+
+### Direct calls without a generated client
+
+When calling `umbHttpClient` directly — without a generated SDK function — there is no spec to derive security metadata from. Pass it explicitly on each call:
+
+```typescript
+const { data } = await umbHttpClient.get({
+    url: '/umbraco/myextension/api/v1/endpoint',
+    security: [{ type: 'http', scheme: 'bearer' }],
+});
+```
+
+See [Umbraco HTTP Client](http-client.md) for more details.
+
+## Fetch API
 
 If you only have a few requests, you can also use the `fetch` function directly. Read more about that here:
 

--- a/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
+++ b/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
@@ -34,7 +34,7 @@ To learn more about OpenAPI and how to define your API specification, visit the 
 
 ## Connecting to the Management API
 
-Your generated client needs the correct base URL, credentials, and authentication to talk to the Management API. The recommended approach uses Hey-API's `runtimeConfigPath` to inherit these settings automatically from the backoffice's built-in HTTP client (`umbHttpClient`).
+Your generated client needs the correct base URL, credentials, and authentication to talk to the Management API. The recommended approach uses hey-api's `runtimeConfigPath` to inherit these settings automatically from the backoffice's built-in HTTP client (`umbHttpClient`).
 
 {% hint style="info" %}
 The [Umbraco Extension Template](../../development-flow/umbraco-extension-template.md) already includes this setup. If you scaffolded your extension with `dotnet new umbraco-extension`, authentication works out of the box — no additional configuration needed.

--- a/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
+++ b/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
@@ -119,7 +119,7 @@ That resolved shape is what `umbHttpClient` checks before invoking the `auth` ca
 
 ### Management API (automatic)
 
-If your controllers are part of the Umbraco Management API — tagged with `[MapToApi("management")]` — Umbraco writes the `operation.security` requirement into the OpenAPI spec automatically. This is done by `BackOfficeSecurityRequirementsOperationFilter`, a Swashbuckle operation filter registered as part of the Management API configuration. It inspects each operation at startup: if neither the controller class nor the action method carries `[AllowAnonymous]`, it adds the security requirement referencing the globally registered `"Backoffice-User"` scheme.
+If your controllers are part of the Umbraco Management API — tagged with `[MapToApi("management")]` — Umbraco writes the `operation.security` requirement into the OpenAPI spec automatically. This is done by `BackOfficeSecurityRequirementsOperationFilter`, a Swashbuckle operation filter registered as part of the Management API configuration. It inspects each operation at startup. If neither the controller class nor the action method carries `[AllowAnonymous]`, it adds a security requirement referencing the globally registered `"Backoffice-User"` scheme.
 
 When hey-api generates your client from that spec, it resolves the scheme and emits the runtime security metadata into each SDK function. No extra setup needed.
 

--- a/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
+++ b/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
@@ -105,17 +105,17 @@ if (data) {
 }
 ```
 
-This uses the backoffice HTTP client directly for that request instead of the generated client. The `umbHttpClient` already has authentication and the correct base URL configured.
+The example above uses the backoffice HTTP client directly instead of the generated client. The `umbHttpClient` already has authentication and the correct base URL configured.
 
 ## How security metadata works
 
 The `auth` callback on `umbHttpClient` only fires when a request carries `security` metadata. Here is how that metadata flows from your API to the generated client:
 
-1. Each operation in your OpenAPI spec has an optional `security` field listing which security schemes it requires — for example, `[{ "Backoffice-User": [] }]`.
+1. Each operation in your OpenAPI spec has an optional `security` field listing the security schemes it requires. Example: `[{ "Backoffice-User": [] }]`.
 2. Those scheme names are defined in `components.securitySchemes`, where their type (OAuth2, HTTP Bearer, and so on) is declared.
-3. When hey-api generates your client, it reads both and resolves them into its own runtime shape — `security: [{ type: 'http', scheme: 'bearer' }]` — emitted directly into each generated SDK function.
+3. When hey-api generates your client, it reads both and resolves them into its own runtime shape - `security: [{ type: 'http', scheme: 'bearer' }]` - emitted directly into each generated SDK function.
 
-That resolved shape is what `umbHttpClient` checks before invoking the `auth` callback.
+The resolved shape is what `umbHttpClient` checks before invoking the `auth` callback.
 
 ### Management API (automatic)
 

--- a/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
+++ b/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
@@ -34,7 +34,7 @@ To learn more about OpenAPI and how to define your API specification, visit the 
 
 ## Connecting to the Management API
 
-Your generated client needs the correct base URL, credentials, and authentication to talk to the Management API. The recommended approach uses hey-api's `runtimeConfigPath` to inherit these settings automatically from the backoffice's built-in HTTP client (`umbHttpClient`).
+Your generated client needs the correct base URL, credentials, and authentication to talk to the Management API. The recommended approach uses hey-api's `runtimeConfigPath` to inherit these settings automatically from the built-in backoffice HTTP client (`umbHttpClient`).
 
 {% hint style="info" %}
 The [Umbraco Extension Template](../../development-flow/umbraco-extension-template.md) already includes this setup. If you scaffolded your extension with `dotnet new umbraco-extension`, authentication works out of the box — no additional configuration needed.
@@ -83,7 +83,7 @@ export const createClientConfig: CreateClientConfig = (config) => ({
 });
 ```
 
-This copies `baseUrl`, `credentials`, `auth`, and `headers` from the backoffice's HTTP client into your generated client at initialization time. Extensions load after the backoffice is fully configured, so all values are available.
+This copies `baseUrl`, `credentials`, `auth`, and `headers` from the backoffice HTTP client into your generated client at initialization time. Extensions load after the backoffice is fully configured, so all values are available.
 
 When the generator runs, the generated `client.gen.ts` will automatically import `createClientConfig` and apply it during client creation. Your SDK functions will be authenticated without any entrypoint setup.
 
@@ -105,7 +105,7 @@ if (data) {
 }
 ```
 
-This uses the backoffice's HTTP client directly for that request instead of the generated client. The `umbHttpClient` already has authentication and the correct base URL configured.
+This uses the backoffice HTTP client directly for that request instead of the generated client. The `umbHttpClient` already has authentication and the correct base URL configured.
 
 ## How security metadata works
 

--- a/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
+++ b/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
@@ -119,7 +119,7 @@ When hey-api then generates your client from that spec, the `security` metadata 
 
 ### Custom separate API
 
-If you expose a separate API with its own Swagger document, you need to add the security scheme to your OpenAPI specification yourself. Umbraco provides `BackOfficeSecurityRequirementsOperationFilterBase` as a public base class you can subclass:
+If you expose a separate API with its own Swagger document, you need to ensure that security requirements are applied to the operations in your OpenAPI specification, for example via an operation filter. Umbraco provides `BackOfficeSecurityRequirementsOperationFilterBase` as a public base class you can subclass:
 
 ```csharp
 using Umbraco.Cms.Api.Management.OpenApi;

--- a/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
+++ b/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
@@ -125,7 +125,7 @@ When hey-api generates your client from that spec, it resolves the scheme and em
 
 ### Custom separate API
 
-If you expose a separate API with its own Swagger document, you need to ensure that security requirements are applied to the operations in your OpenAPI specification, for example via an operation filter. Umbraco provides `BackOfficeSecurityRequirementsOperationFilterBase` as a public base class you can subclass:
+If you expose a separate API with its own Swagger document, security requirements are not added automatically. You must apply them to each operation in your OpenAPI specification, for example via an operation filter. Umbraco provides `BackOfficeSecurityRequirementsOperationFilterBase` as a public base class you can subclass:
 
 ```csharp
 using Umbraco.Cms.Api.Management.OpenApi;

--- a/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
+++ b/17/umbraco-cms/customizing/foundation/fetching-data/custom-generated-client.md
@@ -109,13 +109,19 @@ This uses the backoffice's HTTP client directly for that request instead of the 
 
 ## How security metadata works
 
-The `auth` callback on `umbHttpClient` only fires when a request carries `security` metadata. This metadata originates from the `security` field on each operation in your OpenAPI specification. When hey-api generates your client from the spec, it reads that field and includes `security: [{ type: 'http', scheme: 'bearer' }]` directly in each generated SDK function.
+The `auth` callback on `umbHttpClient` only fires when a request carries `security` metadata. Here is how that metadata flows from your API to the generated client:
+
+1. Each operation in your OpenAPI spec has an optional `security` field listing which security schemes it requires — for example, `[{ "Backoffice-User": [] }]`.
+2. Those scheme names are defined in `components.securitySchemes`, where their type (OAuth2, HTTP Bearer, and so on) is declared.
+3. When hey-api generates your client, it reads both and resolves them into its own runtime shape — `security: [{ type: 'http', scheme: 'bearer' }]` — emitted directly into each generated SDK function.
+
+That resolved shape is what `umbHttpClient` checks before invoking the `auth` callback.
 
 ### Management API (automatic)
 
-If your controllers are part of the Umbraco Management API — tagged with `[MapToApi("management")]` — Umbraco adds the `security` field to every non-anonymous endpoint automatically. This is done by `BackOfficeSecurityRequirementsOperationFilter`, a Swashbuckle operation filter registered as part of the Management API configuration. It inspects each operation at startup: if neither the controller class nor the action method carries `[AllowAnonymous]`, it writes the security requirement into the OpenAPI spec.
+If your controllers are part of the Umbraco Management API — tagged with `[MapToApi("management")]` — Umbraco writes the `operation.security` requirement into the OpenAPI spec automatically. This is done by `BackOfficeSecurityRequirementsOperationFilter`, a Swashbuckle operation filter registered as part of the Management API configuration. It inspects each operation at startup: if neither the controller class nor the action method carries `[AllowAnonymous]`, it adds the security requirement referencing the globally registered `"Backoffice-User"` scheme.
 
-When hey-api then generates your client from that spec, the `security` metadata is already in place. No extra setup needed.
+When hey-api generates your client from that spec, it resolves the scheme and emits the runtime security metadata into each SDK function. No extra setup needed.
 
 ### Custom separate API
 


### PR DESCRIPTION
## 📋 Description

Adds a new "How security metadata works" section to `custom-generated-client.md`, explaining where the `security` metadata in generated SDK functions comes from and what to do when it is absent.

- **Management API (automatic)**: Controllers tagged with `[MapToApi("management")]` get security metadata written into the OpenAPI spec automatically via `BackOfficeSecurityRequirementsOperationFilter`. No extra setup needed.
- **Custom separate API**: Subclass `BackOfficeSecurityRequirementsOperationFilterBase` with your own `ApiName` and register it in SwaggerGen. No `AddSecurityDefinition` call needed — Umbraco already registers the `"Backoffice-User"` scheme globally.
- **Direct calls without a generated client**: Pass `security: [{ type: 'http', scheme: 'bearer' }]` explicitly on each `umbHttpClient.get()`/`.post()` call.

This replaces the previous one-line warning with actionable guidance covering all three scenarios.

## 📎 Related Issues (if applicable)

ADO #63892
Related: [umbraco/Umbraco-CMS#21830](https://github.com/umbraco/Umbraco-CMS/pull/21830)

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco CMS 17

## Deadline (if relevant)

-

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)