### PR TITLE
Add code example for UserLogoutSuccessNotification with Auth0

### DIFF
--- a/17/umbraco-cms/reference/security/backofficeusermanager-and-notifications.md
+++ b/17/umbraco-cms/reference/security/backofficeusermanager-and-notifications.md
@@ -2,7 +2,7 @@
 description: >-
   The BackOfficeUserManager is the ASP.NET Core Identity UserManager
   implementation in Umbraco. It exposes APIs for working with Umbraco User's via
-  the ASP.NET Core Identity including password handling.
+  the ASP.NET Core Identity, including password handling.
 ---
 
 # BackOfficeUserManager and Events

--- a/17/umbraco-cms/reference/security/backofficeusermanager-and-notifications.md
+++ b/17/umbraco-cms/reference/security/backofficeusermanager-and-notifications.md
@@ -88,8 +88,8 @@ Internally these are mainly used for auditing but there are some that allow you 
     The notification has a property `SignOutRedirectUrl`. If this property is assigned then Umbraco will redirect to that URL upon successful\
     backoffice sign out in order to sign the user out of the external login provider.
 
-### Example: Signing out of an external OIDC provider
-  The following handler demonstrates how to assign `SignOutRedirectUrl` using Auth0 as the external login provider. The following handler retrieves the user's stored `id_token` and constructs a logout URL for the external provider with the appropriate `id_token_hint` and `post_logout_redirect_uri` parameters, then assigns that URL to `notification.SignOutRedirectUrl`.
+### Example: Signing out of Auth0 after backoffice logout
+  The following handler demonstrates how to assign `SignOutRedirectUrl` when using Auth0. 
   
 ```csharp
 public class UserLogoutSuccessNotificationHandler

--- a/17/umbraco-cms/reference/security/backofficeusermanager-and-notifications.md
+++ b/17/umbraco-cms/reference/security/backofficeusermanager-and-notifications.md
@@ -87,3 +87,92 @@ Internally these are mainly used for auditing but there are some that allow you 
     and you want to log out of that external provider when the user is logged out of the backoffice (that is log out of everywhere).\
     The notification has a property `SignOutRedirectUrl`. If this property is assigned then Umbraco will redirect to that URL upon successful\
     backoffice sign out in order to sign the user out of the external login provider.
+
+### Example: Signing out of an external OIDC provider
+  The following handler demonstrates how to assign `SignOutRedirectUrl` using Auth0 as the external login provider. The following handler retrieves the user's stored `id_token` and constructs a logout URL for the external provider with the appropriate `id_token_hint` and `post_logout_redirect_uri` parameters, then assigns that URL to `notification.SignOutRedirectUrl`.
+  
+```csharp
+public class UserLogoutSuccessNotificationHandler
+    : INotificationAsyncHandler<UserLogoutSuccessNotification>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IUserService _userService;
+    private readonly IExternalLoginWithKeyService _externalLoginWithKeyService;
+
+    public UserLogoutSuccessNotificationHandler(
+        IHttpContextAccessor httpContextAccessor,
+        IUserService userService,
+        IExternalLoginWithKeyService externalLoginWithKeyService)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _userService = userService;
+        _externalLoginWithKeyService = externalLoginWithKeyService;
+    }
+
+    public Task HandleAsync(
+        UserLogoutSuccessNotification notification,
+        CancellationToken cancellationToken)
+    {
+        HttpRequest? request = _httpContextAccessor.HttpContext?.Request;
+        if (request is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        Guid? userKey = GetUserKey(notification.AffectedUserId);
+        if (userKey is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        var schemeName = BackOfficeAuthenticationBuilder
+            .SchemeForBackOffice(Auth0ProviderOptions.SchemeName);
+
+        var idToken = _externalLoginWithKeyService
+            .GetExternalLoginTokens(userKey.Value)
+            .Where(e => schemeName.Equals(e.LoginProvider, StringComparison.Ordinal))
+            .FirstOrDefault(e => OpenIdConnectParameterNames.IdToken
+                .Equals(e.Name, StringComparison.Ordinal))
+            ?.Value;
+
+        if (idToken is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        // Replace with your actual tenant ID, 
+        const string ExternalLoginProviderTenant = "{your-tenant-id}";
+
+        notification.SignOutRedirectUrl =
+            $"https://{ExternalLoginProviderTenant}/oidc/logout" +
+            $"?id_token_hint={Uri.EscapeDataString(idToken)}" +
+            $"&post_logout_redirect_uri={Uri.EscapeDataString(
+                $"{request.Scheme}://{request.Host}/umbraco/logout")}";
+
+        return Task.CompletedTask;
+    }
+
+    private Guid? GetUserKey(string? userId)
+    {
+        if (userId is null)
+        {
+            return null;
+        }
+
+        if (int.TryParse(userId, NumberStyles.Integer,
+            CultureInfo.InvariantCulture, out var id))
+        {
+            return _userService.GetUserById(id)?.Key;
+        }
+
+        if (Guid.TryParse(userId, out Guid key))
+        {
+            return key;
+        }
+
+        return null;
+    }
+}
+```
+> **Note:** Replace `{your-tenant-id}` with your external login provider tenant ID, and adjust `Auth0ProviderOptions.SchemeName` to match your provider's scheme name.
+

--- a/17/umbraco-cms/reference/security/backofficeusermanager-and-notifications.md
+++ b/17/umbraco-cms/reference/security/backofficeusermanager-and-notifications.md
@@ -89,7 +89,8 @@ Internally these are mainly used for auditing but there are some that allow you 
     backoffice sign out in order to sign the user out of the external login provider.
 
 ### Example: Signing out of Auth0 after backoffice logout
-  The following handler demonstrates how to assign `SignOutRedirectUrl` when using Auth0. 
+
+The following handler demonstrates how to assign `SignOutRedirectUrl` when using Auth0. 
   
 ```csharp
 public class UserLogoutSuccessNotificationHandler
@@ -174,5 +175,8 @@ public class UserLogoutSuccessNotificationHandler
     }
 }
 ```
-> **Note:** Replace `{your-tenant-id}` with your external login provider tenant ID, and adjust `Auth0ProviderOptions.SchemeName` to match your provider's scheme name.
+
+{% hint style="info" %}
+Replace `{your-tenant-id}` with your external login provider tenant ID, and adjust `Auth0ProviderOptions.SchemeName` to match your provider's scheme name.
+{% endhint %}
 


### PR DESCRIPTION
## 📋 Description

<!-- A clear and concise description of what this PR changes or adds. Include context if necessary. -->
Added a complete code example demonstrating how to use the `SignOutRedirectUrl `property on `UserLogoutSuccessNotification `to sign out of Auth0 after backoffice logout.

The existing documentation explained the `SignOutRedirectUrl `property but lacked a practical example, making it difficult for developers to implement external provider logout. This is especially relevant for setups using Auth0 or similar OIDC providers where single sign-out is expected.

## 📎 Related Issues (if applicable)
https://github.com/umbraco/Umbraco-CMS/issues/21854
<!-- List any related issues, e.g. "Fixes #1234" -->
https://github.com/umbraco/Umbraco-CMS/pull/21952
## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
