### PR TITLE
Search: document the @umbraco-cms/search npm types package

### DIFF
--- a/17/umbraco-search/extending/backoffice-extensions.md
+++ b/17/umbraco-search/extending/backoffice-extensions.md
@@ -8,6 +8,38 @@ description: >-
 
 This guide is for **extension developers** and **search provider developers** who want to add custom UI to the Umbraco Search backoffice.
 
+## Installing the TypeScript types
+
+Umbraco Search ships its TypeScript types as a types-only npm package, `@umbraco-cms/search`. Add the package as a development dependency to get IntelliSense for contexts, manifests, and shared models:
+
+```bash
+npm install --save-dev @umbraco-cms/search
+```
+
+{% hint style="info" %}
+While Umbraco Search is in prerelease, install from the `next` dist-tag:
+
+```bash
+npm install --save-dev @umbraco-cms/search@next
+```
+{% endhint %}
+
+The package exposes two entry points that mirror the runtime bundles loaded by the backoffice:
+
+* `@umbraco-cms/search/global` - constants and global contexts loaded upfront, covering entity types, repository aliases, and the notification context.
+* `@umbraco-cms/search/settings` - the lazy-loaded implementation surface, covering workspace context tokens, repositories, and models.
+
+The package ships no runtime code. The Umbraco backoffice serves the JavaScript at runtime through an importmap, so you only need the types at build time:
+
+{% code title="my-extension.ts" %}
+```typescript
+import { UMB_SEARCH_INDEX_ENTITY_TYPE } from '@umbraco-cms/search/global';
+import { UMB_SEARCH_WORKSPACE_CONTEXT, type UmbSearchIndex } from '@umbraco-cms/search/settings';
+```
+{% endcode %}
+
+The package declares `@umbraco-cms/backoffice` as a peer dependency. Install the backoffice package in your project too.
+
 ## Adding a detail box to the search workspace
 
 <figure><img src="../.gitbook/assets/searchIndexDetailBox.jpg" alt="Search index detail boxes"><figcaption><p>The marked areas illustrate locations of search index detail boxes.</p></figcaption></figure>


### PR DESCRIPTION
## 📋 Description

Adds a new **Installing the TypeScript types** section to `17/umbraco-search/extending/backoffice-extensions.md`. Every other section on that page already imports from `@umbraco-cms/search/global` and `@umbraco-cms/search/settings` without telling readers where the types come from — this fills the gap.

The section covers:

* Installing `@umbraco-cms/search` as a development dependency
* The `next` dist-tag for the current prerelease line
* The two subpath entry points (`/global` and `/settings`) and what each contains
* The fact that the package is types-only and runtime resolves through the backoffice's importmap
* The peer-dependency requirement on `@umbraco-cms/backoffice`

Content was ported from the "Docs to port to UmbracoDocs" snippet drafted in [umbraco/Umbraco.Cms.Search#133](https://github.com/umbraco/Umbraco.Cms.Search/pull/133).

### AI disclosure

This PR is **AI-assisted**. Claude helped restructure the original PR snippet to match the GitBook conventions used in the file (`{% hint %}`, `{% code title %}`), tighten passive constructions, and remove vague pronouns per the style guide. The AI-generated label is applied on this PR.

## 📎 Related Issues (if applicable)

* Source snippet: umbraco/Umbraco.Cms.Search#133
* Package README + metadata: umbraco/Umbraco.Cms.Search#136

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful. _(not applicable — text-only addition)_
* [x] Any code examples or instructions have been tested. The `import` example was verified against the published package's exports (`UmbSearchIndex` re-exported via `settings/index.ts`; constants present in `global/`).
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Search — v17 (only documented version).

## Deadline (if relevant)

Not urgent, but ideally lands before the next `@umbraco-cms/search` prerelease so users landing on the docs page from npmjs.com find the install instructions.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)