### PR TITLE
Fixed broken link

### DIFF
--- a/17/umbraco-cms/extend-your-project/server-side-extensions/flag-providers.md
+++ b/17/umbraco-cms/extend-your-project/server-side-extensions/flag-providers.md
@@ -86,8 +86,8 @@ The flag provider needs to be registered with Umbraco in a composer or applicati
 
 For some flags, there may be sufficient information on the view models to map whether a flag should be created.
 
-For an example of this, see the core flag provider `IsProtectedFlagProvider` whose [source code can be found here](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Cms.Api.Management/Services/Flags/IsProtectedFlagProvider.cs).
+For an example of this, see the core flag provider `IsProtectedFlagProvider` whose [source code can be found here](https://github.com/umbraco/Umbraco-CMS/blob/v17/dev/src/Umbraco.Cms.Api.Management/Services/Flags/IsProtectedFlagProvider.cs).
 
 More complex flags will require additional information, using the identifiers of the view models to retrieve the necessary data. It's important to avoid "N+1" issues. The aim should be to retrieve all the data needed to populate the flags for the whole collection in one step.
 
-In core, the flag provider `HasScheduleFlagProvider` shows a good example of this. The [source code can be found here](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Cms.Api.Management/Services/Flags/HasScheduleFlagProvider.cs).
+In core, the flag provider `HasScheduleFlagProvider` shows a good example of this. The [source code can be found here](https://github.com/umbraco/Umbraco-CMS/blob/v17/dev/src/Umbraco.Cms.Api.Management/Services/Flags/HasScheduleFlagProvider.cs).

--- a/18/umbraco-cms/extend-your-project/server-side-extensions/flag-providers.md
+++ b/18/umbraco-cms/extend-your-project/server-side-extensions/flag-providers.md
@@ -90,4 +90,4 @@ For an example of this, see the core flag provider `IsProtectedFlagProvider` who
 
 More complex flags will require additional information, using the identifiers of the view models to retrieve the necessary data. It's important to avoid "N+1" issues. The aim should be to retrieve all the data needed to populate the flags for the whole collection in one step.
 
-In core, the flag provider `HasScheduleFlagProvider` shows a good example of this. The [source code can be found here](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Cms.Api.Management/Services/Flags/HasScheduleFlagProvider.cs).
+In core, the flag provider `HasDocumentScheduleFlagProvider` shows a good example of this. The [source code can be found here](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Cms.Api.Management/Services/Flags/HasDocumentScheduleFlagProvider.cs).


### PR DESCRIPTION
## 📋 Description

`HasScheduleFlagProvider` has been renamed to `HasDocumentScheduleFlagProvider` with the introduction of Elements, which has its own `HasElementScheduleFlagProvider`.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS v17 and v17

## Deadline (if relevant)

Anytime

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
