### PR TITLE
Update Content Security Policy documented for backoffice compatibility

### DIFF
--- a/17/umbraco-cms/extending/health-check/guides/contentsecuritypolicy.md
+++ b/17/umbraco-cms/extending/health-check/guides/contentsecuritypolicy.md
@@ -35,7 +35,7 @@ app.Use(async (context, next) =>
         $"default-src 'self'; " +
         $"script-src 'self' 'nonce-{nonce}'; " +
         $"style-src 'self' 'unsafe-inline'; " +
-        $"img-src 'self' data: https://news-dashboard.umbraco.com; " +
+        $"img-src 'self' blob: data: https://news-dashboard.umbraco.com; " +
         $"connect-src 'self'; " +
         $"font-src 'self'; " +
         $"frame-src 'self' https://marketplace.umbraco.com");
@@ -62,6 +62,7 @@ app.UseCsp(options => options
         .Self()
         .CustomSources(
             "data:",
+            "blob:",
             "https://news-dashboard.umbraco.com"))
     .ScriptSources(s => s
         .Self())


### PR DESCRIPTION
## 📋 Description

Adds `blob:` as an allowed image source, which is used in the backoffice to display images that have been selected but are pending for upload.

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/pull/21581#issuecomment-4161618361
https://github.com/umbraco/Umbraco-CMS/pull/22343

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [X] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [X] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17

## Deadline (if relevant)

Any time.