### PR TITLE
Backoffice Localization (v18.1): Document type-safe keys for plugin authors

### DIFF
--- a/18/umbraco-cms/extend-your-project/backoffice-extensions/foundation/localization.md
+++ b/18/umbraco-cms/extend-your-project/backoffice-extensions/foundation/localization.md
@@ -88,6 +88,53 @@ export class MyController extends UmbControllerBase {
 }
 ```
 
+## Type-safe localization keys
+
+{% hint style="info" %}
+Available from Umbraco 18.1.
+{% endhint %}
+
+The `localize.term()` and `localize.termOrDefault()` methods, and the `key` attribute on `<umb-localize>`, are typed against the canonical English dictionary that ships with the backoffice. Editors that support TypeScript (VS Code, WebStorm, Rider) autocomplete every known key as you type, and function-valued entries forward their parameter list so calls are checked at compile time:
+
+```typescript
+this.localize.term('user_languageNotFound', 'da-DK', 'da');
+// Error: Argument of type 'undefined' is not assignable to parameter of type 'string'.
+this.localize.term('user_languageNotFound', undefined, 'da');
+```
+
+The signature keeps an escape hatch so dynamic keys composed at runtime still work without a cast:
+
+```typescript
+const day = new Date().getDay();
+this.localize.term(`login_greeting${day}`); // still type-checks
+```
+
+### Adding plugin-specific keys
+
+Once you have [registered your localization extension](#registering-localization), you can teach the type system about your own keys by extending the global `UmbKnownLocalizationSet` interface from anywhere in your code (same pattern as `UmbExtensionManifestMap`):
+
+{% code title="types.d.ts" %}
+```typescript
+declare global {
+    interface UmbKnownLocalizationSet {
+        mypkg_anything: string;
+        mypkg_greeting: (name: string) => string;
+    }
+}
+
+export {};
+```
+{% endcode %}
+
+Once declared, the augmented keys participate in autocomplete and argument-type inference exactly like the built-in ones:
+
+```typescript
+this.localize.term('mypkg_anything');           // autocompletes alongside built-in keys
+this.localize.term('mypkg_greeting', 'Alice');  // 'Alice' checked against (name: string) => string
+```
+
+The type declaration is opt-in — plugins that skip it still work, because the `term()` signature accepts any string. You just lose autocomplete and argument-type checking on the plugin's own keys.
+
 ## Using arguments
 
 Sometimes you need to pass arguments to the localization to return different values based on the arguments. A localization value can be either a string or a function. Given a localization file like this, we can return different values based on the number of items:


### PR DESCRIPTION
## 📋 Description

Adds a new **Type-safe localization keys** section to `18/umbraco-cms/extend-your-project/backoffice-extensions/foundation/localization.md`, documenting the compile-time validation that ships in Umbraco 18.1 via umbraco/Umbraco-CMS#22887.

The new section covers:

- **For consumers of the built-in dictionary** — `localize.term()`, `termOrDefault()`, and the `<umb-localize key=\"…\">` element now autocomplete every canonical key and check function-entry arguments at compile time.
- **For plugin authors** — how to extend the type system with the plugin's own keys via plain global interface merging (`declare global { interface UmbKnownLocalizationSet { … } }`), same pattern as `UmbExtensionManifestMap`.
- **Escape hatch** — dynamic keys composed at runtime (e.g. \`\`\`login_greeting${day}\`\`\`) still type-check without casts, and plugins that skip the type declaration still work — they just lose autocomplete on their own keys.

Lives between **Using the Localizations** and **Using arguments** in the existing article — the natural flow goes: register → use → type-safety story → arg/placeholder details.

v17 docs are intentionally left unchanged. The feature is v18.1+.

## 📎 Related Issues (if applicable)

Documents umbraco/Umbraco-CMS#22887.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (\"we\", \"I\") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful. <!-- N/A — text-only change -->
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco CMS v18.1.

## Deadline (if relevant)

Ideally lands alongside the v18.1 release so the docs and the feature ship together.