### PR TITLE
Adding explanation to new Subscriber Servers database write operations.

### DIFF
--- a/17/umbraco-cms/fundamentals/setup/server-setup/load-balancing/flexible-advanced.md
+++ b/17/umbraco-cms/fundamentals/setup/server-setup/load-balancing/flexible-advanced.md
@@ -62,7 +62,7 @@ In order to have read-only database access configured for your front-end servers
 
 Now that your subscriber servers are using your custom `SubscriberServerRoleAccessor` class, they will always be deemed 'Subscriber' servers and will not attempt to run the automatic server role election process or task scheduling. Because you are no longer using the default `ElectedServerRoleAccessor` they will not try to ping the umbracoServer table.
 
-When configuring a server as a read-only subscriber, Umbraco automatically detects the state and disables specific background database write operations, such as DistributedBackgroundJobs. A notable exception is the LastSynced process. To ensure the subscriber server can still track synchronization across the cluster without database write access, Umbraco redirects these updates to a local file instead of the database.
+When configuring a server as a read-only subscriber, Umbraco automatically detects the state and disables specific background database write operations, such as DistributedBackgroundJobs. A notable exception is the LastSynced process. To ensure the subscriber server tracks synchronization without database write access, Umbraco redirects these updates to a local file instead of the database.
 
 {% hint style="info" %}
 If using [SqlMainDomLock](azure-web-apps.md#appdomain-synchronization) on Azure WebApps then write-permissions are required for the following tables for all server roles including 'Subscriber'.

--- a/17/umbraco-cms/fundamentals/setup/server-setup/load-balancing/flexible-advanced.md
+++ b/17/umbraco-cms/fundamentals/setup/server-setup/load-balancing/flexible-advanced.md
@@ -62,6 +62,8 @@ In order to have read-only database access configured for your front-end servers
 
 Now that your subscriber servers are using your custom `SubscriberServerRoleAccessor` class, they will always be deemed 'Subscriber' servers and will not attempt to run the automatic server role election process or task scheduling. Because you are no longer using the default `ElectedServerRoleAccessor` they will not try to ping the umbracoServer table.
 
+When configuring a server as a read-only subscriber, Umbraco automatically detects the state and disables specific background database write operations, such as DistributedBackgroundJobs. A notable exception is the LastSynced process. To ensure the subscriber server can still track synchronization across the cluster without database write access, Umbraco redirects these updates to a local file instead of the database.
+
 {% hint style="info" %}
 If using [SqlMainDomLock](azure-web-apps.md#appdomain-synchronization) on Azure WebApps then write-permissions are required for the following tables for all server roles including 'Subscriber'.
 


### PR DESCRIPTION
## 📋 Description
Recent changes in the CMS (https://github.com/umbraco/Umbraco-CMS/pull/22145) has implemented functionality to check if a server is a subscriber, and the database is read-only. This forces some services to not attempt to write to the database, and forces others to write to a file on the system instead.

This PR attempts to explain this behavior in the relevant section.

<!-- A clear and concise description of what this PR changes or adds. Include context if necessary. -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)
Changes will be introduced in V17.4

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)
By the time 17.4 rolls out. (April 30th)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
