### PR TITLE
Enhance email template example

### DIFF
--- a/17/umbraco-forms/developer/email-templates.md
+++ b/17/umbraco-forms/developer/email-templates.md
@@ -16,14 +16,14 @@ The Razor view must inherit from FormsHtmlModel:
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Forms.Core.Models.FormsHtmlModel>
 ```
 
-You now have a model that contains your Form fields which can be used in your email HTML markup, along with the UmbracoHelper methods such as `Umbraco.TypedContent` and `Umbraco.TypedMedia` etc.
+You now have a model that contains your Form fields, which can be used in your email HTML markup, along with the UmbracoHelper methods such as `Umbraco.TypedContent` and `Umbraco.TypedMedia`, etc.
 
 Below is an example of an email template based on `Example-Template.cshtml` shipped with Umbraco Forms. Use this as a base for creating your own template.
 
 ```csharp
-@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Forms.Core.Models.FormsHtmlModel>
-@using System.Net
+@using Microsoft.AspNetCore.Html
 @using Umbraco.Forms.Core.Extensions
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Forms.Core.Models.FormsHtmlModel>
 
 @{
 	//This is an example email template where you can use Razor Views to send HTML emails
@@ -36,9 +36,9 @@ Below is an example of an email template based on `Example-Template.cshtml` ship
 	//@foreach (var color in Model.GetValues("checkboxField")){}
 
 
-	//Images need to be absolute - so fetching domain to prefix with images
-	var siteDomain = Context.Request.Scheme + "://" + Context.Request.Host;
-	var assetUrl = siteDomain + "/App_Plugins/UmbracoForms/assets/Email-Example";
+    //Images need to be absolute - so fetching domain to prefix with images
+    var siteDomain = Context.Request.Scheme + "://" + Context.Request.Host;
+    var assetUrl = siteDomain + "/App_Plugins/UmbracoForms/assets/Email-Example";
 
 }
 <!DOCTYPE html>
@@ -179,6 +179,7 @@ Below is an example of an email template based on `Example-Template.cshtml` ship
 								{
 									"FieldType.Recaptcha2.cshtml",
 									"FieldType.Recaptcha3.cshtml",
+									"FieldType.RecaptchaEnterprise.cshtml",
 									"FieldType.RichText.cshtml",
 									"FieldType.Text.cshtml"
 								};
@@ -219,30 +220,33 @@ Below is an example of an email template based on `Example-Template.cshtml` ship
 											}
 											break;
 
-										default:
-											var values = field.GetValues();
-											if (values != null)
-											{
-												foreach (var value in values)
-												{
-													if (value != null)
-													{
+                                        default:
+                                            var values = field.GetValues();
+                                            if (values != null)
+                                            {
+                                                foreach (var value in values)
+                                                {
+                                                    if (value != null)
+                                                    {
 														if (value is string strValue)
 														{
-															@Html.Raw(WebUtility.HtmlEncode(strValue.ApplyPrevalueCaptions(field.Id, Model.PrevalueMaps)).ReplaceLineEndings("<br/>"))
+															var captionedValue = strValue.ApplyPrevalueCaptions(field.Id, Model.PrevalueMaps);
+															var encodedValue = System.Net.WebUtility.HtmlEncode(captionedValue);
+															var processedValue = encodedValue.ReplaceLineEndings("<br/>");
+															@Html.Raw(processedValue)
 														}
 														else
 														{
 															@value
 														}
 														<br />
-													}
-												}
-											}
-											break;
-									}
-								</p>
-							}
+                                                    }
+                                                }
+                                            }
+                                            break;
+                                    }
+                                </p>
+                            }
 
 						</td>
 					</tr>

--- a/17/umbraco-forms/developer/email-templates.md
+++ b/17/umbraco-forms/developer/email-templates.md
@@ -18,10 +18,12 @@ The Razor view must inherit from FormsHtmlModel:
 
 You now have a model that contains your Form fields which can be used in your email HTML markup, along with the UmbracoHelper methods such as `Umbraco.TypedContent` and `Umbraco.TypedMedia` etc.
 
-Below is an example of an email template from the `~/Views/Partials/Forms/Emails/` folder:
+Below is an example of an email template based on `Example-Template.cshtml` shipped with Umbraco Forms. Use this as a base for creating your own template.
 
 ```csharp
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Forms.Core.Models.FormsHtmlModel>
+@using System.Net
+@using Umbraco.Forms.Core.Extensions
 
 @{
 	//This is an example email template where you can use Razor Views to send HTML emails
@@ -225,8 +227,14 @@ Below is an example of an email template from the `~/Views/Partials/Forms/Emails
 												{
 													if (value != null)
 													{
-														@(value is string strValue ? strValue.ApplyPrevalueCaptions(field.Id, Model.PrevalueMaps) : value)
-
+														if (value is string strValue)
+														{
+															@Html.Raw(WebUtility.HtmlEncode(strValue.ApplyPrevalueCaptions(field.Id, Model.PrevalueMaps)).ReplaceLineEndings("<br/>"))
+														}
+														else
+														{
+															@value
+														}
 														<br />
 													}
 												}

--- a/17/umbraco-forms/developer/email-templates.md
+++ b/17/umbraco-forms/developer/email-templates.md
@@ -16,7 +16,7 @@ The Razor view must inherit from FormsHtmlModel:
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Forms.Core.Models.FormsHtmlModel>
 ```
 
-You now have a model that contains your Form fields, which can be used in your email HTML markup, along with the UmbracoHelper methods such as `Umbraco.TypedContent` and `Umbraco.TypedMedia`, etc.
+You now have a model with your Form fields. This can be used in your email HTML markup, along with the UmbracoHelper methods like `Umbraco.TypedContent` and `Umbraco.TypedMedia`, and so on.
 
 Below is an example of an email template based on `Example-Template.cshtml` shipped with Umbraco Forms. Use this as a base for creating your own template.
 


### PR DESCRIPTION
Updated the email template example using ILSpy on Umbraco Forms Static assets and the default template. The old example didn't work because it's missing a FieldType and correct ApplyPreValueCaptions etc for string values.

## 📋 Description

Updates the example code in "Creating an Email Template" to a working version.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Forms 17.x (tested with 17.3.2)

## 📚 Helpful Resources

* ✍️ [Umbraco Forms Documentation](https://docs.umbraco.com/umbraco-forms/developer/email-templates)
