### PR TITLE
Fix Program.Cs casing in Content Delivery API getting started

### DIFF
--- a/16/umbraco-cms/reference/content-delivery-api/README.md
+++ b/16/umbraco-cms/reference/content-delivery-api/README.md
@@ -25,7 +25,7 @@ You can also enable the Delivery API at a later point by following these steps:
 1. Open your project's `appsettings.json`.
 2. Insert the `DeliveryApi` configuration section under `Umbraco:CMS`.
 3. Add the `Enabled` key and set its value to `true`.
-4. Open `Program.Cs`
+4. Open `Program.cs`
 5. Add `.AddDeliveryApi()` to `builder.CreateUmbracoBuilder()`
 
 {% code title="appsettings.json" %}

--- a/17/umbraco-cms/reference/content-delivery-api/README.md
+++ b/17/umbraco-cms/reference/content-delivery-api/README.md
@@ -25,7 +25,7 @@ You can also enable the Delivery API at a later point by following these steps:
 1. Open your project's `appsettings.json`.
 2. Insert the `DeliveryApi` configuration section under `Umbraco:CMS`.
 3. Add the `Enabled` key and set its value to `true`.
-4. Open `Program.Cs`
+4. Open `Program.cs`
 5. Add `.AddDeliveryApi()` to `builder.CreateUmbracoBuilder()`
 
 {% code title="appsettings.json" %}

--- a/18/umbraco-cms/reference/content-delivery-api/README.md
+++ b/18/umbraco-cms/reference/content-delivery-api/README.md
@@ -25,7 +25,7 @@ You can also enable the Delivery API at a later point by following these steps:
 1. Open your project's `appsettings.json`.
 2. Insert the `DeliveryApi` configuration section under `Umbraco:CMS`.
 3. Add the `Enabled` key and set its value to `true`.
-4. Open `Program.Cs`
+4. Open `Program.cs`
 5. Add `.AddDeliveryApi()` to `builder.CreateUmbracoBuilder()`
 
 {% code title="appsettings.json" %}


### PR DESCRIPTION
The "Enable the Delivery API" steps tell the reader to open `Program.Cs`, but the .NET file is `Program.cs` (lowercase `c`). Every other reference in the same article uses the correct casing.

Fixed in v16, v17, and v18:
- `16/umbraco-cms/reference/content-delivery-api/README.md`
- `17/umbraco-cms/reference/content-delivery-api/README.md`
- `18/umbraco-cms/reference/content-delivery-api/README.md`