### PR TITLE
Detailed of `shareUmbracoConnection` parameter for `AddUmbracoDbContext` (CMS 17.4)

### DIFF
--- a/17/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
+++ b/17/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
@@ -137,17 +137,19 @@ public class BlogCommentsComposer : IComposer
 {
     public void Compose(IUmbracoBuilder builder)
     {
-        builder.Services.AddUmbracoDbContext<BlogContext>((serviceProvider, options, connectionString, providerName) =>
-        {
-            if (string.IsNullOrEmpty(providerName) || string.IsNullOrEmpty(connectionString))
+        builder.Services.AddUmbracoDbContext<BlogContext>(
+            (serviceProvider, options, connectionString, providerName) =>
             {
-                return;
-            }
+                if (string.IsNullOrEmpty(providerName) || string.IsNullOrEmpty(connectionString))
+                {
+                    return;
+                }
 
-            // Automatically uses the correct provider (SQL Server, SQLite, etc.)
-            // based on your Umbraco connection string configuration.
-            options.UseDatabaseProvider(providerName, connectionString);
-        });
+                // Automatically uses the correct provider (SQL Server, SQLite, etc.)
+                // based on your Umbraco connection string configuration.
+                options.UseDatabaseProvider(providerName, connectionString);
+            },
+            shareUmbracoConnection: true);
     }
 }
 ```
@@ -155,6 +157,8 @@ public class BlogCommentsComposer : IComposer
 {% endcode %}
 
 Using `UseDatabaseProvider(providerName, connectionString)` is the recommended approach. It reads the provider name and connection string directly from your Umbraco configuration (`appsettings.json`). It works correctly for SQL Server, SQLite, and any other supported database without any hardcoding.
+
+The `shareUmbracoConnection: true` argument tells Umbraco that your `DbContext` uses the Umbraco database. EF Core queries then run on the same connection and transaction as Umbraco's own data access. See [Using a separate database](#using-a-separate-database) below if your `DbContext` targets a different database.
 
 ## Step 4: Generate the Migration
 
@@ -248,15 +252,17 @@ public class BlogCommentsComposer : IComposer
 {
     public void Compose(IUmbracoBuilder builder)
     {
-        builder.Services.AddUmbracoDbContext<BlogContext>((serviceProvider, options, connectionString, providerName) =>
-        {
-            if (string.IsNullOrEmpty(providerName) || string.IsNullOrEmpty(connectionString))
+        builder.Services.AddUmbracoDbContext<BlogContext>(
+            (serviceProvider, options, connectionString, providerName) =>
             {
-                return;
-            }
+                if (string.IsNullOrEmpty(providerName) || string.IsNullOrEmpty(connectionString))
+                {
+                    return;
+                }
 
-            options.UseDatabaseProvider(providerName, connectionString);
-        });
+                options.UseDatabaseProvider(providerName, connectionString);
+            },
+            shareUmbracoConnection: true);
 
         builder.AddNotificationAsyncHandler<UmbracoApplicationStartedNotification, RunBlogCommentsMigration>();
     }
@@ -352,3 +358,32 @@ public class BlogCommentsController : Controller
 ```
 
 {% endcode %}
+
+### Using a separate database
+
+By default, `AddUmbracoDbContext<T>(..., shareUmbracoConnection: true)` binds your `DbContext` to Umbraco's database connection and transaction scope. Every EF Core query runs against the Umbraco database, and writes commit or roll back together with the enclosing Umbraco scope. That is the right choice when your custom tables live inside the Umbraco database.
+
+If your `DbContext` targets a **different** database — for example, a separate SQLite file or an entirely different SQL Server instance — pass `shareUmbracoConnection: false`. Without it, the connection string you configure through `UseSqlite(...)` or `UseSqlServer(...)` is replaced at runtime and your queries run against the Umbraco database instead.
+
+{% code title="BlogCommentsComposer.cs" %}
+
+```csharp
+builder.Services.AddUmbracoDbContext<BlogContext>(
+    (serviceProvider, options, connectionString, providerName) =>
+    {
+        options.UseSqlite("Data Source=blog-comments.db");
+    },
+    shareUmbracoConnection: false);
+```
+
+{% endcode %}
+
+{% hint style="info" %}
+When `shareUmbracoConnection` is `false`, the custom `DbContext` has its own connection and transaction. Completing an Umbraco scope does not commit writes made through your EF Core scope (and vice versa). You still use `IEFCoreScopeProvider<T>` and `IEfCoreScope<T>` the same way as before — the scope manages the separate connection on your behalf.
+{% endhint %}
+
+{% hint style="info" %}
+
+The `shareUmbracoConnection` parameter was added in Umbraco 17.4. Calls to `AddUmbracoDbContext<T>` without it are marked as obsolete and scheduled for removal in Umbraco 19.
+
+{% endhint %}

--- a/18/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
+++ b/18/umbraco-cms/tutorials/getting-started-with-entity-framework-core.md
@@ -137,17 +137,19 @@ public class BlogCommentsComposer : IComposer
 {
     public void Compose(IUmbracoBuilder builder)
     {
-        builder.Services.AddUmbracoDbContext<BlogContext>((serviceProvider, options, connectionString, providerName) =>
-        {
-            if (string.IsNullOrEmpty(providerName) || string.IsNullOrEmpty(connectionString))
+        builder.Services.AddUmbracoDbContext<BlogContext>(
+            (serviceProvider, options, connectionString, providerName) =>
             {
-                return;
-            }
+                if (string.IsNullOrEmpty(providerName) || string.IsNullOrEmpty(connectionString))
+                {
+                    return;
+                }
 
-            // Automatically uses the correct provider (SQL Server, SQLite, etc.)
-            // based on your Umbraco connection string configuration.
-            options.UseDatabaseProvider(providerName, connectionString);
-        });
+                // Automatically uses the correct provider (SQL Server, SQLite, etc.)
+                // based on your Umbraco connection string configuration.
+                options.UseDatabaseProvider(providerName, connectionString);
+            },
+            shareUmbracoConnection: true);
     }
 }
 ```
@@ -155,6 +157,8 @@ public class BlogCommentsComposer : IComposer
 {% endcode %}
 
 Using `UseDatabaseProvider(providerName, connectionString)` is the recommended approach. It reads the provider name and connection string directly from your Umbraco configuration (`appsettings.json`). It works correctly for SQL Server, SQLite, and any other supported database without any hardcoding.
+
+The `shareUmbracoConnection: true` argument tells Umbraco that your `DbContext` uses the Umbraco database. EF Core queries then run on the same connection and transaction as Umbraco's own data access. See [Using a separate database](#using-a-separate-database) below if your `DbContext` targets a different database.
 
 ## Step 4: Generate the Migration
 
@@ -248,15 +252,17 @@ public class BlogCommentsComposer : IComposer
 {
     public void Compose(IUmbracoBuilder builder)
     {
-        builder.Services.AddUmbracoDbContext<BlogContext>((serviceProvider, options, connectionString, providerName) =>
-        {
-            if (string.IsNullOrEmpty(providerName) || string.IsNullOrEmpty(connectionString))
+        builder.Services.AddUmbracoDbContext<BlogContext>(
+            (serviceProvider, options, connectionString, providerName) =>
             {
-                return;
-            }
+                if (string.IsNullOrEmpty(providerName) || string.IsNullOrEmpty(connectionString))
+                {
+                    return;
+                }
 
-            options.UseDatabaseProvider(providerName, connectionString);
-        });
+                options.UseDatabaseProvider(providerName, connectionString);
+            },
+            shareUmbracoConnection: true);
 
         builder.AddNotificationAsyncHandler<UmbracoApplicationStartedNotification, RunBlogCommentsMigration>();
     }
@@ -352,3 +358,26 @@ public class BlogCommentsController : Controller
 ```
 
 {% endcode %}
+
+### Using a separate database
+
+By default, `AddUmbracoDbContext<T>(..., shareUmbracoConnection: true)` binds your `DbContext` to Umbraco's database connection and transaction scope. Every EF Core query runs against the Umbraco database, and writes commit or roll back together with the enclosing Umbraco scope. That is the right choice when your custom tables live inside the Umbraco database.
+
+If your `DbContext` targets a **different** database — for example, a separate SQLite file or an entirely different SQL Server instance — pass `shareUmbracoConnection: false`. Without it, the connection string you configure through `UseSqlite(...)` or `UseSqlServer(...)` is replaced at runtime and your queries run against the Umbraco database instead.
+
+{% code title="BlogCommentsComposer.cs" %}
+
+```csharp
+builder.Services.AddUmbracoDbContext<BlogContext>(
+    (serviceProvider, options, connectionString, providerName) =>
+    {
+        options.UseSqlite("Data Source=blog-comments.db");
+    },
+    shareUmbracoConnection: false);
+```
+
+{% endcode %}
+
+{% hint style="info" %}
+When `shareUmbracoConnection` is `false`, the custom `DbContext` has its own connection and transaction. Completing an Umbraco scope does not commit writes made through your EF Core scope (and vice versa). You still use `IEFCoreScopeProvider<T>` and `IEfCoreScope<T>` the same way as before — the scope manages the separate connection on your behalf.
+{% endhint %}


### PR DESCRIPTION
## 📋 Description

Adds details of the `shareUmbracoConnection` parameter for `AddUmbracoDbContext`

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/pull/22133
https://github.com/umbraco/Umbraco-CMS/issues/22131

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [X] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [X] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [X] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17.4

## Deadline (if relevant)

With the release candidate of 17.4, scheduled for Thursday 30th April