### PR TITLE
Add Forms 17.3.0 release notes and UTC fix SQL script

### DIFF
--- a/17/umbraco-forms/release-notes.md
+++ b/17/umbraco-forms/release-notes.md
@@ -16,6 +16,37 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 17 including all changes for this version.
 
+### [17.3.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F17.3.0) (April 9th 2026)
+
+#### UTC date handling fix
+
+The v17.0.0 release included a migration (`MigrateSystemDatesToUtc`) that converted all existing system dates to UTC. However, the application code continued using `DateTime.Now` (local server time) when writing new records, causing inconsistent timestamps for form entries, workflow audit trails, and entity metadata.
+
+This release fixes the issue by:
+
+* Using `DateTime.UtcNow` consistently across all code paths that write to UTC-stored database columns [#1684](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1684)
+* Ensuring all date properties in API responses serialize with a UTC indicator (`Z` suffix), so the backoffice correctly converts to local time
+* Removing the legacy server-side timezone offset conversion in the entries list — the browser now handles UTC-to-local conversion consistently
+
+{% hint style="warning" %}
+
+Data written between v17.0.0 and this release may contain local server timestamps instead of UTC. A SQL script is provided below to correct historical data.
+
+Before running it, set `@TimeZone` to your server's Windows timezone name. Set `@UpgradeDate` to the approximate date you first upgraded to v17.0.0. The script excludes the `UFRecordDataDateTime` table, as those values represent user-entered dates that should not be shifted.
+
+The original `MigrateSystemDatesToUtc` migration contained a duplicate conversion for `UFPrevalueSource`. Created and Updated columns were converted twice. This has been fixed, but sites on v17.0–v17.2 may have double-converted PrevalueSource dates that require manual correction.
+
+{% endhint %}
+
+{% file src="scripts/correct-utc-timestamps.sql" %}
+Corrects historical data written with local server time instead of UTC between v17.0.0 and v17.3.0. Set the timezone and cutoff date before running.
+{% endfile %}
+
+#### Other
+
+* Mark `RecordFilter.LocalTimeOffset` as obsolete (will be removed in v18)
+* All items detailed under release candidates for 17.3.0.
+
 ### 17.3.0-rc2 (April 9th 2026)
 * Optimized startup performance when processing a large number of forms and records for analytics
 

--- a/17/umbraco-forms/scripts/correct-utc-timestamps.sql
+++ b/17/umbraco-forms/scripts/correct-utc-timestamps.sql
@@ -1,0 +1,25 @@
+-- Correct post-v17 data that was stored with DateTime.Now instead of DateTime.UtcNow.
+-- @TimeZone: your server Windows timezone name (e.g. Romance Standard Time)
+-- @UpgradeDate: approximate date you first upgraded to v17.0.0
+--               (rows BEFORE this date were already correctly migrated to UTC)
+
+DECLARE @TimeZone NVARCHAR(100) = 'Romance Standard Time'
+DECLARE @UpgradeDate DATETIME = '2026-03-01'
+
+-- Record tables
+UPDATE UFRecords SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
+UPDATE UFRecords SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
+UPDATE UFRecordAudit SET UpdatedOn = UpdatedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE UpdatedOn > @UpgradeDate
+UPDATE UFRecordWorkflowAudit SET ExecutedOn = ExecutedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE ExecutedOn > @UpgradeDate
+
+-- Entity metadata tables
+UPDATE UFPrevalueSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
+UPDATE UFPrevalueSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
+UPDATE UFWorkflows SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
+UPDATE UFWorkflows SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
+UPDATE UFDataSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
+UPDATE UFDataSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
+UPDATE UFFolders SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
+UPDATE UFFolders SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
+UPDATE UFForms SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
+UPDATE UFForms SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate

--- a/17/umbraco-forms/upgrading/migration-ids.md
+++ b/17/umbraco-forms/upgrading/migration-ids.md
@@ -32,3 +32,4 @@ A unique **migration ID** is generated for each Umbraco Forms upgrade that requi
 | 3f4e5d6c-7b8a-4c9d-0e1f-2a3b4c5d6e7f | 17.1.0                | Updates the form picker property editor UI alias.                                  |
 | 6a094cba-aa2c-4254-aaff-ced3d09eccf3 | 17.3.0                | Adds pre-aggregated analytics tables.                                              |
 | a7b3c9d2-4e5f-6a1b-8c7d-9e0f1a2b3c4d | 17.3.0                | Adds an index on the Record table for form and created date.                       |
+| c3d4e5f6-7a8b-4c9d-0e1f-2a3b4c5d6e7f | 17.3.0                | Adds an index on the Workflow Audit table for executed date and status.             |


### PR DESCRIPTION
## Summary
- Add 17.3.0 final release notes with detailed description of the UTC date handling fix ([Forms PR #1281](https://github.com/umbraco/Forms/pull/1281))
- Add downloadable SQL script (`scripts/correct-utc-timestamps.sql`) for correcting historical data affected by the DateTime.Now bug
- Add missing migration ID `c3d4e5f6-7a8b-4c9d-0e1f-2a3b4c5d6e7f` (Workflow Audit index) to migration-ids.md

## Product & Version

Umbraco Forms 17.3.0

## Deadline

Ready to merge on **2026-04-16** (Forms 17.3.0 release date).

🤖 Generated with [Claude Code](https://claude.com/claude-code)