### PR TITLE
Clarify endpoint registration order in service registration

### DIFF
--- a/17/umbraco-cms/reference/service-registration.md
+++ b/17/umbraco-cms/reference/service-registration.md
@@ -73,6 +73,8 @@ await app.RunAsync();
 ```
 {% endcode %}
 
+{% hint style="info" %} The order of registration of the endpoints is important. `UseBackOfficeEndpoints()` must be registered before `UseWebsiteEndpoints`. If they are mistakenly registered in the opposite order, site installation won't start. {% endhint %}
+
 ## Website + Delivery API (no backoffice)
 
 The following configuration is useful for front-end servers in a load-balanced setup where a single backoffice instance is running.

--- a/17/umbraco-cms/reference/service-registration.md
+++ b/17/umbraco-cms/reference/service-registration.md
@@ -73,7 +73,9 @@ await app.RunAsync();
 ```
 {% endcode %}
 
-{% hint style="info" %} The order of registration of the endpoints is important. `UseBackOfficeEndpoints()` must be registered before `UseWebsiteEndpoints`. If they are mistakenly registered in the opposite order, site installation won't start. {% endhint %}
+{% hint style="info" %}
+Endpoint registration is order-dependent. `UseBackOfficeEndpoints()` must be registered before `UseWebsiteEndpoints`. If they are mistakenly registered in the opposite order, the site installation won't start.
+{% endhint %}
 
 ## Website + Delivery API (no backoffice)
 

--- a/18/umbraco-cms/reference/service-registration.md
+++ b/18/umbraco-cms/reference/service-registration.md
@@ -73,6 +73,10 @@ await app.RunAsync();
 ```
 {% endcode %}
 
+{% hint style="info" %}
+Endpoint registration is order-dependent. `UseBackOfficeEndpoints()` must be registered before `UseWebsiteEndpoints`. If they are mistakenly registered in the opposite order, the site installation won't start.
+{% endhint %}
+
 ## Website + Delivery API (no backoffice)
 
 The following configuration is useful for front-end servers in a load-balanced setup where a single backoffice instance is running.


### PR DESCRIPTION
Added note about endpoint registration order for site installation.

## 📋 Description

I've created a ticket about a possible bug that happens when the order of registration is switched.
https://github.com/umbraco/Umbraco-CMS/issues/22718

For the moment, I thought it would be a good idea to add a warning in the docs.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
