### PR TITLE
docs(sdk): document tool-types codegen

### DIFF
--- a/.github/styles/config/dictionaries/umbraco.dic
+++ b/.github/styles/config/dictionaries/umbraco.dic
@@ -106,6 +106,7 @@ CMS's
 codebase
 codeblock
 Codegarden
+codegen
 collectionAction
 collectionConfig
 collectionView
@@ -380,6 +381,7 @@ masterpages
 Matryoshka
 maxLength
 Maxmind
+MCPs
 Mecanik
 memberGroups
 memberIds

--- a/17/umbraco-in-ai/SUMMARY.md
+++ b/17/umbraco-in-ai/SUMMARY.md
@@ -37,6 +37,7 @@
     * [Testing and Evals](mcp/base-mcp/sdk/testing.md)
     * [Tool Authoring](mcp/base-mcp/sdk/tool-authoring.md)
     * [Tool Filtering](mcp/base-mcp/sdk/tool-filtering.md)
+    * [Tool Types Codegen](mcp/base-mcp/sdk/tool-types.md)
 * [Developer Model Context Protocol (MCP) Server](mcp/cms-developer-mcp/README.md)
   * [Available Tools](mcp/cms-developer-mcp/available-tools.md)
   * [Configuration Options](mcp/cms-developer-mcp/configuration.md)

--- a/17/umbraco-in-ai/mcp/base-mcp/sdk/README.md
+++ b/17/umbraco-in-ai/mcp/base-mcp/sdk/README.md
@@ -18,6 +18,7 @@ Create a new MCP server project with the [Create Umbraco MCP Server](../create-u
 | [API Helpers](./api-helpers.md) | API call helpers, HTTP client, ProblemDetails handling |
 | [Tool Filtering](./tool-filtering.md) | Modes, slices, collections, configuration flow |
 | [MCP Chaining](./mcp-chaining.md) | Proxying, delegation, and composite tool patterns |
+| [Tool Types Codegen](./tool-types.md) | Generate per-tool TypeScript types for downstream chained MCPs |
 | [Configuration](./configuration.md) | Server config, env vars, CLI flags, custom fields |
 | [Constants](./constants.md) | Well-known Umbraco IDs reference |
 | [Testing and Evals](./testing.md) | Unit testing, snapshot helpers, LLM eval framework |

--- a/17/umbraco-in-ai/mcp/base-mcp/sdk/tool-types.md
+++ b/17/umbraco-in-ai/mcp/base-mcp/sdk/tool-types.md
@@ -23,7 +23,7 @@ Types are compile-time only. Runtime Zod validation inside each MCP remains auth
 
 ## Setup
 
-Add the codegen as a `postbuild` script in your MCP package's `package.json`, and expose the generated `.d.ts` via a `./tool-types` subpath export so consumers can import it:
+Add the codegen as a `postbuild` script in your MCP package's `package.json`, and expose the generated `.d.ts` via a `./tool-types` export so consumers can import it:
 
 ```json
 {
@@ -120,4 +120,4 @@ const tools = collections.flatMap((c) =>
 );
 ```
 
-The returned object should only be passed to `collection.tools(user)` — its properties are Proxy-backed and not safe to read directly (`user.id` is not a string).
+Pass the returned object only to `collection.tools(user)` — its properties are Proxy-backed and not safe to read directly (`user.id` is not a string).

--- a/17/umbraco-in-ai/mcp/base-mcp/sdk/tool-types.md
+++ b/17/umbraco-in-ai/mcp/base-mcp/sdk/tool-types.md
@@ -1,0 +1,123 @@
+---
+description: Generate per-tool TypeScript types from your MCP server's collections so downstream MCPs can chain calls with full compile-time safety.
+---
+
+# Tool Types Codegen
+
+Downstream MCPs that chain another MCP server's tools (via `mcpClientManager.callTool(...)`) usually want compile-time types for tool inputs and outputs. The SDK ships a CLI binary that walks your built collections and emits a single `.d.ts` registry covering every tool.
+
+The boundary between two MCPs is type-safe at compile time. Renaming a tool, changing its input schema, or adding a required field surfaces as a TypeScript error in every consumer that imports the registry.
+
+## How It Works
+
+The codegen runs after your build:
+
+1. Dynamic-imports your compiled `dist/collections.js`.
+2. Walks every `collection.tools(user)` using a synthetic permissive user that passes any authorization check.
+3. Runs each tool's input and output Zod schema through `z.toJSONSchema()`, then through `json-schema-to-typescript`.
+4. Writes a single `.d.ts` file containing per-tool interfaces and a registry interface that maps tool names to `{ input, output }` pairs.
+
+{% hint style="info" %}
+Types are compile-time only. Runtime Zod validation inside each MCP remains authoritative — the codegen does not change runtime behaviour.
+{% endhint %}
+
+## Setup
+
+Add the codegen as a `postbuild` script in your MCP package's `package.json`, and expose the generated `.d.ts` via a `./tool-types` subpath export so consumers can import it:
+
+```json
+{
+  "scripts": {
+    "build": "tsup",
+    "postbuild": "umbraco-mcp-generate-types --registry-name CmsTools"
+  },
+  "exports": {
+    "./tool-types": { "types": "./dist/tool-types.d.ts" }
+  }
+}
+```
+
+That's the entire setup. Every `npm run build` regenerates the types.
+
+## CLI Options
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--collections <path>` | `./dist/collections.js` | Compiled module that exports a `collections` array (or default-exports one). |
+| `--out <path>` | `./dist/tool-types.d.ts` | Output `.d.ts` path. Parent directories are created if missing. |
+| `--registry-name <name>` | derived from `package.json` | Name of the emitted registry interface. Default strips the npm scope and PascalCases the package name (for example, `@umbraco-cms/mcp-cms` → `McpCmsTools`). |
+| `--help`, `-h` | — | Show usage and exit. |
+
+## Generated Output
+
+A typical generated file looks like this:
+
+```typescript
+export interface GetDocumentByIdInput {
+  id: string;
+}
+
+export interface GetDocumentByIdOutput {
+  id: string;
+  variants: { culture?: string | null; name: string }[];
+  // ...
+}
+
+export interface CmsTools {
+  "get-document-by-id": {
+    input: GetDocumentByIdInput;
+    output: GetDocumentByIdOutput;
+  };
+  // ... one entry per tool
+}
+
+export type CmsToolsName = keyof CmsTools;
+```
+
+## Consuming the Registry
+
+A downstream MCP imports the registry to type its chained calls:
+
+```typescript
+import type {
+  CmsTools,
+  CmsToolsName,
+} from "@umbraco-cms/mcp-cms/tool-types";
+
+async function callCms<N extends CmsToolsName>(
+  name: N,
+  args: CmsTools[N]["input"],
+): Promise<CmsTools[N]["output"]> {
+  return mcpClientManager.callTool("cms", name, args) as Promise<
+    CmsTools[N]["output"]
+  >;
+}
+```
+
+The TypeScript compiler now enforces:
+
+* That `name` is a real tool exported by the chained server.
+* That `args` matches the tool's input schema.
+* That callers handle the tool's actual output shape.
+
+For chaining patterns more broadly (proxying, delegation, composite tools), see [MCP Chaining](./mcp-chaining.md).
+
+## Caveats
+
+* **Schema conversion failures fall back gracefully.** If a single tool's input or output schema cannot be converted to a JSON Schema, the registry falls back to `Record<string, unknown>` for that input or `unknown` for that output. The build still succeeds, and the binary logs the skipped tools at the end.
+* **Type-name collisions are detected.** Two tool names that PascalCase to the same identifier (for example, `get-document` and `getDocument`) cause the binary to fail with a clear error naming both colliding tools. Rename one before publishing.
+* **Tools with no schema are generic.** A tool with neither `inputSchema` nor `outputSchema` produces `Record<string, unknown>` / `unknown` registry entries. This is intentional — the codegen has nothing to narrow the type to.
+
+## Programmatic API
+
+For tests or custom build pipelines that need to walk every tool with the same permissive user the CLI uses:
+
+```typescript
+import { createPermissiveCodegenUser } from "@umbraco-cms/mcp-server-sdk";
+
+const tools = collections.flatMap((c) =>
+  c.tools(createPermissiveCodegenUser()),
+);
+```
+
+The returned object should only be passed to `collection.tools(user)` — its properties are Proxy-backed and not safe to read directly (`user.id` is not a string).

--- a/17/umbraco-in-ai/mcp/base-mcp/sdk/tool-types.md
+++ b/17/umbraco-in-ai/mcp/base-mcp/sdk/tool-types.md
@@ -79,6 +79,7 @@ export type CmsToolsName = keyof CmsTools;
 A downstream MCP imports the registry to type its chained calls:
 
 ```typescript
+import { extractChainedResult } from "@umbraco-cms/mcp-server-sdk";
 import type {
   CmsTools,
   CmsToolsName,
@@ -88,11 +89,13 @@ async function callCms<N extends CmsToolsName>(
   name: N,
   args: CmsTools[N]["input"],
 ): Promise<CmsTools[N]["output"]> {
-  return mcpClientManager.callTool("cms", name, args) as Promise<
-    CmsTools[N]["output"]
-  >;
+  const result = await mcpClientManager.callTool("cms", name, args);
+  if (result.isError) throw new Error(extractChainedResult(result));
+  return extractChainedResult(result) as CmsTools[N]["output"];
 }
 ```
+
+`callTool()` returns the raw MCP envelope (`{ content, structuredContent?, isError? }`), not the tool's output directly. `extractChainedResult` unwraps it into the plain object the registry types describe. See [MCP Chaining](./mcp-chaining.md) for the same pattern applied inline in a tool handler.
 
 The TypeScript compiler now enforces:
 


### PR DESCRIPTION
## Summary

Adds a new SDK guide page covering the `umbraco-mcp-generate-types` CLI shipped from `@umbraco-cms/mcp-server-sdk` ([umbraco/Umbraco-MCP-Base#66](https://github.com/umbraco/Umbraco-MCP-Base/pull/66)). Replaces the inline README content with a proper docs entry.

The page covers:

- How the codegen works
- One-time setup (`postbuild` script + `./tool-types` subpath export)
- CLI options table
- Sample generated output
- Consumer usage with type-safe `callCms` helper
- Caveats (fallback behaviour, collision detection, missing schemas)
- Programmatic API (`createPermissiveCodegenUser`)

Linked from the SDK index README under MCP Chaining.

Draft until the upstream SDK PR ([umbraco/Umbraco-MCP-Base#66](https://github.com/umbraco/Umbraco-MCP-Base/pull/66)) is merged and a release is published, since the docs reference `npx umbraco-mcp-generate-types` which won't resolve until the package is on npm.

## Test plan

- [x] Page renders with the existing GitBook-style frontmatter and ` {% hint %} ` callouts
- [x] Linked from \`17/umbraco-in-ai/mcp/base-mcp/sdk/README.md\`
- [ ] GitBook preview looks right (reviewer to confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)