### PR TITLE
Added TokenIgnore filter to filter out matching inline patterns

### DIFF
--- a/.github/styles/UmbracoDocs/SentenceLength.yml
+++ b/.github/styles/UmbracoDocs/SentenceLength.yml
@@ -9,3 +9,6 @@ scope: sentence
 level: warning
 max: 25
 token: \b(\w+)\b
+filters:
+  - '\([^)]*\/[^)]*\)'
+  - 'url="[^"]*"'

--- a/.github/styles/UmbracoDocs/SentenceLength.yml
+++ b/.github/styles/UmbracoDocs/SentenceLength.yml
@@ -9,6 +9,3 @@ scope: sentence
 level: warning
 max: 25
 token: \b(\w+)\b
-filters:
-  - '\([^)]*\/[^)]*\)'
-  - 'url="[^"]*"'

--- a/.vale.ini
+++ b/.vale.ini
@@ -6,6 +6,7 @@ StylesPath = .github/styles
 [*.md]
 #BasedOnStyles = Vale, write-good
 BasedOnStyles = UmbracoDocs
+TokenIgnores = (\([^)]*\/[^)]*\)|url="[^"]*")
 
 [.claude/**/*.md]
 BasedOnStyles =


### PR DESCRIPTION
## 📋 Description

The linter is flagging {% content-ref %} block because the URL path inside it is very long. This is a false positive as the linter is treating the long URL as a "sentence."

Added `TokenIgnores`  to strip matching inline URL patterns from the source text before any rule runs. 

<img width="806" height="526" alt="image" src="https://github.com/user-attachments/assets/3e934a6a-f82d-495f-b351-fa27db303ea1" />

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

Anytime

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
