### PR TITLE
Fix conditional checks in rich text editor README

### DIFF
--- a/17/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/README.md
+++ b/17/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/README.md
@@ -45,10 +45,11 @@ Customize the appearance of the Rich Text Editor with custom CSS properties.
 ### With Models Builder
 
 ```csharp
+@using Umbraco.Extensions
 @{
-    if (!string.IsNullOrEmpty(Model.RichText.ToString()))
+    if (!Model.MyRichTextEditorProperty.IsNullOrWhiteSpace()))
     {
-        <p>@Model.RichText</p>
+        @Model.MyRichTextEditorProperty
     }
 }
 ```
@@ -57,8 +58,8 @@ Customize the appearance of the Rich Text Editor with custom CSS properties.
 
 ```csharp
 @{
-    if (Model.HasValue("richText")){
-        <p>@(Model.Value("richText"))</p>
+    if (Model.HasValue("richTextEditorAlias")){
+        @(Model.Value("richTextEditorAlias"))
     }
 }
 ```

--- a/17/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/README.md
+++ b/17/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/README.md
@@ -47,7 +47,7 @@ Customize the appearance of the Rich Text Editor with custom CSS properties.
 ```csharp
 @using Umbraco.Extensions
 @{
-    if (!Model.MyRichTextEditorProperty.IsNullOrWhiteSpace()))
+    if (!Model.MyRichTextEditorProperty.IsNullOrWhiteSpace())
     {
         @Model.MyRichTextEditorProperty
     }

--- a/18/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/README.md
+++ b/18/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/rich-text-editor/README.md
@@ -45,10 +45,11 @@ Customize the appearance of the Rich Text Editor with custom CSS properties.
 ### With Models Builder
 
 ```csharp
+@using Umbraco.Extensions
 @{
-    if (!string.IsNullOrEmpty(Model.RichText.ToString()))
+    if (!Model.MyRichTextEditorProperty.IsNullOrWhiteSpace())
     {
-        <p>@Model.RichText</p>
+        @Model.MyRichTextEditorProperty
     }
 }
 ```
@@ -57,8 +58,8 @@ Customize the appearance of the Rich Text Editor with custom CSS properties.
 
 ```csharp
 @{
-    if (Model.HasValue("richText")){
-        <p>@(Model.Value("richText"))</p>
+    if (Model.HasValue("richTextEditorAlias")){
+        @(Model.Value("richTextEditorAlias"))
     }
 }
 ```


### PR DESCRIPTION
## 📋 Description

Tippy Tip Tap rich text editor often return empty HTML instead of an empty string

The current example here for checking whether the rich text editor is empty, would fail, as it uses ToString() and then checks for null or empty... and so it would report that `<p></p>` was indeed a value.

Umbraco Core however ships with an extension method designed to check for this eventuality.

https://github.com/umbraco/Umbraco-CMS/blob/9c0c301a2618978f0b4ebe600135802678af54f6/src/Umbraco.Core/Extensions/HtmlEncodedStringExtensions.cs#L9

Therefore I have updated the example here to use this approach.

Also if you are writing out the contents of a rich text editor, you never need to wrap it in paragraph tags... so I've removed them toooooo

## 📎 Related Issues (if applicable)

Related Issue: https://github.com/umbraco/Umbraco-CMS/issues/20881

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)
Extension method has existed for 3years, but at least it should be updated for LTS v17,

