### PR TITLE
Update public access information in documentation

### DIFF
--- a/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/public-access.md
+++ b/umbraco-cloud/build-and-customize-your-solution/set-up-your-project/project-settings/public-access.md
@@ -10,8 +10,6 @@ description: >-
 Public access is by default available for projects created after the 10th of January 2023.
 
 The [Umbraco.Cloud.Cms.PublicAccess](https://www.nuget.org/packages/Umbraco.Cloud.Cms.PublicAccess) package can be installed to enable Public access for projects created before the 10th of January 2023.
-
-The public access feature is available for all Umbraco Cloud projects on the standard plan or higher.
 {% endhint %}
 
 **Public Access** lets you deny access to your Umbraco Cloud project.


### PR DESCRIPTION
Clarify public access availability for Umbraco Cloud projects. 

This feature is now for all plan levels
