### PR TITLE
Forms: update default workflows example for Forms 14+ API

### DIFF
--- a/16/umbraco-forms/developer/extending/customize-default-workflows.md
+++ b/16/umbraco-forms/developer/extending/customize-default-workflows.md
@@ -182,6 +182,7 @@ The following class shows the default implementation provided with Forms. You ca
 using Microsoft.Extensions.Options;
 using Umbraco.Forms.Core.Configuration;
 using Umbraco.Forms.Core.Models;
+using Umbraco.Forms.Core.Providers;
 using Umbraco.Forms.Web.Extensions;
 using Umbraco.Forms.Web.Models.Backoffice;
 
@@ -190,9 +191,13 @@ namespace Umbraco.Forms.Web.Behaviors
     internal class CustomApplyDefaultFieldsBehavior : IApplyDefaultFieldsBehavior
     {
         private readonly FormDesignSettings _formDesignSettings;
+        private readonly FieldCollection _fieldCollection;
 
-        public CustomApplyDefaultFieldsBehavior(IOptions<FormDesignSettings> formDesignSettings) =>
+        public CustomApplyDefaultFieldsBehavior(IOptions<FormDesignSettings> formDesignSettings, FieldCollection fieldCollection)
+        {
             _formDesignSettings = formDesignSettings.Value;
+            _fieldCollection = fieldCollection;
+        }
 
         public virtual void ApplyDefaultFields(FormDesign form)
         {

--- a/16/umbraco-forms/developer/extending/customize-default-workflows.md
+++ b/16/umbraco-forms/developer/extending/customize-default-workflows.md
@@ -50,7 +50,7 @@ namespace MyNamespace
             _logger = logger;
         }
 
-        [Setting("Message", Description = "The log message to write", View = "TextField")]
+        [Setting("Message", Description = "The log message to write", View = "Umb.PropertyEditorUi.TextBox")]
         public string Message { get; set; }
 
         public override List<Exception> ValidateSettings()
@@ -79,8 +79,8 @@ Secondly, the custom implementation of `IApplyDefaultWorkflowsBehavior`:
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Umbraco.Cms.Core.Hosting;
 using Umbraco.Forms.Core;
+using Umbraco.Forms.Core.Attributes;
 using Umbraco.Forms.Core.Enums;
 using Umbraco.Forms.Core.Providers;
 using Umbraco.Forms.Web.Behaviors;
@@ -90,20 +90,19 @@ namespace MyNamespace
 {
     public class CustomApplyDefaultWorkflowsBehavior : IApplyDefaultWorkflowsBehavior
     {
-        private readonly WorkflowCollection _workflowCollection;
-        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly WorkflowCollectionFactory _workflowCollectionFactory;
 
-        public CustomApplyDefaultWorkflowsBehavior(
-            WorkflowCollection workflowCollection, IHostingEnvironment hostingEnvironment)
-        {
-            _workflowCollection = workflowCollection;
-            _hostingEnvironment = hostingEnvironment;
-        }
+        public CustomApplyDefaultWorkflowsBehavior(WorkflowCollectionFactory workflowCollectionFactory) =>
+            _workflowCollectionFactory = workflowCollectionFactory;
 
         public void ApplyDefaultWorkflows(FormDesign form)
         {
+            // WorkflowCollection is registered as transient, so resolve it via the factory
+            // rather than injecting it directly into this singleton service.
+            WorkflowCollection workflowCollection = _workflowCollectionFactory.GetWorkflowCollection();
+
             // Retrieve the type of the default workflow to add.
-            WorkflowType testWorkflowType = _workflowCollection[new Guid(LogMessageWorkflow.LogMessageWorkflowId)];
+            WorkflowType testWorkflowType = workflowCollection[new Guid(LogMessageWorkflow.LogMessageWorkflowId)];
 
             // Create a workflow object based on the workflow type.
             var defaultWorkflow = new FormWorkflowWithTypeSettings
@@ -124,35 +123,15 @@ namespace MyNamespace
                 IsMandatory = true
             };
 
-            // Retrieve the settings from the type.
-            Dictionary<string, Core.Attributes.Setting> workflowTypeSettings = testWorkflowType.Settings();
-
-            // Create a collection for the specific settings to be applied to the workflow.
-            // Populate with the setting details from the type.
-            var workflowSettings = new List<SettingWithValue>();
-            foreach (KeyValuePair<string, Core.Attributes.Setting> setting in workflowTypeSettings)
-            {
-                Core.Attributes.Setting settingItem = setting.Value;
-
-                var settingItemToAdd = new SettingWithValue
-                {
-                    Name = settingItem.Name,
-                    Alias = settingItem.Alias,
-                    Description = settingItem.Description,
-                    Prevalues = settingItem.GetPreValues(),
-                    View = _hostingEnvironment.ToAbsolute(settingItem.GetSettingView()),
-                    Value = string.Empty
-                };
-
-                workflowSettings.Add(settingItemToAdd);
-            }
+            // Retrieve the settings declared on the type and build a dictionary keyed by setting alias.
+            // FormWorkflowWithTypeSettings.Settings is an IDictionary<string, string> mapping alias to value.
+            Dictionary<string, SettingAttribute> workflowTypeSettings = testWorkflowType.Settings();
+            var workflowSettings = workflowTypeSettings.ToDictionary(
+                kvp => kvp.Value.Alias,
+                kvp => string.Empty);
 
             // For each setting, provide a value for the workflow instance (in this example, we only have one).
-            SettingWithValue messageSetting = workflowSettings.SingleOrDefault(x => x.Alias == "Message");
-            if (messageSetting != null)
-            {
-                messageSetting.Value = "A test log message";
-            }
+            workflowSettings["Message"] = "A test log message";
 
             // Apply the settings to the workflow.
             defaultWorkflow.Settings = workflowSettings;

--- a/17/umbraco-forms/developer/extending/customize-default-workflows.md
+++ b/17/umbraco-forms/developer/extending/customize-default-workflows.md
@@ -182,6 +182,7 @@ The following class shows the default implementation provided with Forms. You ca
 using Microsoft.Extensions.Options;
 using Umbraco.Forms.Core.Configuration;
 using Umbraco.Forms.Core.Models;
+using Umbraco.Forms.Core.Providers;
 using Umbraco.Forms.Web.Extensions;
 using Umbraco.Forms.Web.Models.Backoffice;
 
@@ -190,9 +191,13 @@ namespace Umbraco.Forms.Web.Behaviors
     internal class CustomApplyDefaultFieldsBehavior : IApplyDefaultFieldsBehavior
     {
         private readonly FormDesignSettings _formDesignSettings;
+        private readonly FieldCollection _fieldCollection;
 
-        public CustomApplyDefaultFieldsBehavior(IOptions<FormDesignSettings> formDesignSettings) =>
+        public CustomApplyDefaultFieldsBehavior(IOptions<FormDesignSettings> formDesignSettings, FieldCollection fieldCollection)
+        {
             _formDesignSettings = formDesignSettings.Value;
+            _fieldCollection = fieldCollection;
+        }
 
         public virtual void ApplyDefaultFields(FormDesign form)
         {

--- a/17/umbraco-forms/developer/extending/customize-default-workflows.md
+++ b/17/umbraco-forms/developer/extending/customize-default-workflows.md
@@ -79,8 +79,8 @@ Secondly, the custom implementation of `IApplyDefaultWorkflowsBehavior`:
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Umbraco.Cms.Core.Hosting;
 using Umbraco.Forms.Core;
+using Umbraco.Forms.Core.Attributes;
 using Umbraco.Forms.Core.Enums;
 using Umbraco.Forms.Core.Providers;
 using Umbraco.Forms.Web.Behaviors;
@@ -90,20 +90,19 @@ namespace MyNamespace
 {
     public class CustomApplyDefaultWorkflowsBehavior : IApplyDefaultWorkflowsBehavior
     {
-        private readonly WorkflowCollection _workflowCollection;
-        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly WorkflowCollectionFactory _workflowCollectionFactory;
 
-        public CustomApplyDefaultWorkflowsBehavior(
-            WorkflowCollection workflowCollection, IHostingEnvironment hostingEnvironment)
-        {
-            _workflowCollection = workflowCollection;
-            _hostingEnvironment = hostingEnvironment;
-        }
+        public CustomApplyDefaultWorkflowsBehavior(WorkflowCollectionFactory workflowCollectionFactory) =>
+            _workflowCollectionFactory = workflowCollectionFactory;
 
         public void ApplyDefaultWorkflows(FormDesign form)
         {
+            // WorkflowCollection is registered as transient, so resolve it via the factory
+            // rather than injecting it directly into this singleton service.
+            WorkflowCollection workflowCollection = _workflowCollectionFactory.GetWorkflowCollection();
+
             // Retrieve the type of the default workflow to add.
-            WorkflowType testWorkflowType = _workflowCollection[new Guid(LogMessageWorkflow.LogMessageWorkflowId)];
+            WorkflowType testWorkflowType = workflowCollection[new Guid(LogMessageWorkflow.LogMessageWorkflowId)];
 
             // Create a workflow object based on the workflow type.
             var defaultWorkflow = new FormWorkflowWithTypeSettings
@@ -124,35 +123,15 @@ namespace MyNamespace
                 IsMandatory = true
             };
 
-            // Retrieve the settings from the type.
-            Dictionary<string, Core.Attributes.Setting> workflowTypeSettings = testWorkflowType.Settings();
-
-            // Create a collection for the specific settings to be applied to the workflow.
-            // Populate with the setting details from the type.
-            var workflowSettings = new List<SettingWithValue>();
-            foreach (KeyValuePair<string, Core.Attributes.Setting> setting in workflowTypeSettings)
-            {
-                Core.Attributes.Setting settingItem = setting.Value;
-
-                var settingItemToAdd = new SettingWithValue
-                {
-                    Name = settingItem.Name,
-                    Alias = settingItem.Alias,
-                    Description = settingItem.Description,
-                    Prevalues = settingItem.GetPreValues(),
-                    View = _hostingEnvironment.ToAbsolute(settingItem.GetSettingView()),
-                    Value = string.Empty
-                };
-
-                workflowSettings.Add(settingItemToAdd);
-            }
+            // Retrieve the settings declared on the type and build a dictionary keyed by setting alias.
+            // FormWorkflowWithTypeSettings.Settings is an IDictionary<string, string> mapping alias to value.
+            Dictionary<string, SettingAttribute> workflowTypeSettings = testWorkflowType.Settings();
+            var workflowSettings = workflowTypeSettings.ToDictionary(
+                kvp => kvp.Value.Alias,
+                kvp => string.Empty);
 
             // For each setting, provide a value for the workflow instance (in this example, we only have one).
-            SettingWithValue messageSetting = workflowSettings.SingleOrDefault(x => x.Alias == "Message");
-            if (messageSetting != null)
-            {
-                messageSetting.Value = "A test log message";
-            }
+            workflowSettings["Message"] = "A test log message";
 
             // Apply the settings to the workflow.
             defaultWorkflow.Settings = workflowSettings;


### PR DESCRIPTION
## 📋 Description

The custom `IApplyDefaultWorkflowsBehavior` example on https://docs.umbraco.com/umbraco-forms/developer/extending/customize-default-workflows no longer compiles on Forms 14+. The breaking changes were introduced in Forms 14 (commit `709f6542` \"Dynamic field settings\", #908). Verified against the Forms v17 source. The v13 doc still matches the v13 API and is left untouched.

This PR also fixes a pre-existing bug in the same article's Apply Fields Behavior example, where `_fieldCollection` was used but never declared.

### What was wrong (workflows example)

| Old (broken in 14+) | New |
|---|---|
| `Core.Attributes.Setting` | `Core.Attributes.SettingAttribute` (renamed) |
| `settingItem.GetSettingView()` | `settingItem.View` (extension removed; `View` is now a Property Editor UI alias, not a file path, so wrapping in `IHostingEnvironment.ToAbsolute(...)` is also wrong) |
| `defaultWorkflow.Settings = List<SettingWithValue>` | `defaultWorkflow.Settings` is `IDictionary<string, string>` keyed by alias |
| `WorkflowCollection` injected directly | Captive dependency: `IApplyDefaultWorkflowsBehavior` is registered as singleton but `WorkflowCollection` is transient. The built-in implementation uses `WorkflowCollectionFactory` for this reason. |
| `View = \"TextField\"` on `[Setting]` (v16 doc only) | `View = \"Umb.PropertyEditorUi.TextBox\"` — the AngularJS-era alias is no longer valid in the new backoffice |

### What was wrong (fields example)

The Apply Fields Behavior example called `container.AddDataConsentField(_formDesignSettings, _fieldCollection)` but never declared `_fieldCollection` or its constructor parameter. A reader copy-pasting this got a compile error. The example is described as the \"default implementation provided with Forms\", so it now matches the actual `ApplyDefaultFieldsBehavior.cs` in the Forms source by adding:

- `using Umbraco.Forms.Core.Providers;` for the `FieldCollection` type
- `private readonly FieldCollection _fieldCollection;` field
- The constructor parameter and assignment

### What changed

- `16/umbraco-forms/developer/extending/customize-default-workflows.md`
- `17/umbraco-forms/developer/extending/customize-default-workflows.md`

Both files now show the same updated example. The workflows section shrinks by ~40 lines because the manual `List<SettingWithValue>` build is replaced with a single `ToDictionary` call, mirroring how Forms' own built-in `ApplyDefaultWorkflowsBehavior` does it.

`13/umbraco-forms/developer/extending/customize-default-workflows.md` is intentionally not changed — the older API model still applies there.

## 📎 Related Issues (if applicable)

Fixes [umbraco/Umbraco.Forms.Issues#1440](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1440)

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (\"we\", \"I\") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Forms 14, 15, 16, 17 — the article lives in the \`16/\` and \`17/\` documentation directories.

## Deadline (if relevant)

N/A

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)