### PR TITLE
Fix link to legacy DateTime

### DIFF
--- a/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/README.md
+++ b/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/README.md
@@ -3,7 +3,7 @@
 The Date Time property editors provide interfaces for selecting dates, times, and time zones. Each editor is designed for specific use cases, from basic date selection to comprehensive date/time handling with time zone support.
 
 {% hint style="info" %}
-These property editors replace the legacy `[Date Time](../date-time.md)` property editor. They offer more focused functionality and specific return types (such as `DateOnly`, `TimeOnly`, `DateTime`, or `DateTimeOffset`). You can switch from the legacy Date Time editor by changing your properties to use the new editors.
+These property editors replace the legacy [`Date Time`](../date-time.md) property editor. They offer more focused functionality and specific return types (such as `DateOnly`, `TimeOnly`, `DateTime`, or `DateTimeOffset`). You can switch from the legacy Date Time editor by changing your properties to use the new editors.
 {% endhint %}
 
 Umbraco CMS currently ships with four Date Time editors:

--- a/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/README.md
+++ b/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/README.md
@@ -3,7 +3,7 @@
 The Date Time property editors provide interfaces for selecting dates, times, and time zones. Each editor is designed for specific use cases, from basic date selection to comprehensive date/time handling with time zone support.
 
 {% hint style="info" %}
-These property editors replace the legacy `[Date Time](../date-time.md)` property editor. They offer more focused functionality and specific return types (such as `DateOnly`, `TimeOnly`, `DateTime`, or `DateTimeOffset`). You can switch from the legacy Date Time editor by changing your properties to use the new editors.
+These property editors replace the legacy [`Date Time`](../date-time.md) property editor. They offer more focused functionality and specific return types (such as `DateOnly`, `TimeOnly`, `DateTime`, or `DateTimeOffset`). You can switch from the legacy Date Time editor by changing your properties to use the new editors.
 {% endhint %}
 
 Umbraco CMS currently ships with four Date Time editors:


### PR DESCRIPTION
## 📋 Description

<!-- A clear and concise description of what this PR changes or adds. Include context if necessary. -->
Fixes link to legacy DateTime property editor instead or rendering `[Date Time](../date-time.md)` it now render [`Date Time`](https://docs.umbraco.com/umbraco-cms/18.latest/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor)

https://docs.umbraco.com/umbraco-cms/18.latest/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
