### PR TITLE
Fix "occured" typo across Heartcore Content Management API docs

### DIFF
--- a/umbraco-heartcore/api-documentation/content-management/content/README.md
+++ b/umbraco-heartcore/api-documentation/content-management/content/README.md
@@ -46,7 +46,7 @@ If an error occours you will receive a HTTP status code along with an API error 
 | 401         | Unauthorized        | Authorization has been denied for this request.                          |
 | 403         | Forbidden           | You are not authorized to access the given resource.                     |
 | 404         | NotFound            | Content with id '{id}' could not be found.                               |
-| 422         | ValidationFailed    | Validation error occured when trying to save or update the content item. |
+| 422         | ValidationFailed    | Validation error occurred when trying to save or update the content item. |
 | 500         | InternalServerError | Internal server error.                                                   |
 
 **JSON example**:

--- a/umbraco-heartcore/api-documentation/content-management/language.md
+++ b/umbraco-heartcore/api-documentation/content-management/language.md
@@ -35,7 +35,7 @@ If an error occours you will receive a HTTP status code along with an API error 
 | 403         | Forbidden                      | You are not authorized to access the given resource.                 |
 | 404         | NotFound                       | Language with id '{id}' could not be found.                          |
 | 409         | LanguageForCultureAlreadyExist | The language '{isoCode}' already exists.                             |
-| 422         | ValidationFailed               | Validation error occured when trying to save or update the language. |
+| 422         | ValidationFailed               | Validation error occurred when trying to save or update the language. |
 | 500         | InternalServerError            | Internal server error.                                               |
 
 **JSON example**:

--- a/umbraco-heartcore/api-documentation/content-management/media/README.md
+++ b/umbraco-heartcore/api-documentation/content-management/media/README.md
@@ -35,7 +35,7 @@ If an error occours you will receive a HTTP status code along with an API error 
 | 401         | Unauthorized        | Authorization has been denied for this request.                        |
 | 403         | Forbidden           | You are not authorized to access the given resource.                   |
 | 404         | NotFound            | Media with id '{id}' could not be found.                               |
-| 422         | ValidationFailed    | Validation error occured when trying to save or update the media item. |
+| 422         | ValidationFailed    | Validation error occurred when trying to save or update the media item. |
 | 500         | InternalServerError | Internal server error.                                                 |
 
 **JSON example**:

--- a/umbraco-heartcore/api-documentation/content-management/member/README.md
+++ b/umbraco-heartcore/api-documentation/content-management/member/README.md
@@ -38,7 +38,7 @@ If an error occours you will receive a HTTP status code along with an API error 
 | 401         | Unauthorized         | Authorization has been denied for this request.                          |
 | 403         | Forbidden            | You are not authorized to access the given resource.                     |
 | 404         | NotFound             | Member with username '{username}' could not be found.                    |
-| 422         | ValidationFailed     | Validation error occured when trying to save or update the member.       |
+| 422         | ValidationFailed     | Validation error occurred when trying to save or update the member.       |
 | 500         | InternalServerError  | Internal server error.                                                   |
 
 **JSON example**:

--- a/umbraco-heartcore/api-documentation/content-management/member/group.md
+++ b/umbraco-heartcore/api-documentation/content-management/member/group.md
@@ -33,7 +33,7 @@ If an error occours you will receive a HTTP status code along with an API error 
 | 401         | Unauthorized         | Authorization has been denied for this request.                          |
 | 403         | Forbidden            | You are not authorized to access the given resource.                     |
 | 404         | NotFound             | Member Group with name '{name}' could not be found.                      |
-| 422         | ValidationFailed     | Validation error occured when trying to save or update the member group. |
+| 422         | ValidationFailed     | Validation error occurred when trying to save or update the member group. |
 | 500         | InternalServerError  | Internal server error.                                                   |
 
 **JSON example**:

--- a/umbraco-heartcore/api-documentation/content-management/relation/README.md
+++ b/umbraco-heartcore/api-documentation/content-management/relation/README.md
@@ -35,7 +35,7 @@ If an error occours you will receive a HTTP status code along with an API error 
 | 401         | Unauthorized         | Authorization has been denied for this request.                          |
 | 403         | Forbidden            | You are not authorized to access the given resource.                     |
 | 404         | NotFound             | Relation with id '{id}' could not be found.                              |
-| 422         | ValidationFailed     | Validation error occured when trying to save or update the relation.     |
+| 422         | ValidationFailed     | Validation error occurred when trying to save or update the relation.     |
 | 500         | InternalServerError  | Internal server error.                                                   |
 
 **JSON example**:


### PR DESCRIPTION
Fixes a recurring `occured` → `occurred` misspelling in the HTTP 422 `ValidationFailed` error-message tables across six Heartcore Content Management API articles:

- `umbraco-heartcore/api-documentation/content-management/language.md`
- `umbraco-heartcore/api-documentation/content-management/relation/README.md`
- `umbraco-heartcore/api-documentation/content-management/member/group.md`
- `umbraco-heartcore/api-documentation/content-management/member/README.md`
- `umbraco-heartcore/api-documentation/content-management/content/README.md`
- `umbraco-heartcore/api-documentation/content-management/media/README.md`