### PR TITLE
Document element cache seeding settings introduced in CMS 18

### DIFF
--- a/18/umbraco-cms/reference/cache/cache-seeding.md
+++ b/18/umbraco-cms/reference/cache/cache-seeding.md
@@ -13,9 +13,13 @@ For certain pages, like the front page, you may not want this delay to be there.
 
 Cache seeding is based on the concept of an `ISeedKeyProvider`. The role of the seed key provider is to specify what keys need to be seeded.
 
-There are two types of seed key providers: an `IDocumentSeedKeyProvider` specifying which document should be seeded, and an `IMediaSeedKeyProvider` specifying which media should be seeded.
+There are three types of seed key providers:
 
-During startup, all the `ISeedKeyProviders` are run, and the keys they return are seeded into their respective caches, `IPublishedContentCache` for documents, and `IPublishedMediaCache` for media. Additionally, whenever a document or media is changed, the cache will immediately be updated with the changed content. This ensures that the content is always present in the cache.
+* `IDocumentSeedKeyProvider` specifies which documents should be seeded.
+* `IMediaSeedKeyProvider` specifies which media should be seeded.
+* `IElementSeedKeyProvider` specifies which elements should be seeded.
+
+During startup, all the `ISeedKeyProviders` are run, and the keys they return are seeded into their respective caches: `IPublishedContentCache` for documents, `IPublishedMediaCache` for media, and `IPublishedElementCache` for elements. Additionally, whenever a document, media or element is changed, the cache will immediately be updated with the changed content. This ensures that the content is always present in the cache.
 
 Whenever a piece of content is changed, the seeded keys must be checked, to see if the updated content was seeded. Because of the need the check all seeded keys, Umbraco caches the keys themselves during startup. This means that if you have a dynamic seed key provider, any newly added content will not be considered seeded until the server restarts. For instance, when seeding by Document Type any new content using the specified Document Type will not be seeded until the server is restarted.
 
@@ -23,11 +27,11 @@ Whenever a piece of content is changed, the seeded keys must be checked, to see 
 
 ### Default implementations
 
-By default, Umbraco ships with two seed key providers for documents, and one for media.
+By default, Umbraco ships with two seed key providers for documents, one for media, and two for elements.
 
-For documents, the `ContentTypeSeedKeyProvider` seeds all documents of the given Document Types specified in the `appSettings.json` file.
+For documents and elements, the `ContentTypeSeedKeyProvider` and `ElementContentTypeSeedKeyProvider` seed all documents or elements of the Document Types and Element Types specified in the `appSettings.json` file.
 
-For documents and media, the `BreadthFirstKeyProvider` does a breadth-first traversal of the content and media tree respectively. This will seed N number of content specified in the `appSettings.json` file.
+For documents, media and elements, the `BreadthFirstKeyProvider` does a breadth-first traversal of the content, media and element tree respectively. This will seed N number of items specified in the `appSettings.json` file.
 
 The default seed key provider configuration can be found in the [cache settings section.](../configuration/cache-settings.md).
 

--- a/18/umbraco-cms/reference/configuration/cache-settings.md
+++ b/18/umbraco-cms/reference/configuration/cache-settings.md
@@ -12,7 +12,7 @@ While most cache configurations are under the `Umbraco:CMS:Cache` settings node,
 
 ## HybridCacheOptions
 
-Umbraco's cache is implemented using Microsofts `HybridCache`, which also has its own settings. For more information [see the HybridCache documentation](https://learn.microsoft.com/en-us/aspnet/core/performance/caching/hybrid?view=aspnetcore-9.0#options).
+Umbraco's cache is implemented using Microsoft's `HybridCache`, which also has its own settings. For more information [see the HybridCache documentation](https://learn.microsoft.com/en-us/aspnet/core/performance/caching/hybrid?view=aspnetcore-9.0#options).
 
 ### MaximumPayLoadBytes
 
@@ -44,7 +44,7 @@ The Seeding settings allow you to specify which content should be seeded into yo
 
 ### ContentTypeKeys
 
-The `ContentTypeKeys` setting specifies which Document Types should be seeded into the cache. The setting is a comma-separated list of Document Type keys.
+The `ContentTypeKeys` setting specifies which Document Types and Element Types should be seeded into the cache. The setting is a comma-separated list of Document Type or Element Type keys.
 
 ```json
 "Umbraco": {
@@ -56,31 +56,33 @@ The `ContentTypeKeys` setting specifies which Document Types should be seeded in
 }
 ```
 
-### DocumentBreadthFirstSeedCount and MediaBreadthFirstSeedCount
+### Breadth-first seed counts
 
-The `DocumentBreadthFirstSeedCount` setting specifies how many documents should be seeded into the cache when doing a breadth-first traversal. `MediaBreadthFirstSeedCount` provides the same for media. The default value for both is 100.
+The `DocumentBreadthFirstSeedCount` setting specifies how many documents should be seeded into the cache when doing a breadth-first traversal. `MediaBreadthFirstSeedCount` and `ElementBreadthFirstSeedCount` provide the same for media and elements respectively. The default value for all three is 100.
 
 ```json
 "Umbraco": {
   "CMS": {
     "Cache": {
       "DocumentBreadthFirstSeedCount": 500,
-      "MediaBreadthFirstSeedCount": 500
+      "MediaBreadthFirstSeedCount": 500,
+      "ElementBreadthFirstSeedCount": 500
     }
   }
 }
 ```
 
-## DocumentSeedBatchSize and MediaSeedBatchSize
+### Seed batch sizes
 
-When populating the cache on startup the content keys defined by the seeding strategy are processed in batches. The batch size for documents and media can be modified via the `DocumentSeedBatchSize` and `MediaSeedBatchSize` respectively. The default value for both is 100.
+When populating the cache on startup the content keys defined by the seeding strategy are processed in batches. The batch size for documents, media and elements can be modified via the `DocumentSeedBatchSize`, `MediaSeedBatchSize` and `ElementSeedBatchSize` respectively. The default value for all three is 100.
 
 ```json
 "Umbraco": {
   "CMS": {
     "Cache": {
       "DocumentSeedBatchSize": 500,
-      "MediaSeedBatchSize": 500
+      "MediaSeedBatchSize": 500,
+      "ElementSeedBatchSize": 500
     }
   }
 }
@@ -88,7 +90,7 @@ When populating the cache on startup the content keys defined by the seeding str
 
 ## Cache Entry settings
 
-The Entry settings allow you to specify how long cache entries should be kept. The cache entry settings are identical for documents and media.
+The Entry settings allow you to specify how long cache entries should be kept. The cache entry settings are identical for documents, media and elements.
 
 ## LocalCacheDuration
 
@@ -104,6 +106,9 @@ Specifies the duration for which cache entries should be kept in the local memor
         },
         "Media": {
           "LocalCacheDuration": "50.00:00:00"
+        },
+        "Element": {
+          "LocalCacheDuration": "2.00:00:00"
         }
       }
     }
@@ -125,6 +130,9 @@ Specifies the duration that cache entries should be kept in the remote cache, se
         },
         "Media": {
           "RemoteCacheDuration": "150.00:00:00"
+        },
+        "Element": {
+          "RemoteCacheDuration": "100.00:00:00"
         }
       }
     }
@@ -146,6 +154,9 @@ Specifies the duration for which seeded cache entries should be kept in the cach
         },
         "Media": {
           "SeedCacheDuration": "250.00:00:00"
+        },
+        "Element": {
+          "SeedCacheDuration": "200.00:00:00"
         }
       }
     }


### PR DESCRIPTION
## 📋 Description

Documents the new Element cache seeding settings introduced in Umbraco CMS 18 via [Umbraco-CMS#22369](https://github.com/umbraco/Umbraco-CMS/pull/22369):

- `ElementBreadthFirstSeedCount` and `ElementSeedBatchSize` (defaults `100`)
- `Entry.Element` cache entry durations
- `ContentTypeKeys` now also seeds Element Types via `ElementContentTypeSeedKeyProvider`
- New `IElementSeedKeyProvider` alongside the existing document and media providers

This contribution was AI assisted.

## 📎 Related Issues (if applicable)

Source: [Umbraco-CMS#22369](https://github.com/umbraco/Umbraco-CMS/pull/22369)

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful. (N/A)
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 18.0

## Deadline (if relevant)

To be published along with the beta release, or later.