### PR TITLE
Fixed Sticky Sessions header in Engage

### DIFF
--- a/13/umbraco-engage/getting-started/for-developers/loadbalancing-and-cm-cd-environments.md
+++ b/13/umbraco-engage/getting-started/for-developers/loadbalancing-and-cm-cd-environments.md
@@ -43,7 +43,7 @@ Make sure the `IsProcessingServer` is set to `true` on the content management (U
 
 The setting can be set in your`appSettings.json`file.
 
-## Sticky sessions
+## Enabling Sticky sessions
 
 Sticky sessions, also known as session affinity, are essential for the proper functioning of Umbraco Engage in a load-balanced environment. Sticky sessions can be enabled using different methods such as cookie-based, IP-based, or URL-based session affinity, depending on the load balancer configuration. By enabling sticky sessions, you can ensure that user sessions remain intact and data consistency is maintained across the Umbraco Engage application. Sticky sessions will ensure that analytics, A/B testing and personalization works properly.
 

--- a/16/umbraco-engage/getting-started/for-developers/loadbalancing-and-cm-cd-environments.md
+++ b/16/umbraco-engage/getting-started/for-developers/loadbalancing-and-cm-cd-environments.md
@@ -43,7 +43,7 @@ Make sure the `IsProcessingServer` is set to `true` on the content management (U
 
 The setting can be set in your`appSettings.json`file.
 
-## Sticky sessions
+## Enabling Sticky sessions
 
 Sticky sessions, also known as session affinity, are essential for the proper functioning of Umbraco Engage in a load-balanced environment. Sticky sessions can be enabled using different methods such as cookie-based, IP-based, or URL-based session affinity, depending on the load balancer configuration. By enabling sticky sessions, you can ensure that user sessions remain intact and data consistency is maintained across the Umbraco Engage application. Sticky sessions will ensure that analytics, A/B testing and personalization works properly.
 

--- a/17/umbraco-engage/getting-started/for-developers/loadbalancing-and-cm-cd-environments.md
+++ b/17/umbraco-engage/getting-started/for-developers/loadbalancing-and-cm-cd-environments.md
@@ -109,7 +109,7 @@ Make sure the `IsProcessingServer` is set to `true` on the content management (U
 
 The setting can be set in your`appSettings.json`file.
 
-## Sticky sessions
+## Enabling Sticky sessions
 
 Sticky sessions, also known as session affinity, are essential for the proper functioning of Umbraco Engage in a load-balanced environment. Sticky sessions can be enabled using different methods such as cookie-based, IP-based, or URL-based session affinity, depending on the load balancer configuration. By enabling sticky sessions, you can ensure that user sessions remain intact and data consistency is maintained across the Umbraco Engage application. Sticky sessions will ensure that analytics, A/B testing and personalization works properly.
 


### PR DESCRIPTION
## 📋 Description

This PR renames the ## Sticky sessions heading to ## Enabling sticky sessions. This updates the generated anchor ID to resolve a infinite loop bug affecting version 17.

Looks like it is a bug reported in Gitbook: https://github.com/GitbookIO/gitbook/issues/4246

As per Gemini:

🐛 The Problem
On the version 17 page, navigating directly via the #sticky-sessions anchor link causes the GitBook router to enter an infinite loop. The URL endlessly appends the hash (#sticky-sessions#sticky-sessions...), the browser console is spammed with thousands of postMessage errors, and the page eventually throttles or hangs.

This issue is unique to v17 because of the added vertical layout height (new nested headers, JSON blocks, tables, and custom {% hint %} containers). When the page loads, these elements cause a layout shift while GitBook's "Scroll-Spy" is calculating the viewport destination. The script miscalculates, falls back (?fallback=true), and repeatedly forces a URL rewrite. Versions 13 and 16 have flat layouts and are unaffected.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

It only afftects Engage v17 but for consistency purposes updated v13 and v16 as well

## Deadline (if relevant)

Anytime

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
