### PR TITLE
Update Engage v17 docs to reflect Deploy support

### DIFF
--- a/17/umbraco-engage/getting-started/for-developers/system-requirements.md
+++ b/17/umbraco-engage/getting-started/for-developers/system-requirements.md
@@ -48,7 +48,7 @@ Umbraco Engage is compatible with Umbraco Cloud (Standard, Professional, and Ent
 If you want to run an Umbraco Cloud site locally, point the connection string to a (local) SQL Server database. SQLite is not supported.
 {% endhint %}
 
-Umbraco Deploy is currently not supported for the Umbraco Engage features.
+Umbraco Deploy is supported for Umbraco Engage from version 17 onwards. Install the [Umbraco.Engage.Deploy](https://www.nuget.org/packages/Umbraco.Engage.Deploy) package to transfer goals, personas, customer journeys, and A/B tests between environments. See the [Installation](../../installation/installation.md#umbraco-deploy) article for details.
 
 ## Frontend Development Requirements
 

--- a/17/umbraco-engage/getting-started/for-developers/system-requirements.md
+++ b/17/umbraco-engage/getting-started/for-developers/system-requirements.md
@@ -48,7 +48,7 @@ Umbraco Engage is compatible with Umbraco Cloud (Standard, Professional, and Ent
 If you want to run an Umbraco Cloud site locally, point the connection string to a (local) SQL Server database. SQLite is not supported.
 {% endhint %}
 
-Umbraco Deploy is supported for Umbraco Engage from version 17 onwards. Install the [Umbraco.Engage.Deploy](https://www.nuget.org/packages/Umbraco.Engage.Deploy) package to transfer goals, personas, customer journeys, and A/B tests between environments. See the [Installation](../../installation/installation.md#umbraco-deploy) article for details.
+Umbraco Deploy is supported for Umbraco Engage from version 17 onwards. Install the [Umbraco.Engage.Deploy](https://www.nuget.org/packages/Umbraco.Engage.Deploy) package to transfer Umbraco Engage configuration and analytics entities between environments. See the [Installation](../../installation/installation.md#umbraco-deploy) article for the full list of supported items and details.
 
 ## Frontend Development Requirements
 

--- a/17/umbraco-engage/getting-started/for-developers/system-requirements.md
+++ b/17/umbraco-engage/getting-started/for-developers/system-requirements.md
@@ -48,7 +48,7 @@ Umbraco Engage is compatible with Umbraco Cloud (Standard, Professional, and Ent
 If you want to run an Umbraco Cloud site locally, point the connection string to a (local) SQL Server database. SQLite is not supported.
 {% endhint %}
 
-Umbraco Deploy is supported for Umbraco Engage from version 17 onwards. Install the [Umbraco.Engage.Deploy](https://www.nuget.org/packages/Umbraco.Engage.Deploy) package to transfer Umbraco Engage configuration and analytics entities between environments. See the [Installation](../../installation/installation.md#umbraco-deploy) article for the full list of supported items and details.
+Umbraco Deploy is supported for Umbraco Engage. Install the [Umbraco.Engage.Deploy](https://www.nuget.org/packages/Umbraco.Engage.Deploy) package to transfer Umbraco Engage configuration and analytics entities between environments. See the [Installation](../../installation/installation.md#umbraco-deploy) article for the full list of supported items and details.
 
 ## Frontend Development Requirements
 

--- a/17/umbraco-engage/installation/installation.md
+++ b/17/umbraco-engage/installation/installation.md
@@ -83,6 +83,28 @@ dotnet add package Umbraco.Engage.Forms
 {% endtab %}
 {% endtabs %}
 
+### Umbraco Deploy
+
+If you are using **Umbraco Deploy** and want to transfer Engage configuration items (goals, personas, customer journeys, and A/B tests) between environments, install the [Umbraco.Engage.Deploy](https://www.nuget.org/packages/Umbraco.Engage.Deploy) package.
+
+{% tabs %}
+{% tab title="Visual Studio Package Manager" %}
+```
+PM> install-package Umbraco.Engage.Deploy
+```
+{% endtab %}
+
+{% tab title="Console" %}
+```console
+dotnet add package Umbraco.Engage.Deploy
+```
+{% endtab %}
+{% endtabs %}
+
+{% hint style="info" %}
+Analytics data is not transferred between environments. Only configuration items such as segments, personas, journey steps, and goals are included in deployments.
+{% endhint %}
+
 ### Clientside tracking
 
 To capture events that happen on the clientside (frontend) of your website, you need to add the [clientside tracking script](../developers/analytics/client-side-events-and-additional-javascript-files/additional-measurements-with-the-analytics-scripts.md). This is done by including the following snippet on all of your pages.

--- a/17/umbraco-engage/installation/installation.md
+++ b/17/umbraco-engage/installation/installation.md
@@ -85,7 +85,7 @@ dotnet add package Umbraco.Engage.Forms
 
 ### Umbraco Deploy
 
-If you are using **Umbraco Deploy** and want to transfer Engage configuration items (goals, personas, customer journeys, and A/B tests) between environments, install the [Umbraco.Engage.Deploy](https://www.nuget.org/packages/Umbraco.Engage.Deploy) package.
+If you are using **Umbraco Deploy** and want to transfer Engage configuration items between environments, install the [Umbraco.Engage.Deploy](https://www.nuget.org/packages/Umbraco.Engage.Deploy) package. These items include (goals, personas, customer journeys, and A/B tests) 
 
 {% tabs %}
 {% tab title="Visual Studio Package Manager" %}
@@ -102,7 +102,7 @@ dotnet add package Umbraco.Engage.Deploy
 {% endtabs %}
 
 {% hint style="info" %}
-Analytics data is not transferred between environments. Only configuration items such as segments, personas, journey steps, and goals are included in deployments.
+Analytics data is not transferred between environments. Only configuration items such as goals, personas, customer journeys, and A/B tests are included in deployments.
 {% endhint %}
 
 ### Clientside tracking

--- a/17/umbraco-engage/installation/installation.md
+++ b/17/umbraco-engage/installation/installation.md
@@ -85,7 +85,7 @@ dotnet add package Umbraco.Engage.Forms
 
 ### Umbraco Deploy
 
-If you are using **Umbraco Deploy** and want to transfer Engage configuration items between environments, install the [Umbraco.Engage.Deploy](https://www.nuget.org/packages/Umbraco.Engage.Deploy) package. These items include (goals, personas, customer journeys, and A/B tests) 
+If you are using **Umbraco Deploy** and want to transfer Engage configuration items between environments, install the [Umbraco.Engage.Deploy](https://www.nuget.org/packages/Umbraco.Engage.Deploy) package. These items include goals, personas, customer journeys, and A/B tests.
 
 {% tabs %}
 {% tab title="Visual Studio Package Manager" %}


### PR DESCRIPTION
## Summary
- Updated the v17 system requirements page to state that Umbraco Deploy **is** supported (was incorrectly saying it is not supported)
- Added installation instructions for the `Umbraco.Engage.Deploy` NuGet package to the v17 installation page, following the same pattern as the existing Umbraco Forms section

## Test plan
- [ ] Verify the system requirements page at `17/umbraco-engage/getting-started/for-developers/system-requirements.md` correctly states Deploy is supported from v17
- [ ] Verify the installation page at `17/umbraco-engage/installation/installation.md` has the new Umbraco Deploy section with correct NuGet install commands
- [ ] Verify v13 and v16 system requirements are unchanged (Deploy is not supported for those versions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)