### PR TITLE
Forms: 16.5.3 and 17.3.1 release notes

### DIFF
--- a/16/umbraco-forms/release-notes.md
+++ b/16/umbraco-forms/release-notes.md
@@ -18,6 +18,12 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 16 including all changes for this version.
 
+### [16.5.3](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F16.5.3) (April 30th 2026)
+* Allow editing hidden fields on submitted form entries [#1605](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1605) [#1693](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1693)
+* Fix Danish casing for 'Ved afvisning' label [#1696](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1696)
+* Localize **Change Record State** action dropdown labels
+* Update design of **Form Picker (Single)** to match CMS style
+
 ### [16.5.2](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F16.5.2) (April 9th 2026)
 
 * Update "Umbraco Forms scheduled record deletion task" log message grammar [#1683](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1683)

--- a/16/umbraco-forms/release-notes.md
+++ b/16/umbraco-forms/release-notes.md
@@ -20,7 +20,7 @@ This section contains the release notes for Umbraco Forms 16 including all chang
 
 ### [16.5.3](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F16.5.3) (April 30th 2026)
 * Allow editing hidden fields on submitted form entries [#1605](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1605) [#1693](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1693)
-* Fix Danish casing for 'Ved afvisning' label [#1696](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1696)
+* Fix casing for "On Reject" label [#1696](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1696)
 * Localize **Change Record State** action dropdown labels
 * Update design of **Form Picker (Single)** to match CMS style
 

--- a/17/umbraco-forms/release-notes.md
+++ b/17/umbraco-forms/release-notes.md
@@ -18,7 +18,7 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 17 including all changes for this version.
 
-### [17.3.1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F17.3.1) (April 29th 2026)
+### [17.3.1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F17.3.1) (April 30th 2026)
 
 * Fix Rich Text field type not allowing blocks [#1194](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1194)
 * Allow editing hidden fields on submitted form entries [#1605](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1605) [#1693](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1693)

--- a/17/umbraco-forms/release-notes.md
+++ b/17/umbraco-forms/release-notes.md
@@ -18,6 +18,20 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 17 including all changes for this version.
 
+### [17.3.1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F17.3.1) (April 29th 2026)
+
+* Fix Rich Text field type not allowing blocks [#1194](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1194)
+* Allow editing hidden fields on submitted form entries [#1605](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1605) [#1693](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1693)
+* Reveal workflow action bar on keyboard focus [#1692](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1692)
+* Fix Danish casing for 'Ved afvisning' label [#1696](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1696)
+* Resolve variant-aware title in the preview modal [#1699](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1699)
+* Prevent `MigrateSystemDatesToUtc` failure on SQL datetime underflow [#1703](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1703)
+* Add **View entries** entity action for submitted records [#1704](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1704)
+* Localize **Change Record State** action dropdown labels
+* Update design of **Form Picker (Single)** to match CMS style
+* Update design of **Field Type** and **Workflow Type** picker modals
+
+
 ### [17.3.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F17.3.0) (April 9th 2026)
 
 #### UTC date handling fix

--- a/17/umbraco-forms/release-notes.md
+++ b/17/umbraco-forms/release-notes.md
@@ -23,7 +23,7 @@ This section contains the release notes for Umbraco Forms 17 including all chang
 * Fix Rich Text field type not allowing blocks [#1194](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1194)
 * Allow editing hidden fields on submitted form entries [#1605](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1605) [#1693](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1693)
 * Reveal workflow action bar on keyboard focus [#1692](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1692)
-* Fix Danish casing for 'Ved afvisning' label [#1696](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1696)
+* Fix casing for "On Reject" label [#1696](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1696)
 * Resolve variant-aware title in the preview modal [#1699](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1699)
 * Prevent `MigrateSystemDatesToUtc` failure on SQL datetime underflow [#1703](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1703)
 * Add **View entries** entity action for submitted records [#1704](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1704)


### PR DESCRIPTION
Release notes for patch versions of Umbraco Forms 16.5.3 and 17.3.1, releasing Thursday 30th April