### PR TITLE
Add hint for UMBRACO-CLOUD license key for Deploy and Forms on v14+

### DIFF
--- a/marketplace-and-integrations/configure-licenses.md
+++ b/marketplace-and-integrations/configure-licenses.md
@@ -84,6 +84,24 @@ You might run into issues when using a period in the product name when using env
 
 {% endhint %}
 
+{% hint style="info" %}
+For version 14 and above, if you are using Umbraco Deploy and Umbraco Forms on Umbraco Cloud, you can use `UMBRACO-CLOUD` as the license key.
+
+```json
+{
+  "Umbraco": {
+    "Licenses": {
+      "Products": {
+        "Umbraco.Deploy": "UMBRACO-CLOUD",
+        "Umbraco.Forms": "UMBRACO-CLOUD"
+      }
+    }
+  }
+}
+```
+
+{% endhint %}
+
 ## Verifying the License Installation
 
 You can verify that your license is successfully installed by logging into your project's backoffice:


### PR DESCRIPTION
## 📋 Description

Adds a hint block to the "Configure Licenses" article clarifying that Umbraco Deploy and Umbraco Forms on Umbraco Cloud (v14+) can use `UMBRACO-CLOUD` as the license key.


If not configured for Cloud projects we get this message in the Umbraco Forms section for example:
<img width="1328" height="273" alt="image" src="https://github.com/user-attachments/assets/91853678-6e3f-4ed1-bffb-63f24ad3ce9b" />