### PR TITLE
AI: note Data Protection requirement for sensitive settings

### DIFF
--- a/ai-in-umbraco/1/extending/providers/provider-settings.md
+++ b/ai-in-umbraco/1/extending/providers/provider-settings.md
@@ -165,7 +165,7 @@ public string? SecretToken { get; set; }
 {% endcode %}
 
 {% hint style="info" %}
-Sensitive values are encrypted at rest using [ASP.NET Core Data Protection](https://learn.microsoft.com/aspnet/core/security/data-protection/configuration/overview). If the Data Protection key ring isn't persisted across restarts (for example, a Windows IIS app pool without a user profile, or a container without a persistent volume), decryption will fail after a restart or on a different machine. The value will appear as `ENC:...` in the UI and the log will show `The key {guid} was not found in the key ring`. Either configure Data Protection to persist keys to a stable store, or use [configuration references](#configuration-references) so the secret lives in `appsettings.json` instead of the database.
+Sensitive values are encrypted at rest using [ASP.NET Core Data Protection](https://learn.microsoft.com/aspnet/core/security/data-protection/configuration/overview). If the Data Protection keyring isn't persisted across restarts, decryption will fail. This occurs when Windows IIS app pools lack profiles or containers with persistent volumes. The value will appear as `ENC:...` in the UI, and the log will show `The key {guid} was not found in the key ring`. Configure Data Protection to persist keys to a stable store. Alternatively, use configuration references to store secrets in appsettings.json instead of the database.
 {% endhint %}
 
 ## Custom Editors

--- a/ai-in-umbraco/1/extending/providers/provider-settings.md
+++ b/ai-in-umbraco/1/extending/providers/provider-settings.md
@@ -164,6 +164,10 @@ public string? SecretToken { get; set; }
 
 {% endcode %}
 
+{% hint style="info" %}
+Sensitive values are encrypted at rest using [ASP.NET Core Data Protection](https://learn.microsoft.com/aspnet/core/security/data-protection/configuration/overview). If the Data Protection key ring isn't persisted across restarts (for example, a Windows IIS app pool without a user profile, or a container without a persistent volume), decryption will fail after a restart or on a different machine. The value will appear as `ENC:...` in the UI and the log will show `The key {guid} was not found in the key ring`. Either configure Data Protection to persist keys to a stable store, or use [configuration references](#configuration-references) so the secret lives in `appsettings.json` instead of the database.
+{% endhint %}
+
 ## Custom Editors
 
 Use Umbraco property editor UI aliases for specialized input:


### PR DESCRIPTION
## Summary

- Adds a short hint to `ai-in-umbraco/1/extending/providers/provider-settings.md` explaining that sensitive AI settings (API keys, secrets) are encrypted at rest via ASP.NET Core Data Protection, and that values appear as `ENC:...` when the key ring isn't persisted across restarts or shared between machines.
- Points readers at the existing Configuration References pattern as the simple workaround when persisting the key ring isn't practical.

Prompted by [umbraco/Umbraco.AI#85](https://github.com/umbraco/Umbraco.AI/issues/85) — users hitting 401s after app-pool recycles or when the same DB is accessed from multiple machines had no docs to look at.

## Test plan

- [ ] Preview the Sensitive Settings section renders the hint block correctly on GitBook
- [ ] Confirm the `#configuration-references` anchor resolves on the same page