### PR TITLE
Add Deploy 17.1.0-rc1 release notes

### DIFF
--- a/17/umbraco-deploy/release-notes.md
+++ b/17/umbraco-deploy/release-notes.md
@@ -22,14 +22,14 @@ This section contains the release notes for Umbraco Deploy 17, including all cha
 * Add entity signs for queued entities.
 * Add environment name header app, showing the current environment with its icon and a badge with the number of items in the transfer queue.
 * Add support for user group descriptions (introduced in Umbraco CMS 17.2).
-* Allow exporting all supported entity tree roots (including a fix for members, so you can now transfer/restore/export all members when `AllowMembersDeploymentOperations` is not set to `None`).
-* Ensure compatibility with Umbraco CMS 17.4, which makes `IHostingEnvironment.ApplicationMainUrl` nullable at runtime ([umbraco/Umbraco-CMS#22307](https://github.com/umbraco/Umbraco-CMS/pull/22307)) by falling back to the current request's origin when the application URL is not configured.
+* Allow exporting all supported entity tree roots, including a fix for members. You can now transfer/restore/export all members when `AllowMembersDeploymentOperations` is not set to `None`.
+* Ensure compatibility with Umbraco CMS 17.4, which makes `IHostingEnvironment.ApplicationMainUrl` nullable at runtime ([umbraco/Umbraco-CMS#22307](https://github.com/umbraco/Umbraco-CMS/pull/22307)). Deploy now falls back to the current request's origin when the application URL is not configured.
 
 #### `@umbraco-deploy/backoffice` NPM package
 
-The new [`@umbraco-deploy/backoffice`](https://www.npmjs.com/package/@umbraco-deploy/backoffice) NPM package publishes Deploy's TypeScript type definitions so external packages can consume Deploy's extension points. It exports extension manifest types (such as `ManifestDeployEntityActionRegistrar` and `ManifestDeployEntityTypeMapping`), entity action base classes, context tokens, conditions, and the referenced API and entity models.
+The new [`@umbraco-deploy/backoffice`](https://www.npmjs.com/package/@umbraco-deploy/backoffice) NPM package publishes Deploy's TypeScript type definitions so external packages can consume Deploy's extension points. The package exports extension manifest types (such as `ManifestDeployEntityActionRegistrar` and `ManifestDeployEntityTypeMapping`), entity action base classes, context tokens, conditions, and the referenced API and entity models.
 
-Add it as a development dependency in your custom backoffice extension to get accurate type information when integrating with Deploy.
+Add the package as a development dependency in your custom backoffice extension to get accurate type information when integrating with Deploy.
 
 ### [17.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.0.2) (March 5th 2026)
 

--- a/17/umbraco-deploy/release-notes.md
+++ b/17/umbraco-deploy/release-notes.md
@@ -16,6 +16,21 @@ If you are upgrading to a new major version, you can find the details about the 
 
 This section contains the release notes for Umbraco Deploy 17, including all changes for this version.
 
+### [17.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.1.0-rc1) (May 6th 2026)
+
+* Add `@umbraco-deploy/backoffice` NPM package (see below for details).
+* Add entity signs for queued entities.
+* Add environment name header app, showing the current environment with its icon and a badge with the number of items in the transfer queue.
+* Add support for user group descriptions (introduced in Umbraco CMS 17.2).
+* Allow exporting all supported entity tree roots (including a fix for members, so you can now transfer/restore/export all members when `AllowMembersDeploymentOperations` is not set to `None`).
+* Ensure compatibility with Umbraco CMS 17.4, which makes `IHostingEnvironment.ApplicationMainUrl` nullable at runtime ([umbraco/Umbraco-CMS#22307](https://github.com/umbraco/Umbraco-CMS/pull/22307)) by falling back to the current request's origin when the application URL is not configured.
+
+#### `@umbraco-deploy/backoffice` NPM package
+
+The new [`@umbraco-deploy/backoffice`](https://www.npmjs.com/package/@umbraco-deploy/backoffice) NPM package publishes Deploy's TypeScript type definitions so external packages can consume Deploy's extension points. It exports extension manifest types (such as `ManifestDeployEntityActionRegistrar` and `ManifestDeployEntityTypeMapping`), entity action base classes, context tokens, conditions, and the referenced API and entity models.
+
+Add it as a development dependency in your custom backoffice extension to get accurate type information when integrating with Deploy.
+
 ### [17.0.2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.0.2) (March 5th 2026)
 
 * Set create date on new documents/media/members [#259](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/259)


### PR DESCRIPTION
## 📋 Description

Adds release notes for Umbraco Deploy 17.1.0-rc1:

- New [`@umbraco-deploy/backoffice`](https://www.npmjs.com/package/@umbraco-deploy/backoffice) NPM package (with a dedicated subsection describing what it exposes).
- Entity signs for queued entities.
- Environment name header app, including the queue count badge.
- User group description support (Umbraco CMS 17.2+).
- Exporting all supported entity tree roots (including the fix that allows transferring/restoring/exporting all members when `AllowMembersDeploymentOperations` is not `None`).
- Compatibility with the Umbraco CMS 17.4 change that makes `IHostingEnvironment.ApplicationMainUrl` nullable ([umbraco/Umbraco-CMS#22307](https://github.com/umbraco/Umbraco-CMS/pull/22307)).

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Deploy 17.1.0-rc1.

## Deadline (if relevant)

Alongside the 17.1.0-rc1 release.