### PR TITLE
Swap alias and name for Tiptap extension

### DIFF
--- a/17/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/extensions.md
+++ b/17/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/extensions.md
@@ -71,8 +71,8 @@ export const manifests: Array<UmbExtensionManifest> = [
     {
         type: 'tiptapExtension',
         kind: 'button',
-        alias: 'My Highlight Tiptap Extension',
-        name: 'My.Tiptap.Highlight',
+        alias: 'My.Tiptap.Highlight',
+        name: 'My Highlight Tiptap Extension',
         api: () => import('./highlight.tiptap-api.js'),
         meta:{
             icon: "icon-thumbnail-list",


### PR DESCRIPTION
## 📋 Description

Without this change no button appears for the highlight extension


