### PR TITLE
Added Notification Context in contexts Overview article

### DIFF
--- a/17/umbraco-cms/customizing/foundation/contexts/README.md
+++ b/17/umbraco-cms/customizing/foundation/contexts/README.md
@@ -34,6 +34,10 @@ Represents a single property on a content item. Provides access to the property'
 
 Manages modal dialog lifecycle and data flow. Used to read input data, set return values, and control how the modal closes (via submit or cancel).
 
+### Notification Context
+
+Provides the ability to display backoffice notifications to the user. Use this to show success, warning, info, or error messages in response to user actions or background operations. As a global context, it can be consumed from anywhere in the backoffice, including workspaces, dashboards, modals, or any other UI element.
+
 ### Entity Context
 
 Identifies the entity currently in scope by providing the entity type and unique ID. Use this to target entity actions, enable conditional UI, or identify the current entity.


### PR DESCRIPTION
## 📋 Description

It has been pointed out in the feedback that the Notification Context is missing. Added the missing section only in v17. In v16,  since the article doesn't list all the contexts, I did not update it there.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS v17. 

## Deadline (if relevant)

Anytime

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
