### PR TITLE
Documents `MaxVersionsToDeletePerRun`

### DIFF
--- a/17/umbraco-cms/reference/configuration/contentsettings.md
+++ b/17/umbraco-cms/reference/configuration/contentsettings.md
@@ -207,7 +207,8 @@ See [Content Version Cleanup](../../fundamentals/data/content-version-cleanup.md
 "ContentVersionCleanupPolicy": {
   "EnableCleanup": false,
   "KeepAllVersionsNewerThanDays": 7,
-  "KeepLatestVersionPerDayForDays": 90
+  "KeepLatestVersionPerDayForDays": 90,
+  "MaxVersionsToDeletePerRun": 50000
 }
 ```
 
@@ -230,6 +231,12 @@ All versions that fall in this period will be kept.
 For content versions that fall in this period, the most recent version for each day is kept. All previous versions for that day are removed unless marked as preventCleanup.
 
 This variable is independent of `KeepAllVersionsNewerThanDays`, if both were set to the same value `KeepLatestVersionPerDayForDays` would never apply as `KeepAllVersionsNewerThanDays` is considered first.
+
+### Maximum versions to delete per run
+
+This setting controls how many content versions are processed in a single cleanup run. When more eligible versions exist than this limit, the remainder will be cleaned up in subsequent hourly runs. This allows large version histories to be cleaned incrementally without overwhelming the database.
+
+Set to 0 to disable the limit and process all eligible versions in a single run.
 
 ## Imaging
 


### PR DESCRIPTION
## 📋 Description

Documents the `MaxVersionsToDeletePerRun` configuration setting available for the content version clean-up scheduled job.

## 📎 Related Issues (if applicable)

Introduced in: https://github.com/umbraco/Umbraco-CMS/pull/22239

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17.4

## Deadline (if relevant)

Should be published along with the release candidate of 17.4, scheduled for 30th April.