### PR TITLE
Modify onChange to include permitted state

### DIFF
--- a/17/umbraco-cms/customizing/extending-overview/extension-types/condition.md
+++ b/17/umbraco-cms/customizing/extending-overview/extension-types/condition.md
@@ -166,7 +166,7 @@ export class MyExtensionCondition
         // enable extension after 10 seconds
         setTimeout(() => {
             this.permitted = true;
-            args.onChange();
+            args.onChange(this.permitted);
         }, 10000);
     }
 }
@@ -188,7 +188,7 @@ export const manifest: UmbExtensionManifest = {
     type: "condition",
     name: "My Condition",
     alias: "My.Condition.CustomName",
-    api: MyExtensionCondition,
+    api: () => import('./MyExtensionCondition').then((m) => m.MyExtensionCondition),
 };
 ```
 
@@ -229,7 +229,7 @@ export class MyExtensionCondition
 
         if (args.config.match === "Yes") {
             this.permitted = true;
-            args.onChange();
+            args.onChange(this.permitted);
         }
     }
 }

--- a/17/umbraco-cms/customizing/extending-overview/extension-types/condition.md
+++ b/17/umbraco-cms/customizing/extending-overview/extension-types/condition.md
@@ -166,7 +166,6 @@ export class MyExtensionCondition
         // enable extension after 10 seconds
         setTimeout(() => {
             this.permitted = true;
-            args.onChange(this.permitted);
         }, 10000);
     }
 }
@@ -231,7 +230,6 @@ export class MyExtensionCondition
 
         if (args.config.match === "Yes") {
             this.permitted = true;
-            args.onChange(this.permitted);
         }
     }
 }

--- a/17/umbraco-cms/customizing/extending-overview/extension-types/condition.md
+++ b/17/umbraco-cms/customizing/extending-overview/extension-types/condition.md
@@ -184,11 +184,13 @@ The global declaration on the last five lines makes your Condition appear valid 
 The Condition then needs to be registered in the Extension Registry:
 
 ```typescript
+import { MyExtensionCondition } from "./MyExtensionCondition";
+
 export const manifest: UmbExtensionManifest = {
     type: "condition",
     name: "My Condition",
     alias: "My.Condition.CustomName",
-    api: () => import('./MyExtensionCondition').then((m) => m.MyExtensionCondition),
+    api: MyExtensionCondition,
 };
 ```
 


### PR DESCRIPTION
## 📋 Description

Updated `onChange` calls to pass the permitted state, required in v17...

and use dynamic import instead of direct import (preferred I think to lazy load as required)
(which would have needed an `import { MyExtensionCondition } from "./MyExtensionCondition"` if we still wanted direct import)

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.
