### PR TITLE
Document the change of default webhook payload type

### DIFF
--- a/18/umbraco-cms/reference/webhooks/README.md
+++ b/18/umbraco-cms/reference/webhooks/README.md
@@ -69,9 +69,9 @@ Extended payloads include all relevant information for an event, where available
 
 #### Legacy
 
-Legacy payloads follow the format used before version 16. They are inconsistent and may include data that should not be exposed or has been superseded (e.g., use of `int` instead of `Guid`).
+Legacy payloads follow the format used before version 16. They are inconsistent and may include data that should not be exposed or has been superseded (for example, use of `int` instead of `Guid`).
 
-This payload type exists for backwards compatability, and will be removed in a future version.
+This payload type exists for backwards compatibility, and will be removed in a future version.
 
 ### Configuring Payload Types
 

--- a/18/umbraco-cms/reference/webhooks/README.md
+++ b/18/umbraco-cms/reference/webhooks/README.md
@@ -57,17 +57,21 @@ Umbraco webhooks come with predefined settings and behaviors.
 
 Each webhook event sends a JSON payload. The following types of payloads are available by default.
 
-#### Legacy
-
-This is the current default but will be removed in a future version. Legacy payloads follow the format used before version 16. They are inconsistent and may include data that should not be exposed or has been superseded (e.g., use of `int` instead of `Guid`).
-
 #### Minimal
 
-This will become the default in version 18 and later. Minimal payloads include only essential information to identify the resource. For most events, this means a unique identifier. Some events may include additional data. For example, a document publish event also includes the list of published cultures.
+Minimal payloads include only essential information to identify the resource. For most events, this means a unique identifier. Some events may include additional data. For example, a document publish event also includes the list of published cultures.
+
+This is the default payload type.
 
 #### Extended
 
 Extended payloads include all relevant information for an event, where available. However, sensitive data, such as usernames, member names, or email addresses, is excluded for privacy and security reasons. If an extended payload is not available for an event, the system falls back to the minimal payload.
+
+#### Legacy
+
+Legacy payloads follow the format used before version 16. They are inconsistent and may include data that should not be exposed or has been superseded (e.g., use of `int` instead of `Guid`).
+
+This payload type exists for backwards compatability, and will be removed in a future version.
 
 ### Configuring Payload Types
 


### PR DESCRIPTION
## 📋 Description

https://github.com/umbraco/Umbraco-CMS/pull/22217 changed the default webhook payload type from `Legacy` to `Minimal`. This PR updates the [corresponding documentation](https://docs.umbraco.com/umbraco-cms/reference/webhooks#json-payload).

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

V18

## Deadline (if relevant)

Ideally before V18 docs are released.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
