### PR TITLE
Update Developer MCP plugin install command

### DIFF
--- a/17/umbraco-in-ai/mcp/cms-developer-mcp/cli-usage.md
+++ b/17/umbraco-in-ai/mcp/cms-developer-mcp/cli-usage.md
@@ -16,7 +16,7 @@ If you are using Claude Code, install the Developer MCP plugin. The `/umb-cms-de
 
 ```bash
 /plugin marketplace add umbraco/Umbraco-CMS-MCP-Dev
-/plugin install umbraco-cms-mcp-dev@umbraco/Umbraco-CMS-MCP-Dev
+/plugin install umb-cms-mcp@umb-cms-mcp-plugins 
 ```
 
 Once installed, use `/umb-cms-dev-cli` with a query to interact with Umbraco:


### PR DESCRIPTION
## Summary

- Updates the `/plugin install` command in `17/umbraco-in-ai/mcp/cms-developer-mcp/cli-usage.md` to use the renamed marketplace (`umb-cms-mcp-plugins`) and plugin id (`umb-cms-mcp`)

## Test plan

- [ ] The install snippet in CLI Usage matches the current plugin marketplace and id
- [ ] Vale and link-check CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)