### PR TITLE
Add Deploy 17.1.0 and 17.1.0-rc2 release notes

### DIFF
--- a/17/umbraco-deploy/release-notes.md
+++ b/17/umbraco-deploy/release-notes.md
@@ -16,6 +16,15 @@ If you are upgrading to a new major version, you can find the details about the 
 
 This section contains the release notes for Umbraco Deploy 17, including all changes for this version.
 
+### [17.1.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.1.0) (May 14th 2026)
+
+* All items from 17.1.0-rc1 and 17.1.0-rc2.
+
+### [17.1.0-rc2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.1.0-rc2) (May 11th 2026)
+
+* Refresh entity signs after a transfer completes and the queue is cleared.
+* Update the `@umbraco-deploy/backoffice` NPM package: prefix non-generated exported types with `Deploy`, add missing types, and fix `UmbExtensionConditionConfigMap` augmentations.
+
 ### [17.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.1.0-rc1) (May 6th 2026)
 
 * Add `@umbraco-deploy/backoffice` NPM package (see below for details).


### PR DESCRIPTION
## 📋 Description

Adds release notes for Umbraco Deploy 17.1.0-rc2 and the stable 17.1.0 release.

**17.1.0-rc2** covers:

- A fix to refresh entity signs after a transfer completes and the queue is cleared.
- An update to the `@umbraco-deploy/backoffice` NPM package: non-generated exported types are now prefixed with `Deploy`, missing types have been added, and `UmbExtensionConditionConfigMap` augmentations have been fixed so condition configs narrow correctly from the alias constants.

**17.1.0** bundles all changes from 17.1.0-rc1 and 17.1.0-rc2.

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Deploy 17.1.0-rc2 and 17.1.0.

## Deadline (if relevant)

14-5-2026 (alongside the 17.1.0 stable release).