### PR TITLE
Remove reference to @typedMediaPickerSingle.Value("alt") and inline styles from image tags in media picker examples for accuracy and consistency

### DIFF
--- a/17/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/media-picker-3.md
+++ b/17/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/media-picker-3.md
@@ -71,7 +71,7 @@ Global crops are configured on the Image Cropper property of the Image Media Typ
     var typedMultiMediaPicker = Model.Value<IEnumerable<MediaWithCrops>>("medias");
     foreach (var entry in typedMultiMediaPicker)
     {
-        <img src="@entry.MediaUrl()" style="width:200px" />
+        <img src="@entry.MediaUrl()" />
     }
 }
 ```
@@ -84,7 +84,7 @@ Global crops are configured on the Image Cropper property of the Image Media Typ
     var listOfImages = Model.Value<IEnumerable<IPublishedContent>>("medias");
     foreach (var image in listOfImages)
     {
-        <img src="@image.Url()" alt="@image.Name" />
+        <img src="@image.Url()" />
     }
 }
 ```
@@ -100,7 +100,7 @@ While `MediaWithCrops` is the default return type, `IPublishedContent` may be us
     var typedMultiMediaPicker = Model.Medias;
     foreach (var entry in typedMultiMediaPicker)
     {
-        <img src="@entry.MediaUrl()" style="width:200px" />
+        <img src="@entry.MediaUrl()" />
     }
 }
 ```
@@ -113,7 +113,7 @@ While `MediaWithCrops` is the default return type, `IPublishedContent` may be us
     var typedMediaPickerSingle = Model.Value<MediaWithCrops>("media");
     if (typedMediaPickerSingle != null)
     {
-        <img src="@typedMediaPickerSingle.MediaUrl()" style="width:200px" alt="@typedMediaPickerSingle.Value("alt")" />
+        <img src="@typedMediaPickerSingle.MediaUrl()" />
     }
 }
 ```
@@ -126,7 +126,7 @@ While `MediaWithCrops` is the default return type, `IPublishedContent` may be us
     var typedMediaPickerSingle = Model.Media;
     if (typedMediaPickerSingle is MediaWithCrops mediaEntry)
     {
-        <img src="@mediaEntry.MediaUrl()" style="width:200px"/>
+        <img src="@mediaEntry.MediaUrl()" />
     }
 }
 ```
@@ -141,7 +141,7 @@ The following is an example of how to retrieve a crop from a `MediaWithCrops` en
 @{
     foreach (var entry in Model.Medias)
     {
-        <img src="@entry.GetCropUrl("cropAlias")"/>
+        <img src="@entry.GetCropUrl("cropAlias")" />
     }
 }
 ```
@@ -154,7 +154,7 @@ You can retrieve globally defined crops explicitly by using `GetCropUrl` on the 
 @{
     foreach (var entry in Model.Medias)
     {
-        <img src="@Url.GetCropUrl(entry, "cropAlias")"/>
+        <img src="@Url.GetCropUrl(entry, "cropAlias")" />
     }
 }
 ```


### PR DESCRIPTION
## 📋 Description

Noticed we have a hangover back to umbraco 8 maybe? where alt texts could be specified when inserting a media item via the RTE.
Removing for accuracy.
Also suggest removing the inline styles and the simple `alt="@image.Name"` as alt should be thought carefully for maybe contextual alt, and maybe culture specific.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

