### PR TITLE
Login: Update greeting customization (v17 + v18)

### DIFF
--- a/17/umbraco-cms/model-your-content/content-types-and-structure/backoffice/login.md
+++ b/17/umbraco-cms/model-your-content/content-types-and-structure/backoffice/login.md
@@ -20,7 +20,8 @@ Below, you will find instructions on how to customize the login screen.
 
 The login screen features a greeting text: The "Welcome" headline. This can be personalized by overriding the existing language translation keys.
 
-To override the greetings, register a 'localization' manifest for the default language of your Umbraco site (usually en-US). Provide the new strings inline under `meta.localizations`:
+1. Register a 'localization' manifest for the default language of your Umbraco site (default: en-US).
+2. Provide the new strings inline under `meta.localizations`:
 
 {% code title="App_Plugins/Login/umbraco-package.json" lineNumbers="true" %}
 ```json
@@ -55,7 +56,7 @@ To override the greetings, register a 'localization' manifest for the default la
 ```
 {% endcode %}
 
-This will override the default greetings with the ones you provide. The login screen will now display "Happy super Sunday" instead of "Welcome" on a Sunday. (These are the day-specific greetings the backoffice shipped with before v13 — a nostalgic drop-in replacement for the plain "Welcome".)
+Adding the code above will override the default greetings with the ones you provide. The login screen will now display "Happy super Sunday" on Sundays instead of "Welcome".
 
 {% hint style="info" %}
 For larger overrides, declare the strings in a separate JavaScript file referenced from the manifest (for example `/App_Plugins/Login/en-us.js`). The file should export a default object with the same `{ group: { key: value } }` shape.

--- a/17/umbraco-cms/model-your-content/content-types-and-structure/backoffice/login.md
+++ b/17/umbraco-cms/model-your-content/content-types-and-structure/backoffice/login.md
@@ -20,9 +20,7 @@ Below, you will find instructions on how to customize the login screen.
 
 The login screen features a greeting text: The "Welcome" headline. This can be personalized by overriding the existing language translation keys.
 
-To do this follow the steps below:
-
-1. Register a 'localization' manifest for the default language of your Umbraco site, (usually en-US) to override the greetings.
+To override the greetings, register a 'localization' manifest for the default language of your Umbraco site (usually en-US). Provide the new strings inline under `meta.localizations`:
 
 {% code title="App_Plugins/Login/umbraco-package.json" lineNumbers="true" %}
 ```json
@@ -36,9 +34,20 @@ To do this follow the steps below:
             "type": "localization",
             "alias": "Login.Localize.EnUS",
             "name": "English",
-            "js": "/App_Plugins/Login/en-us.js",
             "meta": {
-                "culture": "en-US"
+                "culture": "en-US",
+                "localizations": {
+                    "auth": {
+                        "instruction": "Log in again to continue",
+                        "greeting0": "Happy super Sunday",
+                        "greeting1": "Happy manic Monday",
+                        "greeting2": "Happy tubular Tuesday",
+                        "greeting3": "Happy wonderful Wednesday",
+                        "greeting4": "Happy thunderous Thursday",
+                        "greeting5": "Happy funky Friday",
+                        "greeting6": "Happy Caturday"
+                    }
+                }
             }
         }
     ]
@@ -46,26 +55,11 @@ To do this follow the steps below:
 ```
 {% endcode %}
 
-2. Add an `en-us.js` file containing the following:
+This will override the default greetings with the ones you provide. The login screen will now display "Happy super Sunday" instead of "Welcome" on a Sunday. (These are the day-specific greetings the backoffice shipped with before v13 — a nostalgic drop-in replacement for the plain "Welcome".)
 
-{% code title="App_Plugins/Login/en-us.js" %}
-```javascript
-export default {
-  auth: {
-    instruction: "Log in again to continue",
-    greeting0: "Is is Sunday",
-    greeting1: "Is is Monday",
-    greeting2: "Is is Tuesday",
-    greeting3: "Is is Wednesday",
-    greeting4: "Is is Thursday",
-    greeting5: "Is is Friday",
-    greeting6: "Is is Saturday",
-  }
-}
-```
-{% endcode %}
-
-This will override the default greetings with the ones you provide. The login screen will now display "It is Sunday" instead of "Welcome" for example.
+{% hint style="info" %}
+For larger overrides, declare the strings in a separate JavaScript file referenced from the manifest (for example `/App_Plugins/Login/en-us.js`). The file should export a default object with the same `{ group: { key: value } }` shape.
+{% endhint %}
 
 {% hint style="info" %}
 The login screen has its own set of localization files independent of the rest of the Backoffice. You can read more about Backoffice localization in the [UI Localization](../../../extend-your-project/backoffice-extensions/foundation/localization.md) article.
@@ -224,7 +218,7 @@ You can customize the time out screen in the same way as the login screen. The t
 
 ### Greeting
 
-To update the greeting message on this screen, you will have to change the section to `login`:
+To update the greeting message on this screen, register a manifest using the `login` section (instead of `auth`):
 
 {% code title="App_Plugins/Login/umbraco-package.json" lineNumbers="true" %}
 ```json
@@ -238,31 +232,23 @@ To update the greeting message on this screen, you will have to change the secti
             "type": "localization",
             "alias": "Login.Localize.EnUS",
             "name": "English",
-            "js": "/App_Plugins/Login/en-us.js",
             "meta": {
-                "culture": "en-US"
+                "culture": "en-US",
+                "localizations": {
+                    "login": {
+                        "instruction": "Log in again to continue",
+                        "greeting0": "Happy super Sunday",
+                        "greeting1": "Happy manic Monday",
+                        "greeting2": "Happy tubular Tuesday",
+                        "greeting3": "Happy wonderful Wednesday",
+                        "greeting4": "Happy thunderous Thursday",
+                        "greeting5": "Happy funky Friday",
+                        "greeting6": "Happy Caturday"
+                    }
+                }
             }
         }
     ]
-}
-```
-{% endcode %}
-
-The `en-us.js` file should contain the following:
-
-{% code title="App_Plugins/Login/en-us.js" %}
-```javascript
-export default {
-  auth: {
-    instruction: "Log in again to continue",
-    greeting0: "Is is Sunday",
-    greeting1: "Is is Monday",
-    greeting2: "Is is Tuesday",
-    greeting3: "Is is Wednesday",
-    greeting4: "Is is Thursday",
-    greeting5: "Is is Friday",
-    greeting6: "Is is Saturday",
-  }
 }
 ```
 {% endcode %}

--- a/18/umbraco-cms/model-your-content/content-types-and-structure/backoffice/login.md
+++ b/18/umbraco-cms/model-your-content/content-types-and-structure/backoffice/login.md
@@ -20,9 +20,7 @@ Below, you will find instructions on how to customize the login screen.
 
 The login screen features a greeting text: The "Welcome" headline. This can be personalized by overriding the existing language translation keys.
 
-To do this follow the steps below:
-
-1. Register a 'localization' manifest for the default language of your Umbraco site, (usually en-US) to override the greetings.
+To override the greetings, register a 'localization' manifest for the default language of your Umbraco site (usually en-US). Provide the new strings inline under `meta.localizations`:
 
 {% code title="App_Plugins/Login/umbraco-package.json" lineNumbers="true" %}
 ```json
@@ -36,9 +34,20 @@ To do this follow the steps below:
             "type": "localization",
             "alias": "Login.Localize.EnUS",
             "name": "English",
-            "js": "/App_Plugins/Login/en-us.js",
             "meta": {
-                "culture": "en-US"
+                "culture": "en-US",
+                "localizations": {
+                    "login": {
+                        "instruction": "Log in again to continue",
+                        "greeting0": "Happy super Sunday",
+                        "greeting1": "Happy manic Monday",
+                        "greeting2": "Happy tubular Tuesday",
+                        "greeting3": "Happy wonderful Wednesday",
+                        "greeting4": "Happy thunderous Thursday",
+                        "greeting5": "Happy funky Friday",
+                        "greeting6": "Happy Caturday"
+                    }
+                }
             }
         }
     ]
@@ -46,32 +55,21 @@ To do this follow the steps below:
 ```
 {% endcode %}
 
-2. Add an `en-us.js` file containing the following:
-
-{% code title="App_Plugins/Login/en-us.js" %}
-```javascript
-export default {
-  auth: {
-    instruction: "Log in again to continue",
-    greeting0: "Is is Sunday",
-    greeting1: "Is is Monday",
-    greeting2: "Is is Tuesday",
-    greeting3: "Is is Wednesday",
-    greeting4: "Is is Thursday",
-    greeting5: "Is is Friday",
-    greeting6: "Is is Saturday",
-  }
-}
-```
-{% endcode %}
-
-This will override the default greetings with the ones you provide. The login screen will now display "It is Sunday" instead of "Welcome" for example.
+This will override the default greetings with the ones you provide. The login screen will now display "Happy super Sunday" instead of "Welcome" on a Sunday. (These are the day-specific greetings the backoffice shipped with before v13 — a nostalgic drop-in replacement for the plain "Welcome".)
 
 {% hint style="info" %}
-The login screen has its own set of localization files independent of the rest of the Backoffice. You can read more about Backoffice localization in the [UI Localization](../../../extend-your-project/backoffice-extensions/foundation/localization.md) article.
+For larger overrides, declare the strings in a separate JavaScript file referenced from the manifest (for example `/App_Plugins/Login/en-us.js`). The file should export a default object with the same `{ group: { key: value } }` shape.
 {% endhint %}
 
-You can customize other text on the login screen as well. First, grab the default values and keys from the [en.ts](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Web.UI.Login/src/localization/lang/en.ts) in the Umbraco CMS GitHub repository. Thereafter copy the ones you want to translate into `~/App_Plugins/Login/umbraco-package.json` file.
+{% hint style="info" %}
+**`culture` must match the active UI locale.** The default is `en-US` (`GlobalSettings.DefaultUILanguage`), so on a default install your override extension must declare `culture: "en-US"` to affect the login screen. The keys themselves live in the canonical `en.ts` dictionary under the `login` group, but that does not change which override file is selected at runtime. An override declared with `culture: "en"` only applies when `en` is the active locale, or if locale fallback resolution uses it; it does not replace an active `en-US` override.
+{% endhint %}
+
+{% hint style="info" %}
+**Renamed in v18: `auth.*` → `login.*`.** Before v18 the login screen had its own dictionary under an `auth` group (`auth.greeting0`, `auth.instruction`, …). In v18 the login screen reuses the shared backoffice dictionary and the keys moved to a `login` group. Existing translation packages still shipping `auth.greeting*` overrides continue to work through v19 with a deprecation warning in the console; the legacy fallback is removed in v20. New packages should target `login.*` directly.
+{% endhint %}
+
+You can customize other text on the login screen as well. Grab the default values and keys from the [`en.ts`](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts) dictionary in the Umbraco CMS GitHub repository — look under the `login` group. Then copy the ones you want to translate into your `en-us.js` file.
 
 ## Password reset
 
@@ -220,54 +218,11 @@ The time out screen is displayed when the user has been inactive for a certain a
 
 If you have added more than one login provider, the users will also see this screen first. This is because they need to choose which provider to use first. In that case, the screen is also referred to as the **Choose provider screen**.
 
-You can customize the time out screen in the same way as the login screen. The time out screen uses the same localization files as the rest of the Backoffice and **not** those of the login screen. The notable difference is that the time out screen is scoped to the `login` section. The login screen is scoped to the `auth` section of the localization files.
+You can customize the time out screen in the same way as the login screen. From v18 both screens share the same backoffice localization dictionary. The `login.*` keys you override for the login screen automatically apply to the time out screen as well.
 
 ### Greeting
 
-To update the greeting message on this screen, you will have to change the section to `login`:
-
-{% code title="App_Plugins/Login/umbraco-package.json" lineNumbers="true" %}
-```json
-{
-    "alias": "login.extensions",
-    "name": "Login extensions",
-    "version": "1.0.0",
-    "allowPublicAccess": true,
-    "extensions": [
-        {
-            "type": "localization",
-            "alias": "Login.Localize.EnUS",
-            "name": "English",
-            "js": "/App_Plugins/Login/en-us.js",
-            "meta": {
-                "culture": "en-US"
-            }
-        }
-    ]
-}
-```
-{% endcode %}
-
-The `en-us.js` file should contain the following:
-
-{% code title="App_Plugins/Login/en-us.js" %}
-```javascript
-export default {
-  auth: {
-    instruction: "Log in again to continue",
-    greeting0: "Is is Sunday",
-    greeting1: "Is is Monday",
-    greeting2: "Is is Tuesday",
-    greeting3: "Is is Wednesday",
-    greeting4: "Is is Thursday",
-    greeting5: "Is is Friday",
-    greeting6: "Is is Saturday",
-  }
-}
-```
-{% endcode %}
-
-The `instruction` key is shown when the user has timed out, and the `greeting0..6` keys are shown when the user has to choose a login provider.
+The greeting on the time out screen uses the same `login.greeting0..6` and `login.instruction` keys as the login screen — override them as shown in the [Greeting](#greeting) section above. The `instruction` key is shown when the user has timed out, and the `greeting0..6` keys are shown when the user has to choose a login provider.
 
 ### Image
 

--- a/18/umbraco-cms/model-your-content/content-types-and-structure/backoffice/login.md
+++ b/18/umbraco-cms/model-your-content/content-types-and-structure/backoffice/login.md
@@ -20,7 +20,8 @@ Below, you will find instructions on how to customize the login screen.
 
 The login screen features a greeting text: The "Welcome" headline. This can be personalized by overriding the existing language translation keys.
 
-To override the greetings, register a 'localization' manifest for the default language of your Umbraco site (usually en-US). Provide the new strings inline under `meta.localizations`:
+1. Register a 'localization' manifest for the default language of your Umbraco site (default: en-US).
+2. Provide the new strings inline under `meta.localizations`:
 
 {% code title="App_Plugins/Login/umbraco-package.json" lineNumbers="true" %}
 ```json
@@ -55,7 +56,7 @@ To override the greetings, register a 'localization' manifest for the default la
 ```
 {% endcode %}
 
-This will override the default greetings with the ones you provide. The login screen will now display "Happy super Sunday" instead of "Welcome" on a Sunday. (These are the day-specific greetings the backoffice shipped with before v13 — a nostalgic drop-in replacement for the plain "Welcome".)
+Adding the code above will override the default greetings with the ones you provide. The login screen will now display "Happy super Sunday" on Sundays instead of "Welcome".
 
 {% hint style="info" %}
 For larger overrides, declare the strings in a separate JavaScript file referenced from the manifest (for example `/App_Plugins/Login/en-us.js`). The file should export a default object with the same `{ group: { key: value } }` shape.
@@ -66,7 +67,7 @@ For larger overrides, declare the strings in a separate JavaScript file referenc
 {% endhint %}
 
 {% hint style="info" %}
-**Renamed in v18: `auth.*` → `login.*`.** Before v18 the login screen had its own dictionary under an `auth` group (`auth.greeting0`, `auth.instruction`, …). In v18 the login screen reuses the shared backoffice dictionary and the keys moved to a `login` group. Existing translation packages still shipping `auth.greeting*` overrides continue to work through v19 with a deprecation warning in the console; the legacy fallback is removed in v20. New packages should target `login.*` directly.
+**Renamed: `auth.*` → `login.*`.** The login screen previously had its own dictionary under an `auth` group (`auth.greeting0`, `auth.instruction`, …). It now reuses the shared backoffice dictionary, with keys moved to a `login` group. Existing translation packages that still ship with `auth.greeting*` overrides will continue to work through version 19, with a deprecation warning in the console. The legacy fallback will eventually be removed. New packages should target `login.*` directly.
 {% endhint %}
 
 You can customize other text on the login screen as well. Grab the default values and keys from the [`en.ts`](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts) dictionary in the Umbraco CMS GitHub repository — look under the `login` group. Then copy the ones you want to translate into your `en-us.js` file.
@@ -218,7 +219,7 @@ The time out screen is displayed when the user has been inactive for a certain a
 
 If you have added more than one login provider, the users will also see this screen first. This is because they need to choose which provider to use first. In that case, the screen is also referred to as the **Choose provider screen**.
 
-You can customize the time out screen in the same way as the login screen. From v18 both screens share the same backoffice localization dictionary. The `login.*` keys you override for the login screen automatically apply to the time out screen as well.
+You can customize the timeout screen in the same way as the login screen. Both screens share the same backoffice localization dictionary. The `login.*` keys you override for the login screen automatically apply to the timeout screen as well.
 
 ### Greeting
 


### PR DESCRIPTION
## 📋 Description

Updates the **Login** article in both v17 and v18 docs.

**Why both versions?** Two of the changes are not version-specific — they're general improvements to the example we ship that apply equally to v17 and v18:

- The inline `meta.localizations` example shape works on every version of the backoffice that supports the `localization` extension type. The "package.json + sibling en-us.js" form the current article uses was always optional for the small-override case, and is harder for first-time readers (two files for seven strings). One file is the better default; the sibling-js form is still documented as the larger-override escape hatch.
- The classic pre-v13 greetings ("Happy super Sunday", "Happy manic Monday", …, "Happy Caturday") are the originals the backoffice shipped with before they were replaced with a plain "Welcome". They apply identically in every version from v13 onwards — so v17 readers benefit from the same nostalgic-but-illustrative example as v18 readers, rather than the "It is Sunday" placeholders that were carried forward by accident.

Layered on top of those shared improvements are a set of **v18-only** changes that reflect umbraco/Umbraco-CMS#22743 (which merged the standalone login screen's localization into the shared backoffice dictionary). Those don't apply to v17 — v17's login screen still has its own dictionary under the `auth` namespace and is correctly documented as such.

---

**v17 + v18 shared changes:**

- Switched the example shape from `umbraco-package.json` + sibling `en-us.js` to a single `umbraco-package.json` declaring the strings inline under `meta.localizations`. Fewer files for the common "override a handful of keys" use case. A trailing hint points at the `js` form for larger overrides (full language packs).
- Used the day-specific greetings the backoffice shipped with before v13 as the worked example, instead of the prior "It is Sunday" placeholders. More evocative, and doubles as a drop-in for users who miss the originals.

**v18-only changes** (umbraco/Umbraco-CMS#22743):

- Example switched from the old `auth` group to the new `login` group. In v18 the login screen reuses the backoffice's shared dictionary; the keys moved from `auth.greeting0..6` / `auth.instruction` to `login.greeting0..6` / `login.instruction`.
- The `en.ts` reference link now points at the canonical dictionary in `Umbraco.Web.UI.Client/src/assets/lang/en.ts` (where the keys live in v18). The previous link pointed at `Umbraco.Web.UI.Login/src/localization/lang/en.ts`, which was deleted by #22743.
- Added a hint clarifying that the override extension's `culture` value must match the active UI locale (`GlobalSettings.DefaultUILanguage`, default `en-US`), not the fallback culture `en`. This was a recurring confusion for testers and package authors after the v18 changes — overrides declared as `culture: "en"` are filtered out on a default install.
- Added a hint explaining the `auth.*` → `login.*` rename, including that existing translation packages shipping `auth.greeting*` overrides keep working through v19 with a deprecation warning in the console (scheduled for removal in v20).
- Replaced the duplicated package.json + en-us.js example under "The Time Out Screen → Greeting" with a cross-link back to the main Greeting section, since both screens now share the same dictionary in v18. Also removed the now-incorrect "scoped to `auth` / `login` section" paragraph.

**What is intentionally NOT changed on v17:**

- The `auth.*` namespace and the "scoped to login / auth" paragraph for the time-out screen — those describe v17 behaviour correctly.
- The `en.ts` GitHub link (pointing at `Umbraco.Web.UI.Login`) and the UI Localization cross-reference — those are out of scope for this PR.
- The "info" hint about the login screen having its own dictionary — true on v17, scope-creep to remove.

Vale fixes carried alongside on the v18 file: dropped a `backoffice's` possessive that tripped the spelling rule, and split two over-long sentences flagged by `UmbracoDocs.SentenceLength`.

## 📎 Related Issues (if applicable)

Documents the v18 changes from umbraco/Umbraco-CMS#22743.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful. <!-- N/A — text-only change -->
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco CMS v17 and v18.

## Deadline (if relevant)

Ideally lands ahead of the v18 GA so the v18 docs are accurate at release.