### PR TITLE
Fix "langauge" typo in Heartcore Languages CM API doc

### DIFF
--- a/umbraco-heartcore/api-documentation/content-management/language.md
+++ b/umbraco-heartcore/api-documentation/content-management/language.md
@@ -123,7 +123,7 @@ Gets all languages available for content creation.
 
 ## Get by ISO code
 
-Get a specific langauge by its ISO code.
+Get a specific language by its ISO code.
 
 **URL**: `/language/{id}`
 


### PR DESCRIPTION
`umbraco-heartcore/api-documentation/content-management/language.md` has "Get a specific langauge by its ISO code" — should be "language".