### PR TITLE
Services and Helpers documentation uses obsolete GetAtRoot in V17 

### DIFF
--- a/17/umbraco-cms/implementation/services/README.md
+++ b/17/umbraco-cms/implementation/services/README.md
@@ -422,7 +422,7 @@ public class SiteService : ISiteService
 
 **2 - The service can be used within or outside of a web request**
 
-In order to replicate `ContentAtRoot` outside of a web request, you can inject `IDocumentNavigationQueryService` (or `IMediaNavigationQueryService` for media). This service provides access to a store in memory of the unique keys of any nodes at the root of the Umbraco Content (or Media tree). 
+In order to replicate `ContentAtRoot` outside of a web request, you can inject `IDocumentNavigationQueryService` (or `IMediaNavigationQueryService` for media). This service provides access to an in-memory store of unique keys for all root nodes within the Umbraco Content or Media trees.
 
 {% hint style="tip" %}
 This replaces the `PublishedContentCache` (or PublishedMediaCache) `GetAtRoot()` method.


### PR DESCRIPTION
Updated SiteService Example to use IDocumentNavigationQueryService for root content retrieval instead of GetAtRoot().

## 📋 Description

Use of GetAtRoot on ContentPublishedCache has been removed in V17

The example in the Services and Helpers documentation, has an example which still uses it

This update, shows an implementation using the new IDocumentNavigationQueryService

## 📎 Related Issues (if applicable)

No related issues?

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

For V17

## Deadline (if relevant)

ASAP, as people are using V17 now.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
