### PR TITLE
Update document-type-localization.md

### DIFF
--- a/17/umbraco-cms/model-your-content/content-types-and-structure/data/defining-content/document-type-localization.md
+++ b/17/umbraco-cms/model-your-content/content-types-and-structure/data/defining-content/document-type-localization.md
@@ -59,9 +59,9 @@ Once you have registered the Document Type localization, you can add your locali
 export default {
     contentTypes: {
         article: 'Article page',
-        'article-desc': 'A textual, article-like page on the site. Use this as the main type of content.',
+        article_desc: 'A textual, article-like page on the site. Use this as the main type of content.',
         landing: 'Landing page',
-        'landing-desc': 'An inviting, very graphical page. Use this as an entry point for a campaign, and supplement with Article pages.'
+        landing_desc: 'An inviting, very graphical page. Use this as an entry point for a campaign, and supplement with Article pages.'
     },
     tabs: {
         content: 'Page content',
@@ -72,10 +72,10 @@ export default {
     },
     properties: {
         title: 'Main title',
-        'title-desc': 'This is the main title of the page.',
-        'title-message': 'The main title is required for this page.',
+        title_desc: 'This is the main title of the page.',
+        title_message: 'The main title is required for this page.',
         subTitle: 'Sub title',
-        'subTitle-desc': 'This is the sub title of the page.',
+        subTitle_desc: 'This is the sub title of the page.',
     }
 };
 ```
@@ -91,14 +91,14 @@ The localizations are applied by using the syntax `#{area alias}_{key alias}`.
 
 1. Create a **Document Type with Template** called `#contentTypes_article` with the **alias**: `articlePage`.
 2. Under the newly created Document Type, follow these steps:
-   * Set the **description** to `#contentTypes_article-desc`.
+   * Set the **description** to `#contentTypes_article_desc`.
    * Create a new **tab** called `#tabs_content`.
    * Add a new **group** called `#groups_titles`.
    * Add a **property** called `#properties_title` with **alias** `title`.
-     * Set the description to `{#properties_title-desc}`.
+     * Set the description to `{#properties_title_desc}`.
      * Use a `TextString` editor.
      * Set the field validation to `mandatory`.
-     * Under validation add `#properties_title-message`.
+     * Under validation add `{#properties_title_message}`.
 
 {% hint style="info" %}
 Property descriptions support [Umbraco Flavored Markdown](../../../property-editors/umbraco-flavored-markdown.md), which uses a different syntax (wrapped in brackets) to avoid conflicts with Markdown headers.
@@ -107,7 +107,7 @@ Property descriptions support [Umbraco Flavored Markdown](../../../property-edit
 ![Applying localization to a property](../../../../.gitbook/assets/localization-document-type-editor-validation-v15.png)
 
 3. Add a **property** called `#properties_subTitle` with **alias** `subTitle`.
-   * Set the description to `{#properties_subTitle-desc}`.
+   * Set the description to `{#properties_subTitle_desc}`.
    * Use a `TextString` editor.
 4. Enable `Allow at root` in the **Structure** tab.
 


### PR DESCRIPTION
For me if I use '-desc' in my .ts file, and as name for the property description. It doesn't show the translation. Instead it shows the translation of the name of the doc type, with suffix '-desc'. When I change it to '_desc' so for example 'article_desc', it does work. Also with the validation message it only works for me when I use this: 'title_message' with an underscore, and the name of the feedback message on the property wrapped around curly braces {#properties_title_message}. However the translation also shows the curly braces on the front end.

Is this a mistake in the documentation that the minus characters should actually be underscores, or am I doing something wrong? Anyway I edited this documentation page to show how the translations work on my instance of Umbraco 17.3.5. Feel free to deny these changes.

The doctype-en.ts file with the aliases, and translations looks like this for me when the translations show on the backoffice:
```js
export default {
	contentTypes: {
		home: 'Homepage Name',
		home_desc: 'Homepage Description.'
	},
	properties: {
		notifications: 'Notifications',
		home_notifications_desc: 'Select a notification to display it on all underlying pages.',
		notifications_message: 'You should select at least one notification.'
	}
};
```

Also a screenshot of how I configured the names of the doc types, and properties so the translations are shown on the backoffice:
<img width="1160" height="709" alt="Screenshot_2" src="https://github.com/user-attachments/assets/9b3e0b71-1d59-40e1-b669-ba9439dc5b4c" />

After applying these names on the doc types, and properties, and adding the translations inside the .ts file, it looks like this on the backoffice:
<img width="1048" height="555" alt="Screenshot_1" src="https://github.com/user-attachments/assets/aea59d3f-5146-4428-9a2e-d373e897e0d6" />

## 📋 Description

<!-- A clear and concise description of what this PR changes or adds. Include context if necessary. -->

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
