### PR TITLE
Update README with TinyMCE migration information

### DIFF
--- a/17/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
+++ b/17/umbraco-cms/fundamentals/setup/upgrading/version-specific/README.md
@@ -250,7 +250,7 @@ In Umbraco 15, two property editors were available for a rich text editor: TinyM
 
 With Umbraco 16, only TipTap is available as an option out of the box. TinyMCE's [change of license](https://github.com/tinymce/tinymce/issues/9453#issuecomment-2327646149) precludes us from shipping it with the MIT-licensed Umbraco CMS.
 
-When upgrading to Umbraco 16, any data types using TinyMCE will be migrated to use TipTap.
+When upgrading to Umbraco 16, any data types using TinyMCE will be migrated to use TipTap. (Data will be migrated for Block List, Block Grid and Rich Text Editor property editors - Third-party property editors data can also be included in the migration by using an implementation of [ITypedLocalLinkProcessor](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/ITypedLocalLinkProcessor.cs)
 
 To continue to use TinyMCE, a third-party package must be installed prior to the upgrade. This will disable the migration and allow you to continue with TinyMCE.
 


### PR DESCRIPTION
Clarified migration details for TinyMCE to TipTap in Umbraco 16 upgrade.

## 📋 Description

I had an issue upgraded to V17, where the built in migration migrated by TinyMCE Data Types to TipTap, the data was migrated too, but NOT when the Data Type was Contentment ContentBlocks.

Raised it as an issue, although not really an issue, but super Andy Butland looked at it and found that it's possible to extend this process to include third party property editors:

https://github.com/umbraco/Umbraco-CMS/issues/22538#issuecomment-4313432053

But here's the thing, it's not really documented, and most people will just run the upgrade, and not be aware of it, so I was thinking would adding this here, give people a clue, as to this possibility?

or is it better that people just hit this issue when the hit it?

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

This is relevant for V16+ but shouldn't be in v18 as at that point the ability to do this will be removed.

## Deadline (if relevant)

Now now, this might help people upgrading from LTSs


