### PR TITLE
Add CLI Reference for Base MCP SDK

### DIFF
--- a/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/SUMMARY.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/SUMMARY.md
@@ -18,6 +18,7 @@
   * [Umbraco Setup](hosted-mcp/umbraco-setup.md)
 * [MCP Server SDK](sdk/README.md)
   * [API Helpers](sdk/api-helpers.md)
+  * [CLI Reference](sdk/cli.md)
   * [Configuration](sdk/configuration.md)
   * [Constants](sdk/constants.md)
   * [Coverage Tracking](sdk/coverage-tracking.md)

--- a/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
@@ -8,17 +8,23 @@ description: >-
 
 Umbraco MCP servers built with `@umbraco-cms/mcp-server-sdk` run as CLI tools over stdio. The CLI handles authentication and configuration, then exposes tools that communicate with the Umbraco Management API. Your AI agent (Claude Code, Cursor, and others) calls these tools to read and manage content in your Umbraco instance.
 
-{% hint style="info" %}
-The CLI is designed to be consumed by AI agents, not operated directly by humans. You configure the CLI with environment variables or flags, then your AI agent connects and interacts with Umbraco through the exposed tools. The introspection commands (`--list-tools`, `--debug-config`, and others) are the human-facing part. Use them to understand and verify what your agent sees.
-{% endhint %}
+## Claude Code Plugin
 
-{% hint style="success" %}
-**Using Claude Code?** Install the `umbraco-mcp-server` plugin for interactive CLI guidance. Run `/mcp-cli` for help with setup, filtering, and debugging.
+If you are using Claude Code, install the `umbraco-mcp-server` plugin. The plugin provides a `/mcp-cli` skill that guides you interactively through setup, configuration, filtering, and debugging. This is the recommended way to work with the CLI.
+
+To install the plugin, run the following commands in Claude Code:
 
 ```bash
 /plugin marketplace add umbraco/Umbraco-MCP-Base
 /plugin install umbraco-mcp-server@umbraco/Umbraco-MCP-Base
 ```
+
+Once installed, run `/mcp-cli` at any time for guided help. The skill understands your current configuration and walks you through each step.
+
+The sections below provide the full reference for all CLI options. You do not need to read them when using the plugin.
+
+{% hint style="info" %}
+The CLI is designed to be consumed by AI agents, not operated directly by humans. You configure the CLI with environment variables or flags, then your AI agent connects and interacts with Umbraco through the exposed tools. The introspection commands (`--list-tools`, `--debug-config`, and others) are the human-facing part. Use them to understand and verify what your agent sees.
 {% endhint %}
 
 ## Authentication and Configuration

--- a/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
@@ -1,12 +1,14 @@
 ---
 description: >-
-  CLI reference for running Umbraco MCP servers built with the SDK, including
-  authentication, runtime modes, tool filtering, and introspection commands.
+  Use any Umbraco MCP server as a CLI tool for direct invocation,
+  debugging, and introspection.
 ---
 
 # CLI Reference
 
-Umbraco MCP servers built with `@umbraco-cms/mcp-server-sdk` run as CLI tools over stdio. The CLI handles authentication and configuration, then exposes tools that communicate with the Umbraco Management API. Your AI agent (Claude Code, Cursor, and others) calls these tools to read and manage content in your Umbraco instance.
+The SDK includes a CLI wrapper that turns any Umbraco MCP server into a command-line tool. This is an alternative way to interact with the same server. Instead of connecting through an MCP client, you run the server directly. CLI flags let you list tools, call tools, inspect configuration, and control runtime behavior.
+
+Both approaches use the same server and the same tools. Use the MCP connection when your AI host supports it. Use the CLI when you need direct invocation, scripting, or debugging.
 
 ## Claude Code Skills
 
@@ -30,15 +32,14 @@ For the full list of configuration fields, precedence rules, and custom field de
 
 ## Starting the Server
 
-```bash
-# Via .env file (recommended) — create .env with credentials, then:
-node dist/index.js
+The examples on this page use the Developer MCP Server (`@umbraco-cms/mcp-dev`) package. Replace the package name with your own MCP server package.
 
-# Via npx with .env file
+```bash
+# With a .env file in the current directory (recommended):
 npx @umbraco-cms/mcp-dev
 
-# Via custom .env path
-node dist/index.js --env /path/to/.env
+# With a custom .env path:
+npx @umbraco-cms/mcp-dev --env /path/to/.env
 ```
 
 ### Claude Code Configuration
@@ -69,13 +70,13 @@ You can control which tools are exposed to the LLM using modes, collections, sli
 # Read-only content browsing
 UMBRACO_INCLUDE_SLICES=read,list,search \
 UMBRACO_INCLUDE_TOOL_COLLECTIONS=content,media \
-node dist/index.js
+npx @umbraco-cms/mcp-dev
 
 # Everything except delete operations
-UMBRACO_EXCLUDE_SLICES=delete node dist/index.js
+UMBRACO_EXCLUDE_SLICES=delete npx @umbraco-cms/mcp-dev
 
 # Only specific tools
-UMBRACO_INCLUDE_TOOLS=get-content-by-id,list-content node dist/index.js
+UMBRACO_INCLUDE_TOOLS=get-content-by-id,list-content npx @umbraco-cms/mcp-dev
 ```
 
 For the full list of filter flags, available slices, and precedence rules, see [Tool Filtering](tool-filtering.md).
@@ -85,7 +86,7 @@ For the full list of filter flags, available slices, and precedence rules, see [
 ### Readonly Mode
 
 ```bash
-node dist/index.js --umbraco-readonly
+npx @umbraco-cms/mcp-dev --umbraco-readonly
 # or: UMBRACO_READONLY=true
 ```
 
@@ -94,7 +95,7 @@ Mutation tools are removed from the server. The agent cannot see or call them. O
 ### Dry-Run Mode
 
 ```bash
-node dist/index.js --umbraco-dry-run
+npx @umbraco-cms/mcp-dev --umbraco-dry-run
 # or: UMBRACO_DRY_RUN=true
 ```
 
@@ -170,24 +171,24 @@ delete-example   | example    | delete | N  | Y     | Deletes an example item by
 
 ```bash
 # See all tools
-node dist/index.js --list-tools
+npx @umbraco-cms/mcp-dev --list-tools
 
 # See only what the LLM sees with filtering
-UMBRACO_READONLY=true node dist/index.js --list-tools
-UMBRACO_INCLUDE_SLICES=read,list node dist/index.js --list-tools
+UMBRACO_READONLY=true npx @umbraco-cms/mcp-dev --list-tools
+UMBRACO_INCLUDE_SLICES=read,list npx @umbraco-cms/mcp-dev --list-tools
 
 # Get schema for a specific tool
-node dist/index.js --describe-tool get-content-by-id
+npx @umbraco-cms/mcp-dev --describe-tool get-content-by-id
 
 # Call a tool directly and print the result
-node dist/index.js --call get-content-by-id --call-args '{"id": "550e8400-e29b-41d4-a716-446655440000"}'
+npx @umbraco-cms/mcp-dev --call get-content-by-id --call-args '{"id": "550e8400-e29b-41d4-a716-446655440000"}'
 
 # Generate documentation
-node dist/index.js --generate-context > CONTEXT.md
+npx @umbraco-cms/mcp-dev --generate-context > CONTEXT.md
 
 # Debug configuration — see resolved values and their sources
-node dist/index.js --debug-config
-UMBRACO_READONLY=true UMBRACO_INCLUDE_SLICES=read node dist/index.js --debug-config
+npx @umbraco-cms/mcp-dev --debug-config
+UMBRACO_READONLY=true UMBRACO_INCLUDE_SLICES=read npx @umbraco-cms/mcp-dev --debug-config
 ```
 
 ### Debug Config Output

--- a/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
@@ -42,7 +42,7 @@ npx @umbraco-cms/mcp-dev --env /path/to/.env
 
 ## Tool Filtering
 
-Tha agent can control which tools are exposed to the LLM using modes, collections, slices, and individual tool names. All filters accept comma-separated values via CLI flags or environment variables.
+The agent can control which tools are exposed to the LLM using modes, collections, slices, and individual tool names. All filters accept comma-separated values via CLI flags or environment variables.
 
 ```bash
 # Read-only content browsing

--- a/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
@@ -8,20 +8,13 @@ description: >-
 
 Umbraco MCP servers built with `@umbraco-cms/mcp-server-sdk` run as CLI tools over stdio. The CLI handles authentication and configuration, then exposes tools that communicate with the Umbraco Management API. Your AI agent (Claude Code, Cursor, and others) calls these tools to read and manage content in your Umbraco instance.
 
-## Claude Code Plugin
+## Claude Code Skills
 
-If you are using Claude Code, install the `umbraco-mcp-server` plugin. The plugin provides a `/mcp-cli` skill that guides you interactively through setup, configuration, filtering, and debugging. This is the recommended way to work with the CLI.
+Each Umbraco MCP server ships with its own Claude Code plugin that provides a `/mcp-cli` skill. The skill guides you interactively through setup, configuration, filtering, and debugging. This is the recommended way to work with the CLI.
 
-To install the plugin, run the following commands in Claude Code:
+Check the documentation for your specific MCP server for plugin install instructions.
 
-```bash
-/plugin marketplace add umbraco/Umbraco-MCP-Base
-/plugin install umbraco-mcp-server@umbraco/Umbraco-MCP-Base
-```
-
-Once installed, run `/mcp-cli` at any time for guided help. The skill understands your current configuration and walks you through each step.
-
-The sections below provide the full reference for all CLI options. You do not need to read them when using the plugin.
+The sections below provide the full reference for all CLI options. You do not need to read them when using the skill.
 
 {% hint style="info" %}
 The CLI is designed to be consumed by AI agents, not operated directly by humans. You configure the CLI with environment variables or flags, then your AI agent connects and interacts with Umbraco through the exposed tools. The introspection commands (`--list-tools`, `--debug-config`, and others) are the human-facing part. Use them to understand and verify what your agent sees.

--- a/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
@@ -12,27 +12,22 @@ Umbraco MCP servers built with `@umbraco-cms/mcp-server-sdk` run as CLI tools ov
 The CLI is designed to be consumed by AI agents, not operated directly by humans. You configure the CLI with environment variables or flags, then your AI agent connects and interacts with Umbraco through the exposed tools. The introspection commands (`--list-tools`, `--debug-config`, and others) are the human-facing part. Use them to understand and verify what your agent sees.
 {% endhint %}
 
-## Authentication
+{% hint style="success" %}
+**Using Claude Code?** Install the `umbraco-mcp-server` plugin for interactive CLI guidance. Run `/mcp-cli` for help with setup, filtering, and debugging.
 
-| Env Var | Required | Description |
-|---------|----------|-------------|
-| `UMBRACO_CLIENT_ID` | Yes | OAuth client ID from Umbraco API user |
-| `UMBRACO_CLIENT_SECRET` | Yes | OAuth client secret |
-| `UMBRACO_BASE_URL` | Yes | Umbraco instance URL |
-
-Create auth credentials in the Umbraco backoffice under **Settings > Users** as an API user.
-
-{% hint style="danger" %}
-Never pass secrets as CLI arguments. CLI arguments are visible in terminal output, process listings, shell history, and AI conversation context. Use a `.env` file or the MCP config `env` block for credentials.
+```bash
+/plugin marketplace add umbraco/Umbraco-MCP-Base
+/plugin install umbraco-mcp-server@umbraco/Umbraco-MCP-Base
+```
 {% endhint %}
 
-### Configuration Precedence
+## Authentication and Configuration
 
-CLI arguments take precedence over environment variables, which take precedence over `.env` file values.
+The CLI requires three environment variables for authentication: `UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, and `UMBRACO_BASE_URL`. Create these credentials in the Umbraco backoffice under **Settings > Users** as an API user.
 
-A `.env` file in the current working directory is loaded automatically. Use `--env /path/to/.env` to specify a custom location.
+CLI arguments take precedence over environment variables, which take precedence over `.env` file values. A `.env` file in the current working directory is loaded automatically. Use `--env /path/to/.env` to specify a custom location.
 
-For a full list of configuration fields, see [Configuration](configuration.md).
+For the full list of configuration fields, precedence rules, and custom field definitions, see [Configuration](configuration.md).
 
 ## Starting the Server
 
@@ -69,36 +64,7 @@ Use the `env` block for credentials. These are passed as environment variables t
 
 ## Tool Filtering
 
-You can control which tools are exposed to the LLM. All filters accept comma-separated values via CLI flags or environment variables.
-
-| Flag | Env Var | Description |
-|------|---------|-------------|
-| `--umbraco-tool-modes` | `UMBRACO_TOOL_MODES` | Enable named groups of collections |
-| `--umbraco-include-tool-collections` | `UMBRACO_INCLUDE_TOOL_COLLECTIONS` | Expose only these collections |
-| `--umbraco-exclude-tool-collections` | `UMBRACO_EXCLUDE_TOOL_COLLECTIONS` | Hide these collections |
-| `--umbraco-include-slices` | `UMBRACO_INCLUDE_SLICES` | Expose only tools with these slices |
-| `--umbraco-exclude-slices` | `UMBRACO_EXCLUDE_SLICES` | Hide tools with these slices |
-| `--umbraco-include-tools` | `UMBRACO_INCLUDE_TOOLS` | Expose only these specific tools |
-| `--umbraco-exclude-tools` | `UMBRACO_EXCLUDE_TOOLS` | Hide these specific tools |
-
-### Available Slices
-
-`read`, `list`, `create`, `update`, `delete`, `search`, `tree`, `publish`, `move`, `copy`
-
-### Filter Precedence
-
-Filters combine in the following order, where the most specific filter wins:
-
-1. Tool exclusions — always excluded
-2. Tool inclusions — if set, only these tools pass
-3. Slice exclusions — tools with these slices are excluded
-4. Slice inclusions — if set, only tools with these slices pass
-5. Collection exclusions — entire collections are excluded
-6. Collection inclusions — if set, only these collections pass
-
-Exclude takes precedence over include at the same level.
-
-### Examples
+You can control which tools are exposed to the LLM using modes, collections, slices, and individual tool names. All filters accept comma-separated values via CLI flags or environment variables.
 
 ```bash
 # Read-only content browsing
@@ -113,7 +79,7 @@ UMBRACO_EXCLUDE_SLICES=delete node dist/index.js
 UMBRACO_INCLUDE_TOOLS=get-content-by-id,list-content node dist/index.js
 ```
 
-For more details on how filtering works, see [Tool Filtering](tool-filtering.md).
+For the full list of filter flags, available slices, and precedence rules, see [Tool Filtering](tool-filtering.md).
 
 ## Runtime Modes
 
@@ -154,7 +120,7 @@ Input validation still runs, so the LLM receives validation feedback. Use dry-ru
 | LLM sees mutation tools | No | Yes |
 | Mutation tools execute | N/A | No (preview only) |
 | Read tools execute | Yes | Yes |
-| Risk level | Zero | Very low |
+| Risk level | Zero | Minimal |
 
 ## Introspection Commands
 
@@ -166,6 +132,8 @@ Introspection respects all filtering configuration. If you set `UMBRACO_READONLY
 |------|-------------|
 | `--list-tools` | Print ASCII table of all tools (name, collection, slices, annotations) |
 | `--describe-tool <name>` | Print full JSON schema and metadata for a specific tool (exits 1 if not found or filtered out) |
+| `--call <name>` | Call a tool by name, print the result as JSON, and exit |
+| `--call-args <json>` | JSON arguments for `--call` (default: `{}`) |
 | `--generate-context` | Output structured CONTEXT.md documenting all tools (pipe to file) |
 | `--debug-config` | Print resolved configuration as JSON (values, sources, filter config) |
 
@@ -211,6 +179,9 @@ UMBRACO_INCLUDE_SLICES=read,list node dist/index.js --list-tools
 
 # Get schema for a specific tool
 node dist/index.js --describe-tool get-content-by-id
+
+# Call a tool directly and print the result
+node dist/index.js --call get-content-by-id --call-args '{"id": "550e8400-e29b-41d4-a716-446655440000"}'
 
 # Generate documentation
 node dist/index.js --generate-context > CONTEXT.md

--- a/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
@@ -1,0 +1,261 @@
+---
+description: >-
+  CLI reference for running Umbraco MCP servers built with the SDK, including
+  authentication, runtime modes, tool filtering, and introspection commands.
+---
+
+# CLI Reference
+
+Umbraco MCP servers built with `@umbraco-cms/mcp-server-sdk` run as CLI tools over stdio. The CLI handles authentication and configuration, then exposes tools that communicate with the Umbraco Management API. Your AI agent (Claude Code, Cursor, and others) calls these tools to read and manage content in your Umbraco instance.
+
+{% hint style="info" %}
+The CLI is designed to be consumed by AI agents, not operated directly by humans. You configure the CLI with environment variables or flags, then your AI agent connects and interacts with Umbraco through the exposed tools. The introspection commands (`--list-tools`, `--debug-config`, and others) are the human-facing part. Use them to understand and verify what your agent sees.
+{% endhint %}
+
+## Authentication
+
+| Env Var | Required | Description |
+|---------|----------|-------------|
+| `UMBRACO_CLIENT_ID` | Yes | OAuth client ID from Umbraco API user |
+| `UMBRACO_CLIENT_SECRET` | Yes | OAuth client secret |
+| `UMBRACO_BASE_URL` | Yes | Umbraco instance URL |
+
+Create auth credentials in the Umbraco backoffice under **Settings > Users** as an API user.
+
+{% hint style="danger" %}
+Never pass secrets as CLI arguments. CLI arguments are visible in terminal output, process listings, shell history, and AI conversation context. Use a `.env` file or the MCP config `env` block for credentials.
+{% endhint %}
+
+### Configuration Precedence
+
+CLI arguments take precedence over environment variables, which take precedence over `.env` file values.
+
+A `.env` file in the current working directory is loaded automatically. Use `--env /path/to/.env` to specify a custom location.
+
+For a full list of configuration fields, see [Configuration](configuration.md).
+
+## Starting the Server
+
+```bash
+# Via .env file (recommended) — create .env with credentials, then:
+node dist/index.js
+
+# Via npx with .env file
+npx @umbraco-cms/mcp-dev
+
+# Via custom .env path
+node dist/index.js --env /path/to/.env
+```
+
+### Claude Code Configuration
+
+Use the `env` block for credentials. These are passed as environment variables to the process, not as CLI arguments:
+
+```json
+{
+  "mcpServers": {
+    "umbraco": {
+      "command": "npx",
+      "args": ["@umbraco-cms/mcp-dev"],
+      "env": {
+        "UMBRACO_CLIENT_ID": "your-client-id",
+        "UMBRACO_CLIENT_SECRET": "your-secret",
+        "UMBRACO_BASE_URL": "https://localhost:44391"
+      }
+    }
+  }
+}
+```
+
+## Tool Filtering
+
+You can control which tools are exposed to the LLM. All filters accept comma-separated values via CLI flags or environment variables.
+
+| Flag | Env Var | Description |
+|------|---------|-------------|
+| `--umbraco-tool-modes` | `UMBRACO_TOOL_MODES` | Enable named groups of collections |
+| `--umbraco-include-tool-collections` | `UMBRACO_INCLUDE_TOOL_COLLECTIONS` | Expose only these collections |
+| `--umbraco-exclude-tool-collections` | `UMBRACO_EXCLUDE_TOOL_COLLECTIONS` | Hide these collections |
+| `--umbraco-include-slices` | `UMBRACO_INCLUDE_SLICES` | Expose only tools with these slices |
+| `--umbraco-exclude-slices` | `UMBRACO_EXCLUDE_SLICES` | Hide tools with these slices |
+| `--umbraco-include-tools` | `UMBRACO_INCLUDE_TOOLS` | Expose only these specific tools |
+| `--umbraco-exclude-tools` | `UMBRACO_EXCLUDE_TOOLS` | Hide these specific tools |
+
+### Available Slices
+
+`read`, `list`, `create`, `update`, `delete`, `search`, `tree`, `publish`, `move`, `copy`
+
+### Filter Precedence
+
+Filters combine in the following order, where the most specific filter wins:
+
+1. Tool exclusions — always excluded
+2. Tool inclusions — if set, only these tools pass
+3. Slice exclusions — tools with these slices are excluded
+4. Slice inclusions — if set, only tools with these slices pass
+5. Collection exclusions — entire collections are excluded
+6. Collection inclusions — if set, only these collections pass
+
+Exclude takes precedence over include at the same level.
+
+### Examples
+
+```bash
+# Read-only content browsing
+UMBRACO_INCLUDE_SLICES=read,list,search \
+UMBRACO_INCLUDE_TOOL_COLLECTIONS=content,media \
+node dist/index.js
+
+# Everything except delete operations
+UMBRACO_EXCLUDE_SLICES=delete node dist/index.js
+
+# Only specific tools
+UMBRACO_INCLUDE_TOOLS=get-content-by-id,list-content node dist/index.js
+```
+
+For more details on how filtering works, see [Tool Filtering](tool-filtering.md).
+
+## Runtime Modes
+
+### Readonly Mode
+
+```bash
+node dist/index.js --umbraco-readonly
+# or: UMBRACO_READONLY=true
+```
+
+Mutation tools are removed from the server. The agent cannot see or call them. Only tools with `readOnlyHint: true` are registered. Use this mode when you want zero risk of data modification.
+
+### Dry-Run Mode
+
+```bash
+node dist/index.js --umbraco-dry-run
+# or: UMBRACO_DRY_RUN=true
+```
+
+Read-only tools execute normally and return real data. Mutation tools return a structured preview without calling the Umbraco API:
+
+```json
+{
+  "dryRun": true,
+  "toolName": "delete-example",
+  "wouldExecute": true,
+  "inputReceived": { "id": "550e8400-e29b-41d4-a716-446655440000" },
+  "annotations": { "readOnlyHint": false, "destructiveHint": true }
+}
+```
+
+Input validation still runs, so the LLM receives validation feedback. Use dry-run mode for safe exploration. The LLM can try mutation tools without risk.
+
+### Readonly vs Dry-Run
+
+| | Readonly | Dry-Run |
+|---|---------|---------|
+| LLM sees mutation tools | No | Yes |
+| Mutation tools execute | N/A | No (preview only) |
+| Read tools execute | Yes | Yes |
+| Risk level | Zero | Very low |
+
+## Introspection Commands
+
+These flags print output and exit immediately. They do not start the MCP server and do not require auth credentials or a running Umbraco instance.
+
+Introspection respects all filtering configuration. If you set `UMBRACO_READONLY=true` or any filtering env var, the output shows only tools that pass those filters. This matches what the LLM sees at runtime.
+
+| Flag | Description |
+|------|-------------|
+| `--list-tools` | Print ASCII table of all tools (name, collection, slices, annotations) |
+| `--describe-tool <name>` | Print full JSON schema and metadata for a specific tool (exits 1 if not found or filtered out) |
+| `--generate-context` | Output structured CONTEXT.md documenting all tools (pipe to file) |
+| `--debug-config` | Print resolved configuration as JSON (values, sources, filter config) |
+
+### `--list-tools` Output
+
+```
+Name             | Collection | Slices | RO | Destr | Description
+-----------------+------------+--------+----+-------+---------------------------------------------
+get-example      | example    | read   | Y  | N     | Gets an example item by ID.
+list-examples    | example    | list   | Y  | N     | Lists all example items with pagination.
+create-example   | example    | create | N  | N     | Creates a new example item.
+delete-example   | example    | delete | N  | Y     | Deletes an example item by ID.
+```
+
+### `--describe-tool` Output
+
+```json
+{
+  "name": "get-example",
+  "collection": "example",
+  "description": "Gets an example item by ID.",
+  "slices": ["read"],
+  "annotations": { "readOnlyHint": true },
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "id": { "type": "string", "description": "The example item ID (UUID)" }
+    },
+    "required": ["id"]
+  }
+}
+```
+
+### Examples
+
+```bash
+# See all tools
+node dist/index.js --list-tools
+
+# See only what the LLM sees with filtering
+UMBRACO_READONLY=true node dist/index.js --list-tools
+UMBRACO_INCLUDE_SLICES=read,list node dist/index.js --list-tools
+
+# Get schema for a specific tool
+node dist/index.js --describe-tool get-content-by-id
+
+# Generate documentation
+node dist/index.js --generate-context > CONTEXT.md
+
+# Debug configuration — see resolved values and their sources
+node dist/index.js --debug-config
+UMBRACO_READONLY=true UMBRACO_INCLUDE_SLICES=read node dist/index.js --debug-config
+```
+
+### Debug Config Output
+
+`--debug-config` prints JSON showing every config field with its resolved value and source (`cli`, `env`, or `none`). Credentials are masked. The `resolvedFilterConfig` section shows the final filter state applied to tools.
+
+```json
+{
+  "envFile": { "source": "default" },
+  "auth": {
+    "baseUrl": { "value": "https://localhost:44391", "source": "env" },
+    "clientId": { "value": "***", "source": "env" },
+    "clientSecret": { "value": "***", "source": "env" }
+  },
+  "filtering": {
+    "readonly": { "value": true, "source": "env" },
+    "includeSlices": { "value": ["read", "list"], "source": "env" }
+  },
+  "resolvedFilterConfig": {
+    "readOnly": true,
+    "enabledSlices": ["read", "list"]
+  }
+}
+```
+
+## Other Options
+
+| Flag | Env Var | Description |
+|------|---------|-------------|
+| `--umbraco-allowed-media-paths` | `UMBRACO_ALLOWED_MEDIA_PATHS` | Restrict media operations to these paths |
+| `--disable-output-compatibility-mode` | `DISABLE_OUTPUT_COMPATIBILITY_MODE` | Use structured output instead of text |
+
+## Input Sanitization
+
+The SDK validates all string inputs before tool handlers run:
+
+* Rejects control characters, path traversal (`../`), embedded query params, and percent-encoded strings
+* Validates UUID format where expected
+* Returns ProblemDetails (RFC 7807) with clear error messages
+
+The LLM receives validation errors and can self-correct. No configuration is needed.

--- a/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
@@ -40,26 +40,6 @@ npx @umbraco-cms/mcp-dev
 npx @umbraco-cms/mcp-dev --env /path/to/.env
 ```
 
-### Claude Code Configuration
-
-Use the `env` block for credentials. These are passed as environment variables to the process, not as CLI arguments:
-
-```json
-{
-  "mcpServers": {
-    "umbraco": {
-      "command": "npx",
-      "args": ["@umbraco-cms/mcp-dev"],
-      "env": {
-        "UMBRACO_CLIENT_ID": "your-client-id",
-        "UMBRACO_CLIENT_SECRET": "your-secret",
-        "UMBRACO_BASE_URL": "https://localhost:44391"
-      }
-    }
-  }
-}
-```
-
 ## Tool Filtering
 
 You can control which tools are exposed to the LLM using modes, collections, slices, and individual tool names. All filters accept comma-separated values via CLI flags or environment variables.

--- a/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
@@ -12,23 +12,21 @@ Both approaches use the same server and the same tools. Use the MCP connection w
 
 ## Claude Code Skills
 
-Each Umbraco MCP server ships with its own Claude Code plugin that provides a `/mcp-cli` skill. The skill guides you interactively through setup, configuration, filtering, and debugging. This is the recommended way to work with the CLI.
+Each Umbraco MCP server ships with its own Claude Code plugin that provides a skill. The skill guides the agent interactively through setup, configuration, filtering, and debugging. This is the recommended way to work with the CLI.
 
 Check the documentation for your specific MCP server for plugin install instructions.
 
 The sections below provide the full reference for all CLI options. You do not need to read them when using the skill.
 
 {% hint style="info" %}
-The CLI is designed to be consumed by AI agents, not operated directly by humans. You configure the CLI with environment variables or flags, then your AI agent connects and interacts with Umbraco through the exposed tools. The introspection commands (`--list-tools`, `--debug-config`, and others) are the human-facing part. Use them to understand and verify what your agent sees.
+The CLI is designed to be consumed by AI agents, not operated directly by humans. You configure the CLI with environment variables and flags, then your AI agent connects and interacts with and understands about Umbraco through the exposed tools.
 {% endhint %}
 
-## Authentication and Configuration
+## Authentication
 
-The CLI requires three environment variables for authentication: `UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, and `UMBRACO_BASE_URL`. Create these credentials in the Umbraco backoffice under **Settings > Users** as an API user.
+The CLI connects to Umbraco the same way as the MCP server, using an API user. Credentials (`UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, and `UMBRACO_BASE_URL`) must always be set as environment variables via a `.env` file or your MCP config `env` block. They are never passed as CLI arguments.
 
-CLI arguments take precedence over environment variables, which take precedence over `.env` file values. A `.env` file in the current working directory is loaded automatically. Use `--env /path/to/.env` to specify a custom location.
-
-For the full list of configuration fields, precedence rules, and custom field definitions, see [Configuration](configuration.md).
+All other options can be set using CLI flags. The AI agent passes these as needed. For the full list of configuration fields, see [Configuration](configuration.md).
 
 ## Starting the Server
 

--- a/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md
@@ -24,7 +24,7 @@ The CLI is designed to be consumed by AI agents, not operated directly by humans
 
 ## Authentication
 
-The CLI connects to Umbraco the same way as the MCP server, using an API user. Credentials (`UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, and `UMBRACO_BASE_URL`) must always be set as environment variables via a `.env` file or your MCP config `env` block. They are never passed as CLI arguments.
+The CLI connects to Umbraco the same way as the MCP server, using an API user. Credentials (`UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, and `UMBRACO_BASE_URL`) must always be set as environment variables via a `.env`. They are never passed as CLI arguments.
 
 All other options can be set using CLI flags. The AI agent passes these as needed. For the full list of configuration fields, see [Configuration](configuration.md).
 
@@ -42,7 +42,7 @@ npx @umbraco-cms/mcp-dev --env /path/to/.env
 
 ## Tool Filtering
 
-You can control which tools are exposed to the LLM using modes, collections, slices, and individual tool names. All filters accept comma-separated values via CLI flags or environment variables.
+Tha agent can control which tools are exposed to the LLM using modes, collections, slices, and individual tool names. All filters accept comma-separated values via CLI flags or environment variables.
 
 ```bash
 # Read-only content browsing

--- a/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/README.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/README.md
@@ -99,6 +99,17 @@ Each MCP-compatible host application has its own setup process. Below you can fi
 * [Cursor](https://app.gitbook.com/s/EuQ7H19kRLMJSurL2nwL/cursor)
 * [OpenAI Codex](https://app.gitbook.com/s/EuQ7H19kRLMJSurL2nwL/openai-codex)
 
+{% hint style="success" %}
+**Using Claude Code?** Install the `umbraco-mcp-server` plugin for guided setup, configuration, filtering, and debugging. The `/mcp-cli` skill walks you through each step interactively.
+
+```bash
+/plugin marketplace add umbraco/Umbraco-MCP-Base
+/plugin install umbraco-mcp-server@umbraco/Umbraco-MCP-Base
+```
+
+Once installed, run `/mcp-cli` to get started. For the full CLI reference, see the [CLI Reference](https://app.gitbook.com/s/qRBjeReNuznLmI2zTKUq/sdk/cli).
+{% endhint %}
+
 Although the details vary slightly, the general pattern is the same across all hosts:
 
 ```json

--- a/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/README.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/README.md
@@ -99,17 +99,6 @@ Each MCP-compatible host application has its own setup process. Below you can fi
 * [Cursor](https://app.gitbook.com/s/EuQ7H19kRLMJSurL2nwL/cursor)
 * [OpenAI Codex](https://app.gitbook.com/s/EuQ7H19kRLMJSurL2nwL/openai-codex)
 
-{% hint style="success" %}
-**Using Claude Code?** Install the `umbraco-mcp-server` plugin for guided setup, configuration, filtering, and debugging. The `/mcp-cli` skill walks you through each step interactively.
-
-```bash
-/plugin marketplace add umbraco/Umbraco-MCP-Base
-/plugin install umbraco-mcp-server@umbraco/Umbraco-MCP-Base
-```
-
-Once installed, run `/mcp-cli` to get started. For the full CLI reference, see the [CLI Reference](https://app.gitbook.com/s/qRBjeReNuznLmI2zTKUq/sdk/cli).
-{% endhint %}
-
 Although the details vary slightly, the general pattern is the same across all hosts:
 
 ```json

--- a/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/SUMMARY.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/SUMMARY.md
@@ -2,6 +2,7 @@
 
 * [Developer Model Context Protocol (MCP) Server](README.md)
 * [Available Tools](available-tools.md)
+* [CLI Usage](cli-usage.md)
 * [Configuration Options](configuration.md)
 * [Excluded Tools](excluded-tools.md)
 * [Use Cases](scenarios.md)

--- a/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/SUMMARY.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/SUMMARY.md
@@ -2,10 +2,10 @@
 
 * [Developer Model Context Protocol (MCP) Server](README.md)
 * [Available Tools](available-tools.md)
-* [CLI Usage](cli-usage.md)
 * [Configuration Options](configuration.md)
 * [Excluded Tools](excluded-tools.md)
 * [Use Cases](scenarios.md)
+* [CLI Usage](cli-usage.md)
 * [Best Practice](best-practice/README.md)
   * [Creating Media](best-practice/creating-media.md)
   * [Example Instructions File](best-practice/example-instructions.md)

--- a/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/cli-usage.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/cli-usage.md
@@ -1,25 +1,31 @@
 ---
 description: >-
-  Use the Developer MCP Server as a CLI for debugging, introspection, and
-  advanced configuration.
+  Use the Developer MCP Server as a CLI tool for a quick connection to
+  Umbraco without additional setup.
 ---
 
 # CLI Usage
 
-The Developer MCP Server is designed to run as an MCP server connected to your AI host. You do not need the CLI for normal usage.
+The Developer MCP Server can also be used as a CLI tool. This wraps the same MCP server and exposes the same tools, but runs them directly from the command line. It is a quick way to connect to Umbraco without any host setup.
 
-The CLI is useful when you want to inspect available tools, debug your configuration, or test tools outside of an MCP session. All MCP servers built on the Base MCP SDK share the same CLI interface.
+The MCP connection is more context-efficient because the host manages tool selection and conversation state. The CLI is a simpler alternative when you want to get started quickly or debug your configuration.
 
 ## Claude Code Plugin
 
-If you are using Claude Code, install the `umbraco-mcp-server` plugin. The `/mcp-cli` skill guides you interactively through configuration, filtering, and troubleshooting.
+If you are using Claude Code, install the Developer MCP plugin. The `/mcp-cli` skill lets you run queries against Umbraco directly from Claude Code.
 
 ```bash
-/plugin marketplace add umbraco/Umbraco-MCP-Base
-/plugin install umbraco-mcp-server@umbraco/Umbraco-MCP-Base
+/plugin marketplace add umbraco/Umbraco-CMS-MCP-Dev
+/plugin install umbraco-cms-mcp-dev@umbraco/Umbraco-CMS-MCP-Dev
 ```
 
-Once installed, run `/mcp-cli` for interactive help.
+Once installed, use `/mcp-cli` with a query to interact with Umbraco:
+
+```
+/mcp-cli tell me what properties the home document type has
+/mcp-cli list all published content under the homepage
+/mcp-cli show me the media library structure
+```
 
 ## CLI Reference
 

--- a/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/cli-usage.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/cli-usage.md
@@ -1,0 +1,26 @@
+---
+description: >-
+  Use the Developer MCP Server as a CLI for debugging, introspection, and
+  advanced configuration.
+---
+
+# CLI Usage
+
+The Developer MCP Server is designed to run as an MCP server connected to your AI host. You do not need the CLI for normal usage.
+
+The CLI is useful when you want to inspect available tools, debug your configuration, or test tools outside of an MCP session. All MCP servers built on the Base MCP SDK share the same CLI interface.
+
+## Claude Code Plugin
+
+If you are using Claude Code, install the `umbraco-mcp-server` plugin. The `/mcp-cli` skill guides you interactively through configuration, filtering, and troubleshooting.
+
+```bash
+/plugin marketplace add umbraco/Umbraco-MCP-Base
+/plugin install umbraco-mcp-server@umbraco/Umbraco-MCP-Base
+```
+
+Once installed, run `/mcp-cli` for interactive help.
+
+## CLI Reference
+
+For the full reference of CLI flags, runtime modes (readonly and dry-run), introspection commands, and input sanitization, see the [CLI Reference](https://app.gitbook.com/s/qRBjeReNuznLmI2zTKUq/sdk/cli).

--- a/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/cli-usage.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/cli-usage.md
@@ -12,19 +12,19 @@ The MCP connection is more context-efficient because the host manages tool selec
 
 ## Claude Code Plugin
 
-If you are using Claude Code, install the Developer MCP plugin. The `/mcp-cli` skill lets you run queries against Umbraco directly from Claude Code.
+If you are using Claude Code, install the Developer MCP plugin. The `/umb-cms-dev-cli` skill lets you run queries against Umbraco directly from Claude Code.
 
 ```bash
 /plugin marketplace add umbraco/Umbraco-CMS-MCP-Dev
 /plugin install umbraco-cms-mcp-dev@umbraco/Umbraco-CMS-MCP-Dev
 ```
 
-Once installed, use `/mcp-cli` with a query to interact with Umbraco:
+Once installed, use `/umb-cms-dev-cli` with a query to interact with Umbraco:
 
 ```
-/mcp-cli tell me what properties the home document type has
-/mcp-cli list all published content under the homepage
-/mcp-cli show me the media library structure
+/umb-cms-dev-cli tell me what properties the home document type has
+/umb-cms-dev-cli list all published content under the homepage
+/umb-cms-dev-cli show me the media library structure
 ```
 
 ## CLI Reference

--- a/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/configuration.md
+++ b/17/umbraco-ai/umbraco-in-ai/mcp/cms-developer-mcp/configuration.md
@@ -6,6 +6,8 @@ description: Configuration options for the Developer MCP server
 
 The Developer MCP Server uses the same configuration fields as any Umbraco MCP server built on the Base MCP SDK. For authentication, environment variables, CLI arguments, precedence rules, and all built-in fields, see the [SDK Configuration reference](https://app.gitbook.com/s/qRBjeReNuznLmI2zTKUq/sdk/configuration).
 
+For a complete reference of CLI flags, runtime modes (readonly and dry-run), introspection commands, and input sanitization, see the [CLI Reference](https://app.gitbook.com/s/qRBjeReNuznLmI2zTKUq/sdk/cli).
+
 This page lists the specific tool modes and slices that the Developer MCP ships with.
 
 ## Tool Filtering


### PR DESCRIPTION
## Summary

- Adds a new **CLI Reference** page to the Base MCP SDK documentation (`17/umbraco-ai/umbraco-in-ai/mcp/base-mcp/sdk/cli.md`)
- Covers authentication, starting the server, tool filtering, runtime modes (readonly and dry-run), introspection commands, and input sanitization
- Updates the **CMS Developer MCP** configuration page to link to the CLI Reference
- Adds entry to the Base MCP `SUMMARY.md`

## Test plan

- [ ] Verify the new CLI Reference page renders correctly on GitBook
- [ ] Verify the SUMMARY.md entry appears in the navigation under MCP Server SDK
- [ ] Verify the cross-reference link from the CMS Developer MCP configuration page resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)