### PR TITLE
Added Restoring Media Between Environments section...

### DIFF
--- a/16/umbraco-deploy/deployment-workflow/content-transfer.md
+++ b/16/umbraco-deploy/deployment-workflow/content-transfer.md
@@ -46,9 +46,29 @@ If everything went well, you will see the confirmation screen saying that the tr
 
 Media items are transferred the same way as content:
 
-1. In the Media section, Click **...** next to the items you want to transfer and choose **Queue for transfer**.
-   * Or click **...** next to the Media section to transfer all you media at once.
-2. Go to the Deployment dashboard in the Content section to see the items you've queued for transfer and to transfer your items.
+1. Click **...** next to an item in the **Media** section.
+2. Choose **Queue for transfer**.
+3. Use the **Deployment dashboard** in the **Content** section to finish the transfer.
+
+#### Restoring Media Between Environments
+
+To synchronize a lower environment's media library with a higher one (for example, pulling Live media down to Staging), use the **Tree Restore** feature. This ensures that media metadata and the physical files are synchronized.
+
+1. Log into the target environment (for example, _Staging_).
+2. Go to the **Media** section of the Umbraco backoffice.
+3. Click **...** next to the **Media** root node.
+4. Select **Tree restore...**(Use **Environment restore...** if you also need to pull all Content and Forms).
+5. Select the source environment (for example, _Live_) from the **Restore this tree from** dropdown.
+6. Click **Restore from Live** and wait for the process to complete.
+7. Reload the Media tree to see the updated library.
+
+{% hint style="info" %}
+A Tree Restore of media will overwrite any media items on the target that also exist in the source. However, it will not delete items that exist on the target but are missing from the source. This is a safety feature to prevent accidental data loss. To achieve a true mirror (including the removal of orphaned items), you must manually empty the Media section (and the Recycle Bin) on the target environment. You could also use the [Import and Export](import-export.md) feature with a full media export from the source environment.
+{% endhint %}
+
+{% hint style="success" %}
+On Umbraco Cloud: Each environment uses a separate Azure Blob Storage container. During a restore, Umbraco Deploy handles the server-side copying of blobs between the unique storage containers of each environment. For more details ,see the [Media on Cloud](https://docs.umbraco.com/umbraco-cloud/build-and-customize-your-solution/handle-deployments-and-environments/media) article.
+{% endhint %}
 
 ### Umbraco Forms
 

--- a/16/umbraco-deploy/deployment-workflow/content-transfer.md
+++ b/16/umbraco-deploy/deployment-workflow/content-transfer.md
@@ -48,7 +48,6 @@ Media items are transferred the same way as content:
 
 1. Click **...** next to an item in the **Media** section.
 2. Choose **Queue for transfer**.
-3. Use the **Deployment dashboard** in the **Content** section to finish the transfer.
 
 #### Restoring Media Between Environments
 
@@ -63,7 +62,7 @@ To synchronize a lower environment's media library with a higher one (for exampl
 7. Reload the Media tree to see the updated library.
 
 {% hint style="info" %}
-A Tree Restore of media will overwrite any media items on the target that also exist in the source. However, it will not delete items that exist on the target but are missing from the source. This is a safety feature to prevent accidental data loss. To achieve a true mirror (including the removal of orphaned items), you must manually empty the Media section (and the Recycle Bin) on the target environment. You could also use the [Import and Export](import-export.md) feature with a full media export from the source environment.
+A Tree Restore of media will overwrite any media items on the target that also exist in the source. However, it will not delete items that exist on the target but are missing from the source. This is a safety feature to prevent accidental data loss. To achieve a true mirror and remove orphaned items, manually empty the Media section and Recycle Bin on the target environment. You could also use the [Import and Export](import-export.md) feature with a full media export from the source environment.
 {% endhint %}
 
 {% hint style="success" %}

--- a/16/umbraco-deploy/deployment-workflow/content-transfer.md
+++ b/16/umbraco-deploy/deployment-workflow/content-transfer.md
@@ -56,7 +56,7 @@ To synchronize a lower environment's media library with a higher one (for exampl
 1. Log into the target environment (for example, _Staging_).
 2. Go to the **Media** section of the Umbraco backoffice.
 3. Click **...** next to the **Media** root node.
-4. Select **Tree restore...**(Use **Environment restore...** if you also need to pull all Content and Forms).
+4. Select **Tree restore...**.
 5. Select the source environment (for example, _Live_) from the **Restore this tree from** dropdown.
 6. Click **Restore from Live** and wait for the process to complete.
 7. Reload the Media tree to see the updated library.

--- a/16/umbraco-deploy/deployment-workflow/restoring-content/README.md
+++ b/16/umbraco-deploy/deployment-workflow/restoring-content/README.md
@@ -38,7 +38,7 @@ The second option for restoring your content and media is found in the Umbraco b
 
 1. Go to the Umbraco backoffice on the environment you want to restore content and media to.
 2. Click **...** next to the Content Tree.
-3. Choose _Workspace restore..._ from the menu.
+3. Choose _Environment restore..._ from the menu.
 4. You will now have the option to restore content from any environment that's _to the right of_ the current environment in the deployment workflow.
 5. To ensure the restore will succeed, [make sure that your environments have the same meta data and structure files](../deploying-changes.md).
 6. Click _Restore from .._ and wait till the process completes - this might take a while, depending on the amount of content and media you have on your project.
@@ -58,7 +58,7 @@ Umbraco Deploy - Content transfer and restore
 
 The operation is triggered in the same way as when restoring everything, but instead the _Tree restore..._ menu option should be selected.
 
-For example, if triggered from the content tree, only content entities will be restored. This will also restore any media that’s referenced in that content, but it won’t attempt to restore the full media library, nor any other entities.
+For example, if triggered from the content tree, only content entities will be restored. This restores referenced media but ignores the full media library and other entities. To restore or sync media across environments, see the [Transferring Content, Media and Forms](../content-transfer.md#restoring-media-between-environments) article.
 
 ### [Partial Restore](partial-restore.md)
 

--- a/17/umbraco-deploy/deployment-workflow/content-transfer.md
+++ b/17/umbraco-deploy/deployment-workflow/content-transfer.md
@@ -47,9 +47,29 @@ If everything went well, you will see the confirmation screen saying that the tr
 
 Media items are transferred the same way as content:
 
-1. In the Media section, Click **...** next to the items you want to transfer and choose **Queue for transfer**.
-   * Or click **...** next to the Media section to transfer all you media at once.
-2. Go to the Deployment dashboard in the Content section to see the items you've queued for transfer and to transfer your items.
+1. Click **...** next to an item in the **Media** section.
+2. Choose **Queue for transfer**.
+3. Use the **Deployment dashboard** in the **Content** section to finish the transfer.
+
+#### Restoring Media Between Environments
+
+To synchronize a lower environment's media library with a higher one (for example, pulling Live media down to Staging), use the **Tree Restore** feature. This ensures that media metadata and the physical files are synchronized.
+
+1. Log into the target environment (for example, _Staging_).
+2. Go to the **Media** section of the Umbraco backoffice.
+3. Click **...** next to the **Media** root node.
+4. Select **Tree restore...**(Use **Environment restore...** if you also need to pull all Content and Forms).
+5. Select the source environment (for example, _Live_) from the **Restore this tree from** dropdown.
+6. Click **Restore from Live** and wait for the process to complete.
+7. Reload the Media tree to see the updated library.
+
+{% hint style="info" %}
+A Tree Restore of media will overwrite any media items on the target that also exist in the source. However, it will not delete items that exist on the target but are missing from the source. This is a safety feature to prevent accidental data loss. To achieve a true mirror (including the removal of orphaned items), you must manually empty the Media section (and the Recycle Bin) on the target environment. You could also use the [Import and Export](import-export.md) feature with a full media export from the source environment.
+{% endhint %}
+
+{% hint style="success" %}
+On Umbraco Cloud: Each environment uses a separate Azure Blob Storage container. During a restore, Umbraco Deploy handles the server-side copying of blobs between the unique storage containers of each environment. For more details ,see the [Media on Cloud](https://docs.umbraco.com/umbraco-cloud/build-and-customize-your-solution/handle-deployments-and-environments/media) article.
+{% endhint %}
 
 ### Umbraco Forms
 

--- a/17/umbraco-deploy/deployment-workflow/content-transfer.md
+++ b/17/umbraco-deploy/deployment-workflow/content-transfer.md
@@ -57,7 +57,7 @@ To synchronize a lower environment's media library with a higher one (for exampl
 1. Log into the target environment (for example, _Staging_).
 2. Go to the **Media** section of the Umbraco backoffice.
 3. Click **...** next to the **Media** root node.
-4. Select **Tree restore...**(Use **Environment restore...** if you also need to pull all Content and Forms).
+4. Select **Tree restore...**.
 5. Select the source environment (for example, _Live_) from the **Restore this tree from** dropdown.
 6. Click **Restore from Live** and wait for the process to complete.
 7. Reload the Media tree to see the updated library.

--- a/17/umbraco-deploy/deployment-workflow/content-transfer.md
+++ b/17/umbraco-deploy/deployment-workflow/content-transfer.md
@@ -49,7 +49,6 @@ Media items are transferred the same way as content:
 
 1. Click **...** next to an item in the **Media** section.
 2. Choose **Queue for transfer**.
-3. Use the **Deployment dashboard** in the **Content** section to finish the transfer.
 
 #### Restoring Media Between Environments
 
@@ -64,7 +63,7 @@ To synchronize a lower environment's media library with a higher one (for exampl
 7. Reload the Media tree to see the updated library.
 
 {% hint style="info" %}
-A Tree Restore of media will overwrite any media items on the target that also exist in the source. However, it will not delete items that exist on the target but are missing from the source. This is a safety feature to prevent accidental data loss. To achieve a true mirror (including the removal of orphaned items), you must manually empty the Media section (and the Recycle Bin) on the target environment. You could also use the [Import and Export](import-export.md) feature with a full media export from the source environment.
+A Tree Restore of media will overwrite any media items on the target that also exist in the source. However, it will not delete items that exist on the target but are missing from the source. This is a safety feature to prevent accidental data loss. To achieve a true mirror and remove orphaned items, manually empty the Media section and Recycle Bin on the target environment. You could also use the [Import and Export](import-export.md) feature with a full media export from the source environment.
 {% endhint %}
 
 {% hint style="success" %}

--- a/17/umbraco-deploy/deployment-workflow/restoring-content/README.md
+++ b/17/umbraco-deploy/deployment-workflow/restoring-content/README.md
@@ -38,7 +38,7 @@ The second option for restoring your content and media is found in the Umbraco b
 
 1. Go to the Umbraco backoffice on the environment you want to restore content and media to.
 2. Click **...** next to the Content Tree.
-3. Choose _Workspace restore..._ from the menu.
+3. Choose _Environment restore..._ from the menu.
 4. You will now have the option to restore content from any environment that's _to the right of_ the current environment in the deployment workflow.
 5. To ensure the restore will succeed, [make sure that your environments have the same meta data and structure files](../deploying-changes.md).
 6. Click _Restore from .._ and wait till the process completes - this might take a while, depending on the amount of content and media you have on your project.
@@ -58,7 +58,7 @@ Umbraco Deploy - Content transfer and restore
 
 The operation is triggered in the same way as when restoring everything, but instead the _Tree restore..._ menu option should be selected.
 
-For example, if triggered from the content tree, only content entities will be restored. This will also restore any media that’s referenced in that content, but it won’t attempt to restore the full media library, nor any other entities.
+For example, if triggered from the content tree, only content entities will be restored. This restores referenced media but ignores the full media library and other entities. To restore or sync media across environments, see the [Transferring Content, Media and Forms](../content-transfer.md#restoring-media-between-environments) article.
 
 ### [Partial Restore](partial-restore.md)
 


### PR DESCRIPTION
## 📋 Description

... based on feedback received: There is not enough detail about media syncing between different environments, be it a sync to a higher environment or a partial restore to a lower one. I'm specifically looking for how to mirror the Live environments media folder (all items) to the staging environment, where it would overwrite existing ones and delete the ones that don't exist in the live environment

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Deploy v16 and v17

## Deadline (if relevant)

Anytime

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
