### PR TITLE
Update Swagger UI navigation path in documentation

### DIFF
--- a/17/umbraco-cms/tutorials/creating-a-backoffice-api/documenting-your-controllers.md
+++ b/17/umbraco-cms/tutorials/creating-a-backoffice-api/documenting-your-controllers.md
@@ -95,5 +95,5 @@ public IActionResult DeleteItem(Guid id)
 
 ## Verifying the changes
 
-Run your application and navigate to the Swagger UI (typically found at /swagger).\
+Run your application and navigate to the Swagger UI (typically found at /umbraco/swagger/).\
 Verify that your API documentation is correctly displaying the routes, parameters, and response types.


### PR DESCRIPTION


## 📋 Description

The documentation suggests visiting `/swagger/` but in an Umbraco site shouldn't that be `/umbraco/swagger/`?

## 📎 Related Issues (if applicable)

n/a

## ✅ Contributor Checklist

Only made a small text change.

## Product & Version (if relevant)

v17 (and possibly lower?)

## Deadline (if relevant)

n/a
