### PR TITLE
Document v13→v17 Commerce notes/comments alias change

### DIFF
--- a/17/umbraco-commerce/upgrading/version-specific-upgrades.md
+++ b/17/umbraco-commerce/upgrading/version-specific-upgrades.md
@@ -1,11 +1,11 @@
 ---
 description: >-
-  Version specific documentation for upgrading to new major versions of Umbraco Commerce.
+  Version-specific documentation for upgrading to new major versions of Umbraco Commerce.
 ---
 
 # Version Specific Upgrade Notes
 
-This page covers specific upgrade documentation for when migrating to version 17 of Umbraco Commerce.
+This page covers specific upgrade documentation for migrating to version 17 of Umbraco Commerce.
 
 {% hint style="info" %}
 If you are upgrading to a new minor or patch version, you can find information about the breaking changes in the [Release Notes](../release-notes/README.md) article.
@@ -28,4 +28,4 @@ If you are upgrading to a new minor or patch version, you can find information a
 
 ## Legacy version specific upgrade notes
 
-You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;
+You can find the version-specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/tree/umbraco-eol-versions).&#x20;

--- a/17/umbraco-commerce/upgrading/version-specific-upgrades.md
+++ b/17/umbraco-commerce/upgrading/version-specific-upgrades.md
@@ -13,6 +13,18 @@ If you are upgrading to a new minor or patch version, you can find information a
 
 ## Version Specific Upgrade Notes History
 
+#### 17.0.0
+
+* The default property aliases for Customer Comments and Internal Notes have changed: `comments` is now `customerNotes`, and `notes` is now `internalNotes`. After upgrading from v13, existing data still lives in the database under the old aliases, so these fields appear empty in the v17 backoffice. To restore visibility without a database migration, remap the fields back to the original aliases in your composer using `OrderPropertyConfig`:
+
+    ```csharp
+    builder.WithOrderPropertyConfigs()
+        .UpdateDefault(cfg => cfg
+            .For(x => x.Notes.CustomerNotes).MapFrom("comments")
+            .For(x => x.Notes.InternalNotes).MapFrom("notes"));
+    ```
+
+    Or scope to a single store with `.Update("yourStoreAlias", cfg => …)` instead of `UpdateDefault`. This remap covers both reads (backoffice display) and writes (saving edits).
 
 ## Legacy version specific upgrade notes
 


### PR DESCRIPTION
Closes umbraco/UmbracoDocs#8019
Refs umbraco/Umbraco.Commerce.Issues#841

## Summary

The default property aliases for Customer Comments (`comments` → `customerNotes`) and Internal Notes (`notes` → `internalNotes`) changed between Umbraco Commerce v13 and v17. After a v13→v17 upgrade, the existing data still lives in the database under the old aliases, so these fields appear empty in the v17 backoffice even though the data is intact.

We won't be shipping a rename migration for this — installs may legitimately have data under either alias, and a blanket rename can't tell those cases apart without risking data loss — so the upgrade notes are the right place to document it.

## Change

Adds a `17.0.0` entry to `17/umbraco-commerce/upgrading/version-specific-upgrades.md` covering:

- Which default aliases changed and why fields appear empty after upgrade.
- The `OrderPropertyConfig` override as the supported workaround, with a copy-pasteable composer snippet.
- A note that the remap covers both reads (backoffice display) and writes (saving edits) — no DB migration needed.

## Test plan

- [ ] Preview the rendered page in GitBook to confirm the nested code block under the bullet renders correctly.
- [ ] Verify the `OrderPropertyConfig` snippet compiles against v17 (it mirrors the API in `Umbraco.Commerce.Core.Models.Builders.OrderPropertyConfigBuilder`).