### PR TITLE
Add Form Name component to Umbraco Flavored Markdown

### DIFF
--- a/17/umbraco-cms/reference/umbraco-flavored-markdown.md
+++ b/17/umbraco-cms/reference/umbraco-flavored-markdown.md
@@ -118,12 +118,6 @@ All expressions are evaluated in a sandbox. Only safe operations and methods are
 
 The following UFM components are available to use.
 
-* Label Value
-* Localize
-* Content Name
-* Link Title
-* Form Name
-
 | Name         | Example syntax                         |
 | ------------ | -------------------------------------- |
 | Label Value  | `{umbValue: headline}`                 |

--- a/17/umbraco-cms/reference/umbraco-flavored-markdown.md
+++ b/17/umbraco-cms/reference/umbraco-flavored-markdown.md
@@ -122,6 +122,15 @@ The following UFM components are available to use.
 * Localize
 * Content Name
 * Link Title
+* Form Name
+
+| Name         | Example syntax                         |
+| ------------ | -------------------------------------- |
+| Label Value  | `{umbValue: headline}`                 |
+| Localize     | `{umbLocalize: general_name}`          |
+| Content Name | `{umbContentName: pickerAlias}`        |
+| Link Title   | `{umbLink: pickerAlias}`               |
+| Form Name    | `{umbFormName: formAlias}`             | 
 
 More UFM components will be available in upcoming Umbraco releases.
 
@@ -154,6 +163,11 @@ The Content Name component supports content-based pickers, such as the Document 
 The Link Title component will render the title of a link from the value of a given Link Picker property editor. Multiple links will render the titles as a comma-separated list.
 
 The alias prefix is `umbLink`. An example of the syntax is `{umbLink: pickerAlias}`, which would render the component as `<ufm-link alias="pickerAlias"></ufm-link>`.
+
+#### Form Name
+The Form Name component will render the name of a selected form. See ["Block List Labels" section in Umbraco Forms documentation](https://docs.umbraco.com/umbraco-forms/16.latest/developer/blocklistlabels) for more information.
+
+The alias prefix is `umbFormName`. An example of the syntax is `{umbFormName: formAlias}`, which would render the component as `<ufm-form-name alias="pickerAlias"></ufm-form-name>`.
 
 ### Custom UFM components
 


### PR DESCRIPTION
Updated the UFM docs with the Form Name Component and added a table showing the names and their syntax to make it quicker to skim and figure out how to use if one has read the docs before but just can't remember the template syntax.

## 📋 Description

Added information about the Form Name UFM component - Also added a table of available/built-in components to quicker get an overview. Perhaps the form description needs to mention that it of course only applies if forms is installed. But I feel like this option belongs in this part of the documentation too. I was personally about to roll my own custom version until a fellow Umbracian pointed me towards the Umbraco Forms docs for this :)

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)
Umbraco CMS.
