### PR TITLE
Document Delivery API content type schemas in OpenAPI (CMS 18.0)

### DIFF
--- a/18/umbraco-cms/SUMMARY.md
+++ b/18/umbraco-cms/SUMMARY.md
@@ -392,6 +392,7 @@
   * [Property expansion and limiting](reference/content-delivery-api/property-expansion-and-limiting.md)
   * [Additional preview environments support](reference/content-delivery-api/additional-preview-environments-support.md)
   * [Custom Delivery API endpoints](reference/content-delivery-api/custom-delivery-api-endpoints.md)
+  * [Content type schemas in OpenAPI](reference/content-delivery-api/content-type-schemas-in-openapi.md)
 * [Webhooks](reference/webhooks/README.md)
   * [Expanding Webhook Events](reference/webhooks/expanding-webhook-events.md)
 * [API versioning and OpenAPI](reference/api-versioning-and-openapi.md)

--- a/18/umbraco-cms/reference/content-delivery-api/README.md
+++ b/18/umbraco-cms/reference/content-delivery-api/README.md
@@ -429,6 +429,8 @@ Returns single or multiple items.
 
 All endpoints are documented in a Swagger document at `{yourdomain}/umbraco/swagger`. This document is not available in production mode by default. For more information read the [API versioning and OpenAPI](https://docs.umbraco.com/umbraco-cms/reference/api-versioning-and-openapi) article.
 
+You can also configure the Delivery API to emit per-content-type schemas in its OpenAPI document. See the [Content type schemas in OpenAPI](content-type-schemas-in-openapi.md) article.
+
 ### Query parameters
 
 The Content Delivery API provides query parameters that allow you to customize the content returned by the API. The relevant query parameters for each endpoint are already specified in the corresponding documentation above.

--- a/18/umbraco-cms/reference/content-delivery-api/content-type-schemas-in-openapi.md
+++ b/18/umbraco-cms/reference/content-delivery-api/content-type-schemas-in-openapi.md
@@ -1,0 +1,68 @@
+---
+description: Generate per-content-type OpenAPI schemas for the Delivery API.
+---
+
+# Content type schemas in OpenAPI
+
+By default, the Delivery API OpenAPI document describes content responses with generic interface schemas. Content type properties are typed as free-form objects, with no relation to the actual content types defined in Umbraco.
+
+The Delivery API offers an opt-in feature to expose your content types directly in the OpenAPI document. Enabling it adds a dedicated schema for each Document Type, Element Type, and Media Type. Each schema replaces the free-form object with the type's own properties.
+
+The interface schemas (`IApiContentResponseModel`, `IApiContentModel`, `IApiMediaWithCropsResponseModel`, `IApiMediaWithCropsModel`) then become discriminated unions keyed on `contentType` or `mediaType`. Consumers can narrow each response to a concrete content type.
+
+{% hint style="info" %}
+This feature only affects the OpenAPI document. The Delivery API responses themselves are unchanged. The JSON returned from the endpoints has the same shape whether content type schemas are enabled or not. What changes is how the spec describes that shape, and what a generated client can infer from it.
+{% endhint %}
+
+## When to enable content type schemas
+
+Enable the feature when you want the OpenAPI document to serve as a complete reference of your content types. The document then describes each content type exposed through the Delivery API and its properties. Consumers without Backoffice access can see which types exist and what shapes the Delivery API returns.
+
+Enabling the feature also lets you generate strongly-typed clients from the spec. The discriminated unions let the generated client identify each content type and expose its properties as concrete fields.
+
+Leave the feature disabled if your consumers neither generate clients from the spec nor rely on it as a content-model reference. The default OpenAPI document is smaller and loads faster.
+
+## Enabling content type schemas
+
+Add the `OpenApi` section to the `DeliveryApi` configuration in `appsettings.json` and set `GenerateContentTypeSchemas` to `true`:
+
+{% code title="appsettings.json" %}
+```json
+{
+  "Umbraco": {
+    "CMS": {
+      "DeliveryApi": {
+        "Enabled": true,
+        "OpenApi": {
+          "GenerateContentTypeSchemas": true
+        }
+      }
+    }
+  }
+}
+```
+{% endcode %}
+
+## Example
+
+Umbraco uses [hey-api](https://heyapi.dev) (the `@hey-api/openapi-ts` package) internally for its TypeScript clients. This is one of multiple compatible generators. See the [Custom Generated Client](../../customizing/foundation/fetching-data/custom-generated-client.md) article for general setup, or [Client generator compatibility](#client-generator-compatibility) for notes on using a different generator.
+
+When you fetch a content item, the response is typed as `IApiContentResponseModel`, the discriminated union over your document types. Narrow on `contentType` to access the type-specific `properties`:
+
+{% code title="app.ts" %}
+```typescript
+const { data } = await getContentItemByPath20({
+    path: { path: '/articles/getting-started' },
+});
+
+if (data?.contentType === 'articlePage') {
+    // data is now typed as ArticlePageContentResponseModel
+    console.log(data.properties?.headline);
+}
+```
+{% endcode %}
+
+## Client generator compatibility
+
+The content type schemas use OpenAPI 3.1 polymorphism (`oneOf` with `discriminator`) and `allOf` for compositions. Support for these patterns varies between OpenAPI client generators. The result depends on the target language and on how the generator handles discriminated unions and schema composition. Verify the generated client against your chosen generator before relying on it.
+


### PR DESCRIPTION
## 📋 Description

Adds a new article documenting the opt-in `GenerateContentTypeSchemas` option introduced in Umbraco 18 (CMS PR [#22666](https://github.com/umbraco/Umbraco-CMS/pull/22666)). When enabled, the Delivery API OpenAPI document emits a schema per Document Type, Element Type, and Media Type, with discriminated unions on `contentType` and `mediaType`.

The article covers:
- The default behaviour and the opt-in shape.                                                                                                          
- When to enable the feature (typed client generation, content-model discovery without Backoffice access).
- The configuration snippet.                                                                                                                           
- An example consuming the schemas with hey-api.                                                                                                       
- A note on OpenAPI 3.1 polymorphism support in client generators.                     
                                                                                                                                                         
Also updates the Content Delivery API landing page and the v18 `SUMMARY.md` with the new entry.

## 📎 Related Issues (if applicable)

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 18.0

## Deadline (if relevant)

When possible, after the CMS 18.0 beta release.
