### PR TITLE
Add documentation for bypassing content protection in searches

### DIFF
--- a/17/umbraco-search/getting-started/README.md
+++ b/17/umbraco-search/getting-started/README.md
@@ -336,3 +336,29 @@ public class MySearchService(ISearcher searcher)
 }
 ```
 {% endcode %}
+
+### Bypassing content protection in search queries
+
+Sometimes it's relevant to surface search results for protected content, regardless if a member is currently logged in. To this end you can pass `AccessContent.BypassProtection()` to the searcher:
+
+{% code title="MySearchService.cs" %}
+```csharp
+using Umbraco.Cms.Search.Core.Models.Searching;
+using Umbraco.Cms.Search.Core.Services;
+using Constants = Umbraco.Cms.Search.Core.Constants;
+
+namespace My.Site.Services;
+
+public class MySearchService(ISearcher searcher)
+{
+    public async Task<SearchResult> SearchWithBypassForProtectedContent()
+    {
+        return await searcher.SearchAsync(
+            indexAlias: Constants.IndexAliases.PublishedContent,
+            query: "pink",
+            accessContext: AccessContext.BypassProtection()
+        );
+    }
+}
+```
+{% endcode %}


### PR DESCRIPTION
## 📋 Description

https://github.com/umbraco/Umbraco.Cms.Search/pull/125 introduced an option to bypass content protection in search queries. This documents that new feature.

## 📎 Related Issues (if applicable)

N/A.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Search beta.5

## Deadline (if relevant)

Whenever possible - beta.5 of Umbraco Search is out now. It's no rush, though 😄 

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
