### PR TITLE
Update author property to use member UDI

### DIFF
--- a/17/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/member-picker.md
+++ b/17/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/member-picker.md
@@ -52,6 +52,7 @@ The example below demonstrates how to add values programmatically using a Razor 
 
 ```csharp
 @using Umbraco.Cms.Core.Services
+@using Umbraco.Cms.Core;
 @inject IContentService ContentService
 @{
     // Create a variable for the GUID of the page you want to update
@@ -63,8 +64,11 @@ The example below demonstrates how to add values programmatically using a Razor 
     // Create a variable for the GUID of the member ID
     var authorId = Guid.Parse("ed944097281e4492bcdf783355219450");
 
+    // Create a udi
+    var memberUdi = Udi.Create(Constants.UdiEntityType.Member, authorId);
+
     // Set the value of the property with alias 'author'. 
-    content.SetValue("author", authorId);
+    content.SetValue("author", memberUdi);
 
     // Save the change
     ContentService.Save(content);


### PR DESCRIPTION


## 📋 Description

When saving a member with the member picker the value should be a UDI and not a guid.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
