### PR TITLE
Update background task documentation for CMS 17.5 (and 18.0)

### DIFF
--- a/17/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
+++ b/17/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
@@ -6,9 +6,9 @@ description: Run a background job on a recurring basis
 
 You can run recurring code using a recurring background job. The recommended way is to inherit from the abstract `RecurringBackgroundJobBase` class. The class provides defaults for delay, server roles, and event handling, so you only need to set the `Period` and implement `RunJobAsync(CancellationToken)`.
 
-If you need more control, you can implement the `IRecurringBackgroundJob` interface directly.
+Alternatively, implement the `IRecurringBackgroundJob` interface directly — for example, when your job class already inherits from another base class. The interface provides the same defaults via default interface methods, so you only need to override what you want to change.
 
-Once you have created your background job class, register it using a Composer. The job is detected at startup and a new `HostedService` is created to run it.
+Once you have created your background job class, register it using `AddRecurringBackgroundJob<TJob>()`. The job is detected at startup and a new hosted service is created to run it.
 
 {% hint style="warning" %}
 Be aware you may or may not want this background job to run on all servers. If you are using Load Balancing with multiple servers, see the [load balancing documentation](../../run-in-production/infrastructure-and-ops/server-setup/load-balancing/) for more information.
@@ -27,18 +27,20 @@ Defines how often the job runs. This property is a `TimeSpan`.
 public override TimeSpan Period => TimeSpan.FromMinutes(5);
 ```
 
-Set `Period` to `Timeout.InfiniteTimeSpan` to disable automatic scheduling. The job then only runs when [triggered manually](scheduling.md#on-demand-triggering).
+Set `Period` to `Timeout.InfiniteTimeSpan` to disable recurring runs. The job then only runs when [triggered manually](scheduling.md#on-demand-triggering).
 
 ### Delay
 
 Defines how long to wait after application startup before running the job for the first time. The default is 3 minutes.
+
+The delay prevents the job from competing with startup work for resources. It also gives caches and other dependencies time to populate before the first run.
 
 ```csharp
 // Wait 1 minute after application startup before running this job for the first time.
 public override TimeSpan Delay => TimeSpan.FromMinutes(1);
 ```
 
-Set `Delay` to `Timeout.InfiniteTimeSpan` to skip the automatic first run. The job then only runs when triggered manually.
+Set `Delay` to `Timeout.InfiniteTimeSpan` to not automatically start the recurring runs. The job then only runs (and starts recurring runs) when triggered manually.
 
 ### IgnoredDelay
 
@@ -148,9 +150,6 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
     }
 
     public override TimeSpan Period => TimeSpan.FromMinutes(60);
-
-    // Run on all servers
-    public override ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();
 
     public override Task RunJobAsync(CancellationToken cancellationToken)
     {
@@ -263,7 +262,7 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
 
 ### Registering with a composer
 
-Create a composer and register the background job with `AddRecurringBackgroundJob`.
+Create a composer and register the background job with `AddRecurringBackgroundJob<TJob>()`.
 
 ```csharp
 using Umbraco.Cms.Core.Composing;
@@ -364,10 +363,12 @@ _trigger.TriggerExecution(NextExecutionStrategy.Reset);
 
 ### Manual-only jobs
 
-To create a job that only runs when triggered manually, set `Period` to `Timeout.InfiniteTimeSpan`. The job is registered and a hosted service is created for it, but no automatic execution occurs.
+To create a job that only runs when triggered manually, set both `Period` and `Delay` to `Timeout.InfiniteTimeSpan`. The job is registered and a hosted service is created for it, but no automatic execution occurs.
 
 ```csharp
 public override TimeSpan Period => Timeout.InfiniteTimeSpan;
+
+public override TimeSpan Delay => Timeout.InfiniteTimeSpan;
 ```
 
 Combine this with `Delay => Timeout.InfiniteTimeSpan` to also skip the initial run after startup.
@@ -388,19 +389,19 @@ When any of these checks fail, the execution is ignored and the loop waits for `
 
 ## Notifications
 
-The `RecurringBackgroundJobHostedService` publishes a number of notifications that can be hooked to report on the status of background jobs. All notifications extend from the base `Umbraco.Cms.Infrastructure.Notifications.RecurringBackgroundJobNotification` class.
+The `RecurringBackgroundJobHostedService` publishes a number of notifications that can be used to report on the status of background jobs. All notifications extend from the base `Umbraco.Cms.Infrastructure.Notifications.RecurringBackgroundJobNotification` class.
 
 The following notifications are available:
 
-* Starting
-* Started
-* Stopping
-* Stopped
-* Executing
-* Executed
-* Failed
-* Canceled
-* Ignored
+* `RecurringBackgroundJobStartingNotification` - published before starting the recurring job
+* `RecurringBackgroundJobStartedNotification` - published after the recurring job has started
+* `RecurringBackgroundJobExecutingNotification` - published before running the job
+* `RecurringBackgroundJobIgnoredNotification` - published when the job is ignored (see `IgnoredDelay`)
+* `RecurringBackgroundJobExecutedNotification` - published after `RunJobAsync()` is called
+* `RecurringBackgroundJobCanceledNotification` - published when the job was cancelled due to application shutdown
+* `RecurringBackgroundJobFailedNotification` - published when an unhandled exception was thrown while running the job
+* `RecurringBackgroundJobStoppingNotification` - published before stopping the recurring job
+* `RecurringBackgroundJobStoppedNotification` - published after the recurring job has stopped
 
 ### Start/Stop
 
@@ -413,6 +414,11 @@ These notifications are there to support low-level debugging of background jobs 
 The Ignored notification is published when a background job's schedule is triggered, but the Umbraco runtime checks prevent it from running.
 
 This notification is there to support low-level debugging of background jobs to ascertain why they are or aren't running. As the runtime checks include runtime state readiness, this event may be triggered during the install phase. Any notification handlers associated with this notification should also conduct their own checks before relying on Umbraco services, including database access.
+
+For **ignored** job runs, the following notifications are published:
+
+1. Executing
+2. Ignored
 
 ### Executing/Executed/Failed/Canceled
 

--- a/17/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
+++ b/17/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
@@ -183,7 +183,7 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
 
 ## Complex example
 
-The complex example builds on the previous one by injecting additional services. It includes a logger to log error messages, a profiler to capture timings, and an `IServerRoleAccessor` to log the current server role. It also injects an `IOptionsMonitor` to allow the period to be updated while the server is running. Assigning the new value to `Period` raises `PeriodChanged` so the host reschedules. The `IOptionsMonitor.OnChange` registration is disposed via the base class's `Dispose(bool)` hook.
+The complex example builds on the previous one by injecting additional services. It includes a logger to log error messages, a profiler to capture timings, and an `IServerRoleAccessor` to log the current server role. It also injects an `IOptionsMonitor` to allow the period to be updated while the server is running. Assigning the new value to `Period` raises `PeriodChanged`, so the host reschedules. The `IOptionsMonitor.OnChange` registration is disposed via the base class's `Dispose(bool)` hook.
 
 ```csharp
 using System;
@@ -374,7 +374,7 @@ _trigger.TriggerExecution(NextExecutionStrategy.Reset);
 
 ### Manual-only jobs
 
-To create a job that only runs when triggered manually, pass `Timeout.InfiniteTimeSpan` to the base constructor and override `Delay` to the same value. The job is registered and a hosted service is created for it, but no automatic execution occurs.
+To create a job that only runs when triggered manually, pass `Timeout.InfiniteTimeSpan` to the base constructor and override `Delay` to the same value. The job is registered, and a hosted service is created for it, but no automatic execution occurs.
 
 ```csharp
 public MyJob()
@@ -399,7 +399,7 @@ The base class also implements `IDisposable` with a `protected virtual Dispose(b
 * MainDom - The `MainDom` lock ensures that only one instance of Umbraco is running at a time on a given machine. This ensures the integrity of certain files used by Umbraco. See [Host Synchronization](../../run-in-production/infrastructure-and-ops/server-setup/load-balancing/azure-web-apps.md#host-synchronization) for more details.
 * Runtime State - On a fresh install or when waiting for a database upgrade, Umbraco may not be fully up and running yet.
 
-When any of these checks fail, the execution is ignored and the loop waits for `IgnoredDelay` before re-evaluating.
+When any of these checks fail, the execution is ignored, and the loop waits for `IgnoredDelay` before re-evaluating.
 
 ## Notifications
 
@@ -407,19 +407,19 @@ The `RecurringBackgroundJobHostedService` publishes a number of notifications th
 
 The following notifications are available:
 
-* `RecurringBackgroundJobStartingNotification` - published before starting the recurring job
-* `RecurringBackgroundJobStartedNotification` - published after the recurring job has started
-* `RecurringBackgroundJobExecutingNotification` - published before running the job
-* `RecurringBackgroundJobIgnoredNotification` - published when the job is ignored (see `IgnoredDelay`)
-* `RecurringBackgroundJobExecutedNotification` - published after `RunJobAsync()` is called
-* `RecurringBackgroundJobCanceledNotification` - published when the job was cancelled due to application shutdown
-* `RecurringBackgroundJobFailedNotification` - published when an unhandled exception was thrown while running the job
-* `RecurringBackgroundJobStoppingNotification` - published before stopping the recurring job
-* `RecurringBackgroundJobStoppedNotification` - published after the recurring job has stopped
+* `RecurringBackgroundJobStartingNotification` - published before starting the recurring job.
+* `RecurringBackgroundJobStartedNotification` - published after the recurring job has started.
+* `RecurringBackgroundJobExecutingNotification` - published before running the job.
+* `RecurringBackgroundJobIgnoredNotification` - published when the job is ignored (see `IgnoredDelay`).
+* `RecurringBackgroundJobExecutedNotification` - published after `RunJobAsync()` is called.
+* `RecurringBackgroundJobCanceledNotification` - published when the job was cancelled due to application shutdown.
+* `RecurringBackgroundJobFailedNotification` - published when an unhandled exception was thrown while running the job.
+* `RecurringBackgroundJobStoppingNotification` - published before stopping the recurring job.
+* `RecurringBackgroundJobStoppedNotification` - published after the recurring job has stopped.
 
 ### Start/Stop
 
-The Starting/Started and Stopping/Stopped notification pairs are published when the `RecurringBackgroundJobHostedService` is started or stopped. The start event normally occurs soon after application start as part of the .NET WebHost startup process. Similarly, the stop event happens as part of application shutdown.
+The Starting/Started and Stopping/Stopped notification pairs are published when the `RecurringBackgroundJobHostedService` is started or stopped. The start event normally occurs soon after application start as part of the .NET WebHost startup process. Similarly, the stop event happens as part of the application shutdown.
 
 These notifications are there to support low-level debugging of background jobs to ensure they are starting and stopping correctly. Due to the timing of the notification, all handlers associated with these notifications should not depend on any Umbraco services, including database access.
 

--- a/17/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
+++ b/17/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
@@ -87,7 +87,7 @@ For example, if the period for your job is controlled by a configuration file se
 
 Mirrors `PeriodChanged`. The base class raises this event automatically when `IgnoredDelay` is assigned a new value via the protected setter. The recurring background job host listens for it and interrupts any in-progress ignored back-off so the new value is picked up immediately.
 
-This makes it possible to start a job with `IgnoredDelay = Timeout.InfiniteTimeSpan` (effectively disabled after the first ignored execution until further notice), and later re-enable it by assigning a finite value. This is useful when an external signal indicates that the previously-ignored condition has cleared.
+This makes it possible to start a job with `IgnoredDelay = Timeout.InfiniteTimeSpan` (effectively disabled after the first ignored execution until further notice). You can later re-enable it by assigning a finite value. This is useful when an external signal indicates that the previously-ignored condition has cleared.
 
 ### RunJobAsync(CancellationToken)
 

--- a/17/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
+++ b/17/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
@@ -4,7 +4,7 @@ description: Run a background job on a recurring basis
 
 # Scheduling
 
-You can run recurring code using a recurring background job. The recommended way is to inherit from the abstract `RecurringBackgroundJobBase` class. The class provides defaults for delay, server roles, and event handling, so you only need to set the `Period` and implement `RunJobAsync(CancellationToken)`.
+You can run recurring code using a recurring background job. The recommended way is to inherit from the abstract `RecurringBackgroundJobBase` class. The class provides defaults for delay, server roles, and event handling. Pass the `Period` to the base constructor and implement `RunJobAsync(CancellationToken)`.
 
 Alternatively, implement the `IRecurringBackgroundJob` interface directly — for example, when your job class already inherits from another base class. The interface provides the same defaults via default interface methods, so you only need to override what you want to change.
 
@@ -20,12 +20,17 @@ The members below are defined on `IRecurringBackgroundJob` and either inherited 
 
 ### Period
 
-Defines how often the job runs. This property is a `TimeSpan`.
+Defines how often the job runs. This property is a `TimeSpan`. Pass the initial value to the base constructor.
 
 ```csharp
 // Run this job every 5 minutes
-public override TimeSpan Period => TimeSpan.FromMinutes(5);
+public CleanUpYourRoom()
+    : base(TimeSpan.FromMinutes(5))
+{
+}
 ```
+
+To change the period at runtime, assign the protected setter (`Period = newValue`). The base class validates the value, no-ops if the value is unchanged, and raises `PeriodChanged` automatically. See the [Complex example](scheduling.md#complex-example) below.
 
 Set `Period` to `Timeout.InfiniteTimeSpan` to disable recurring runs. The job then only runs when [triggered manually](scheduling.md#on-demand-triggering).
 
@@ -74,11 +79,15 @@ For more information about server roles, see the [Load Balancing](../../run-in-p
 
 ### PeriodChanged
 
-An event used to notify the background job service if the job's period changes dynamically.
+An event used to notify the background job service when the job's period changes dynamically. The base class raises this automatically when `Period` is assigned via the protected setter.
 
-For example, if the period for your job is controlled by a configuration file setting, raise the `PeriodChanged` event when the configuration changes.
+For example, if the period for your job is controlled by a configuration file setting, assign `Period = newValue` when the configuration changes. See the [Complex example](scheduling.md#complex-example) below for an implementation.
 
-`RecurringBackgroundJobBase` provides a no-op implementation. Override the event when you need to raise it. See the [Complex example](scheduling.md#complex-example) below for an implementation.
+### IgnoredDelayChanged
+
+Mirrors `PeriodChanged`. The base class raises this event automatically when `IgnoredDelay` is assigned a new value via the protected setter. The recurring background job host listens for it and interrupts any in-progress ignored back-off so the new value is picked up immediately.
+
+This makes it possible to start a job with `IgnoredDelay = Timeout.InfiniteTimeSpan` (effectively disabled after the first ignored execution until further notice), and later re-enable it by assigning a finite value. This is useful when an external signal indicates that the previously-ignored condition has cleared.
 
 ### RunJobAsync(CancellationToken)
 
@@ -110,7 +119,10 @@ namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
 
 public class CleanUpYourRoom : RecurringBackgroundJobBase
 {
-    public override TimeSpan Period => TimeSpan.FromMinutes(60);
+    public CleanUpYourRoom()
+        : base(TimeSpan.FromMinutes(60))
+    {
+    }
 
     public override Task RunJobAsync(CancellationToken cancellationToken)
     {
@@ -144,12 +156,11 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
     public CleanUpYourRoom(
         IContentService contentService,
         ICoreScopeProvider scopeProvider)
+        : base(TimeSpan.FromMinutes(60))
     {
         _contentService = contentService;
         _scopeProvider = scopeProvider;
     }
-
-    public override TimeSpan Period => TimeSpan.FromMinutes(60);
 
     public override Task RunJobAsync(CancellationToken cancellationToken)
     {
@@ -172,7 +183,7 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
 
 ## Complex example
 
-The complex example builds on the previous one by injecting additional services. It includes a logger to log error messages, a profiler to capture timings, and an `IServerRoleAccessor` to log the current server role. It also injects an `IOptionsMonitor` to allow the period to be updated while the server is running. It demonstrates how to override and raise the `PeriodChanged` event to signal the job's host.
+The complex example builds on the previous one by injecting additional services. It includes a logger to log error messages, a profiler to capture timings, and an `IServerRoleAccessor` to log the current server role. It also injects an `IOptionsMonitor` to allow the period to be updated while the server is running. Assigning the new value to `Period` raises `PeriodChanged` so the host reschedules. The `IOptionsMonitor.OnChange` registration is disposed via the base class's `Dispose(bool)` hook.
 
 ```csharp
 using System;
@@ -192,33 +203,24 @@ namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
 
 public class CleanUpYourRoom : RecurringBackgroundJobBase
 {
-    private TimeSpan _period = TimeSpan.FromMinutes(60);
-
-    public override TimeSpan Period => _period;
-
-    // Run on all servers
-    public override ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();
-
-    private event EventHandler? _periodChanged;
-    public override event EventHandler PeriodChanged
-    {
-        add { _periodChanged += value; }
-        remove { _periodChanged -= value; }
-    }
-
     private readonly IContentService _contentService;
     private readonly IServerRoleAccessor _serverRoleAccessor;
     private readonly IProfilingLogger _profilingLogger;
     private readonly ILogger<CleanUpYourRoom> _logger;
     private readonly ICoreScopeProvider _scopeProvider;
+    private readonly IDisposable? _onChangeRegistration;
+
+    // Run on all servers
+    public override ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();
 
     public CleanUpYourRoom(
         IContentService contentService,
         IServerRoleAccessor serverRoleAccessor,
         IProfilingLogger profilingLogger,
         ILogger<CleanUpYourRoom> logger,
-        ICoreScopeProvider scopeProvider,
-        IOptionsMonitor<HealthChecksSettings> healthChecksSettings)
+        IOptionsMonitor<HealthChecksSettings> healthChecksSettings,
+        ICoreScopeProvider scopeProvider)
+        : base(healthChecksSettings.CurrentValue.Notification.Period)
     {
         _contentService = contentService;
         _serverRoleAccessor = serverRoleAccessor;
@@ -226,12 +228,8 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
         _logger = logger;
         _scopeProvider = scopeProvider;
 
-        // When the settings change, update the period and raise the event so the host reschedules.
-        healthChecksSettings.OnChange(x =>
-        {
-            _period = x.Notification.Period;
-            _periodChanged?.Invoke(this, EventArgs.Empty);
-        });
+        // When the period config changes, assign Period - the setter raises PeriodChanged.
+        _onChangeRegistration = healthChecksSettings.OnChange(x => Period = x.Notification.Period);
     }
 
     public override Task RunJobAsync(CancellationToken cancellationToken)
@@ -256,6 +254,16 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
         // Remember to complete the scope when done.
         scope.Complete();
         return Task.CompletedTask;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _onChangeRegistration?.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
 }
 ```
@@ -303,7 +311,10 @@ namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
 
 public class CleanUpYourRoom : RecurringBackgroundJobBase, ITriggerableRecurringBackgroundJob
 {
-    public override TimeSpan Period => TimeSpan.FromMinutes(60);
+    public CleanUpYourRoom()
+        : base(TimeSpan.FromMinutes(60))
+    {
+    }
 
     public override Task RunJobAsync(CancellationToken cancellationToken)
     {
@@ -363,19 +374,22 @@ _trigger.TriggerExecution(NextExecutionStrategy.Reset);
 
 ### Manual-only jobs
 
-To create a job that only runs when triggered manually, set both `Period` and `Delay` to `Timeout.InfiniteTimeSpan`. The job is registered and a hosted service is created for it, but no automatic execution occurs.
+To create a job that only runs when triggered manually, pass `Timeout.InfiniteTimeSpan` to the base constructor and override `Delay` to the same value. The job is registered and a hosted service is created for it, but no automatic execution occurs.
 
 ```csharp
-public override TimeSpan Period => Timeout.InfiniteTimeSpan;
+public MyJob()
+    : base(Timeout.InfiniteTimeSpan)
+{
+}
 
 public override TimeSpan Delay => Timeout.InfiniteTimeSpan;
 ```
 
-Combine this with `Delay => Timeout.InfiniteTimeSpan` to also skip the initial run after startup.
-
 ## Base Classes
 
-`RecurringBackgroundJobBase` is the recommended base class for new jobs. It implements `IRecurringBackgroundJob` and provides defaults for `Delay`, `IgnoredDelay`, `ServerRoles`, and `PeriodChanged`. Implementors only need to provide `Period` and `RunJobAsync(CancellationToken)`.
+`RecurringBackgroundJobBase` is the recommended base class for new jobs. It implements `IRecurringBackgroundJob` and provides defaults for `Delay`, `IgnoredDelay`, `ServerRoles`, `PeriodChanged`, and `IgnoredDelayChanged`. Implementors pass `Period` to the base constructor and provide `RunJobAsync(CancellationToken)`.
+
+The base class also implements `IDisposable` with a `protected virtual Dispose(bool disposing)` hook. Subclasses with disposable resources (for example, an `IOptionsMonitor.OnChange` registration) should override the hook and call `base.Dispose(disposing)`.
 
 `RecurringHostedServiceBase` is a low-level base class. It inherits from .NET's `BackgroundService` and runs the job on a recurring basis using a wait loop with cancellation support. The loop supports periodic execution, manual triggering, exception resilience, and cooperative cancellation on host shutdown.
 

--- a/17/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
+++ b/17/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
@@ -44,7 +44,7 @@ Set `Delay` to `Timeout.InfiniteTimeSpan` to skip the automatic first run. The j
 
 Defines how long to wait after an ignored execution before re-evaluating execution conditions. The default is 1 minute.
 
-A job is ignored when the runtime is not ready, the current server role is not in the allowed list, or this instance is not the main domain. The back-off prevents tight looping when `Period` is short and the runtime keeps skipping the job.
+A job is ignored when the runtime is not ready, the server role is not allowed, or this instance is not the main domain. The back-off prevents tight looping when `Period` is short and the runtime keeps skipping the job.
 
 ```csharp
 // Wait 5 minutes before re-evaluating after an ignored execution.
@@ -80,7 +80,7 @@ For example, if the period for your job is controlled by a configuration file se
 
 ### RunJobAsync(CancellationToken)
 
-The main method where your job logic is implemented. The `CancellationToken` is signalled when the host is shutting down. Pass it through to async operations to support cooperative cancellation.
+The main method where your job logic is implemented. The `CancellationToken` is signaled when the host is shutting down. Pass it through to async operations to support cooperative cancellation.
 
 ```csharp
 public override Task RunJobAsync(CancellationToken cancellationToken)
@@ -91,7 +91,7 @@ public override Task RunJobAsync(CancellationToken cancellationToken)
 ```
 
 {% hint style="info" %}
-The parameterless `RunJobAsync()` overload is obsolete and scheduled for removal in Umbraco 19. New jobs should use `RunJobAsync(CancellationToken)`.
+The `RunJobAsync()` overload without a cancellation token is obsolete and scheduled for removal in Umbraco 19. New jobs should use `RunJobAsync(CancellationToken)`.
 {% endhint %}
 
 ## Example
@@ -279,9 +279,9 @@ Learn more about how to register dependencies in the [Dependency Injection](../.
 
 A recurring background job can be triggered to run immediately, in addition to its normal schedule. This is useful when you want to run a job in response to an event or a user action. For example, after a configuration change or from an API endpoint.
 
-Triggering is opt-in. A job must implement the marker interface `ITriggerableRecurringBackgroundJob` to be triggerable.
+Triggering is opt-in. A job must implement the marker interface `ITriggerableRecurringBackgroundJob` to support manual triggering.
 
-### Marking a job as triggerable
+### Opting in to manual triggering
 
 Add `ITriggerableRecurringBackgroundJob` to the job declaration. The interface is empty and extends `IRecurringBackgroundJob`.
 
@@ -364,7 +364,7 @@ Combine this with `Delay => Timeout.InfiniteTimeSpan` to also skip the initial r
 
 `RecurringBackgroundJobBase` is the recommended base class for new jobs. It implements `IRecurringBackgroundJob` and provides defaults for `Delay`, `IgnoredDelay`, `ServerRoles`, and `PeriodChanged`. Implementors only need to provide `Period` and `RunJobAsync(CancellationToken)`.
 
-`RecurringHostedServiceBase` is a low-level base class. It inherits from .NET's `BackgroundService` and runs the job on a recurring basis using a cancellable wait loop. The loop supports periodic execution, manual triggering, exception resilience, and cooperative cancellation on host shutdown.
+`RecurringHostedServiceBase` is a low-level base class. It inherits from .NET's `BackgroundService` and runs the job on a recurring basis using a wait loop with cancellation support. The loop supports periodic execution, manual triggering, exception resilience, and cooperative cancellation on host shutdown.
 
 `RecurringBackgroundJobHostedService` is an Umbraco-specific hosted service that extends `RecurringHostedServiceBase`. It uses Umbraco system services to ensure that your jobs only execute once Umbraco is up and running. It checks:
 

--- a/17/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
+++ b/17/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
@@ -4,15 +4,19 @@ description: Run a background job on a recurring basis
 
 # Scheduling
 
-It is possible to run recurring code using a recurring background job. Background job classes should implement the `IRecurringBackgroundJob` interface, which controls when and where the job gets run.
+You can run recurring code using a recurring background job. The recommended way is to inherit from the abstract `RecurringBackgroundJobBase` class. The class provides defaults for delay, server roles, and event handling, so you only need to set the `Period` and implement `RunJobAsync(CancellationToken)`.
 
-Once you have created your background job class, register it using a Composer. It will be detected at startup and a new `HostedService` will be created to run your job.
+If you need more control, you can implement the `IRecurringBackgroundJob` interface directly.
+
+Once you have created your background job class, register it using a Composer. The job is detected at startup and a new `HostedService` is created to run it.
 
 {% hint style="warning" %}
-Be aware you may or may not want this background job to run on all servers. If you are using Load Balancing with multiple servers, see [load balancing documentation](../../run-in-production/infrastructure-and-ops/server-setup/load-balancing/) for more information
+Be aware you may or may not want this background job to run on all servers. If you are using Load Balancing with multiple servers, see the [load balancing documentation](../../run-in-production/infrastructure-and-ops/server-setup/load-balancing/) for more information.
 {% endhint %}
 
-## `IRecurringBackgroundJob` Properties and Methods
+## `RecurringBackgroundJobBase` Properties and Methods
+
+The members below are defined on `IRecurringBackgroundJob` and either inherited or overridden via `RecurringBackgroundJobBase`. The signatures and behavior are the same whether you inherit the base class or implement the interface directly.
 
 ### Period
 
@@ -20,94 +24,103 @@ Defines how often the job runs. This property is a `TimeSpan`.
 
 ```csharp
 // Run this job every 5 minutes
-TimeSpan Period = TimeSpan.FromMinutes(5);
+public override TimeSpan Period => TimeSpan.FromMinutes(5);
 ```
+
+Set `Period` to `Timeout.InfiniteTimeSpan` to disable automatic scheduling. The job then only runs when [triggered manually](scheduling.md#on-demand-triggering).
 
 ### Delay
 
-Defines how long to wait after application startup before running the task for the first time. Default is 3 minutes. This property is a `TimeSpan`.
+Defines how long to wait after application startup before running the job for the first time. The default is 3 minutes.
 
 ```csharp
-// Wait 3 minutes after application startup before starting to run this job.
-TimeSpan Delay = TimeSpan.FromMinutes(3);
+// Wait 1 minute after application startup before running this job for the first time.
+public override TimeSpan Delay => TimeSpan.FromMinutes(1);
 ```
+
+Set `Delay` to `Timeout.InfiniteTimeSpan` to skip the automatic first run. The job then only runs when triggered manually.
+
+### IgnoredDelay
+
+Defines how long to wait after an ignored execution before re-evaluating execution conditions. The default is 1 minute.
+
+A job is ignored when the runtime is not ready, the current server role is not in the allowed list, or this instance is not the main domain. The back-off prevents tight looping when `Period` is short and the runtime keeps skipping the job.
+
+```csharp
+// Wait 5 minutes before re-evaluating after an ignored execution.
+public override TimeSpan IgnoredDelay => TimeSpan.FromMinutes(5);
+```
+
+Set `IgnoredDelay` to `Timeout.InfiniteTimeSpan` to disable the job for the rest of the application lifecycle once an ignored condition is encountered. Use this when the ignored condition is known not to change. For example, on a subscriber server where the job is restricted to a publisher role.
+
+Set `IgnoredDelay` to `TimeSpan.Zero` to skip the back-off entirely.
 
 ### ServerRoles
 
-Specifies a list of roles that should run this job. In a multi-server setup, you may want your job to run on _all_ servers or only on _one_ of your servers.
+Specifies the server roles that run this job. In a multi-server setup, you may want your job to run on _all_ servers or only on _one_ of your servers.
 
-For example, a temporary file cleanup task might need to run on all servers. A database import job might be better to be run once per day on a single server.
+For example, a temporary file cleanup task might need to run on all servers. A database import job might be better to run once per day on a single server.
 
-By default: `{ Single, SchedulingPublisher }`, meaning it runs on one server only.
+By default: `{ Single, SchedulingPublisher }`, meaning the job runs on one server only.
 
 ```csharp
 // Run this job on all servers
-ServerRole[] ServerRoles = Enum.GetValues<ServerRole>();
+public override ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();
 ```
 
 For more information about server roles, see the [Load Balancing](../../run-in-production/infrastructure-and-ops/server-setup/load-balancing/#scheduling-and-server-role-election) documentation.
 
 ### PeriodChanged
 
-An event used to notify the background job service if the job’s period changes dynamically.
+An event used to notify the background job service if the job's period changes dynamically.
 
-For example, if the period for your job is controlled by a configuration file setting, you can trigger the `PeriodChanged` event when the configuration changes.
+For example, if the period for your job is controlled by a configuration file setting, raise the `PeriodChanged` event when the configuration changes.
 
-```csharp
-// No-op event as the period never changes on this job
-public event EventHandler PeriodChanged { add { } remove { } }
-```
+`RecurringBackgroundJobBase` provides a no-op implementation. Override the event when you need to raise it. See the [Complex example](scheduling.md#complex-example) below for an implementation.
 
-See the [Example](scheduling.md#example) below on how to implement the `PeriodChanged` event.
+### RunJobAsync(CancellationToken)
 
-### RunJobAsync()
-
-The main method where your job logic is implemented.
+The main method where your job logic is implemented. The `CancellationToken` is signalled when the host is shutting down. Pass it through to async operations to support cooperative cancellation.
 
 ```csharp
-public Task RunJobAsync() {
-// your job code goes here
+public override Task RunJobAsync(CancellationToken cancellationToken)
+{
+    // your job code goes here
+    return Task.CompletedTask;
 }
 ```
 
+{% hint style="info" %}
+The parameterless `RunJobAsync()` overload is obsolete and scheduled for removal in Umbraco 19. New jobs should use `RunJobAsync(CancellationToken)`.
+{% endhint %}
+
 ## Example
 
-This example shows the minimum code necessary to implement the `IRecurringBackgroundJob` interface. The job runs every 60 minutes on all servers.
+This example shows the minimum code necessary to implement a recurring background job using `RecurringBackgroundJobBase`. The job runs every 60 minutes on the default server roles (`Single` and `SchedulingPublisher`).
 
 ```csharp
-using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Logging;
-using Umbraco.Cms.Core.Scoping;
-using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.BackgroundJobs;
 
 namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
 
-public class CleanUpYourRoom : IRecurringBackgroundJob
+public class CleanUpYourRoom : RecurringBackgroundJobBase
 {
-    public TimeSpan Period { get => TimeSpan.FromMinutes(60); }
+    public override TimeSpan Period => TimeSpan.FromMinutes(60);
 
-    // Runs on all servers
-    public ServerRole[] ServerRoles { get => Enum.GetValues<ServerRole>(); }
-
-    // No-op event as the period never changes on this job
-    public event EventHandler PeriodChanged { add { } remove { } }
-
-    public async Task RunJobAsync()
+    public override Task RunJobAsync(CancellationToken cancellationToken)
     {
         // YOUR CODE GOES HERE
+        return Task.CompletedTask;
     }
 }
 ```
 
 ## Example with dependency injection
 
-This example shows how to inject other Umbraco services into your background job. This example cleans the recycle bin every 60 minutes. To do so, it injects an `IContentService` to access the Recycle bin and an `IScopeProvider` to provide an ambient scope for the `EmptyRecycleBin` method.
+This example shows how to inject other Umbraco services into your background job. The job cleans the recycle bin every 60 minutes. It injects an `IContentService` to access the Recycle Bin and an `ICoreScopeProvider` to provide an ambient scope for the `EmptyRecycleBin` method.
 
 ```csharp
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
@@ -115,16 +128,8 @@ using Umbraco.Cms.Infrastructure.BackgroundJobs;
 
 namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
 
-public class CleanUpYourRoom : IRecurringBackgroundJob
+public class CleanUpYourRoom : RecurringBackgroundJobBase
 {
-    public TimeSpan Period { get => TimeSpan.FromMinutes(60); }
-
-    // Runs on all servers
-    public ServerRole[] ServerRoles { get => Enum.GetValues<ServerRole>(); }
-
-    // No-op event as the period never changes on this job
-    public event EventHandler PeriodChanged { add { } remove { } }
-
     private readonly IContentService _contentService;
     private readonly ICoreScopeProvider _scopeProvider;
 
@@ -136,17 +141,23 @@ public class CleanUpYourRoom : IRecurringBackgroundJob
         _scopeProvider = scopeProvider;
     }
 
-    public Task RunJobAsync()
+    public override TimeSpan Period => TimeSpan.FromMinutes(60);
+
+    // Run on all servers
+    public override ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();
+
+    public override Task RunJobAsync(CancellationToken cancellationToken)
     {
-        // Wrap the three content service calls in a scope to do it all in one transaction.
+        // Wrap the content service calls in a scope to do them in one transaction.
         using ICoreScope scope = _scopeProvider.CreateCoreScope();
 
         int numberOfThingsInBin = _contentService.CountChildren(Constants.System.RecycleBinContent);
 
-        if (_contentService.RecycleBinSmells())
+        if (numberOfThingsInBin > 0)
         {
             _contentService.EmptyRecycleBin(userId: -1);
         }
+
         // Remember to complete the scope when done.
         scope.Complete();
         return Task.CompletedTask;
@@ -156,10 +167,13 @@ public class CleanUpYourRoom : IRecurringBackgroundJob
 
 ## Complex example
 
-The complex example builds on the previous one by injecting additional services. It includes a logger to log error messages, a profiler to capture timings, and an `IServerRoleAccessor` to log the current server role. Additionally, it injects an `IOptionsMonitor` to allow the period to be updated while the server is running. It also demonstrates how to trigger the `PeriodChanged` event to signal the job's host.
+The complex example builds on the previous one by injecting additional services. It includes a logger to log error messages, a profiler to capture timings, and an `IServerRoleAccessor` to log the current server role. It also injects an `IOptionsMonitor` to allow the period to be updated while the server is running. It demonstrates how to override and raise the `PeriodChanged` event to signal the job's host.
 
 ```csharp
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
@@ -168,28 +182,27 @@ using Umbraco.Cms.Infrastructure.BackgroundJobs;
 
 namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
 
-public class CleanUpYourRoom : IRecurringBackgroundJob
+public class CleanUpYourRoom : RecurringBackgroundJobBase
 {
-    public TimeSpan Period { get; set; } = TimeSpan.FromMinutes(60);
+    private TimeSpan _period = TimeSpan.FromMinutes(60);
 
-    // Runs on all servers
-    public ServerRole[] ServerRoles { get => Enum.GetValues<ServerRole>(); }
+    public override TimeSpan Period => _period;
 
-    //
+    // Run on all servers
+    public override ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();
+
     private event EventHandler? _periodChanged;
-    public event EventHandler PeriodChanged
+    public override event EventHandler PeriodChanged
     {
         add { _periodChanged += value; }
         remove { _periodChanged -= value; }
     }
-
 
     private readonly IContentService _contentService;
     private readonly IServerRoleAccessor _serverRoleAccessor;
     private readonly IProfilingLogger _profilingLogger;
     private readonly ILogger<CleanUpYourRoom> _logger;
     private readonly ICoreScopeProvider _scopeProvider;
-
 
     public CleanUpYourRoom(
         IContentService contentService,
@@ -205,25 +218,24 @@ public class CleanUpYourRoom : IRecurringBackgroundJob
         _logger = logger;
         _scopeProvider = scopeProvider;
 
-        // if the settings are updated trigger the event to let the job host know
+        // When the settings change, update the period and raise the event so the host reschedules.
         healthChecksSettings.OnChange(x =>
         {
-            Period = x.Notification.Period;
+            _period = x.Notification.Period;
             _periodChanged?.Invoke(this, EventArgs.Empty);
         });
     }
 
-    public Task RunJobAsync()
+    public override Task RunJobAsync(CancellationToken cancellationToken)
     {
-
-        // Wrap the three content service calls in a scope to do it all in one transaction.
+        // Wrap the content service calls in a scope to do them in one transaction.
         using ICoreScope scope = _scopeProvider.CreateCoreScope();
 
         int numberOfThingsInBin = _contentService.CountChildren(Constants.System.RecycleBinContent);
         _logger.LogInformation("Go clean your room - {ServerRole}", _serverRoleAccessor.CurrentServerRole);
         _logger.LogInformation("You have {NumberOfThingsInTheBin} items to clean", numberOfThingsInBin);
 
-        if (_contentService.RecycleBinSmells())
+        if (numberOfThingsInBin > 0)
         {
             // Take out the trash
             using (_profilingLogger.TraceDuration<CleanUpYourRoom>("Mum, I am emptying out the bin",
@@ -242,10 +254,11 @@ public class CleanUpYourRoom : IRecurringBackgroundJob
 
 ### Registering with a composer
 
-All we need to do here is to create the composer where we register the background job with `AddRecurringBackgroundJob`.
+Create a composer and register the background job with `AddRecurringBackgroundJob`.
 
 ```csharp
 using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
 
 namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
 
@@ -262,19 +275,108 @@ public class CleanUpYourRoomComposer : IComposer
 Learn more about how to register dependencies in the [Dependency Injection](../../develop-with-umbraco/application-code/backend-and-custom-logic/using-ioc.md) article.
 {% endhint %}
 
+## On-demand triggering
+
+A recurring background job can be triggered to run immediately, in addition to its normal schedule. This is useful when you want to run a job in response to an event or a user action. For example, after a configuration change or from an API endpoint.
+
+Triggering is opt-in. A job must implement the marker interface `ITriggerableRecurringBackgroundJob` to be triggerable.
+
+### Marking a job as triggerable
+
+Add `ITriggerableRecurringBackgroundJob` to the job declaration. The interface is empty and extends `IRecurringBackgroundJob`.
+
+```csharp
+using Umbraco.Cms.Infrastructure.BackgroundJobs;
+
+namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
+
+public class CleanUpYourRoom : RecurringBackgroundJobBase, ITriggerableRecurringBackgroundJob
+{
+    public override TimeSpan Period => TimeSpan.FromMinutes(60);
+
+    public override Task RunJobAsync(CancellationToken cancellationToken)
+    {
+        // your job code goes here
+        return Task.CompletedTask;
+    }
+}
+```
+
+Register the job the usual way with `AddRecurringBackgroundJob<CleanUpYourRoom>()`. No additional registration is required to enable triggering.
+
+### Triggering a job
+
+Inject `IRecurringBackgroundJobTrigger<TJob>` where you want to trigger the job. The generic type parameter must be a class implementing `ITriggerableRecurringBackgroundJob`. The generic constraint makes requesting a trigger for a job without the marker interface a compile error.
+
+```csharp
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Infrastructure.BackgroundJobs;
+
+namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
+
+public class CleanUpController : Controller
+{
+    private readonly IRecurringBackgroundJobTrigger<CleanUpYourRoom> _trigger;
+
+    public CleanUpController(IRecurringBackgroundJobTrigger<CleanUpYourRoom> trigger)
+    {
+        _trigger = trigger;
+    }
+
+    public IActionResult RunNow()
+    {
+        bool triggered = _trigger.TriggerExecution();
+        return Ok(triggered);
+    }
+}
+```
+
+`TriggerExecution` returns `false` if no hosted service is currently running for the job. For example, before `StartAsync` is called, or if the job is not registered.
+
+### Controlling the next execution after a manual trigger
+
+The `TriggerExecution` method has three overloads that control what happens after the triggered execution finishes.
+
+| Overload | Behavior after the triggered execution |
+| --- | --- |
+| `TriggerExecution()` | Resume the original schedule. If the triggered execution overshot the next scheduled tick, skip it to avoid double-execution. Same as `NextExecutionStrategy.None`. |
+| `TriggerExecution(NextExecutionStrategy.Reset)` | Wait a full period. The schedule shifts forward from the triggered execution. |
+| `TriggerExecution(NextExecutionStrategy.Replace)` | The triggered execution replaces the next scheduled tick. The following execution occurs one full period after the originally-scheduled time. |
+| `TriggerExecution(TimeSpan nextDelay)` | Wait the specified custom delay before the next execution. |
+
+For example, to trigger a job and reset its schedule:
+
+```csharp
+_trigger.TriggerExecution(NextExecutionStrategy.Reset);
+```
+
+### Manual-only jobs
+
+To create a job that only runs when triggered manually, set `Period` to `Timeout.InfiniteTimeSpan`. The job is registered and a hosted service is created for it, but no automatic execution occurs.
+
+```csharp
+public override TimeSpan Period => Timeout.InfiniteTimeSpan;
+```
+
+Combine this with `Delay => Timeout.InfiniteTimeSpan` to also skip the initial run after startup.
+
 ## Base Classes
 
-`RecurringHostedServiceBase` is a low-level base class. It implements the dotnetcore interface `IHostedService` to run itself in the background, and creates and manages the timer that runs the job on a recurring basis.
+`RecurringBackgroundJobBase` is the recommended base class for new jobs. It implements `IRecurringBackgroundJob` and provides defaults for `Delay`, `IgnoredDelay`, `ServerRoles`, and `PeriodChanged`. Implementors only need to provide `Period` and `RunJobAsync(CancellationToken)`.
 
-`RecurringBackgroundJobHostedService` is an Umbraco specific Hosted Service that extends `RecurringHostedServiceBase`. It uses some system-level Umbraco services to ensure that your jobs only execute once Umbraco is up and running. It checks:
+`RecurringHostedServiceBase` is a low-level base class. It inherits from .NET's `BackgroundService` and runs the job on a recurring basis using a cancellable wait loop. The loop supports periodic execution, manual triggering, exception resilience, and cooperative cancellation on host shutdown.
 
-* Server Roles - see above for more discussion about Server roles
+`RecurringBackgroundJobHostedService` is an Umbraco-specific hosted service that extends `RecurringHostedServiceBase`. It uses Umbraco system services to ensure that your jobs only execute once Umbraco is up and running. It checks:
+
+* Server Roles - see above for more discussion about Server roles.
 * MainDom - The `MainDom` lock ensures that only one instance of Umbraco is running at a time on a given machine. This ensures the integrity of certain files used by Umbraco. See [Host Synchronization](../../run-in-production/infrastructure-and-ops/server-setup/load-balancing/azure-web-apps.md#host-synchronization) for more details.
-* Runtime State - On a fresh install or when waiting for a database upgrade, Umbraco may be fully up and running yet.
+* Runtime State - On a fresh install or when waiting for a database upgrade, Umbraco may not be fully up and running yet.
+
+When any of these checks fail, the execution is ignored and the loop waits for `IgnoredDelay` before re-evaluating.
 
 ## Notifications
 
-The `RecurringBackgroundJobHostedService` publishes a number of notifications that can be hooked to report on the status of background jobs. All notifications extend from the base `Umbraco.CMS.Infrastructure.Notifications.RecurringBackgroundJobNotification` class.
+The `RecurringBackgroundJobHostedService` publishes a number of notifications that can be hooked to report on the status of background jobs. All notifications extend from the base `Umbraco.Cms.Infrastructure.Notifications.RecurringBackgroundJobNotification` class.
 
 The following notifications are available:
 
@@ -285,37 +387,44 @@ The following notifications are available:
 * Executing
 * Executed
 * Failed
+* Canceled
 * Ignored
 
 ### Start/Stop
 
-The Starting/Started and Stopping/Stopped notification pairs are published when the `RecurringBackgroundJobHostedService` is started or stopped. The start event normally occurs soon after application start as part of the .Net WebHost startup process. Similarly the stop event would happen as part of application shutdown.
+The Starting/Started and Stopping/Stopped notification pairs are published when the `RecurringBackgroundJobHostedService` is started or stopped. The start event normally occurs soon after application start as part of the .NET WebHost startup process. Similarly, the stop event happens as part of application shutdown.
 
-These notifications are there to support low-level debugging of background jobs to ensure they are starting/stopping correctly. Due to the timing of the notification, all handlers associated with these notifications should not depend on any Umbraco services, including database access.
+These notifications are there to support low-level debugging of background jobs to ensure they are starting and stopping correctly. Due to the timing of the notification, all handlers associated with these notifications should not depend on any Umbraco services, including database access.
 
 ### Ignored
 
 The Ignored notification is published when a background job's schedule is triggered, but the Umbraco runtime checks prevent it from running.
 
-This notification is there to support low-level debugging of background jobs to ascertain why they are/aren't running. As the runtime checks include runtime state readiness, this event may be triggered during the install phase. Any notification handlers associated with this notification should **also** conduct their own checks before relying on Umbraco services, including database access.
+This notification is there to support low-level debugging of background jobs to ascertain why they are or aren't running. As the runtime checks include runtime state readiness, this event may be triggered during the install phase. Any notification handlers associated with this notification should also conduct their own checks before relying on Umbraco services, including database access.
 
-### Executing/Executed/Failed
+### Executing/Executed/Failed/Canceled
 
-These notifications will be triggered in pairs depending on the success/failure of the job itself.
+These notifications are triggered in pairs depending on the success, failure, or cancellation of the job.
 
-* The executing notification is triggered before the job is run.
-* The executed notification is triggered after the job is completed.
-* The failed notification is triggered from the catch block if an exception is thrown.
+* The Executing notification is triggered before the job is run.
+* The Executed notification is triggered after the job completes.
+* The Failed notification is triggered from the catch block if an exception is thrown.
+* The Canceled notification is triggered when the job is cancelled during host shutdown.
 
-For **successful** job runs, the following notifications will be published:
+For **successful** job runs, the following notifications are published:
 
 1. Executing
 2. Executed
 
-For **failed** job runs, the following notifications will be published:
+For **failed** job runs, the following notifications are published:
 
 1. Executing
 2. Failed
+
+For **cancelled** job runs (typically during host shutdown), the following notifications are published:
+
+1. Executing
+2. Canceled
 
 ```csharp
 // Do not run the code on subscribers or unknown role servers
@@ -333,13 +442,13 @@ switch (_serverRoleAccessor.CurrentServerRole)
 
 ## Background jobs when load balancing the backoffice
 
-When load balancing the backoffice, all servers will have the `SchedulingPublisher` role. This means the approach described above for restricting jobs to specific server roles will not work as intended. All servers will match the `SchedulingPublisher` role.
+When load balancing the backoffice, all servers have the `SchedulingPublisher` role. This means the approach described above for restricting jobs to specific server roles does not work as intended. All servers match the `SchedulingPublisher` role.
 
-Instead, for jobs that should only run on a single server, you should implement an `IDistributedBackgroundJob`.
+Instead, for jobs that should only run on a single server, implement an `IDistributedBackgroundJob`.
 
-`IDistributedBackgroundJob` is separate from `IRecurringBackgroundJob`, and is tracked in the database to ensure that only a single server runs the job at any given time. This also means that you are not guaranteed what server will run the job, but you are guaranteed that only one server will run it.
+`IDistributedBackgroundJob` is separate from `IRecurringBackgroundJob`. The job is tracked in the database to ensure that only a single server runs it at any given time. This also means you are not guaranteed which server runs the job, but you are guaranteed that only one server runs it.
 
-By default, distributed background jobs are checked every 5 seconds, with an initial delay of 1 minute after application startup. These settings can be changed in appsettings, see [Distributed jobs settings](../../develop-with-umbraco/configuration/distributedjobssettings.md) for more information.
+By default, distributed background jobs are checked every 5 seconds, with an initial delay of 1 minute after application startup. These settings can be changed via configuration. See [Distributed jobs settings](../../develop-with-umbraco/configuration/distributedjobssettings.md) for more information.
 
 ### Implementing a custom distributed background job
 
@@ -350,7 +459,7 @@ public class MyCustomBackgroundJob : IDistributedBackgroundJob
 {
     private readonly ILogger<MyCustomBackgroundJob> _logger;
     public string Name => "MyCustomBackgroundJob";
-    
+
     public TimeSpan Period { get; private set; }
 
     public MyCustomBackgroundJob(ILogger<MyCustomBackgroundJob> logger)
@@ -358,7 +467,7 @@ public class MyCustomBackgroundJob : IDistributedBackgroundJob
         _logger = logger;
         Period = TimeSpan.FromSeconds(20);
     }
-    
+
     public Task ExecuteAsync()
     {
         // Your custom background job logic here
@@ -368,11 +477,11 @@ public class MyCustomBackgroundJob : IDistributedBackgroundJob
 }
 ```
 
-It's required to give your job a unique name via the `Name` property. This is used to track the job in the database.
+It's required to give your job a unique name via the `Name` property. The name is used to track the job in the database.
 
 The period is specified via the `Period` property, which controls how often the job should run. In this example, it runs every 20 seconds.
 
-It's not required to manually register the job in the database, however, you must register it to DI so Umbraco can find it. This can be done with a composer or in `Program.cs`
+It's not required to manually register the job in the database. However, you must register it with the dependency injection container so Umbraco can find it. This can be done with a composer or in `Program.cs`:
 
 ```csharp
 public class MyComposer : IComposer

--- a/17/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
+++ b/17/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
@@ -99,6 +99,9 @@ The `RunJobAsync()` overload without a cancellation token is obsolete and schedu
 This example shows the minimum code necessary to implement a recurring background job using `RecurringBackgroundJobBase`. The job runs every 60 minutes on the default server roles (`Single` and `SchedulingPublisher`).
 
 ```csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Umbraco.Cms.Infrastructure.BackgroundJobs;
 
 namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
@@ -120,6 +123,9 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
 This example shows how to inject other Umbraco services into your background job. The job cleans the recycle bin every 60 minutes. It injects an `IContentService` to access the Recycle Bin and an `ICoreScopeProvider` to provide an ambient scope for the `EmptyRecycleBin` method.
 
 ```csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
@@ -170,6 +176,9 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
 The complex example builds on the previous one by injecting additional services. It includes a logger to log error messages, a profiler to capture timings, and an `IServerRoleAccessor` to log the current server role. It also injects an `IOptionsMonitor` to allow the period to be updated while the server is running. It demonstrates how to override and raise the `PeriodChanged` event to signal the job's host.
 
 ```csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
@@ -286,6 +295,9 @@ Triggering is opt-in. A job must implement the marker interface `ITriggerableRec
 Add `ITriggerableRecurringBackgroundJob` to the job declaration. The interface is empty and extends `IRecurringBackgroundJob`.
 
 ```csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Umbraco.Cms.Infrastructure.BackgroundJobs;
 
 namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
@@ -409,7 +421,7 @@ These notifications are triggered in pairs depending on the success, failure, or
 * The Executing notification is triggered before the job is run.
 * The Executed notification is triggered after the job completes.
 * The Failed notification is triggered from the catch block if an exception is thrown.
-* The Canceled notification is triggered when the job is cancelled during host shutdown.
+* The Canceled notification is triggered when the job is canceled during host shutdown.
 
 For **successful** job runs, the following notifications are published:
 
@@ -421,7 +433,7 @@ For **failed** job runs, the following notifications are published:
 1. Executing
 2. Failed
 
-For **cancelled** job runs (typically during host shutdown), the following notifications are published:
+For **canceled** job runs (typically during host shutdown), the following notifications are published:
 
 1. Executing
 2. Canceled
@@ -455,6 +467,11 @@ By default, distributed background jobs are checked every 5 seconds, with an ini
 To implement a custom distributed background job, create a class that implements the `IDistributedBackgroundJob` interface. As with `IRecurringBackgroundJob`, dependency injection (DI) is available in the constructor.
 
 ```csharp
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Infrastructure.BackgroundJobs;
+
 public class MyCustomBackgroundJob : IDistributedBackgroundJob
 {
     private readonly ILogger<MyCustomBackgroundJob> _logger;

--- a/18/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
+++ b/18/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
@@ -6,9 +6,9 @@ description: Run a background job on a recurring basis
 
 You can run recurring code using a recurring background job. The recommended way is to inherit from the abstract `RecurringBackgroundJobBase` class. The class provides defaults for delay, server roles, and event handling, so you only need to set the `Period` and implement `RunJobAsync(CancellationToken)`.
 
-If you need more control, you can implement the `IRecurringBackgroundJob` interface directly.
+Alternatively, implement the `IRecurringBackgroundJob` interface directly — for example, when your job class already inherits from another base class. The interface provides the same defaults via default interface methods, so you only need to override what you want to change.
 
-Once you have created your background job class, register it using a Composer. The job is detected at startup and a new `HostedService` is created to run it.
+Once you have created your background job class, register it using `AddRecurringBackgroundJob<TJob>()`. The job is detected at startup and a new hosted service is created to run it.
 
 {% hint style="warning" %}
 Be aware you may or may not want this background job to run on all servers. If you are using Load Balancing with multiple servers, see the [load balancing documentation](../../run-in-production/infrastructure-and-ops/server-setup/load-balancing/) for more information.
@@ -27,18 +27,20 @@ Defines how often the job runs. This property is a `TimeSpan`.
 public override TimeSpan Period => TimeSpan.FromMinutes(5);
 ```
 
-Set `Period` to `Timeout.InfiniteTimeSpan` to disable automatic scheduling. The job then only runs when [triggered manually](scheduling.md#on-demand-triggering).
+Set `Period` to `Timeout.InfiniteTimeSpan` to disable recurring runs. The job then only runs when [triggered manually](scheduling.md#on-demand-triggering).
 
 ### Delay
 
 Defines how long to wait after application startup before running the job for the first time. The default is 3 minutes.
+
+The delay prevents the job from competing with startup work for resources. It also gives caches and other dependencies time to populate before the first run.
 
 ```csharp
 // Wait 1 minute after application startup before running this job for the first time.
 public override TimeSpan Delay => TimeSpan.FromMinutes(1);
 ```
 
-Set `Delay` to `Timeout.InfiniteTimeSpan` to skip the automatic first run. The job then only runs when triggered manually.
+Set `Delay` to `Timeout.InfiniteTimeSpan` to not automatically start the recurring runs. The job then only runs (and starts recurring runs) when triggered manually.
 
 ### IgnoredDelay
 
@@ -148,9 +150,6 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
     }
 
     public override TimeSpan Period => TimeSpan.FromMinutes(60);
-
-    // Run on all servers
-    public override ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();
 
     public override Task RunJobAsync(CancellationToken cancellationToken)
     {
@@ -263,7 +262,7 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
 
 ### Registering with a composer
 
-Create a composer and register the background job with `AddRecurringBackgroundJob`.
+Create a composer and register the background job with `AddRecurringBackgroundJob<TJob>()`.
 
 ```csharp
 using Umbraco.Cms.Core.Composing;
@@ -364,10 +363,12 @@ _trigger.TriggerExecution(NextExecutionStrategy.Reset);
 
 ### Manual-only jobs
 
-To create a job that only runs when triggered manually, set `Period` to `Timeout.InfiniteTimeSpan`. The job is registered and a hosted service is created for it, but no automatic execution occurs.
+To create a job that only runs when triggered manually, set both `Period` and `Delay` to `Timeout.InfiniteTimeSpan`. The job is registered and a hosted service is created for it, but no automatic execution occurs.
 
 ```csharp
 public override TimeSpan Period => Timeout.InfiniteTimeSpan;
+
+public override TimeSpan Delay => Timeout.InfiniteTimeSpan;
 ```
 
 Combine this with `Delay => Timeout.InfiniteTimeSpan` to also skip the initial run after startup.
@@ -388,19 +389,19 @@ When any of these checks fail, the execution is ignored and the loop waits for `
 
 ## Notifications
 
-The `RecurringBackgroundJobHostedService` publishes a number of notifications that can be hooked to report on the status of background jobs. All notifications extend from the base `Umbraco.Cms.Infrastructure.Notifications.RecurringBackgroundJobNotification` class.
+The `RecurringBackgroundJobHostedService` publishes a number of notifications that can be used to report on the status of background jobs. All notifications extend from the base `Umbraco.Cms.Infrastructure.Notifications.RecurringBackgroundJobNotification` class.
 
 The following notifications are available:
 
-* Starting
-* Started
-* Stopping
-* Stopped
-* Executing
-* Executed
-* Failed
-* Canceled
-* Ignored
+* `RecurringBackgroundJobStartingNotification` - published before starting the recurring job
+* `RecurringBackgroundJobStartedNotification` - published after the recurring job has started
+* `RecurringBackgroundJobExecutingNotification` - published before running the job
+* `RecurringBackgroundJobIgnoredNotification` - published when the job is ignored (see `IgnoredDelay`)
+* `RecurringBackgroundJobExecutedNotification` - published after `RunJobAsync()` is called
+* `RecurringBackgroundJobCanceledNotification` - published when the job was cancelled due to application shutdown
+* `RecurringBackgroundJobFailedNotification` - published when an unhandled exception was thrown while running the job
+* `RecurringBackgroundJobStoppingNotification` - published before stopping the recurring job
+* `RecurringBackgroundJobStoppedNotification` - published after the recurring job has stopped
 
 ### Start/Stop
 
@@ -413,6 +414,11 @@ These notifications are there to support low-level debugging of background jobs 
 The Ignored notification is published when a background job's schedule is triggered, but the Umbraco runtime checks prevent it from running.
 
 This notification is there to support low-level debugging of background jobs to ascertain why they are or aren't running. As the runtime checks include runtime state readiness, this event may be triggered during the install phase. Any notification handlers associated with this notification should also conduct their own checks before relying on Umbraco services, including database access.
+
+For **ignored** job runs, the following notifications are published:
+
+1. Executing
+2. Ignored
 
 ### Executing/Executed/Failed/Canceled
 

--- a/18/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
+++ b/18/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
@@ -87,7 +87,7 @@ For example, if the period for your job is controlled by a configuration file se
 
 Mirrors `PeriodChanged`. The base class raises this event automatically when `IgnoredDelay` is assigned a new value via the protected setter. The recurring background job host listens for it and interrupts any in-progress ignored back-off so the new value is picked up immediately.
 
-This makes it possible to start a job with `IgnoredDelay = Timeout.InfiniteTimeSpan` (effectively disabled after the first ignored execution until further notice), and later re-enable it by assigning a finite value. This is useful when an external signal indicates that the previously-ignored condition has cleared.
+This makes it possible to start a job with `IgnoredDelay = Timeout.InfiniteTimeSpan` (effectively disabled after the first ignored execution until further notice). You can later re-enable it by assigning a finite value. This is useful when an external signal indicates that the previously-ignored condition has cleared.
 
 ### RunJobAsync(CancellationToken)
 

--- a/18/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
+++ b/18/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
@@ -4,7 +4,7 @@ description: Run a background job on a recurring basis
 
 # Scheduling
 
-You can run recurring code using a recurring background job. The recommended way is to inherit from the abstract `RecurringBackgroundJobBase` class. The class provides defaults for delay, server roles, and event handling, so you only need to set the `Period` and implement `RunJobAsync(CancellationToken)`.
+You can run recurring code using a recurring background job. The recommended way is to inherit from the abstract `RecurringBackgroundJobBase` class. The class provides defaults for delay, server roles, and event handling. Pass the `Period` to the base constructor and implement `RunJobAsync(CancellationToken)`.
 
 Alternatively, implement the `IRecurringBackgroundJob` interface directly — for example, when your job class already inherits from another base class. The interface provides the same defaults via default interface methods, so you only need to override what you want to change.
 
@@ -20,12 +20,17 @@ The members below are defined on `IRecurringBackgroundJob` and either inherited 
 
 ### Period
 
-Defines how often the job runs. This property is a `TimeSpan`.
+Defines how often the job runs. This property is a `TimeSpan`. Pass the initial value to the base constructor.
 
 ```csharp
 // Run this job every 5 minutes
-public override TimeSpan Period => TimeSpan.FromMinutes(5);
+public CleanUpYourRoom()
+    : base(TimeSpan.FromMinutes(5))
+{
+}
 ```
+
+To change the period at runtime, assign the protected setter (`Period = newValue`). The base class validates the value, no-ops if the value is unchanged, and raises `PeriodChanged` automatically. See the [Complex example](scheduling.md#complex-example) below.
 
 Set `Period` to `Timeout.InfiniteTimeSpan` to disable recurring runs. The job then only runs when [triggered manually](scheduling.md#on-demand-triggering).
 
@@ -74,11 +79,15 @@ For more information about server roles, see the [Load Balancing](../../run-in-p
 
 ### PeriodChanged
 
-An event used to notify the background job service if the job's period changes dynamically.
+An event used to notify the background job service when the job's period changes dynamically. The base class raises this automatically when `Period` is assigned via the protected setter.
 
-For example, if the period for your job is controlled by a configuration file setting, raise the `PeriodChanged` event when the configuration changes.
+For example, if the period for your job is controlled by a configuration file setting, assign `Period = newValue` when the configuration changes. See the [Complex example](scheduling.md#complex-example) below for an implementation.
 
-`RecurringBackgroundJobBase` provides a no-op implementation. Override the event when you need to raise it. See the [Complex example](scheduling.md#complex-example) below for an implementation.
+### IgnoredDelayChanged
+
+Mirrors `PeriodChanged`. The base class raises this event automatically when `IgnoredDelay` is assigned a new value via the protected setter. The recurring background job host listens for it and interrupts any in-progress ignored back-off so the new value is picked up immediately.
+
+This makes it possible to start a job with `IgnoredDelay = Timeout.InfiniteTimeSpan` (effectively disabled after the first ignored execution until further notice), and later re-enable it by assigning a finite value. This is useful when an external signal indicates that the previously-ignored condition has cleared.
 
 ### RunJobAsync(CancellationToken)
 
@@ -110,7 +119,10 @@ namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
 
 public class CleanUpYourRoom : RecurringBackgroundJobBase
 {
-    public override TimeSpan Period => TimeSpan.FromMinutes(60);
+    public CleanUpYourRoom()
+        : base(TimeSpan.FromMinutes(60))
+    {
+    }
 
     public override Task RunJobAsync(CancellationToken cancellationToken)
     {
@@ -144,12 +156,11 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
     public CleanUpYourRoom(
         IContentService contentService,
         ICoreScopeProvider scopeProvider)
+        : base(TimeSpan.FromMinutes(60))
     {
         _contentService = contentService;
         _scopeProvider = scopeProvider;
     }
-
-    public override TimeSpan Period => TimeSpan.FromMinutes(60);
 
     public override Task RunJobAsync(CancellationToken cancellationToken)
     {
@@ -172,7 +183,7 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
 
 ## Complex example
 
-The complex example builds on the previous one by injecting additional services. It includes a logger to log error messages, a profiler to capture timings, and an `IServerRoleAccessor` to log the current server role. It also injects an `IOptionsMonitor` to allow the period to be updated while the server is running. It demonstrates how to override and raise the `PeriodChanged` event to signal the job's host.
+The complex example builds on the previous one by injecting additional services. It includes a logger to log error messages, a profiler to capture timings, and an `IServerRoleAccessor` to log the current server role. It also injects an `IOptionsMonitor` to allow the period to be updated while the server is running. Assigning the new value to `Period` raises `PeriodChanged` so the host reschedules. The `IOptionsMonitor.OnChange` registration is disposed via the base class's `Dispose(bool)` hook.
 
 ```csharp
 using System;
@@ -192,33 +203,24 @@ namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
 
 public class CleanUpYourRoom : RecurringBackgroundJobBase
 {
-    private TimeSpan _period = TimeSpan.FromMinutes(60);
-
-    public override TimeSpan Period => _period;
-
-    // Run on all servers
-    public override ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();
-
-    private event EventHandler? _periodChanged;
-    public override event EventHandler PeriodChanged
-    {
-        add { _periodChanged += value; }
-        remove { _periodChanged -= value; }
-    }
-
     private readonly IContentService _contentService;
     private readonly IServerRoleAccessor _serverRoleAccessor;
     private readonly IProfilingLogger _profilingLogger;
     private readonly ILogger<CleanUpYourRoom> _logger;
     private readonly ICoreScopeProvider _scopeProvider;
+    private readonly IDisposable? _onChangeRegistration;
+
+    // Run on all servers
+    public override ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();
 
     public CleanUpYourRoom(
         IContentService contentService,
         IServerRoleAccessor serverRoleAccessor,
         IProfilingLogger profilingLogger,
         ILogger<CleanUpYourRoom> logger,
-        ICoreScopeProvider scopeProvider,
-        IOptionsMonitor<HealthChecksSettings> healthChecksSettings)
+        IOptionsMonitor<HealthChecksSettings> healthChecksSettings,
+        ICoreScopeProvider scopeProvider)
+        : base(healthChecksSettings.CurrentValue.Notification.Period)
     {
         _contentService = contentService;
         _serverRoleAccessor = serverRoleAccessor;
@@ -226,12 +228,8 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
         _logger = logger;
         _scopeProvider = scopeProvider;
 
-        // When the settings change, update the period and raise the event so the host reschedules.
-        healthChecksSettings.OnChange(x =>
-        {
-            _period = x.Notification.Period;
-            _periodChanged?.Invoke(this, EventArgs.Empty);
-        });
+        // When the period config changes, assign Period - the setter raises PeriodChanged.
+        _onChangeRegistration = healthChecksSettings.OnChange(x => Period = x.Notification.Period);
     }
 
     public override Task RunJobAsync(CancellationToken cancellationToken)
@@ -256,6 +254,16 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
         // Remember to complete the scope when done.
         scope.Complete();
         return Task.CompletedTask;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _onChangeRegistration?.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
 }
 ```
@@ -303,7 +311,10 @@ namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
 
 public class CleanUpYourRoom : RecurringBackgroundJobBase, ITriggerableRecurringBackgroundJob
 {
-    public override TimeSpan Period => TimeSpan.FromMinutes(60);
+    public CleanUpYourRoom()
+        : base(TimeSpan.FromMinutes(60))
+    {
+    }
 
     public override Task RunJobAsync(CancellationToken cancellationToken)
     {
@@ -363,19 +374,22 @@ _trigger.TriggerExecution(NextExecutionStrategy.Reset);
 
 ### Manual-only jobs
 
-To create a job that only runs when triggered manually, set both `Period` and `Delay` to `Timeout.InfiniteTimeSpan`. The job is registered and a hosted service is created for it, but no automatic execution occurs.
+To create a job that only runs when triggered manually, pass `Timeout.InfiniteTimeSpan` to the base constructor and override `Delay` to the same value. The job is registered and a hosted service is created for it, but no automatic execution occurs.
 
 ```csharp
-public override TimeSpan Period => Timeout.InfiniteTimeSpan;
+public MyJob()
+    : base(Timeout.InfiniteTimeSpan)
+{
+}
 
 public override TimeSpan Delay => Timeout.InfiniteTimeSpan;
 ```
 
-Combine this with `Delay => Timeout.InfiniteTimeSpan` to also skip the initial run after startup.
-
 ## Base Classes
 
-`RecurringBackgroundJobBase` is the recommended base class for new jobs. It implements `IRecurringBackgroundJob` and provides defaults for `Delay`, `IgnoredDelay`, `ServerRoles`, and `PeriodChanged`. Implementors only need to provide `Period` and `RunJobAsync(CancellationToken)`.
+`RecurringBackgroundJobBase` is the recommended base class for new jobs. It implements `IRecurringBackgroundJob` and provides defaults for `Delay`, `IgnoredDelay`, `ServerRoles`, `PeriodChanged`, and `IgnoredDelayChanged`. Implementors pass `Period` to the base constructor and provide `RunJobAsync(CancellationToken)`.
+
+The base class also implements `IDisposable` with a `protected virtual Dispose(bool disposing)` hook. Subclasses with disposable resources (for example, an `IOptionsMonitor.OnChange` registration) should override the hook and call `base.Dispose(disposing)`.
 
 `RecurringHostedServiceBase` is a low-level base class. It inherits from .NET's `BackgroundService` and runs the job on a recurring basis using a wait loop with cancellation support. The loop supports periodic execution, manual triggering, exception resilience, and cooperative cancellation on host shutdown.
 

--- a/18/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
+++ b/18/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
@@ -44,7 +44,7 @@ Set `Delay` to `Timeout.InfiniteTimeSpan` to skip the automatic first run. The j
 
 Defines how long to wait after an ignored execution before re-evaluating execution conditions. The default is 1 minute.
 
-A job is ignored when the runtime is not ready, the current server role is not in the allowed list, or this instance is not the main domain. The back-off prevents tight looping when `Period` is short and the runtime keeps skipping the job.
+A job is ignored when the runtime is not ready, the server role is not allowed, or this instance is not the main domain. The back-off prevents tight looping when `Period` is short and the runtime keeps skipping the job.
 
 ```csharp
 // Wait 5 minutes before re-evaluating after an ignored execution.
@@ -80,7 +80,7 @@ For example, if the period for your job is controlled by a configuration file se
 
 ### RunJobAsync(CancellationToken)
 
-The main method where your job logic is implemented. The `CancellationToken` is signalled when the host is shutting down. Pass it through to async operations to support cooperative cancellation.
+The main method where your job logic is implemented. The `CancellationToken` is signaled when the host is shutting down. Pass it through to async operations to support cooperative cancellation.
 
 ```csharp
 public override Task RunJobAsync(CancellationToken cancellationToken)
@@ -91,7 +91,7 @@ public override Task RunJobAsync(CancellationToken cancellationToken)
 ```
 
 {% hint style="info" %}
-The parameterless `RunJobAsync()` overload is obsolete and scheduled for removal in Umbraco 19. New jobs should use `RunJobAsync(CancellationToken)`.
+The `RunJobAsync()` overload without a cancellation token is obsolete and scheduled for removal in Umbraco 19. New jobs should use `RunJobAsync(CancellationToken)`.
 {% endhint %}
 
 ## Example
@@ -279,9 +279,9 @@ Learn more about how to register dependencies in the [Dependency Injection](../.
 
 A recurring background job can be triggered to run immediately, in addition to its normal schedule. This is useful when you want to run a job in response to an event or a user action. For example, after a configuration change or from an API endpoint.
 
-Triggering is opt-in. A job must implement the marker interface `ITriggerableRecurringBackgroundJob` to be triggerable.
+Triggering is opt-in. A job must implement the marker interface `ITriggerableRecurringBackgroundJob` to support manual triggering.
 
-### Marking a job as triggerable
+### Opting in to manual triggering
 
 Add `ITriggerableRecurringBackgroundJob` to the job declaration. The interface is empty and extends `IRecurringBackgroundJob`.
 
@@ -364,7 +364,7 @@ Combine this with `Delay => Timeout.InfiniteTimeSpan` to also skip the initial r
 
 `RecurringBackgroundJobBase` is the recommended base class for new jobs. It implements `IRecurringBackgroundJob` and provides defaults for `Delay`, `IgnoredDelay`, `ServerRoles`, and `PeriodChanged`. Implementors only need to provide `Period` and `RunJobAsync(CancellationToken)`.
 
-`RecurringHostedServiceBase` is a low-level base class. It inherits from .NET's `BackgroundService` and runs the job on a recurring basis using a cancellable wait loop. The loop supports periodic execution, manual triggering, exception resilience, and cooperative cancellation on host shutdown.
+`RecurringHostedServiceBase` is a low-level base class. It inherits from .NET's `BackgroundService` and runs the job on a recurring basis using a wait loop with cancellation support. The loop supports periodic execution, manual triggering, exception resilience, and cooperative cancellation on host shutdown.
 
 `RecurringBackgroundJobHostedService` is an Umbraco-specific hosted service that extends `RecurringHostedServiceBase`. It uses Umbraco system services to ensure that your jobs only execute once Umbraco is up and running. It checks:
 

--- a/18/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
+++ b/18/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
@@ -4,15 +4,19 @@ description: Run a background job on a recurring basis
 
 # Scheduling
 
-It is possible to run recurring code using a recurring background job. Background job classes should implement the `IRecurringBackgroundJob` interface, which controls when and where the job gets run.
+You can run recurring code using a recurring background job. The recommended way is to inherit from the abstract `RecurringBackgroundJobBase` class. The class provides defaults for delay, server roles, and event handling, so you only need to set the `Period` and implement `RunJobAsync(CancellationToken)`.
 
-Once you have created your background job class, register it using a Composer. It will be detected at startup and a new `HostedService` will be created to run your job.
+If you need more control, you can implement the `IRecurringBackgroundJob` interface directly.
+
+Once you have created your background job class, register it using a Composer. The job is detected at startup and a new `HostedService` is created to run it.
 
 {% hint style="warning" %}
-Be aware you may or may not want this background job to run on all servers. If you are using Load Balancing with multiple servers, see [load balancing documentation](../../run-in-production/infrastructure-and-ops/server-setup/load-balancing/) for more information
+Be aware you may or may not want this background job to run on all servers. If you are using Load Balancing with multiple servers, see the [load balancing documentation](../../run-in-production/infrastructure-and-ops/server-setup/load-balancing/) for more information.
 {% endhint %}
 
-## `IRecurringBackgroundJob` Properties and Methods
+## `RecurringBackgroundJobBase` Properties and Methods
+
+The members below are defined on `IRecurringBackgroundJob` and either inherited or overridden via `RecurringBackgroundJobBase`. The signatures and behavior are the same whether you inherit the base class or implement the interface directly.
 
 ### Period
 
@@ -20,94 +24,103 @@ Defines how often the job runs. This property is a `TimeSpan`.
 
 ```csharp
 // Run this job every 5 minutes
-TimeSpan Period = TimeSpan.FromMinutes(5);
+public override TimeSpan Period => TimeSpan.FromMinutes(5);
 ```
+
+Set `Period` to `Timeout.InfiniteTimeSpan` to disable automatic scheduling. The job then only runs when [triggered manually](scheduling.md#on-demand-triggering).
 
 ### Delay
 
-Defines how long to wait after application startup before running the task for the first time. Default is 3 minutes. This property is a `TimeSpan`.
+Defines how long to wait after application startup before running the job for the first time. The default is 3 minutes.
 
 ```csharp
-// Wait 3 minutes after application startup before starting to run this job.
-TimeSpan Delay = TimeSpan.FromMinutes(3);
+// Wait 1 minute after application startup before running this job for the first time.
+public override TimeSpan Delay => TimeSpan.FromMinutes(1);
 ```
+
+Set `Delay` to `Timeout.InfiniteTimeSpan` to skip the automatic first run. The job then only runs when triggered manually.
+
+### IgnoredDelay
+
+Defines how long to wait after an ignored execution before re-evaluating execution conditions. The default is 1 minute.
+
+A job is ignored when the runtime is not ready, the current server role is not in the allowed list, or this instance is not the main domain. The back-off prevents tight looping when `Period` is short and the runtime keeps skipping the job.
+
+```csharp
+// Wait 5 minutes before re-evaluating after an ignored execution.
+public override TimeSpan IgnoredDelay => TimeSpan.FromMinutes(5);
+```
+
+Set `IgnoredDelay` to `Timeout.InfiniteTimeSpan` to disable the job for the rest of the application lifecycle once an ignored condition is encountered. Use this when the ignored condition is known not to change. For example, on a subscriber server where the job is restricted to a publisher role.
+
+Set `IgnoredDelay` to `TimeSpan.Zero` to skip the back-off entirely.
 
 ### ServerRoles
 
-Specifies a list of roles that should run this job. In a multi-server setup, you may want your job to run on _all_ servers or only on _one_ of your servers.
+Specifies the server roles that run this job. In a multi-server setup, you may want your job to run on _all_ servers or only on _one_ of your servers.
 
-For example, a temporary file cleanup task might need to run on all servers. A database import job might be better to be run once per day on a single server.
+For example, a temporary file cleanup task might need to run on all servers. A database import job might be better to run once per day on a single server.
 
-By default: `{ Single, SchedulingPublisher }`, meaning it runs on one server only.
+By default: `{ Single, SchedulingPublisher }`, meaning the job runs on one server only.
 
 ```csharp
 // Run this job on all servers
-ServerRole[] ServerRoles = Enum.GetValues<ServerRole>();
+public override ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();
 ```
 
 For more information about server roles, see the [Load Balancing](../../run-in-production/infrastructure-and-ops/server-setup/load-balancing/#scheduling-and-server-role-election) documentation.
 
 ### PeriodChanged
 
-An event used to notify the background job service if the job’s period changes dynamically.
+An event used to notify the background job service if the job's period changes dynamically.
 
-For example, if the period for your job is controlled by a configuration file setting, you can trigger the `PeriodChanged` event when the configuration changes.
+For example, if the period for your job is controlled by a configuration file setting, raise the `PeriodChanged` event when the configuration changes.
 
-```csharp
-// No-op event as the period never changes on this job
-public event EventHandler PeriodChanged { add { } remove { } }
-```
+`RecurringBackgroundJobBase` provides a no-op implementation. Override the event when you need to raise it. See the [Complex example](scheduling.md#complex-example) below for an implementation.
 
-See the [Example](scheduling.md#example) below on how to implement the `PeriodChanged` event.
+### RunJobAsync(CancellationToken)
 
-### RunJobAsync()
-
-The main method where your job logic is implemented.
+The main method where your job logic is implemented. The `CancellationToken` is signalled when the host is shutting down. Pass it through to async operations to support cooperative cancellation.
 
 ```csharp
-public Task RunJobAsync() {
-// your job code goes here
+public override Task RunJobAsync(CancellationToken cancellationToken)
+{
+    // your job code goes here
+    return Task.CompletedTask;
 }
 ```
 
+{% hint style="info" %}
+The parameterless `RunJobAsync()` overload is obsolete and scheduled for removal in Umbraco 19. New jobs should use `RunJobAsync(CancellationToken)`.
+{% endhint %}
+
 ## Example
 
-This example shows the minimum code necessary to implement the `IRecurringBackgroundJob` interface. The job runs every 60 minutes on all servers.
+This example shows the minimum code necessary to implement a recurring background job using `RecurringBackgroundJobBase`. The job runs every 60 minutes on the default server roles (`Single` and `SchedulingPublisher`).
 
 ```csharp
-using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Logging;
-using Umbraco.Cms.Core.Scoping;
-using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.BackgroundJobs;
 
 namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
 
-public class CleanUpYourRoom : IRecurringBackgroundJob
+public class CleanUpYourRoom : RecurringBackgroundJobBase
 {
-    public TimeSpan Period { get => TimeSpan.FromMinutes(60); }
+    public override TimeSpan Period => TimeSpan.FromMinutes(60);
 
-    // Runs on all servers
-    public ServerRole[] ServerRoles { get => Enum.GetValues<ServerRole>(); }
-
-    // No-op event as the period never changes on this job
-    public event EventHandler PeriodChanged { add { } remove { } }
-
-    public async Task RunJobAsync()
+    public override Task RunJobAsync(CancellationToken cancellationToken)
     {
         // YOUR CODE GOES HERE
+        return Task.CompletedTask;
     }
 }
 ```
 
 ## Example with dependency injection
 
-This example shows how to inject other Umbraco services into your background job. This example cleans the recycle bin every 60 minutes. To do so, it injects an `IContentService` to access the Recycle bin and an `IScopeProvider` to provide an ambient scope for the `EmptyRecycleBin` method.
+This example shows how to inject other Umbraco services into your background job. The job cleans the recycle bin every 60 minutes. It injects an `IContentService` to access the Recycle Bin and an `ICoreScopeProvider` to provide an ambient scope for the `EmptyRecycleBin` method.
 
 ```csharp
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
@@ -115,16 +128,8 @@ using Umbraco.Cms.Infrastructure.BackgroundJobs;
 
 namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
 
-public class CleanUpYourRoom : IRecurringBackgroundJob
+public class CleanUpYourRoom : RecurringBackgroundJobBase
 {
-    public TimeSpan Period { get => TimeSpan.FromMinutes(60); }
-
-    // Runs on all servers
-    public ServerRole[] ServerRoles { get => Enum.GetValues<ServerRole>(); }
-
-    // No-op event as the period never changes on this job
-    public event EventHandler PeriodChanged { add { } remove { } }
-
     private readonly IContentService _contentService;
     private readonly ICoreScopeProvider _scopeProvider;
 
@@ -136,17 +141,23 @@ public class CleanUpYourRoom : IRecurringBackgroundJob
         _scopeProvider = scopeProvider;
     }
 
-    public Task RunJobAsync()
+    public override TimeSpan Period => TimeSpan.FromMinutes(60);
+
+    // Run on all servers
+    public override ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();
+
+    public override Task RunJobAsync(CancellationToken cancellationToken)
     {
-        // Wrap the three content service calls in a scope to do it all in one transaction.
+        // Wrap the content service calls in a scope to do them in one transaction.
         using ICoreScope scope = _scopeProvider.CreateCoreScope();
 
         int numberOfThingsInBin = _contentService.CountChildren(Constants.System.RecycleBinContent);
 
-        if (_contentService.RecycleBinSmells())
+        if (numberOfThingsInBin > 0)
         {
             _contentService.EmptyRecycleBin(userId: -1);
         }
+
         // Remember to complete the scope when done.
         scope.Complete();
         return Task.CompletedTask;
@@ -156,10 +167,13 @@ public class CleanUpYourRoom : IRecurringBackgroundJob
 
 ## Complex example
 
-The complex example builds on the previous one by injecting additional services. It includes a logger to log error messages, a profiler to capture timings, and an `IServerRoleAccessor` to log the current server role. Additionally, it injects an `IOptionsMonitor` to allow the period to be updated while the server is running. It also demonstrates how to trigger the `PeriodChanged` event to signal the job's host.
+The complex example builds on the previous one by injecting additional services. It includes a logger to log error messages, a profiler to capture timings, and an `IServerRoleAccessor` to log the current server role. It also injects an `IOptionsMonitor` to allow the period to be updated while the server is running. It demonstrates how to override and raise the `PeriodChanged` event to signal the job's host.
 
 ```csharp
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
@@ -168,28 +182,27 @@ using Umbraco.Cms.Infrastructure.BackgroundJobs;
 
 namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
 
-public class CleanUpYourRoom : IRecurringBackgroundJob
+public class CleanUpYourRoom : RecurringBackgroundJobBase
 {
-    public TimeSpan Period { get; set; } = TimeSpan.FromMinutes(60);
+    private TimeSpan _period = TimeSpan.FromMinutes(60);
 
-    // Runs on all servers
-    public ServerRole[] ServerRoles { get => Enum.GetValues<ServerRole>(); }
+    public override TimeSpan Period => _period;
 
-    //
+    // Run on all servers
+    public override ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();
+
     private event EventHandler? _periodChanged;
-    public event EventHandler PeriodChanged
+    public override event EventHandler PeriodChanged
     {
         add { _periodChanged += value; }
         remove { _periodChanged -= value; }
     }
-
 
     private readonly IContentService _contentService;
     private readonly IServerRoleAccessor _serverRoleAccessor;
     private readonly IProfilingLogger _profilingLogger;
     private readonly ILogger<CleanUpYourRoom> _logger;
     private readonly ICoreScopeProvider _scopeProvider;
-
 
     public CleanUpYourRoom(
         IContentService contentService,
@@ -205,25 +218,24 @@ public class CleanUpYourRoom : IRecurringBackgroundJob
         _logger = logger;
         _scopeProvider = scopeProvider;
 
-        // if the settings are updated trigger the event to let the job host know
+        // When the settings change, update the period and raise the event so the host reschedules.
         healthChecksSettings.OnChange(x =>
         {
-            Period = x.Notification.Period;
+            _period = x.Notification.Period;
             _periodChanged?.Invoke(this, EventArgs.Empty);
         });
     }
 
-    public Task RunJobAsync()
+    public override Task RunJobAsync(CancellationToken cancellationToken)
     {
-
-        // Wrap the three content service calls in a scope to do it all in one transaction.
+        // Wrap the content service calls in a scope to do them in one transaction.
         using ICoreScope scope = _scopeProvider.CreateCoreScope();
 
         int numberOfThingsInBin = _contentService.CountChildren(Constants.System.RecycleBinContent);
         _logger.LogInformation("Go clean your room - {ServerRole}", _serverRoleAccessor.CurrentServerRole);
         _logger.LogInformation("You have {NumberOfThingsInTheBin} items to clean", numberOfThingsInBin);
 
-        if (_contentService.RecycleBinSmells())
+        if (numberOfThingsInBin > 0)
         {
             // Take out the trash
             using (_profilingLogger.TraceDuration<CleanUpYourRoom>("Mum, I am emptying out the bin",
@@ -242,10 +254,11 @@ public class CleanUpYourRoom : IRecurringBackgroundJob
 
 ### Registering with a composer
 
-All we need to do here is to create the composer where we register the background job with `AddRecurringBackgroundJob`.
+Create a composer and register the background job with `AddRecurringBackgroundJob`.
 
 ```csharp
 using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
 
 namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
 
@@ -262,19 +275,108 @@ public class CleanUpYourRoomComposer : IComposer
 Learn more about how to register dependencies in the [Dependency Injection](../../develop-with-umbraco/application-code/backend-and-custom-logic/using-ioc.md) article.
 {% endhint %}
 
+## On-demand triggering
+
+A recurring background job can be triggered to run immediately, in addition to its normal schedule. This is useful when you want to run a job in response to an event or a user action. For example, after a configuration change or from an API endpoint.
+
+Triggering is opt-in. A job must implement the marker interface `ITriggerableRecurringBackgroundJob` to be triggerable.
+
+### Marking a job as triggerable
+
+Add `ITriggerableRecurringBackgroundJob` to the job declaration. The interface is empty and extends `IRecurringBackgroundJob`.
+
+```csharp
+using Umbraco.Cms.Infrastructure.BackgroundJobs;
+
+namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
+
+public class CleanUpYourRoom : RecurringBackgroundJobBase, ITriggerableRecurringBackgroundJob
+{
+    public override TimeSpan Period => TimeSpan.FromMinutes(60);
+
+    public override Task RunJobAsync(CancellationToken cancellationToken)
+    {
+        // your job code goes here
+        return Task.CompletedTask;
+    }
+}
+```
+
+Register the job the usual way with `AddRecurringBackgroundJob<CleanUpYourRoom>()`. No additional registration is required to enable triggering.
+
+### Triggering a job
+
+Inject `IRecurringBackgroundJobTrigger<TJob>` where you want to trigger the job. The generic type parameter must be a class implementing `ITriggerableRecurringBackgroundJob`. The generic constraint makes requesting a trigger for a job without the marker interface a compile error.
+
+```csharp
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Infrastructure.BackgroundJobs;
+
+namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
+
+public class CleanUpController : Controller
+{
+    private readonly IRecurringBackgroundJobTrigger<CleanUpYourRoom> _trigger;
+
+    public CleanUpController(IRecurringBackgroundJobTrigger<CleanUpYourRoom> trigger)
+    {
+        _trigger = trigger;
+    }
+
+    public IActionResult RunNow()
+    {
+        bool triggered = _trigger.TriggerExecution();
+        return Ok(triggered);
+    }
+}
+```
+
+`TriggerExecution` returns `false` if no hosted service is currently running for the job. For example, before `StartAsync` is called, or if the job is not registered.
+
+### Controlling the next execution after a manual trigger
+
+The `TriggerExecution` method has three overloads that control what happens after the triggered execution finishes.
+
+| Overload | Behavior after the triggered execution |
+| --- | --- |
+| `TriggerExecution()` | Resume the original schedule. If the triggered execution overshot the next scheduled tick, skip it to avoid double-execution. Same as `NextExecutionStrategy.None`. |
+| `TriggerExecution(NextExecutionStrategy.Reset)` | Wait a full period. The schedule shifts forward from the triggered execution. |
+| `TriggerExecution(NextExecutionStrategy.Replace)` | The triggered execution replaces the next scheduled tick. The following execution occurs one full period after the originally-scheduled time. |
+| `TriggerExecution(TimeSpan nextDelay)` | Wait the specified custom delay before the next execution. |
+
+For example, to trigger a job and reset its schedule:
+
+```csharp
+_trigger.TriggerExecution(NextExecutionStrategy.Reset);
+```
+
+### Manual-only jobs
+
+To create a job that only runs when triggered manually, set `Period` to `Timeout.InfiniteTimeSpan`. The job is registered and a hosted service is created for it, but no automatic execution occurs.
+
+```csharp
+public override TimeSpan Period => Timeout.InfiniteTimeSpan;
+```
+
+Combine this with `Delay => Timeout.InfiniteTimeSpan` to also skip the initial run after startup.
+
 ## Base Classes
 
-`RecurringHostedServiceBase` is a low-level base class. It implements the dotnetcore interface `IHostedService` to run itself in the background, and creates and manages the timer that runs the job on a recurring basis.
+`RecurringBackgroundJobBase` is the recommended base class for new jobs. It implements `IRecurringBackgroundJob` and provides defaults for `Delay`, `IgnoredDelay`, `ServerRoles`, and `PeriodChanged`. Implementors only need to provide `Period` and `RunJobAsync(CancellationToken)`.
 
-`RecurringBackgroundJobHostedService` is an Umbraco specific Hosted Service that extends `RecurringHostedServiceBase`. It uses some system-level Umbraco services to ensure that your jobs only execute once Umbraco is up and running. It checks:
+`RecurringHostedServiceBase` is a low-level base class. It inherits from .NET's `BackgroundService` and runs the job on a recurring basis using a cancellable wait loop. The loop supports periodic execution, manual triggering, exception resilience, and cooperative cancellation on host shutdown.
 
-* Server Roles - see above for more discussion about Server roles
+`RecurringBackgroundJobHostedService` is an Umbraco-specific hosted service that extends `RecurringHostedServiceBase`. It uses Umbraco system services to ensure that your jobs only execute once Umbraco is up and running. It checks:
+
+* Server Roles - see above for more discussion about Server roles.
 * MainDom - The `MainDom` lock ensures that only one instance of Umbraco is running at a time on a given machine. This ensures the integrity of certain files used by Umbraco. See [Host Synchronization](../../run-in-production/infrastructure-and-ops/server-setup/load-balancing/azure-web-apps.md#host-synchronization) for more details.
-* Runtime State - On a fresh install or when waiting for a database upgrade, Umbraco may be fully up and running yet.
+* Runtime State - On a fresh install or when waiting for a database upgrade, Umbraco may not be fully up and running yet.
+
+When any of these checks fail, the execution is ignored and the loop waits for `IgnoredDelay` before re-evaluating.
 
 ## Notifications
 
-The `RecurringBackgroundJobHostedService` publishes a number of notifications that can be hooked to report on the status of background jobs. All notifications extend from the base `Umbraco.CMS.Infrastructure.Notifications.RecurringBackgroundJobNotification` class.
+The `RecurringBackgroundJobHostedService` publishes a number of notifications that can be hooked to report on the status of background jobs. All notifications extend from the base `Umbraco.Cms.Infrastructure.Notifications.RecurringBackgroundJobNotification` class.
 
 The following notifications are available:
 
@@ -285,37 +387,44 @@ The following notifications are available:
 * Executing
 * Executed
 * Failed
+* Canceled
 * Ignored
 
 ### Start/Stop
 
-The Starting/Started and Stopping/Stopped notification pairs are published when the `RecurringBackgroundJobHostedService` is started or stopped. The start event normally occurs soon after application start as part of the .Net WebHost startup process. Similarly the stop event would happen as part of application shutdown.
+The Starting/Started and Stopping/Stopped notification pairs are published when the `RecurringBackgroundJobHostedService` is started or stopped. The start event normally occurs soon after application start as part of the .NET WebHost startup process. Similarly, the stop event happens as part of application shutdown.
 
-These notifications are there to support low-level debugging of background jobs to ensure they are starting/stopping correctly. Due to the timing of the notification, all handlers associated with these notifications should not depend on any Umbraco services, including database access.
+These notifications are there to support low-level debugging of background jobs to ensure they are starting and stopping correctly. Due to the timing of the notification, all handlers associated with these notifications should not depend on any Umbraco services, including database access.
 
 ### Ignored
 
 The Ignored notification is published when a background job's schedule is triggered, but the Umbraco runtime checks prevent it from running.
 
-This notification is there to support low-level debugging of background jobs to ascertain why they are/aren't running. As the runtime checks include runtime state readiness, this event may be triggered during the install phase. Any notification handlers associated with this notification should **also** conduct their own checks before relying on Umbraco services, including database access.
+This notification is there to support low-level debugging of background jobs to ascertain why they are or aren't running. As the runtime checks include runtime state readiness, this event may be triggered during the install phase. Any notification handlers associated with this notification should also conduct their own checks before relying on Umbraco services, including database access.
 
-### Executing/Executed/Failed
+### Executing/Executed/Failed/Canceled
 
-These notifications will be triggered in pairs depending on the success/failure of the job itself.
+These notifications are triggered in pairs depending on the success, failure, or cancellation of the job.
 
-* The executing notification is triggered before the job is run.
-* The executed notification is triggered after the job is completed.
-* The failed notification is triggered from the catch block if an exception is thrown.
+* The Executing notification is triggered before the job is run.
+* The Executed notification is triggered after the job completes.
+* The Failed notification is triggered from the catch block if an exception is thrown.
+* The Canceled notification is triggered when the job is cancelled during host shutdown.
 
-For **successful** job runs, the following notifications will be published:
+For **successful** job runs, the following notifications are published:
 
 1. Executing
 2. Executed
 
-For **failed** job runs, the following notifications will be published:
+For **failed** job runs, the following notifications are published:
 
 1. Executing
 2. Failed
+
+For **cancelled** job runs (typically during host shutdown), the following notifications are published:
+
+1. Executing
+2. Canceled
 
 ```csharp
 // Do not run the code on subscribers or unknown role servers
@@ -333,13 +442,13 @@ switch (_serverRoleAccessor.CurrentServerRole)
 
 ## Background jobs when load balancing the backoffice
 
-When load balancing the backoffice, all servers will have the `SchedulingPublisher` role. This means the approach described above for restricting jobs to specific server roles will not work as intended. All servers will match the `SchedulingPublisher` role.
+When load balancing the backoffice, all servers have the `SchedulingPublisher` role. This means the approach described above for restricting jobs to specific server roles does not work as intended. All servers match the `SchedulingPublisher` role.
 
-Instead, for jobs that should only run on a single server, you should implement an `IDistributedBackgroundJob`.
+Instead, for jobs that should only run on a single server, implement an `IDistributedBackgroundJob`.
 
-`IDistributedBackgroundJob` is separate from `IRecurringBackgroundJob`, and is tracked in the database to ensure that only a single server runs the job at any given time. This also means that you are not guaranteed what server will run the job, but you are guaranteed that only one server will run it.
+`IDistributedBackgroundJob` is separate from `IRecurringBackgroundJob`. The job is tracked in the database to ensure that only a single server runs it at any given time. This also means you are not guaranteed which server runs the job, but you are guaranteed that only one server runs it.
 
-By default, distributed background jobs are checked every 5 seconds, with an initial delay of 1 minute after application startup. These settings can be changed in appsettings, see [Distributed jobs settings](../../develop-with-umbraco/configuration/distributedjobssettings.md) for more information.
+By default, distributed background jobs are checked every 5 seconds, with an initial delay of 1 minute after application startup. These settings can be changed via configuration. See [Distributed jobs settings](../../develop-with-umbraco/configuration/distributedjobssettings.md) for more information.
 
 ### Implementing a custom distributed background job
 
@@ -350,7 +459,7 @@ public class MyCustomBackgroundJob : IDistributedBackgroundJob
 {
     private readonly ILogger<MyCustomBackgroundJob> _logger;
     public string Name => "MyCustomBackgroundJob";
-    
+
     public TimeSpan Period { get; private set; }
 
     public MyCustomBackgroundJob(ILogger<MyCustomBackgroundJob> logger)
@@ -358,7 +467,7 @@ public class MyCustomBackgroundJob : IDistributedBackgroundJob
         _logger = logger;
         Period = TimeSpan.FromSeconds(20);
     }
-    
+
     public Task ExecuteAsync()
     {
         // Your custom background job logic here
@@ -368,11 +477,11 @@ public class MyCustomBackgroundJob : IDistributedBackgroundJob
 }
 ```
 
-It's required to give your job a unique name via the `Name` property. This is used to track the job in the database.
+It's required to give your job a unique name via the `Name` property. The name is used to track the job in the database.
 
 The period is specified via the `Period` property, which controls how often the job should run. In this example, it runs every 20 seconds.
 
-It's not required to manually register the job in the database, however, you must register it to DI so Umbraco can find it. This can be done with a composer or in `Program.cs`
+It's not required to manually register the job in the database. However, you must register it with the dependency injection container so Umbraco can find it. This can be done with a composer or in `Program.cs`:
 
 ```csharp
 public class MyComposer : IComposer

--- a/18/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
+++ b/18/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
@@ -8,7 +8,7 @@ You can run recurring code using a recurring background job. The recommended way
 
 Alternatively, implement the `IRecurringBackgroundJob` interface directly — for example, when your job class already inherits from another base class. The interface provides the same defaults via default interface methods, so you only need to override what you want to change.
 
-Once you have created your background job class, register it using `AddRecurringBackgroundJob<TJob>()`. The job is detected at startup and a new hosted service is created to run it.
+Once you have created your background job class, register it using `AddRecurringBackgroundJob<TJob>()`. The job is detected at startup, and a new hosted service is created to run it.
 
 {% hint style="warning" %}
 Be aware you may or may not want this background job to run on all servers. If you are using Load Balancing with multiple servers, see the [load balancing documentation](../../run-in-production/infrastructure-and-ops/server-setup/load-balancing/) for more information.
@@ -183,7 +183,7 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
 
 ## Complex example
 
-The complex example builds on the previous one by injecting additional services. It includes a logger to log error messages, a profiler to capture timings, and an `IServerRoleAccessor` to log the current server role. It also injects an `IOptionsMonitor` to allow the period to be updated while the server is running. Assigning the new value to `Period` raises `PeriodChanged` so the host reschedules. The `IOptionsMonitor.OnChange` registration is disposed via the base class's `Dispose(bool)` hook.
+The complex example builds on the previous one by injecting additional services. It includes a logger to log error messages, a profiler to capture timings, and an `IServerRoleAccessor` to log the current server role. It also injects an `IOptionsMonitor` to allow the period to be updated while the server is running. Assigning the new value to `Period` raises `PeriodChanged`, so the host reschedules. The `IOptionsMonitor.OnChange` registration is disposed via the base class's `Dispose(bool)` hook.
 
 ```csharp
 using System;
@@ -374,7 +374,7 @@ _trigger.TriggerExecution(NextExecutionStrategy.Reset);
 
 ### Manual-only jobs
 
-To create a job that only runs when triggered manually, pass `Timeout.InfiniteTimeSpan` to the base constructor and override `Delay` to the same value. The job is registered and a hosted service is created for it, but no automatic execution occurs.
+To create a job that only runs when triggered manually, pass `Timeout.InfiniteTimeSpan` to the base constructor and override `Delay` to the same value. The job is registered, and a hosted service is created for it, but no automatic execution occurs.
 
 ```csharp
 public MyJob()
@@ -399,7 +399,7 @@ The base class also implements `IDisposable` with a `protected virtual Dispose(b
 * MainDom - The `MainDom` lock ensures that only one instance of Umbraco is running at a time on a given machine. This ensures the integrity of certain files used by Umbraco. See [Host Synchronization](../../run-in-production/infrastructure-and-ops/server-setup/load-balancing/azure-web-apps.md#host-synchronization) for more details.
 * Runtime State - On a fresh install or when waiting for a database upgrade, Umbraco may not be fully up and running yet.
 
-When any of these checks fail, the execution is ignored and the loop waits for `IgnoredDelay` before re-evaluating.
+When any of these checks fail, the execution is ignored, and the loop waits for `IgnoredDelay` before re-evaluating.
 
 ## Notifications
 
@@ -407,19 +407,19 @@ The `RecurringBackgroundJobHostedService` publishes a number of notifications th
 
 The following notifications are available:
 
-* `RecurringBackgroundJobStartingNotification` - published before starting the recurring job
-* `RecurringBackgroundJobStartedNotification` - published after the recurring job has started
-* `RecurringBackgroundJobExecutingNotification` - published before running the job
-* `RecurringBackgroundJobIgnoredNotification` - published when the job is ignored (see `IgnoredDelay`)
-* `RecurringBackgroundJobExecutedNotification` - published after `RunJobAsync()` is called
-* `RecurringBackgroundJobCanceledNotification` - published when the job was cancelled due to application shutdown
-* `RecurringBackgroundJobFailedNotification` - published when an unhandled exception was thrown while running the job
-* `RecurringBackgroundJobStoppingNotification` - published before stopping the recurring job
-* `RecurringBackgroundJobStoppedNotification` - published after the recurring job has stopped
+* `RecurringBackgroundJobStartingNotification` - published before starting the recurring job.
+* `RecurringBackgroundJobStartedNotification` - published after the recurring job has started.
+* `RecurringBackgroundJobExecutingNotification` - published before running the job.
+* `RecurringBackgroundJobIgnoredNotification` - published when the job is ignored (see `IgnoredDelay`).
+* `RecurringBackgroundJobExecutedNotification` - published after `RunJobAsync()` is called.
+* `RecurringBackgroundJobCanceledNotification` - published when the job was cancelled due to application shutdown.
+* `RecurringBackgroundJobFailedNotification` - published when an unhandled exception was thrown while running the job.
+* `RecurringBackgroundJobStoppingNotification` - published before stopping the recurring job.
+* `RecurringBackgroundJobStoppedNotification` - published after the recurring job has stopped.
 
 ### Start/Stop
 
-The Starting/Started and Stopping/Stopped notification pairs are published when the `RecurringBackgroundJobHostedService` is started or stopped. The start event normally occurs soon after application start as part of the .NET WebHost startup process. Similarly, the stop event happens as part of application shutdown.
+The Starting/Started and Stopping/Stopped notification pairs are published when the `RecurringBackgroundJobHostedService` is started or stopped. The start event normally occurs soon after application start as part of the .NET WebHost startup process. Similarly, the stop event happens as part of the application shutdown.
 
 These notifications are there to support low-level debugging of background jobs to ensure they are starting and stopping correctly. Due to the timing of the notification, all handlers associated with these notifications should not depend on any Umbraco services, including database access.
 

--- a/18/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
+++ b/18/umbraco-cms/extend-your-project/server-side-extensions/scheduling.md
@@ -99,6 +99,9 @@ The `RunJobAsync()` overload without a cancellation token is obsolete and schedu
 This example shows the minimum code necessary to implement a recurring background job using `RecurringBackgroundJobBase`. The job runs every 60 minutes on the default server roles (`Single` and `SchedulingPublisher`).
 
 ```csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Umbraco.Cms.Infrastructure.BackgroundJobs;
 
 namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
@@ -120,6 +123,9 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
 This example shows how to inject other Umbraco services into your background job. The job cleans the recycle bin every 60 minutes. It injects an `IContentService` to access the Recycle Bin and an `ICoreScopeProvider` to provide an ambient scope for the `EmptyRecycleBin` method.
 
 ```csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
@@ -170,6 +176,9 @@ public class CleanUpYourRoom : RecurringBackgroundJobBase
 The complex example builds on the previous one by injecting additional services. It includes a logger to log error messages, a profiler to capture timings, and an `IServerRoleAccessor` to log the current server role. It also injects an `IOptionsMonitor` to allow the period to be updated while the server is running. It demonstrates how to override and raise the `PeriodChanged` event to signal the job's host.
 
 ```csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
@@ -286,6 +295,9 @@ Triggering is opt-in. A job must implement the marker interface `ITriggerableRec
 Add `ITriggerableRecurringBackgroundJob` to the job declaration. The interface is empty and extends `IRecurringBackgroundJob`.
 
 ```csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Umbraco.Cms.Infrastructure.BackgroundJobs;
 
 namespace Umbraco.Docs.Samples.Web.RecurringBackgroundJob;
@@ -409,7 +421,7 @@ These notifications are triggered in pairs depending on the success, failure, or
 * The Executing notification is triggered before the job is run.
 * The Executed notification is triggered after the job completes.
 * The Failed notification is triggered from the catch block if an exception is thrown.
-* The Canceled notification is triggered when the job is cancelled during host shutdown.
+* The Canceled notification is triggered when the job is canceled during host shutdown.
 
 For **successful** job runs, the following notifications are published:
 
@@ -421,7 +433,7 @@ For **failed** job runs, the following notifications are published:
 1. Executing
 2. Failed
 
-For **cancelled** job runs (typically during host shutdown), the following notifications are published:
+For **canceled** job runs (typically during host shutdown), the following notifications are published:
 
 1. Executing
 2. Canceled
@@ -455,6 +467,11 @@ By default, distributed background jobs are checked every 5 seconds, with an ini
 To implement a custom distributed background job, create a class that implements the `IDistributedBackgroundJob` interface. As with `IRecurringBackgroundJob`, dependency injection (DI) is available in the constructor.
 
 ```csharp
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Infrastructure.BackgroundJobs;
+
 public class MyCustomBackgroundJob : IDistributedBackgroundJob
 {
     private readonly ILogger<MyCustomBackgroundJob> _logger;


### PR DESCRIPTION
## 📋 Description

Updates the documentation on background tasks for CMS 17.5 (and 18.0)

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/pull/22331

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17.5 and 18.0

## Deadline (if relevant)

I suggest this goes live with CMS 17.5-rc due on 11th June.  Strictly speaking it's in the 18.0-rc1 that's released earlier, but I think it'll be less confusing if we update this with 17.5 availability.  The old code continues to work, but the newer constructs that are part of this PR of course need to wait for releases.
