### PR TITLE
Add Hosted MCP Setup section for Umbraco-side configuration

### DIFF
--- a/.github/styles/UmbracoDocs/Acronyms.yml
+++ b/.github/styles/UmbracoDocs/Acronyms.yml
@@ -105,6 +105,7 @@ exceptions:
   - SDK      # Software Development Kit
   - SEO      # Search Engine Optimization
   - SHIFT    # Keyboard key
+  - SPA      # Single-Page Application
   - SPACE    # Keyboard key
   - SKU      # Stock Keeping Unit
   - SMTP     # Simple Mail Transfer Protocol
@@ -112,6 +113,7 @@ exceptions:
   - SSD      # Solid State Drive
   - SSE      # Server-Sent Events
   - SSL      # Secure Sockets Layer
+  - SSO      # Single Sign-On
   - SVG      # Scalable Vector Graphics
   - TCP      # Transmission Control Protocol
   - TEMP     # Temporary

--- a/17/umbraco-in-ai/.gitbook.yaml
+++ b/17/umbraco-in-ai/.gitbook.yaml
@@ -6,3 +6,6 @@ root: ./
 
 redirects:
     concepts/context-enginerring: concepts/context-engineering.md
+    mcp/base-mcp/hosted-mcp/umbraco-setup: mcp/hosted-mcp-setup/oauth-composer.md
+    mcp/base-mcp/hosted-mcp/external-login-short-circuit: mcp/hosted-mcp-setup/external-login-short-circuit.md
+    mcp/hosted-mcp-setup/url-based-routing: mcp/base-mcp/hosted-mcp/url-based-routing.md

--- a/17/umbraco-in-ai/SUMMARY.md
+++ b/17/umbraco-in-ai/SUMMARY.md
@@ -27,7 +27,7 @@
     * [Multi-Site Deployments](mcp/base-mcp/hosted-mcp/multi-site.md)
     * [Security](mcp/base-mcp/hosted-mcp/security.md)
     * [Troubleshooting](mcp/base-mcp/hosted-mcp/troubleshooting.md)
-    * [Umbraco Setup](mcp/base-mcp/hosted-mcp/umbraco-setup.md)
+    * [URL-Based Routing](mcp/base-mcp/hosted-mcp/url-based-routing.md)
   * [MCP Server SDK](mcp/base-mcp/sdk/README.md)
     * [API Helpers](mcp/base-mcp/sdk/api-helpers.md)
     * [CLI Reference](mcp/base-mcp/sdk/cli.md)
@@ -53,6 +53,9 @@
   * [Cursor](mcp/local-mcp-setup/cursor.md)
   * [GitHub Copilot](mcp/local-mcp-setup/github-copilot.md)
   * [OpenAI Codex Setup](mcp/local-mcp-setup/openai-codex.md)
+* [Hosted MCP Setup](mcp/hosted-mcp-setup/README.md)
+  * [OAuth Client Registration](mcp/hosted-mcp-setup/oauth-composer.md)
+  * [External Login Short Circuit](mcp/hosted-mcp-setup/external-login-short-circuit.md)
 
 ## Agent Skills
 

--- a/17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/README.md
+++ b/17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/README.md
@@ -37,7 +37,7 @@ Each MCP request creates a fresh `McpServer` instance. No state is shared betwee
 - A [Cloudflare account](https://dash.cloudflare.com/sign-up)
 - The [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/) (`npm install -g wrangler`)
 - An Umbraco instance with Management API enabled
-- An OAuth client registered in the Umbraco instance (see [Umbraco Setup](umbraco-setup.md))
+- An OAuth client registered in the Umbraco instance (see [Hosted MCP Setup](../../hosted-mcp-setup/README.md))
 
 ## Getting Set Up
 
@@ -90,7 +90,7 @@ See [Multi-Site Deployments](multi-site.md) for setup instructions, route struct
 
 Read these articles in order:
 
-1. [Umbraco Setup](umbraco-setup.md) - Register the Worker as an OAuth client (one-time).
+1. [Hosted MCP Setup](../../hosted-mcp-setup/README.md) - Prepare the Umbraco instance (OAuth composer and Cloud-specific configuration).
 2. [Deployment](deployment.md) - Deploy, set secrets, and verify the connection.
 3. [Manual Setup](manual-setup.md) - Worker entry point, wrangler.toml, and secrets (reference).
 
@@ -98,6 +98,7 @@ Read these articles in order:
 
 4. [Customization](customization.md) - Consent screen tool selection, branding, and custom rendering.
 5. [Multi-Site Deployments](multi-site.md) - Serve multiple Umbraco instances from one Worker.
+6. [URL-Based Routing](url-based-routing.md) - Serve multiple Umbraco Cloud projects through one Worker.
 
 ### Understanding the System
 

--- a/17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/customization.md
+++ b/17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/customization.md
@@ -56,7 +56,7 @@ The Umbraco OAuth client registration must include:
 - `PostLogoutRedirectUris` with the Worker's `/logout-callback` URL.
 - `OpenIddictConstants.Permissions.Endpoints.EndSession` permission.
 
-See [Umbraco Setup - Post-Logout Redirect URIs](umbraco-setup.md#post-logout-redirect-uris) for the full registration example.
+See [OAuth Client Registration - Post-Logout Redirect URIs](../../hosted-mcp-setup/oauth-composer.md#post-logout-redirect-uris) for the full registration example.
 
 ## Custom Server Name
 

--- a/17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/local-dev-setup.md
+++ b/17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/local-dev-setup.md
@@ -22,13 +22,13 @@ Copy `McpOAuthComposer.cs` from the template into your Umbraco project. Update t
 
 The Composer registers the Worker as an `authorization_code` OAuth client with redirect URIs for `localhost:8787` and `localhost:8788`. Umbraco auto-discovers it via `IComposer`. No changes to `Program.cs` are needed for the OAuth client registration.
 
-See [Umbraco Setup](umbraco-setup.md) for the full Composer code.
+See [OAuth Client Registration](../../hosted-mcp-setup/oauth-composer.md) for the full Composer code.
 
 ## Step 2: Allow HTTP for Token Exchange
 
 The Cloudflare Workers runtime (`workerd`) cannot connect to HTTPS endpoints with self-signed certificates. You need to allow HTTP in your local Umbraco's OpenIdDict configuration.
 
-See [Umbraco Setup - Allow HTTP for Token Exchange](umbraco-setup.md#allow-http-for-token-exchange) for the `Program.cs` change.
+See [OAuth Client Registration - Allow HTTP for Token Exchange](../../hosted-mcp-setup/oauth-composer.md#allow-http-for-token-exchange) for the `Program.cs` change.
 
 ## Step 3: Configure the Worker
 

--- a/17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/multi-site.md
+++ b/17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/multi-site.md
@@ -88,7 +88,7 @@ RedirectUris =
 },
 ```
 
-See [Umbraco Setup](umbraco-setup.md) for the full Composer code.
+See [OAuth Client Registration](../../hosted-mcp-setup/oauth-composer.md) for the full Composer code.
 
 ### 3. Set Worker Secrets
 

--- a/17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/troubleshooting.md
+++ b/17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/troubleshooting.md
@@ -17,7 +17,7 @@ description: Common errors and fixes for the Hosted MCP server.
 - For custom domains, ensure the custom domain callback is registered.
 - The URL must match exactly. No trailing slashes. Correct protocol.
 
-See [Umbraco Setup - Redirect URI Configuration](umbraco-setup.md#redirect-uri-configuration) for the full URI table.
+See [OAuth Client Registration - Redirect URI Configuration](../../hosted-mcp-setup/oauth-composer.md#redirect-uri-configuration) for the full URI table.
 
 ### "Token exchange failed" / TLS Errors in Local Dev
 
@@ -25,7 +25,7 @@ See [Umbraco Setup - Redirect URI Configuration](umbraco-setup.md#redirect-uri-c
 
 **Fix**: Two things are needed:
 
-1. **Disable OpenIdDict's HTTPS requirement** in your Umbraco `Program.cs` (dev only). See [Umbraco Setup - Allow HTTP for Token Exchange](umbraco-setup.md#allow-http-for-token-exchange) for the code.
+1. **Disable OpenIdDict's HTTPS requirement** in your Umbraco `Program.cs` (dev only). See [OAuth Client Registration - Allow HTTP for Token Exchange](../../hosted-mcp-setup/oauth-composer.md#allow-http-for-token-exchange) for the code.
 
 2. **Set `UMBRACO_SERVER_URL`** in `.dev.vars` to point at Umbraco's HTTP port. `UMBRACO_BASE_URL` (HTTPS) is used for browser redirects. `UMBRACO_SERVER_URL` (HTTP) is used for server-side token exchange.
 

--- a/17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/url-based-routing.md
+++ b/17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/url-based-routing.md
@@ -88,7 +88,7 @@ You can override `pathPrefix`, `region`, `validateProject`, or `cacheTtl` if nee
 
 ## OAuthProvider Wiring
 
-`OAuthProvider` must recognise both `/mcp` and `/at/` as protected resources. The rewrite from `/at/<alias>/` to `/mcp` happens **inside** `apiHandler`, after the audience check passes:
+`OAuthProvider` must recognize both `/mcp` and `/at/` as protected resources. The rewrite from `/at/<alias>/` to `/mcp` happens **inside** `apiHandler`, after the audience check passes:
 
 {% code title="worker.ts" %}
 ```typescript
@@ -150,16 +150,16 @@ The first time an MCP client connects to `/at/<alias>/`:
 
 1. The Worker returns 401 with `WWW-Authenticate: Bearer`.
 2. The client fetches `/.well-known/oauth-protected-resource/at/<alias>` and learns the token must bind to `https://<worker-host>/at/<alias>`.
-3. The client registers (DCR) and reads the issuer metadata.
+3. The client registers via Dynamic Client Registration and reads the issuer metadata.
 4. The client opens `/authorize?...&resource=https://<worker-host>/at/<alias>`. The Worker shows the consent screen.
 5. The user approves. The Worker stores `siteId=<alias>` in KV state and redirects to the project's authorize endpoint.
 6. The Cloud project redirects to Umbraco login. The short-circuit composer appends `identity_provider=Umbraco.UmbracoId` to route through the Cloud SSO provider.
 7. The user logs in at `identity.umbraco.com` (Azure B2C).
-8. The OIDC callback (`/umbraco-signin-oidc`) converts the external login into a back-office cookie sign-in.
+8. The OIDC callback (`/umbraco-signin-oidc`) converts the external login into a backoffice cookie sign-in.
 9. The Cloud project redirects back to the Worker's `/callback/<alias>`. The Worker exchanges the authorization code and issues an access token bound to `aud=https://<worker-host>/at/<alias>`.
 10. The MCP client retries `/at/<alias>/` with the access token. The audience matches, the request is rewritten to `/mcp`, and the tools list is returned.
 
-The siteId reaches per-request server creation through `props.consentChoices.siteId`. `createPerRequestServer` calls `siteRouting.resolveSite` to look up the project's `baseUrl` for outbound API calls.
+The `siteId` reaches per-request server creation through `props.consentChoices.siteId`. `createPerRequestServer` calls `siteRouting.resolveSite` to look up the project's `baseUrl` for outbound API calls.
 
 ## Adding a New Cloud Project
 
@@ -211,9 +211,9 @@ Audience validation works the same way for self-hosted projects.
 
 ### Authentication loops between the project authorize endpoint and `identity.umbraco.com`
 
-**Cause**: The OIDC callback is not converting the external sign-in to a back-office cookie.
+**Cause**: The OIDC callback is not converting the external sign-in to a backoffice cookie.
 
-**Fix**: Confirm the short-circuit composer appends `identity_provider=Umbraco.UmbracoId` to the redirect, which routes through `BackOfficeController.AuthorizeExternal`. Direct OIDC challenges bypass the cookie sign-in.
+**Fix**: Confirm the short-circuit composer appends `identity_provider=Umbraco.UmbracoId` to the redirect, which routes through `BackOfficeController.AuthorizeExternal`. Direct OIDC challenges bypass the backoffice cookie sign-in.
 
 ## Related Articles
 

--- a/17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/url-based-routing.md
+++ b/17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/url-based-routing.md
@@ -1,0 +1,223 @@
+---
+description: >-
+  Serve multiple Umbraco Cloud projects from one hosted MCP Worker using
+  per-project URLs and audience-bound OAuth tokens.
+---
+
+# URL-Based Routing
+
+URL-based routing lets a single hosted MCP Worker serve many Umbraco projects. MCP clients connect to a per-project URL (`https://<worker-host>/at/<project-alias>/`) and the Worker resolves each project on demand. There is no site picker on the consent screen and no per-project Worker deployment.
+
+This is the recommended pattern for Umbraco Cloud, where every project has a known alias.
+
+## How It Compares to Other Patterns
+
+| Pattern | Per-tenant deploy | Site picker | Tokens scoped per site |
+|---------|-------------------|-------------|------------------------|
+| Single-site (one Umbraco per Worker) | Yes | n/a | n/a |
+| [Multi-site](multi-site.md) with consent picker | No | User picks at consent | No (shared) |
+| **URL-based routing** | No | URL determines site | Yes (per the MCP spec) |
+
+URL-based routing is the right shape for Umbraco Cloud because each Cloud project already has a unique alias. The alias becomes part of the MCP URL.
+
+## URL Shape
+
+```
+https://<worker-host>/at/<project-alias>/
+```
+
+- `<project-alias>` is the project's Cloud alias verbatim. The `dev-` prefix on development environments works without extra configuration.
+- The `/at/` prefix is a fixed namespace marker. The marker avoids collisions with reserved OAuth routes (`/authorize`, `/token`, `/.well-known/*`).
+
+Examples:
+
+```
+https://mcp.example.com/at/hosted-mcp-worker-test/
+https://mcp.example.com/at/cloud-setup-training-pjw/
+https://mcp.example.com/at/dev-hosted-mcp-worker-test/
+```
+
+The MCP client URL is the only difference between projects. The consent flow, the discovery document, and the OAuth dance are shared across all projects.
+
+## Architecture
+
+```
+┌──────────────┐  /at/abc/   ┌─────────────────┐   OAuth    ┌──────────────┐    SSO     ┌──────────────────────┐
+│  MCP Client  │────────────▶│  Hosted Worker  │───────────▶│ Cloud Project│───────────▶│ identity.umbraco.com │
+│              │             │   (Cloudflare)  │            │ (Umbraco CMS)│            │   (Azure B2C)        │
+└──────────────┘   tokens    └─────────────────┘  redirect  └──────────────┘  redirect  └──────────────────────┘
+```
+
+Three things to know:
+
+1. **The Worker validates per-project access tokens.** The token's `aud` claim binds to `<worker-host>/at/<alias>` (per RFC 8707). `OAuthProvider`'s built-in audience check enforces the binding.
+2. **The Worker rewrites `/at/<alias>/` to `/mcp` internally.** The rewrite happens after the audience check, so token validation still passes.
+3. **Each Cloud project must opt in.** Two composers are required (see [Cloud Project Setup](#cloud-project-setup) below).
+
+## Worker Configuration
+
+Use the `umbracoCloudSiteRouting` preset in `worker.ts`:
+
+{% code title="worker.ts" %}
+```typescript
+import { umbracoCloudSiteRouting } from "@umbraco-cms/mcp-hosted/cloud";
+
+const options = {
+  name: "my-umbraco-mcp",
+  version: "1.0.0",
+  collections,
+  modeRegistry: allModes,
+  allModeNames,
+  allSliceNames,
+  siteRouting: umbracoCloudSiteRouting({
+    oauthClientId: "umbraco-mcp-cms-hosted",
+    // region: "euwest01",  // or set env.UMBRACO_CLOUD_REGION
+  }),
+};
+```
+{% endcode %}
+
+The preset takes care of:
+
+- URL composition: `https://{alias}.{region}.umbraco.io`.
+- Project validation through a `HEAD /umbraco` probe with a five-second timeout.
+- Per-isolate caching of resolved sites (60 seconds OK, 30 seconds miss, 10 seconds error).
+- PKCE-only authentication. No client secret is required unless you set `resolveOauthClientSecret`.
+
+You can override `pathPrefix`, `region`, `validateProject`, or `cacheTtl` if needed.
+
+## OAuthProvider Wiring
+
+`OAuthProvider` must recognise both `/mcp` and `/at/` as protected resources. The rewrite from `/at/<alias>/` to `/mcp` happens **inside** `apiHandler`, after the audience check passes:
+
+{% code title="worker.ts" %}
+```typescript
+const provider = new OAuthProvider({
+  apiRoute: ["/mcp", "/at/"],
+  apiHandler: {
+    async fetch(request, env, ctx) {
+      // OAuthProvider has already validated the audience against /at/{alias}.
+      // Rewrite to /mcp so McpAgent.serve("/mcp") dispatches.
+      const url = new URL(request.url);
+      if (url.pathname.startsWith("/at/")) {
+        const rewritten = new URL(request.url);
+        rewritten.pathname = "/mcp";
+        request = new Request(rewritten.toString(), request);
+      }
+      return baseApiHandler.fetch(request, env, ctx);
+    },
+  },
+  // ...rest of OAuthProvider config
+});
+```
+{% endcode %}
+
+`OAuthProvider.matchApiRoute()` matches both prefixes, so a request to `/at/abc/anything` is recognised as accessing the `/at/` resource. The token's `aud` is checked against that prefix. The rewrite then happens inside `apiHandler` so `McpAgent.serve("/mcp")` can dispatch the request.
+
+## Cloud Project Setup
+
+Each Umbraco Cloud project participating in URL-based routing needs three things:
+
+### 1. The OAuth Composer
+
+Register the Worker as a public OAuth client with PKCE. See [OAuth Client Registration](../../hosted-mcp-setup/oauth-composer.md) for the full Composer code. The redirect URI for each project must include the Cloud alias:
+
+```csharp
+descriptor.RedirectUris.Add(new Uri($"https://<worker-host>/callback/<alias>"));
+descriptor.RedirectUris.Add(new Uri($"http://127.0.0.1:8787/callback/<alias>"));
+```
+
+The same `clientId` value works across all Cloud projects when you use `umbracoCloudSiteRouting` with a shared `oauthClientId`.
+
+### 2. The External Login Short Circuit Composer
+
+This composer ensures the cold-start MCP authentication flow routes through the Cloud SSO provider. Without it, first-time users land on a local username and password form they cannot use.
+
+See [External Login Short Circuit](../../hosted-mcp-setup/external-login-short-circuit.md) for the full setup.
+
+### 3. Redirect URI Registration
+
+Each project's OpenIddict client must list the following redirect URIs:
+
+| Environment | Redirect URI |
+|-------------|--------------|
+| Local development | `http://127.0.0.1:8787/callback/<alias>` |
+| Production Worker | `https://<worker-host>/callback/<alias>` |
+
+## Authentication Flow
+
+The first time an MCP client connects to `/at/<alias>/`:
+
+1. The Worker returns 401 with `WWW-Authenticate: Bearer`.
+2. The client fetches `/.well-known/oauth-protected-resource/at/<alias>` and learns the token must bind to `https://<worker-host>/at/<alias>`.
+3. The client registers (DCR) and reads the issuer metadata.
+4. The client opens `/authorize?...&resource=https://<worker-host>/at/<alias>`. The Worker shows the consent screen.
+5. The user approves. The Worker stores `siteId=<alias>` in KV state and redirects to the project's authorize endpoint.
+6. The Cloud project redirects to Umbraco login. The short-circuit composer appends `identity_provider=Umbraco.UmbracoId` to route through the Cloud SSO provider.
+7. The user logs in at `identity.umbraco.com` (Azure B2C).
+8. The OIDC callback (`/umbraco-signin-oidc`) converts the external login into a back-office cookie sign-in.
+9. The Cloud project redirects back to the Worker's `/callback/<alias>`. The Worker exchanges the authorization code and issues an access token bound to `aud=https://<worker-host>/at/<alias>`.
+10. The MCP client retries `/at/<alias>/` with the access token. The audience matches, the request is rewritten to `/mcp`, and the tools list is returned.
+
+The siteId reaches per-request server creation through `props.consentChoices.siteId`. `createPerRequestServer` calls `siteRouting.resolveSite` to look up the project's `baseUrl` for outbound API calls.
+
+## Adding a New Cloud Project
+
+Three steps, all on the project. The Worker requires no changes:
+
+1. Add the OAuth composer and the external login short-circuit composer.
+2. Register the standard OAuth client ID (for example, `umbraco-mcp-cms-hosted`) in OpenIddict.
+3. Register `<worker-host>/callback/<alias>` and `http://127.0.0.1:8787/callback/<alias>` as allowed redirect URIs.
+
+`umbracoCloudSiteRouting` resolves new aliases on demand the first time a client connects.
+
+## Non-Cloud Usage
+
+URL-based routing works with self-hosted Umbraco instances too. Pass a generic `siteRouting` config instead of `umbracoCloudSiteRouting`:
+
+{% code title="worker.ts" %}
+```typescript
+const options = {
+  // ...
+  siteRouting: {
+    pathPrefix: "/at/",
+    resolveSite: async (alias, env) => {
+      // Return SiteConfig: baseUrl, oauthClientId, optional oauthClientSecret
+      return {
+        baseUrl: `https://${alias}.example.com`,
+        oauthClientId: "umbraco-mcp-cms-hosted",
+      };
+    },
+  },
+};
+```
+{% endcode %}
+
+Audience validation works the same way for self-hosted projects.
+
+## Troubleshooting
+
+### "Token audience does not match resource server" on the first MCP request
+
+**Cause**: The Worker's `apiRoute` configuration does not include `/at/`, or the path rewrite happens before `OAuthProvider` validates the audience.
+
+**Fix**: Confirm `apiRoute: ["/mcp", "/at/"]` is set on `OAuthProvider`. Move the path rewrite inside `apiHandler`, not into `createWorkerExport`.
+
+### Cold-start authentication dies on a local username and password form
+
+**Cause**: The Cloud project is missing the [External Login Short Circuit](../../hosted-mcp-setup/external-login-short-circuit.md) composer, or `Umbraco.Cloud.Cms` is not installed.
+
+**Fix**: Add the composer and confirm the project references the Cloud package.
+
+### Authentication loops between the project authorize endpoint and `identity.umbraco.com`
+
+**Cause**: The OIDC callback is not converting the external sign-in to a back-office cookie.
+
+**Fix**: Confirm the short-circuit composer appends `identity_provider=Umbraco.UmbracoId` to the redirect, which routes through `BackOfficeController.AuthorizeExternal`. Direct OIDC challenges bypass the cookie sign-in.
+
+## Related Articles
+
+- [OAuth Client Registration](../../hosted-mcp-setup/oauth-composer.md) — register the OAuth client.
+- [External Login Short Circuit](../../hosted-mcp-setup/external-login-short-circuit.md) — required Cloud-only composer.
+- [Multi-Site Deployments](multi-site.md) — alternative pattern that uses a consent-screen site picker.
+- [Architecture](architecture.md) — three-tier configuration and component diagram.

--- a/17/umbraco-in-ai/mcp/hosted-mcp-setup/README.md
+++ b/17/umbraco-in-ai/mcp/hosted-mcp-setup/README.md
@@ -40,7 +40,7 @@ Every Umbraco instance that connects to a hosted MCP Worker needs:
         └────── access token ──────────┘
 ```
 
-The Worker registers itself with Umbraco's OpenIddict as an `authorization_code` OAuth client. When an MCP client connects, the Worker redirects the user to Umbraco for login, exchanges the resulting code for an access token, and uses the token on every Management API call.
+The Worker registers itself with Umbraco's OpenIddict as an `authorization_code` OAuth client. When an MCP client connects, the Worker redirects the user to Umbraco for login. The Worker exchanges the resulting code for an access token and uses the token on every Management API call.
 
 ## Articles in This Section
 

--- a/17/umbraco-in-ai/mcp/hosted-mcp-setup/README.md
+++ b/17/umbraco-in-ai/mcp/hosted-mcp-setup/README.md
@@ -1,0 +1,49 @@
+---
+description: >-
+  Prepare your Umbraco instance to connect to a hosted MCP Worker, including
+  OAuth client registration and Umbraco Cloud-specific configuration.
+---
+
+# Hosted MCP Setup
+
+A hosted MCP Worker is a Cloudflare Worker that runs an Umbraco MCP server on the edge. Before a Worker can talk to your Umbraco instance, the Umbraco project needs a few one-time changes. This section covers those Umbraco-side changes.
+
+{% hint style="info" %}
+The Worker side of the deployment (Cloudflare configuration, Wrangler, Worker entry point) lives in [Hosted MCP Server](../base-mcp/hosted-mcp/README.md). Use this section together with that one.
+{% endhint %}
+
+## What You Need
+
+Every Umbraco instance that connects to a hosted MCP Worker needs:
+
+1. **An OAuth client registration** so the Worker can authenticate as a backoffice user. See [OAuth Client Registration](oauth-composer.md).
+2. **An external login short-circuit** if the project runs on Umbraco Cloud. The default login flow does not render Cloud SSO. See [External Login Short Circuit](external-login-short-circuit.md).
+3. **URL-based routing** if you want one Worker to serve many Umbraco Cloud projects. See [URL-Based Routing](../base-mcp/hosted-mcp/url-based-routing.md).
+
+## Self-Hosted vs Umbraco Cloud
+
+| Step | Self-hosted | Umbraco Cloud |
+|------|-------------|---------------|
+| OAuth Client Registration | Required | Required |
+| External Login Short Circuit | Not needed | Required |
+| URL-Based Routing | Optional (multi-tenant) | Recommended |
+
+## How It Connects to the Worker
+
+```
+┌─────────────────┐    OAuth     ┌──────────────────┐    Login    ┌────────────────────┐
+│  Hosted Worker  │─────────────▶│ Umbraco instance │────────────▶│ Backoffice or SSO  │
+│ (Cloudflare)    │              │ (your project)   │             │                    │
+└─────────────────┘              └──────────────────┘             └────────────────────┘
+        ▲                              │
+        │                              │
+        └────── access token ──────────┘
+```
+
+The Worker registers itself with Umbraco's OpenIddict as an `authorization_code` OAuth client. When an MCP client connects, the Worker redirects the user to Umbraco for login, exchanges the resulting code for an access token, and uses the token on every Management API call.
+
+## Articles in This Section
+
+- [OAuth Client Registration](oauth-composer.md) — register the Worker as an OpenIddict client.
+- [External Login Short Circuit](external-login-short-circuit.md) — Umbraco Cloud only. Routes cold-start MCP login through Cloud SSO.
+- [URL-Based Routing](../base-mcp/hosted-mcp/url-based-routing.md) — serve multiple Umbraco projects from one Worker.

--- a/17/umbraco-in-ai/mcp/hosted-mcp-setup/external-login-short-circuit.md
+++ b/17/umbraco-in-ai/mcp/hosted-mcp-setup/external-login-short-circuit.md
@@ -1,0 +1,161 @@
+---
+description: >-
+  Add the Umbraco Cloud short-circuit composer so cold-start MCP authentication
+  redirects to the Cloud SSO provider instead of the local login form.
+---
+
+# External Login Short Circuit
+
+This composer is required for hosted MCP servers that connect to **Umbraco Cloud** projects. It fixes the cold-start authentication flow so that unauthenticated users are routed to the Cloud SSO provider (`identity.umbraco.com`) rather than the local username and password form.
+
+{% hint style="info" %}
+Self-hosted Umbraco instances do not need this composer. Skip this page if your project is not running on Umbraco Cloud.
+{% endhint %}
+
+## The Problem
+
+When an unauthenticated browser hits the Management API OAuth authorize endpoint, the back-office cookie scheme redirects to `/umbraco/login`. That URL is served by the standalone Umbraco Login app, which does not render external authentication providers.
+
+A first-time MCP user lands on a local username and password form they cannot complete with their Cloud credentials. The authentication flow dead-ends before reaching the Cloud SSO provider.
+
+## How the Composer Fixes It
+
+The composer intercepts the redirect and bounces the user back to the same OAuth authorize URL with `identity_provider=Umbraco.UmbracoId` appended.
+
+That second request routes through `BackOfficeController.AuthorizeExternal`, which:
+
+1. Configures the OIDC challenge with the original authorize URL as the return target.
+2. Calls `BackOfficeSignInManager.ExternalLoginSignInAsync` after the `/umbraco-signin-oidc` callback fires, converting the external claims into a back-office cookie sign-in.
+3. Completes the OAuth flow by issuing an authorization code.
+
+Challenging the OIDC scheme directly skips the controller path and the back-office cookie never gets set, which causes an authentication loop. Going via `AuthorizeExternal` matches the path the SPA uses for its working `/umbraco` flow.
+
+## Add the Composer
+
+Create a file in your Umbraco Cloud project (for example, `McpExternalLoginShortCircuitComposer.cs`):
+
+{% code title="McpExternalLoginShortCircuitComposer.cs" %}
+```csharp
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+
+public class McpExternalLoginShortCircuitComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.Services
+            .AddSingleton<IPostConfigureOptions<CookieAuthenticationOptions>,
+                McpExternalLoginShortCircuitCookieOptions>();
+    }
+}
+
+internal sealed class McpExternalLoginShortCircuitCookieOptions
+    : IPostConfigureOptions<CookieAuthenticationOptions>
+{
+    private const string OAuthAuthorizePath =
+        "/umbraco/management/api/v1/security/back-office/authorize";
+
+    private const string IdentityProviderParam = "identity_provider";
+
+    // Registered by Umbraco.Cloud.Cms via AddUmbracoId.
+    private const string ExternalLoginScheme = "Umbraco.UmbracoId";
+
+    private readonly ILogger<McpExternalLoginShortCircuitCookieOptions> _logger;
+
+    public McpExternalLoginShortCircuitCookieOptions(
+        ILogger<McpExternalLoginShortCircuitCookieOptions> logger)
+    {
+        _logger = logger;
+    }
+
+    public void PostConfigure(string? name, CookieAuthenticationOptions options)
+    {
+        if (name != Constants.Security.BackOfficeAuthenticationType)
+        {
+            return;
+        }
+
+        Func<RedirectContext<CookieAuthenticationOptions>, Task> previousLogin =
+            options.Events.OnRedirectToLogin;
+
+        options.Events.OnRedirectToLogin = ctx =>
+        {
+            string path = ctx.Request.Path.Value ?? string.Empty;
+            bool isOAuthAuthorize = path.StartsWith(
+                OAuthAuthorizePath,
+                StringComparison.OrdinalIgnoreCase);
+            bool isHtmlGet = HttpMethods.IsGet(ctx.Request.Method)
+                && ctx.Request.Headers.Accept.ToString().Contains(
+                    "text/html",
+                    StringComparison.OrdinalIgnoreCase);
+            bool alreadyHasIdentityProvider =
+                ctx.Request.Query.ContainsKey(IdentityProviderParam);
+
+            if (!isOAuthAuthorize || !isHtmlGet || alreadyHasIdentityProvider)
+            {
+                return previousLogin(ctx);
+            }
+
+            string pathAndQuery = ctx.Request.Path + ctx.Request.QueryString;
+            string redirectUrl = QueryHelpers.AddQueryString(
+                pathAndQuery,
+                IdentityProviderParam,
+                ExternalLoginScheme);
+
+            _logger.LogInformation(
+                "[McpAuth] Adding identity_provider to OAuth authorize. Redirect={RedirectUrl}",
+                redirectUrl);
+
+            ctx.Response.Redirect(redirectUrl);
+            return Task.CompletedTask;
+        };
+    }
+}
+```
+{% endcode %}
+
+## Scope of the Interception
+
+The composer only rewrites the redirect when all three conditions are met:
+
+| Condition | Reason |
+|-----------|--------|
+| The path starts with `/umbraco/management/api/v1/security/back-office/authorize` | Limits the rewrite to the OAuth authorize endpoint |
+| The request is an HTML `GET` (`Accept: text/html`) | Targets browser navigations, not API or AJAX calls |
+| `identity_provider` is not already in the query string | Prevents redirect loops when `AuthorizeExternal` falls back to the default |
+
+Other unauthenticated requests fall through to the previous `OnRedirectToLogin` handler, which preserves the default behaviour for non-MCP traffic.
+
+## Verifying the Setup
+
+1. Deploy the composer to your Umbraco Cloud project.
+2. Connect a fresh MCP client to the hosted Worker.
+3. Approve the consent screen.
+4. The browser should redirect to `identity.umbraco.com` (Azure B2C) for Cloud login, not the local Umbraco username and password form.
+
+## Troubleshooting
+
+### Cold-start authentication lands on the local username and password form
+
+**Cause**: The composer is not registered, or `Umbraco.Cloud.Cms` is not installed in the project.
+
+**Fix**: Confirm the composer file is present in the project and the project references `Umbraco.Cloud.Cms`. Restart the project and try again.
+
+### Authentication loops between the project authorize endpoint and `identity.umbraco.com`
+
+**Cause**: The OIDC callback is not converting the external sign-in to a back-office cookie. The composer might be challenging the OIDC scheme directly instead of routing through `AuthorizeExternal`.
+
+**Fix**: Confirm the composer appends `identity_provider=Umbraco.UmbracoId` to the redirect URL. Direct OIDC challenges bypass the cookie sign-in and cause the loop.
+
+## Related Articles
+
+- [OAuth Client Registration](oauth-composer.md) — register the OAuth client used by the Worker.
+- [URL-Based Routing](../base-mcp/hosted-mcp/url-based-routing.md) — connect multiple Cloud projects through one hosted Worker.

--- a/17/umbraco-in-ai/mcp/hosted-mcp-setup/external-login-short-circuit.md
+++ b/17/umbraco-in-ai/mcp/hosted-mcp-setup/external-login-short-circuit.md
@@ -6,7 +6,7 @@ description: >-
 
 # External Login Short Circuit
 
-This composer is required for hosted MCP servers that connect to **Umbraco Cloud** projects. It fixes the cold-start authentication flow so that unauthenticated users are routed to the Cloud SSO provider (`identity.umbraco.com`) rather than the local username and password form.
+This composer is required for hosted MCP servers that connect to **Umbraco Cloud** projects. It fixes the cold-start authentication flow. Unauthenticated users are routed to the Cloud SSO provider (`identity.umbraco.com`) rather than the local username and password form.
 
 {% hint style="info" %}
 Self-hosted Umbraco instances do not need this composer. Skip this page if your project is not running on Umbraco Cloud.
@@ -14,7 +14,7 @@ Self-hosted Umbraco instances do not need this composer. Skip this page if your 
 
 ## The Problem
 
-When an unauthenticated browser hits the Management API OAuth authorize endpoint, the back-office cookie scheme redirects to `/umbraco/login`. That URL is served by the standalone Umbraco Login app, which does not render external authentication providers.
+When an unauthenticated browser hits the Management API OAuth authorize endpoint, the backoffice cookie scheme redirects to `/umbraco/login`. That URL is served by the standalone Umbraco Login app, which does not render external authentication providers.
 
 A first-time MCP user lands on a local username and password form they cannot complete with their Cloud credentials. The authentication flow dead-ends before reaching the Cloud SSO provider.
 
@@ -25,10 +25,10 @@ The composer intercepts the redirect and bounces the user back to the same OAuth
 That second request routes through `BackOfficeController.AuthorizeExternal`, which:
 
 1. Configures the OIDC challenge with the original authorize URL as the return target.
-2. Calls `BackOfficeSignInManager.ExternalLoginSignInAsync` after the `/umbraco-signin-oidc` callback fires, converting the external claims into a back-office cookie sign-in.
+2. Calls `BackOfficeSignInManager.ExternalLoginSignInAsync` after the `/umbraco-signin-oidc` callback fires, converting the external claims into a backoffice cookie sign-in.
 3. Completes the OAuth flow by issuing an authorization code.
 
-Challenging the OIDC scheme directly skips the controller path and the back-office cookie never gets set, which causes an authentication loop. Going via `AuthorizeExternal` matches the path the SPA uses for its working `/umbraco` flow.
+Challenging the OIDC scheme directly skips the controller path and the backoffice cookie never gets set, which causes an authentication loop. Going via `AuthorizeExternal` matches the path the single-page application uses for its working `/umbraco` flow.
 
 ## Add the Composer
 
@@ -129,7 +129,7 @@ The composer only rewrites the redirect when all three conditions are met:
 | Condition | Reason |
 |-----------|--------|
 | The path starts with `/umbraco/management/api/v1/security/back-office/authorize` | Limits the rewrite to the OAuth authorize endpoint |
-| The request is an HTML `GET` (`Accept: text/html`) | Targets browser navigations, not API or AJAX calls |
+| The request is an HTML `GET` (`Accept: text/html`) | Targets browser requests, not API or AJAX calls |
 | `identity_provider` is not already in the query string | Prevents redirect loops when `AuthorizeExternal` falls back to the default |
 
 Other unauthenticated requests fall through to the previous `OnRedirectToLogin` handler, which preserves the default behaviour for non-MCP traffic.
@@ -151,7 +151,7 @@ Other unauthenticated requests fall through to the previous `OnRedirectToLogin` 
 
 ### Authentication loops between the project authorize endpoint and `identity.umbraco.com`
 
-**Cause**: The OIDC callback is not converting the external sign-in to a back-office cookie. The composer might be challenging the OIDC scheme directly instead of routing through `AuthorizeExternal`.
+**Cause**: The OIDC callback is not converting the external sign-in to a backoffice cookie. The composer might be challenging the OIDC scheme directly instead of routing through `AuthorizeExternal`.
 
 **Fix**: Confirm the composer appends `identity_provider=Umbraco.UmbracoId` to the redirect URL. Direct OIDC challenges bypass the cookie sign-in and cause the loop.
 

--- a/17/umbraco-in-ai/mcp/hosted-mcp-setup/external-login-short-circuit.md
+++ b/17/umbraco-in-ai/mcp/hosted-mcp-setup/external-login-short-circuit.md
@@ -134,13 +134,6 @@ The composer only rewrites the redirect when all three conditions are met:
 
 Other unauthenticated requests fall through to the previous `OnRedirectToLogin` handler, which preserves the default behaviour for non-MCP traffic.
 
-## Verifying the Setup
-
-1. Deploy the composer to your Umbraco Cloud project.
-2. Connect a fresh MCP client to the hosted Worker.
-3. Approve the consent screen.
-4. The browser should redirect to `identity.umbraco.com` (Azure B2C) for Cloud login, not the local Umbraco username and password form.
-
 ## Troubleshooting
 
 ### Cold-start authentication lands on the local username and password form

--- a/17/umbraco-in-ai/mcp/hosted-mcp-setup/oauth-composer.md
+++ b/17/umbraco-in-ai/mcp/hosted-mcp-setup/oauth-composer.md
@@ -51,7 +51,7 @@ public class RegisterMcpClientHandler
         UmbracoApplicationStartingNotification notification,
         CancellationToken cancellationToken)
     {
-        const string clientId = "umbraco-back-office-mcp";
+        const string clientId = "umbraco-back-office-hosted-mcp";
 
         // Remove any existing registration so we can update it cleanly
         var existing = await _applicationManager.FindByClientIdAsync(clientId, cancellationToken);
@@ -95,6 +95,10 @@ public class RegisterMcpClientHandler
 }
 ```
 {% endcode %}
+
+{% hint style="warning" %}
+Use a `clientId` value that is unique to the hosted MCP Worker. The composer deletes any existing client with the same ID on every startup. API user clients registered through **Settings > Users** would silently lose their registration if their client ID matches.
+{% endhint %}
 
 ## How It Works
 

--- a/17/umbraco-in-ai/mcp/hosted-mcp-setup/oauth-composer.md
+++ b/17/umbraco-in-ai/mcp/hosted-mcp-setup/oauth-composer.md
@@ -219,14 +219,6 @@ The redirect URI registered in the Composer must match the Worker's callback URL
 
 You can register multiple redirect URIs in the Composer for different environments.
 
-## Verifying the Setup
-
-1. Restart the Umbraco instance (so the Composer runs).
-2. Start the Worker: `npx wrangler dev --port 8787`.
-3. Visit `http://localhost:8787`. You should see the landing page.
-4. Use the MCP Inspector in Direct mode with `http://localhost:8787/`.
-5. The Inspector should trigger the OAuth flow: consent screen, then Umbraco login, then connected.
-
 ## Troubleshooting
 
 ### "The specified `redirect_uri` is not valid" (OpenIdDict ID2043)

--- a/17/umbraco-in-ai/mcp/hosted-mcp-setup/oauth-composer.md
+++ b/17/umbraco-in-ai/mcp/hosted-mcp-setup/oauth-composer.md
@@ -2,7 +2,7 @@
 description: Register the Hosted MCP Worker as an OAuth client in your Umbraco instance.
 ---
 
-# Umbraco Setup
+# OAuth Client Registration
 
 The Umbraco instance needs the hosted MCP server registered as an OAuth client. This is a one-time setup per Umbraco instance.
 
@@ -20,6 +20,7 @@ The hosted MCP Worker must be registered as an **Authorization Code** OAuth clie
 
 Create a file in your Umbraco project (for example, `McpOAuthComposer.cs`):
 
+{% code title="McpOAuthComposer.cs" %}
 ```csharp
 using OpenIddict.Abstractions;
 using Umbraco.Cms.Core;
@@ -93,6 +94,7 @@ public class RegisterMcpClientHandler
     }
 }
 ```
+{% endcode %}
 
 ## How It Works
 
@@ -112,6 +114,7 @@ The Cloudflare Workers runtime (`workerd`) cannot connect to HTTPS endpoints wit
 
 Add this to your `Program.cs` **after** the Umbraco builder and **before** `app.Build()`:
 
+{% code title="Program.cs" %}
 ```csharp
 using OpenIddict.Server.AspNetCore;
 
@@ -129,6 +132,7 @@ if (builder.Environment.IsDevelopment())
 
 WebApplication app = builder.Build();
 ```
+{% endcode %}
 
 {% hint style="warning" %}
 This is gated behind `IsDevelopment()` so it applies only when `ASPNETCORE_ENVIRONMENT=Development`. Never disable transport security in production.
@@ -140,17 +144,63 @@ The `PostLogoutRedirectUris` and `Endpoints.EndSession` permission are required 
 
 If you do not need user switching, you can omit `PostLogoutRedirectUris` and the `Endpoints.EndSession` permission.
 
+## One Client ID Per Hosted MCP Worker
+
+If you connect more than one hosted MCP Worker to the same Umbraco instance, register each Worker as a separate OpenIddict client. Each client must have a unique `ClientId` and the redirect URIs that match its own callback URL.
+
+Sharing a single client ID across multiple Workers is not supported. The Worker uses the `clientId` to identify itself during the token exchange, and OpenIddict validates the redirect URI against the client's registered list.
+
+For example, if you run `mcp-content` and `mcp-commerce` against the same Umbraco instance, register two clients:
+
+{% code title="McpOAuthComposer.cs" %}
+```csharp
+// Worker 1: content tools
+new OpenIddictApplicationDescriptor
+{
+    ClientId = "umbraco-mcp-content",
+    RedirectUris =
+    {
+        new Uri("https://mcp-content.workers.dev/callback"),
+        new Uri("http://localhost:8787/callback"),
+    },
+    // ...permissions
+};
+
+// Worker 2: commerce tools
+new OpenIddictApplicationDescriptor
+{
+    ClientId = "umbraco-mcp-commerce",
+    RedirectUris =
+    {
+        new Uri("https://mcp-commerce.workers.dev/callback"),
+        new Uri("http://localhost:8788/callback"),
+    },
+    // ...permissions
+};
+```
+{% endcode %}
+
+Each Worker reads its own `UMBRACO_OAUTH_CLIENT_ID` environment variable and uses that value at the token endpoint.
+
 ## Multi-Site Setup
 
 For multi-site deployments, each Umbraco instance needs its own OAuth client registered. Include the site ID in the callback path (for example, `/callback/prod`). Each site can use different OAuth client IDs. Register a separate Composer (or parameterize a single one) for each Umbraco instance.
 
-See [Multi-Site Deployments](multi-site.md) for the full setup including redirect URI examples.
+See [Multi-Site Deployments](../base-mcp/hosted-mcp/multi-site.md) for the full setup including redirect URI examples.
+
+For URL-based routing across many Umbraco Cloud projects, see [URL-Based Routing](../base-mcp/hosted-mcp/url-based-routing.md).
+
+## Umbraco Cloud Projects
+
+Umbraco Cloud projects need an extra composer in addition to `McpOAuthComposer`. The default cookie scheme redirects unauthenticated users to a local username and password form that does not work with Cloud SSO. The [External Login Short Circuit](external-login-short-circuit.md) composer routes the redirect through the Cloud identity provider.
+
+Self-hosted Umbraco instances do not need the short-circuit composer.
 
 ## Set Worker Secrets
 
 The Worker's `UMBRACO_OAUTH_CLIENT_ID` must match the `clientId` in the Composer above. No client secret is needed — the OAuth client is registered as a **public** client with PKCE.
 
-See [Deployment](deployment.md) for all required secrets and [Local Development Setup](local-dev-setup.md) for `.dev.vars` configuration.
+See [Deployment](../base-mcp/hosted-mcp/deployment.md) for all required secrets and [Local Development Setup](../base-mcp/hosted-mcp/local-dev-setup.md) for `.dev.vars` configuration.
 
 ## Redirect URI Configuration
 
@@ -185,7 +235,7 @@ You can register multiple redirect URIs in the Composer for different environmen
 
 **Cause**: The Worker (`workerd`) cannot connect to Umbraco over HTTPS with a self-signed certificate.
 
-**Fix**: Disable OpenIdDict's transport security requirement in dev mode and set `UMBRACO_SERVER_URL` to Umbraco's HTTP port. See [Local Development Setup](local-dev-setup.md) for the full walkthrough.
+**Fix**: Disable OpenIdDict's transport security requirement in dev mode and set `UMBRACO_SERVER_URL` to Umbraco's HTTP port. See [Local Development Setup](../base-mcp/hosted-mcp/local-dev-setup.md) for the full walkthrough.
 
 ### `invalid_client` on token exchange
 
@@ -193,4 +243,4 @@ You can register multiple redirect URIs in the Composer for different environmen
 
 **Fix**: Verify that `UMBRACO_OAUTH_CLIENT_ID` (in `.dev.vars` or Wrangler secrets) matches the `ClientId` in your `McpOAuthComposer.cs`. Check that the client is registered as `Public` (not `Confidential`). A public client uses PKCE and does not require a client secret.
 
-For Worker-specific errors (Durable Object bindings, SQLite migrations), see the [Troubleshooting](troubleshooting.md) guide.
+For Worker-specific errors (Durable Object bindings, SQLite migrations), see the [Troubleshooting](../base-mcp/hosted-mcp/troubleshooting.md) guide.


### PR DESCRIPTION
## Summary

- Adds a new top-level **Hosted MCP Setup** section under MCP, sibling of **Local MCP Setup**, focused on the Umbraco-side prep needed to connect a hosted MCP Worker.
- New articles: **OAuth Client Registration** (renamed from the previous *Umbraco Setup*, expanded with guidance on registering a unique `client_id` per Worker) and **External Login Short Circuit** (Umbraco Cloud only — routes cold-start MCP login through Cloud SSO).
- Adds **URL-Based Routing** under *Hosted MCP Server* as a Worker deployment pattern, alongside *Multi-Site Deployments*.
- Cross-references and `.gitbook.yaml` redirects updated for moved files so existing URLs still resolve.

## Files

New:
- `17/umbraco-in-ai/mcp/hosted-mcp-setup/README.md`
- `17/umbraco-in-ai/mcp/hosted-mcp-setup/oauth-composer.md` (renamed from `mcp/base-mcp/hosted-mcp/umbraco-setup.md`)
- `17/umbraco-in-ai/mcp/hosted-mcp-setup/external-login-short-circuit.md`
- `17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/url-based-routing.md`

Updated:
- `17/umbraco-in-ai/SUMMARY.md` — new section + URL-Based Routing entry
- `17/umbraco-in-ai/.gitbook.yaml` — redirects for moved files
- `17/umbraco-in-ai/mcp/base-mcp/hosted-mcp/README.md`, `customization.md`, `local-dev-setup.md`, `multi-site.md`, `troubleshooting.md` — link path updates

## Test plan

- [ ] GitBook preview renders the new **Hosted MCP Setup** section in the sidebar
- [ ] Navigation links between articles in the new section resolve
- [ ] Cross-references from `mcp/base-mcp/hosted-mcp/*.md` to the new section resolve
- [ ] Old URLs (`mcp/base-mcp/hosted-mcp/umbraco-setup`, `mcp/base-mcp/hosted-mcp/external-login-short-circuit`, `mcp/hosted-mcp-setup/url-based-routing`) redirect correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)