### PR TITLE
Modify rendering scripts example replacing macro

### DIFF
--- a/16/umbraco-forms/developer/rendering-scripts.md
+++ b/16/umbraco-forms/developer/rendering-scripts.md
@@ -66,7 +66,7 @@ To enable `ExcludeScripts`:
 *   While inserting Forms **directly** in your template:
 
     ```csharp
-    @await Umbraco.RenderMacroAsync("renderUmbracoForm", new {FormGuid="6c3f053c-1774-43fa-ad95-710a01d9cd12", FormTheme="bootstrap3-horizontal", ExcludeScripts="1"})
+    @await Component.InvokeAsync("RenderForm", new { formId = Guid.Parse("6c3f053c-1774-43fa-ad95-710a01d9cd12"), theme = "bootstrap3-horizontal", includeScripts = false })
     ```
 
 {% hint style="info" %}

--- a/16/umbraco-forms/developer/rendering-scripts.md
+++ b/16/umbraco-forms/developer/rendering-scripts.md
@@ -70,5 +70,5 @@ To enable `ExcludeScripts`:
     ```
 
 {% hint style="info" %}
-`ExcludeScripts = "1"` prevents the associated scripts from being rendered. Any other value, an empty value, or if the parameter is excluded, will render the scripts on the Form.
+`includeScripts = false` prevents the associated scripts from being rendered. Any other value, an empty value, or if the parameter is excluded, will render the scripts on the Form.
 {% endhint %}

--- a/16/umbraco-forms/developer/rendering-scripts.md
+++ b/16/umbraco-forms/developer/rendering-scripts.md
@@ -70,5 +70,5 @@ To enable `ExcludeScripts`:
     ```
 
 {% hint style="info" %}
-`includeScripts = false` prevents the associated scripts from being rendered. Any other value, an empty value, or if the parameter is excluded, will render the scripts on the Form.
+`includeScripts = false` prevents the associated scripts from being rendered. If value is `includeScripts = true`, or if the parameter is excluded, it will render the scripts on the form.
 {% endhint %}

--- a/17/umbraco-forms/developer/rendering-scripts.md
+++ b/17/umbraco-forms/developer/rendering-scripts.md
@@ -92,5 +92,5 @@ To enable `ExcludeScripts`:
     ```
 
 {% hint style="info" %}
-`ExcludeScripts = "1"` prevents the associated scripts from being rendered. Any other value, an empty value, or if the parameter is excluded, will render the scripts on the Form.
+`includeScripts = false` prevents the associated scripts from being rendered. Any other value, an empty value, or if the parameter is excluded, will render the scripts on the Form.
 {% endhint %}

--- a/17/umbraco-forms/developer/rendering-scripts.md
+++ b/17/umbraco-forms/developer/rendering-scripts.md
@@ -88,7 +88,7 @@ To enable `ExcludeScripts`:
 *   While inserting Forms **directly** in your template:
 
     ```csharp
-    @await Umbraco.RenderMacroAsync("renderUmbracoForm", new {FormGuid="6c3f053c-1774-43fa-ad95-710a01d9cd12", FormTheme="bootstrap3-horizontal", ExcludeScripts="1"})
+    @await Component.InvokeAsync("RenderForm", new { formId = Guid.Parse("6c3f053c-1774-43fa-ad95-710a01d9cd12"), theme = "bootstrap3-horizontal", includeScripts = false })
     ```
 
 {% hint style="info" %}

--- a/17/umbraco-forms/developer/rendering-scripts.md
+++ b/17/umbraco-forms/developer/rendering-scripts.md
@@ -92,5 +92,5 @@ To enable `ExcludeScripts`:
     ```
 
 {% hint style="info" %}
-`includeScripts = false` prevents the associated scripts from being rendered. Any other value, an empty value, or if the parameter is excluded, will render the scripts on the Form.
+`includeScripts = false` prevents the associated scripts from being rendered. If value is `includeScripts = true`, or if the parameter is excluded, it will render the scripts on the form.
 {% endhint %}


### PR DESCRIPTION
Updated example code for rendering forms to use Component.InvokeAsync with includeScripts parameter.

## 📋 Description

<!-- A clear and concise description of what this PR changes or adds. Include context if necessary. -->
Replace code example rendering Umbraco Form as macro using view component instead.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
