### PR TITLE
Forms: 17.3.0, 16.5.2, and 13.9.6 release notes

### DIFF
--- a/13/umbraco-forms/release-notes.md
+++ b/13/umbraco-forms/release-notes.md
@@ -16,6 +16,13 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 13 including all changes for this version.
 
+### [13.9.6](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F13.9.6) (April 9th 2026)
+
+* Update "Umbraco Forms scheduled record deletion task" log message grammar [#1683](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1683)
+* Fix `ManageSecurityWithUserGroups` not working [#1675](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1675)
+* Fix value failing to save [#1673](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1673)
+* Fix "Updated By" not updating accordingly [#1671](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1671)
+
 ### 13.9.5
 * Umbraco Licenses dependency updated to 13.3.4
 

--- a/16/umbraco-forms/developer/magic-strings.md
+++ b/16/umbraco-forms/developer/magic-strings.md
@@ -47,6 +47,7 @@ Some extra variables are:
 
 * `[#pageName]`: The nodename of the current page
 * `[#pageID]`: The node ID of the current page
+* `[#pageKey]`: The GUID key of the current page
 
 ### Recursive Umbraco Page field
 

--- a/16/umbraco-forms/release-notes.md
+++ b/16/umbraco-forms/release-notes.md
@@ -18,6 +18,21 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 16 including all changes for this version.
 
+### [16.5.2](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F16.5.2) (April 9th 2026)
+
+* Update "Umbraco Forms scheduled record deletion task" log message grammar [#1683](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1683)
+* Fix form entries not visible in Firefox [#1677](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1677) [#1678](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1678)
+* Fix `ManageSecurityWithUserGroups` not working [#1675](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1675)
+* Fix page-specific magic strings not working in delivery API [#1674](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1674)
+* Fix value failing to save [#1673](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1673)
+* Fix creating form inside folder adding the form to root [#1672](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1672)
+* Fix "Updated By" not updating accordingly [#1671](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1671)
+* Fix save & preview opening modal with blank node names [#1670](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1670)
+* Fix store records setting not respected from template [#1669](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1669)
+* Add validation for prevalue options on dropdown and similar fields [#1660](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1660)
+* Fix data consent field included when created from template [#1651](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1651)
+* Fix workflow failing to submit with decimal field [#1574](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1574)
+
 ### 16.5.1
 * Fix: string length validation for file upload fields
 

--- a/16/umbraco-forms/release-notes.md
+++ b/16/umbraco-forms/release-notes.md
@@ -32,6 +32,7 @@ This section contains the release notes for Umbraco Forms 16 including all chang
 * Add validation for prevalue options on dropdown and similar fields [#1660](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1660)
 * Fix data consent field included when created from template [#1651](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1651)
 * Fix workflow failing to submit with decimal field [#1574](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1574)
+* Allow any integer for textarea `NumberOfRows` setting [#1685](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1685)
 
 ### 16.5.1
 * Fix: string length validation for file upload fields

--- a/17/umbraco-forms/developer/magic-strings.md
+++ b/17/umbraco-forms/developer/magic-strings.md
@@ -47,6 +47,7 @@ Some extra variables are:
 
 * `[#pageName]`: The nodename of the current page
 * `[#pageID]`: The node ID of the current page
+* `[#pageKey]`: The GUID key of the current page
 
 ### Recursive Umbraco Page field
 

--- a/17/umbraco-forms/release-notes.md
+++ b/17/umbraco-forms/release-notes.md
@@ -16,6 +16,37 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 17 including all changes for this version.
 
+### [17.3.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F17.3.0) (April 9th 2026)
+
+#### UTC date handling fix
+
+The v17.0.0 release included a migration (`MigrateSystemDatesToUtc`) that converted all existing system dates to UTC. However, the application code continued using `DateTime.Now` (local server time) when writing new records, causing inconsistent timestamps for form entries, workflow audit trails, and entity metadata.
+
+This release fixes the issue by:
+
+* Using `DateTime.UtcNow` consistently across all code paths that write to UTC-stored database columns [#1684](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1684)
+* Ensuring all date properties in API responses serialize with a UTC indicator (`Z` suffix), so the backoffice correctly converts to local time
+* Removing the legacy server-side timezone offset conversion in the entries list — the browser now handles UTC-to-local conversion consistently
+
+{% hint style="warning" %}
+
+Data written between v17.0.0 and this release may contain local server timestamps instead of UTC. A SQL script is provided below to correct historical data.
+
+Before running it, set `@TimeZone` to your server's Windows timezone name. Set `@UpgradeDate` to the approximate date you first upgraded to v17.0.0. The script excludes the `UFRecordDataDateTime` table, as those values represent user-entered dates that should not be shifted.
+
+The original `MigrateSystemDatesToUtc` migration contained a duplicate conversion for `UFPrevalueSource`. Created and Updated columns were converted twice. This has been fixed, but sites on v17.0–v17.2 may have double-converted PrevalueSource dates that require manual correction.
+
+{% endhint %}
+
+{% file src="scripts/correct-utc-timestamps.sql" %}
+Corrects historical data written with local server time instead of UTC between v17.0.0 and v17.3.0. Set the timezone and cutoff date before running.
+{% endfile %}
+
+#### Other
+
+* Mark `RecordFilter.LocalTimeOffset` as obsolete (will be removed in v18)
+* All items detailed under release candidates for 17.3.0.
+
 ### 17.3.0-rc2 (April 9th 2026)
 * Optimized startup performance when processing a large number of forms and records for analytics
 

--- a/17/umbraco-forms/release-notes.md
+++ b/17/umbraco-forms/release-notes.md
@@ -45,6 +45,7 @@ Corrects historical data written with local server time instead of UTC between v
 #### Other
 
 * Mark `RecordFilter.LocalTimeOffset` as obsolete (will be removed in v18)
+* Update "Umbraco Forms scheduled record deletion task" log message grammar [#1683](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1683)
 * All items detailed under release candidates for 17.3.0.
 
 ### 17.3.0-rc2 (April 9th 2026)

--- a/17/umbraco-forms/release-notes.md
+++ b/17/umbraco-forms/release-notes.md
@@ -45,7 +45,9 @@ Corrects historical data written with local server time instead of UTC between v
 #### Other
 
 * Mark `RecordFilter.LocalTimeOffset` as obsolete (will be removed in v18)
+* Improved performance of Analytics database queries
 * Update "Umbraco Forms scheduled record deletion task" log message grammar [#1683](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1683)
+* Allow any integer for textarea `NumberOfRows` setting [#1685](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1685)
 * All items detailed under release candidates for 17.3.0.
 
 ### 17.3.0-rc2 (April 9th 2026)

--- a/17/umbraco-forms/scripts/correct-utc-timestamps.sql
+++ b/17/umbraco-forms/scripts/correct-utc-timestamps.sql
@@ -1,0 +1,25 @@
+-- Correct post-v17 data that was stored with DateTime.Now instead of DateTime.UtcNow.
+-- @TimeZone: your server Windows timezone name (e.g. Romance Standard Time)
+-- @UpgradeDate: approximate date you first upgraded to v17.0.0
+--               (rows BEFORE this date were already correctly migrated to UTC)
+
+DECLARE @TimeZone NVARCHAR(100) = 'Romance Standard Time'
+DECLARE @UpgradeDate DATETIME = '2026-03-01'
+
+-- Record tables
+UPDATE UFRecords SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
+UPDATE UFRecords SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
+UPDATE UFRecordAudit SET UpdatedOn = UpdatedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE UpdatedOn > @UpgradeDate
+UPDATE UFRecordWorkflowAudit SET ExecutedOn = ExecutedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE ExecutedOn > @UpgradeDate
+
+-- Entity metadata tables
+UPDATE UFPrevalueSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
+UPDATE UFPrevalueSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
+UPDATE UFWorkflows SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
+UPDATE UFWorkflows SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
+UPDATE UFDataSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
+UPDATE UFDataSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
+UPDATE UFFolders SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
+UPDATE UFFolders SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
+UPDATE UFForms SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
+UPDATE UFForms SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate

--- a/17/umbraco-forms/upgrading/migration-ids.md
+++ b/17/umbraco-forms/upgrading/migration-ids.md
@@ -32,3 +32,4 @@ A unique **migration ID** is generated for each Umbraco Forms upgrade that requi
 | 3f4e5d6c-7b8a-4c9d-0e1f-2a3b4c5d6e7f | 17.1.0                | Updates the form picker property editor UI alias.                                  |
 | 6a094cba-aa2c-4254-aaff-ced3d09eccf3 | 17.3.0                | Adds pre-aggregated analytics tables.                                              |
 | a7b3c9d2-4e5f-6a1b-8c7d-9e0f1a2b3c4d | 17.3.0                | Adds an index on the Record table for form and created date.                       |
+| c3d4e5f6-7a8b-4c9d-0e1f-2a3b4c5d6e7f | 17.3.0                | Adds an index on the Workflow Audit table for executed date and status.             |

--- a/17/umbraco-forms/upgrading/migration-ids.md
+++ b/17/umbraco-forms/upgrading/migration-ids.md
@@ -32,4 +32,6 @@ A unique **migration ID** is generated for each Umbraco Forms upgrade that requi
 | 3f4e5d6c-7b8a-4c9d-0e1f-2a3b4c5d6e7f | 17.1.0                | Updates the form picker property editor UI alias.                                  |
 | 6a094cba-aa2c-4254-aaff-ced3d09eccf3 | 17.3.0                | Adds pre-aggregated analytics tables.                                              |
 | a7b3c9d2-4e5f-6a1b-8c7d-9e0f1a2b3c4d | 17.3.0                | Adds an index on the Record table for form and created date.                       |
-| c3d4e5f6-7a8b-4c9d-0e1f-2a3b4c5d6e7f | 17.3.0                | Adds an index on the Workflow Audit table for executed date and status.             |
+| c3d4e5f6-7a8b-4c9d-0e1f-2a3b4c5d6e7f | 17.3.0                | Adds an index on the Workflow Audit table for executed date and status.            |
+| b8e2f4a1-3c5d-4e6f-9a7b-1d2e3f4a5b6c | 17.3.0                | Adds an index on UniqueId to the UFRecords table for analytics performance.        |
+| d4f5e6a7-8b9c-4d0e-1f2a-3b4c5d6e7f8a | 17.3.0                | Replaces the index on UFRecords with a covering index that includes UmbracoPageId. |


### PR DESCRIPTION
## Summary
- Add Forms 17.3.0 release notes including UTC date handling fix, analytics feature, and bug fixes
- Add Forms 16.5.2 release notes with 12 backported bug fixes
- Add Forms 13.9.6 release notes with 4 backported bug fixes
- Include SQL script for correcting historical UTC timestamps
- Add missing migration ID documentation

Supersedes #7945 (branch renamed from `forms/17.3.0-release-notes` to `forms/march-release-notes`).

To be merged in on Thursday 16th April 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)