### PR TITLE
Fix "accross" typo in Adding Language Variants tutorial

### DIFF
--- a/16/umbraco-cms/tutorials/creating-a-basic-website/adding-language-variants.md
+++ b/16/umbraco-cms/tutorials/creating-a-basic-website/adding-language-variants.md
@@ -30,7 +30,7 @@ To enable language variants on Document Types, follow these steps:
     ![Enable Vary by Culture](../../.gitbook/assets/enable-vary-by-culture.png)
 4. Click **Save**.
 5. Go to the **Design** tab.
-6. Click on the Data Type of the **Page Title** and disable **Shared accross cultures**.
+6. Click on the Data Type of the **Page Title** and disable **Shared across cultures**.
 7. Click **Submit**.
 8.  Click **Save**.
 

--- a/17/umbraco-cms/tutorials/creating-a-basic-website/adding-language-variants.md
+++ b/17/umbraco-cms/tutorials/creating-a-basic-website/adding-language-variants.md
@@ -30,7 +30,7 @@ To enable language variants on Document Types, follow these steps:
     ![Enable Vary by Culture](../../.gitbook/assets/enable-vary-by-culture.png)
 4. Click **Save**.
 5. Go to the **Design** tab.
-6. Click on the Data Type of the **Page Title** and disable **Shared accross cultures**.
+6. Click on the Data Type of the **Page Title** and disable **Shared across cultures**.
 7. Click **Submit**.
 8.  Click **Save**.
 

--- a/18/umbraco-cms/tutorials/creating-a-basic-website/adding-language-variants.md
+++ b/18/umbraco-cms/tutorials/creating-a-basic-website/adding-language-variants.md
@@ -30,7 +30,7 @@ To enable language variants on Document Types, follow these steps:
     ![Enable Vary by Culture](../../.gitbook/assets/enable-vary-by-culture.png)
 4. Click **Save**.
 5. Go to the **Design** tab.
-6. Click on the Data Type of the **Page Title** and disable **Shared accross cultures**.
+6. Click on the Data Type of the **Page Title** and disable **Shared across cultures**.
 7. Click **Submit**.
 8.  Click **Save**.
 


### PR DESCRIPTION
Step 6 of the "Adding Language Variants" tutorial says "disable **Shared accross cultures**" — should be "across". Fixed in v16, v17, and v18.