### PR TITLE
Added missing conditions section in Umbraco Package article

### DIFF
--- a/16/umbraco-cms/customizing/umbraco-package.md
+++ b/16/umbraco-cms/customizing/umbraco-package.md
@@ -129,6 +129,31 @@ Read more about Extension Types in the Backoffice to get a better understanding 
 [extending-overview/extension-types/README.md#full-list-of-extension-types](extending-overview/extension-types/README.md#full-list-of-extension-types)
 {% endcontent-ref %}
 
+#### The `conditions` property
+
+Each extension in the `extensions` array can include an optional `conditions` property. This is an array of condition objects that must all be satisfied before the extension is loaded and activated. It gives you fine-grained control over where and when an extension appears in the backoffice.
+
+##### Structure
+
+```json
+{
+    "type": "workspaceAction",
+    "alias": "My.WorkspaceAction",
+    "name": "My Workspace Action",
+    "element": "/App_Plugins/MyPackage/my-action.js",
+    "conditions": [
+        {
+            "alias": "Umb.Condition.WorkspaceAlias",
+            "match": "Umb.Workspace.Document"
+        }
+    ]
+}
+```
+
+Each condition object requires at minimum an `alias` identifying which condition to evaluate. Many conditions also accept a `match` value specifying what to match against.
+
+Common aliases include `Umb.Condition.WorkspaceAlias`, `Umb.Condition.SectionAlias`, `Umb.Condition.WorkspaceEntityType`, and `Umb.Condition.UserPermission.Document`. For a full list and details, see the [Extension Conditions](extending-overview/extension-types/condition.md) article.
+
 ## Package Manifest IntelliSense
 
 Make your IDE be aware about the opportunities of the `umbraco-package.json` by adding a JSON schema. This gives your code editor abilities to autocomplete and knowledge about the format. This helps to avoid mistakes or errors when editing the `umbraco-package.json` file.

--- a/16/umbraco-cms/customizing/umbraco-package.md
+++ b/16/umbraco-cms/customizing/umbraco-package.md
@@ -152,7 +152,14 @@ Each extension in the `extensions` array can include an optional `conditions` pr
 
 Each condition object requires at minimum an `alias` identifying which condition to evaluate. Many conditions also accept a `match` value specifying what to match against.
 
-Common aliases include `Umb.Condition.WorkspaceAlias`, `Umb.Condition.SectionAlias`, `Umb.Condition.WorkspaceEntityType`, and `Umb.Condition.UserPermission.Document`. For a full list and details, see the [Extension Conditions](extending-overview/extension-types/condition.md) article.
+Common aliases include:
+
+- `Umb.Condition.WorkspaceAlias`
+- `Umb.Condition.SectionAlias`
+- `Umb.Condition.WorkspaceEntityType`
+- `Umb.Condition.UserPermission.Document`.
+
+For a full list and details, see the [Extension Conditions](extending-overview/extension-types/condition.md) article.
 
 ## Package Manifest IntelliSense
 

--- a/17/umbraco-cms/customizing/umbraco-package.md
+++ b/17/umbraco-cms/customizing/umbraco-package.md
@@ -129,6 +129,31 @@ Read more about Extension Types in the Backoffice to get a better understanding 
 [extending-overview/extension-types/README.md#full-list-of-extension-types](extending-overview/extension-types/README.md#full-list-of-extension-types)
 {% endcontent-ref %}
 
+#### The `conditions` property
+
+Each extension in the `extensions` array can include an optional `conditions` property. This is an array of condition objects that must all be satisfied before the extension is loaded and activated. It gives you fine-grained control over where and when an extension appears in the backoffice.
+
+##### Structure
+
+```json
+{
+    "type": "workspaceAction",
+    "alias": "My.WorkspaceAction",
+    "name": "My Workspace Action",
+    "element": "/App_Plugins/MyPackage/my-action.js",
+    "conditions": [
+        {
+            "alias": "Umb.Condition.WorkspaceAlias",
+            "match": "Umb.Workspace.Document"
+        }
+    ]
+}
+```
+
+Each condition object requires at minimum an `alias` identifying which condition to evaluate. Many conditions also accept a `match` value specifying what to match against.
+
+Common aliases include `Umb.Condition.WorkspaceAlias`, `Umb.Condition.SectionAlias`, `Umb.Condition.WorkspaceEntityType`, and `Umb.Condition.UserPermission.Document`. For a full list and details, see the [Extension Conditions](extending-overview/extension-types/condition.md) article.
+
 ## Package Manifest IntelliSense
 
 Make your IDE be aware about the opportunities of the `umbraco-package.json` by adding a JSON schema. This gives your code editor abilities to autocomplete and knowledge about the format. This helps to avoid mistakes or errors when editing the `umbraco-package.json` file.

--- a/17/umbraco-cms/customizing/umbraco-package.md
+++ b/17/umbraco-cms/customizing/umbraco-package.md
@@ -152,7 +152,14 @@ Each extension in the `extensions` array can include an optional `conditions` pr
 
 Each condition object requires at minimum an `alias` identifying which condition to evaluate. Many conditions also accept a `match` value specifying what to match against.
 
-Common aliases include `Umb.Condition.WorkspaceAlias`, `Umb.Condition.SectionAlias`, `Umb.Condition.WorkspaceEntityType`, and `Umb.Condition.UserPermission.Document`. For a full list and details, see the [Extension Conditions](extending-overview/extension-types/condition.md) article.
+Common aliases include:
+
+- `Umb.Condition.WorkspaceAlias`
+- `Umb.Condition.SectionAlias`
+- `Umb.Condition.WorkspaceEntityType`
+- `Umb.Condition.UserPermission.Document`.
+
+For a full list and details, see the [Extension Conditions](extending-overview/extension-types/condition.md) article.
 
 ## Package Manifest IntelliSense
 

--- a/18/umbraco-cms/customizing/umbraco-package.md
+++ b/18/umbraco-cms/customizing/umbraco-package.md
@@ -129,6 +129,31 @@ Read more about Extension Types in the Backoffice to get a better understanding 
 [extending-overview/extension-types/README.md#full-list-of-extension-types](extending-overview/extension-types/README.md#full-list-of-extension-types)
 {% endcontent-ref %}
 
+#### The `conditions` property
+
+Each extension in the `extensions` array can include an optional `conditions` property. This is an array of condition objects that must all be satisfied before the extension is loaded and activated. It gives you fine-grained control over where and when an extension appears in the backoffice.
+
+##### Structure
+
+```json
+{
+    "type": "workspaceAction",
+    "alias": "My.WorkspaceAction",
+    "name": "My Workspace Action",
+    "element": "/App_Plugins/MyPackage/my-action.js",
+    "conditions": [
+        {
+            "alias": "Umb.Condition.WorkspaceAlias",
+            "match": "Umb.Workspace.Document"
+        }
+    ]
+}
+```
+
+Each condition object requires at minimum an `alias` identifying which condition to evaluate. Many conditions also accept a `match` value specifying what to match against.
+
+Common aliases include `Umb.Condition.WorkspaceAlias`, `Umb.Condition.SectionAlias`, `Umb.Condition.WorkspaceEntityType`, and `Umb.Condition.UserPermission.Document`. For a full list and details, see the [Extension Conditions](extending-overview/extension-types/condition.md) article.
+
 ## Package Manifest IntelliSense
 
 Make your IDE be aware about the opportunities of the `umbraco-package.json` by adding a JSON schema. This gives your code editor abilities to autocomplete and knowledge about the format. This helps to avoid mistakes or errors when editing the `umbraco-package.json` file.

--- a/18/umbraco-cms/customizing/umbraco-package.md
+++ b/18/umbraco-cms/customizing/umbraco-package.md
@@ -152,7 +152,14 @@ Each extension in the `extensions` array can include an optional `conditions` pr
 
 Each condition object requires at minimum an `alias` identifying which condition to evaluate. Many conditions also accept a `match` value specifying what to match against.
 
-Common aliases include `Umb.Condition.WorkspaceAlias`, `Umb.Condition.SectionAlias`, `Umb.Condition.WorkspaceEntityType`, and `Umb.Condition.UserPermission.Document`. For a full list and details, see the [Extension Conditions](extending-overview/extension-types/condition.md) article.
+Common aliases include:
+
+- `Umb.Condition.WorkspaceAlias`
+- `Umb.Condition.SectionAlias`
+- `Umb.Condition.WorkspaceEntityType`
+- `Umb.Condition.UserPermission.Document`.
+
+For a full list and details, see the [Extension Conditions](extending-overview/extension-types/condition.md) article.
 
 ## Package Manifest IntelliSense
 


### PR DESCRIPTION
## 📋 Description

This PR tries to address user's feedback : The conditions property to control where and when the extension should be loaded.  With example aliases.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS v16, 17, 18

## Deadline (if relevant)

Anytime

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
