### PR TITLE
Fix Restore Code Command

### DIFF
--- a/umbraco-cloud/build-and-customize-your-solution/handle-deployments-and-environments/umbraco-cicd/troubleshooting.md
+++ b/umbraco-cloud/build-and-customize-your-solution/handle-deployments-and-environments/umbraco-cicd/troubleshooting.md
@@ -19,7 +19,7 @@ This happens even though the CI/CD deployments were successfull, and files were 
 To resolve this issue, you need to ensure that when the site is restoring on Umbraco Cloud it is not using the lock file. You can do this by adding this line in your csproj file:
 
 ```xml
-<RestoreForceEvaluate Condition="'$(KUDU_SYNC_CMD)' != ''">>true</RestoreForceEvaluate>
+<RestoreForceEvaluate Condition="'$(KUDU_SYNC_CMD)' != ''">true</RestoreForceEvaluate>
 ```
 
 [Force Evaluate option on dotnet restore](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-restore#options)


### PR DESCRIPTION
## 📋 Description

On the [troubleshooting ](https://docs.umbraco.com/umbraco-cloud/build-and-customize-your-solution/handle-deployments-and-environments/umbraco-cicd/troubleshooting#special-cases)page under CI/CD flow, the code example contained incorrect syntax.

Corrected syntax:
`<RestoreForceEvaluate Condition="'$(KUDU_SYNC_CMD)' != ''">true</RestoreForceEvaluate>`

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

No urgent deadline, as it's just a typo :) 

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
