### PR TITLE
Remove obsolete .azurewebsites.net references from Cloud docs

### DIFF
--- a/umbraco-cloud/go-live/manage-hostnames/rewrites-on-cloud.md
+++ b/umbraco-cloud/go-live/manage-hostnames/rewrites-on-cloud.md
@@ -118,16 +118,11 @@ Another example would be to redirect from non-www to www:
   <conditions>
     <add input="{HTTP_HOST}" negate="true" pattern="^www\." />
     <add input="{HTTP_HOST}" negate="true" pattern="^localhost(:[0-9]+)?$" />
-    <add input="{HTTP_HOST}" negate="true" pattern="\.azurewebsites\.net$" />
     <add input="{HTTP_HOST}" negate="true" pattern="\.umbraco\.io$" />
   </conditions>
   <action type="Redirect" url="https://www.{HTTP_HOST}/{R:0}" />
 </rule>
 ```
-
-{% hint style="warning" %}
-Adding the `.azurewebsites.net` pattern is required for the deployment service and the content transfer between environments to continue to function.
-{% endhint %}
 
 ## Custom Rewrite Rules for Umbraco Cloud
 
@@ -148,26 +143,3 @@ An example configuration to help ensure your custom rules integrate properly:
 </configuration>
 ```
 
-## Troubleshooting
-
-Sometimes, you might experience an issue where a `.azurewebsites.net` link will appear instead of the custom hostname. In this case, a restart will usually fix the issue, however, it is not ideal that this appears at all.
-
-The following redirect is a way to amend the issue where the `.azurewebsites.net` link appears instead of the hostname. It will redirect from the `.azurewebsites.net` link to the hostname of the website, should this link be called instead.
-
-```xml
-<rule name="Redirects azurewebsites.net to actual domain" stopProcessing="true">
-  <match url=".*" />
-  <conditions>
-    <add input="{HTTP_HOST}" pattern="^(.*)?.azurewebsites.net$" />
-    <add input="{REQUEST_URI}" negate="true" pattern="^/umbraco" />
-    <add input="{REQUEST_URI}" negate="true" pattern="^/DependencyHandler.axd" />
-    <add input="{REQUEST_URI}" negate="true" pattern="^/App_Plugins" />
-    <add input="{REQUEST_URI}" negate="true" pattern="localhost" />
-  </conditions>
-  <action type="Redirect" url="https://www.hostname.com/{R:0}" appendQueryString="true" redirectType="Permanent" />
-</rule>
-```
-
-{% hint style="warning" %}
-The redirect for `.azurewebsites.net` can be used on projects where only one custom hostname is configured.
-{% endhint %}


### PR DESCRIPTION
## 📋 Description

Removes `.azurewebsites.net` references from the Umbraco Cloud rewrite rules documentation. These references become obsolete once private origins are enabled and the URLs return 403.

Changes to `umbraco-cloud/go-live/manage-hostnames/rewrites-on-cloud.md`:
- Removed `.azurewebsites.net` exclusion pattern from the "Redirect from non-www to www" rewrite rule
- Removed the warning hint about `.azurewebsites.net` being required for deployment service / content transfer
- Deleted the entire "Troubleshooting" section which only covered redirecting leaked `.azurewebsites.net` URLs

The only remaining mention of `azurewebsites.net` in the repo is in the Feb 2026 release notes, which is a historical record of a related bug fix and should stay as-is.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Cloud (all versions)

## Deadline (if relevant)

Before private origins rollout completes for existing websites.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)