### PR TITLE
Added info box about save and publish for ContentService

### DIFF
--- a/17/umbraco-cms/reference/management/using-services/contentservice.md
+++ b/17/umbraco-cms/reference/management/using-services/contentservice.md
@@ -49,7 +49,7 @@ public class PublishContentDemo
 ```
 
 {% hint style="info" %}
-Always call `Save()` before `Publish()`, as publishing without saving first will not persistthe changes.
+Always call `Save()` before `Publish()`, as publishing without saving first will not persist the changes.
 {% endhint %}
 
 In a multi-language setup, it is necessary to set the name of the content item for a specified culture:

--- a/17/umbraco-cms/reference/management/using-services/contentservice.md
+++ b/17/umbraco-cms/reference/management/using-services/contentservice.md
@@ -48,6 +48,10 @@ public class PublishContentDemo
 }
 ```
 
+{% hint style="info" %}
+Always call `Save()` before `Publish()`, as publishing without saving first will not persistthe changes.
+{% endhint %}
+
 In a multi-language setup, it is necessary to set the name of the content item for a specified culture:
 
 ```csharp

--- a/18/umbraco-cms/reference/management/using-services/contentservice.md
+++ b/18/umbraco-cms/reference/management/using-services/contentservice.md
@@ -48,6 +48,10 @@ public class PublishContentDemo
 }
 ```
 
+{% hint style="info" %}
+Always call `Save()` before `Publish()`, as publishing without saving first will not persist the changes.
+{% endhint %}
+
 In a multi-language setup, it is necessary to set the name of the content item for a specified culture:
 
 ```csharp


### PR DESCRIPTION
## 📋 Description

Added a info box about having to use `.Save()` and then `.Publish()` since `.SaveAndPublish()` has been removed. This is just a precaution for people who's coming from Umbraco 13 and are used to using `.SaveAndPublish()`.

## 📎 Related Issues (if applicable)

#7997 

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
