### PR TITLE
Update link to default property editor schema aliases

### DIFF
--- a/17/umbraco-cms/customizing/property-editors/composition/property-editor-schema.md
+++ b/17/umbraco-cms/customizing/property-editors/composition/property-editor-schema.md
@@ -30,7 +30,7 @@ You can see the used schema of a Property Editor in the backoffice of Umbraco wh
 
 ## A custom schema or not?
 
-Umbraco ships with a collection of [default property editor schemas](../../../tutorials/creating-a-property-editor/default-property-editor-schema-aliases/) that cover most scenarios that are less demanding. Although each situation is different, if you answer yes to any of the following statements, it makes sense to create a custom schema:
+Umbraco ships with a collection of [default property editor schemas](../../../tutorials/creating-a-property-editor/adding-server-side-validation/default-property-editor-schema-aliases/) that cover most scenarios that are less demanding. Although each situation is different, if you answer yes to any of the following statements, it makes sense to create a custom schema:
 
 * You expect the schema to be used by multiple Property Editor UIs.
 * You need a custom [Property Value Converter](../property-value-converters.md) to convert the data going into the cache, or you want the Umbraco ModelsBuilder to have a more specific, strongly-typed model.


### PR DESCRIPTION
## 📋 Description

Broken link to default property editor schemas here:
https://docs.umbraco.com/umbraco-cms/customizing/property-editors/composition/property-editor-schema#a-custom-schema-or-not

Correct link is to this page:
https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-property-editor/adding-server-side-validation/default-property-editor-schema-aliases

Not sure if docs need this sub level for just a single page though.

<img width="1579" height="1018" alt="image" src="https://github.com/user-attachments/assets/1dd0508a-5109-4e9e-93a6-2cd247fa07d3" />


## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
