### PR TITLE
Fix "occours" typo across Heartcore API docs

### DIFF
--- a/umbraco-heartcore/api-documentation/content-delivery/content.md
+++ b/umbraco-heartcore/api-documentation/content-delivery/content.md
@@ -34,7 +34,7 @@ The lowest supported depth value is `0` and the highest is `5`.
 
 ## Errors
 
-If an error occours you will receive a HTTP status code along with an API error code and an error message in the response body.
+If an error occurs you will receive a HTTP status code along with an API error code and an error message in the response body.
 
 | Status Code | Error Code                 | Message                                                                                                                                                       |
 | ----------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/umbraco-heartcore/api-documentation/content-delivery/media.md
+++ b/umbraco-heartcore/api-documentation/content-delivery/media.md
@@ -19,7 +19,7 @@ Umb-Project-Alias: {project-alias}
 
 ## Errors
 
-If an error occours you will receive a HTTP status code along with an API error code and an error message in the response body.
+If an error occurs you will receive a HTTP status code along with an API error code and an error message in the response body.
 
 | Status Code | Error Code          | Message                                         |
 | ----------- | ------------------- | ----------------------------------------------- |

--- a/umbraco-heartcore/api-documentation/content-management/content/README.md
+++ b/umbraco-heartcore/api-documentation/content-management/content/README.md
@@ -38,7 +38,7 @@ In addition to the specific permissions listed under each endpoint, all requests
 
 ## Errors
 
-If an error occours you will receive a HTTP status code along with an API error code and an error message in the response body.
+If an error occurs you will receive a HTTP status code along with an API error code and an error message in the response body.
 
 | Status Code | Error Code          | Message                                                                  |
 | ----------- | ------------------- | ------------------------------------------------------------------------ |

--- a/umbraco-heartcore/api-documentation/content-management/content/type.md
+++ b/umbraco-heartcore/api-documentation/content-management/content/type.md
@@ -22,7 +22,7 @@ Authentication is required for this API. You must supply a Bearer Token via an A
 
 ## Errors
 
-If an error occours you will receive a HTTP status code along with an API error code and an error message in the response body.
+If an error occurs you will receive a HTTP status code along with an API error code and an error message in the response body.
 
 | Status Code | Error Code           | Message                                                                  |
 | ----------- | -------------------- | ------------------------------------------------------------------------ |

--- a/umbraco-heartcore/api-documentation/content-management/language.md
+++ b/umbraco-heartcore/api-documentation/content-management/language.md
@@ -26,7 +26,7 @@ Authentication is required for this API. You must supply a Bearer Token via an A
 
 ## Errors
 
-If an error occours you will receive a HTTP status code along with an API error code and an error message in the response body.
+If an error occurs you will receive a HTTP status code along with an API error code and an error message in the response body.
 
 | Status Code | Error Code                     | Message                                                              |
 | ----------- | ------------------------------ | -------------------------------------------------------------------- |

--- a/umbraco-heartcore/api-documentation/content-management/media/README.md
+++ b/umbraco-heartcore/api-documentation/content-management/media/README.md
@@ -27,7 +27,7 @@ Auth is required for this API meaning that you must supply a Bearer Token via an
 
 ## Errors
 
-If an error occours you will receive a HTTP status code along with an API error code and an error message in the response body.
+If an error occurs you will receive a HTTP status code along with an API error code and an error message in the response body.
 
 | Status Code | Error Code          | Message                                                                |
 | ----------- | ------------------- | ---------------------------------------------------------------------- |

--- a/umbraco-heartcore/api-documentation/content-management/media/type.md
+++ b/umbraco-heartcore/api-documentation/content-management/media/type.md
@@ -23,7 +23,7 @@ Auth is required for this API meaning that you must supply a Bearer Token via an
 
 ## Errors
 
-If an error occours you will receive a HTTP status code along with an API error code and an error message in the response body.
+If an error occurs you will receive a HTTP status code along with an API error code and an error message in the response body.
 
 | Status Code | Error Code           | Message                                                                  |
 | ----------- | -------------------- | ------------------------------------------------------------------------ |

--- a/umbraco-heartcore/api-documentation/content-management/member/README.md
+++ b/umbraco-heartcore/api-documentation/content-management/member/README.md
@@ -29,7 +29,7 @@ Authentication is required for this API. You must supply a Bearer Token via an A
 
 ## Errors
 
-If an error occours you will receive a HTTP status code along with an API error code and an error message in the response body.
+If an error occurs you will receive a HTTP status code along with an API error code and an error message in the response body.
 
 | Status Code | Error Code           | Message                                                                  |
 | ----------- | -------------------- | ------------------------------------------------------------------------ |

--- a/umbraco-heartcore/api-documentation/content-management/member/group.md
+++ b/umbraco-heartcore/api-documentation/content-management/member/group.md
@@ -25,7 +25,7 @@ Auth is required for this API meaning that you must supply a Bearer Token via an
 
 ## Errors
 
-If an error occours you will receive a HTTP status code along with an API error code and an error message in the response body.
+If an error occurs you will receive a HTTP status code along with an API error code and an error message in the response body.
 
 | Status Code | Error Code           | Message                                                                  |
 | ----------- | -------------------- | ------------------------------------------------------------------------ |

--- a/umbraco-heartcore/api-documentation/content-management/member/type.md
+++ b/umbraco-heartcore/api-documentation/content-management/member/type.md
@@ -22,7 +22,7 @@ Auth is required for this API meaning that you must supply a Bearer Token via an
 
 ## Errors
 
-If an error occours you will receive a HTTP status code along with an API error code and an error message in the response body.
+If an error occurs you will receive a HTTP status code along with an API error code and an error message in the response body.
 
 | Status Code | Error Code           | Message                                                                  |
 | ----------- | -------------------- | ------------------------------------------------------------------------ |

--- a/umbraco-heartcore/api-documentation/content-management/relation/README.md
+++ b/umbraco-heartcore/api-documentation/content-management/relation/README.md
@@ -27,7 +27,7 @@ Auth is required for this API meaning that you must supply a Bearer Token via an
 
 ## Errors
 
-If an error occours you will receive a HTTP status code along with an API error code and an error message in the response body.
+If an error occurs you will receive a HTTP status code along with an API error code and an error message in the response body.
 
 | Status Code | Error Code           | Message                                                                  |
 | ----------- | -------------------- | ------------------------------------------------------------------------ |

--- a/umbraco-heartcore/api-documentation/content-management/relation/type.md
+++ b/umbraco-heartcore/api-documentation/content-management/relation/type.md
@@ -23,7 +23,7 @@ Auth is required for this API meaning that you must supply a Bearer Token via an
 
 ## Errors
 
-If an error occours you will receive a HTTP status code along with an API error code and an error message in the response body.
+If an error occurs you will receive a HTTP status code along with an API error code and an error message in the response body.
 
 | Status Code | Error Code           | Message                                                                  |
 | ----------- | -------------------- | ------------------------------------------------------------------------ |


### PR DESCRIPTION
The Errors section of every Heartcore API article opens with "If an error occours you will receive a HTTP status code...". `occours` should be `occurs`. Fixed in all 12 affected files (Content Delivery + Content Management).