### PR TITLE
add mention of the force evaluate setting if using lockfiles for restores

### DIFF
--- a/umbraco-cloud/build-and-customize-your-solution/handle-deployments-and-environments/umbraco-cicd/troubleshooting.md
+++ b/umbraco-cloud/build-and-customize-your-solution/handle-deployments-and-environments/umbraco-cicd/troubleshooting.md
@@ -16,7 +16,13 @@ This happens even though the CI/CD deployments were successfull, and files were 
 
 #### How to resolve the issue
 
-To resolve this issue, remove `RestorePackagesWithLockFile` for deployments to go through as expected.
+To resolve this issue, you need to ensure that when the site is restoring on Umbraco Cloud it is not using the lock file. You can do this by adding this line in your csproj file:
+
+```xml
+<RestoreForceEvaluate Condition="'$(KUDU_SYNC_CMD)' != ''">>true</RestoreForceEvaluate>
+```
+
+[Force Evaluate option on dotnet restore](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-restore#options)
 
 ### Deployment report: No changes detected - cleaning up
 


### PR DESCRIPTION
## 📋 Description

While looking into what is required to get projects using lock files for nuget restores to run on Umbraco Cloud we have found that users can opt into it themselves via this setting.

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco.Cloud.Issues/issues/830

