### PR TITLE
Fix usings and add `FieldTypeViewName` to make example work

### DIFF
--- a/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Fieldtype.md
+++ b/Add-ons/UmbracoForms/Developer/Extending/Adding-a-Fieldtype.md
@@ -12,9 +12,10 @@ meta.Title: "Adding a field type to Umbraco Forms"
 Add a new class to the Visual Studio solution, make it inherit from `Umbraco.Forms.Core.FieldType` and fill in the constructor:
 
 ```csharp
-using Umbraco.Forms.Core.Data.Storage;
+using Umbraco.Forms.Core;
 using Umbraco.Forms.Core.Enums;
 using Umbraco.Forms.Core.Models;
+using System;
 
 public class MyCustomField : Umbraco.Forms.Core.FieldType
 {
@@ -25,6 +26,7 @@ public class MyCustomField : Umbraco.Forms.Core.FieldType
         this.Description = "Render a custom text field.";
         this.Icon = "icon-autofill";
         this.DataType = FieldDataType.String;
+        this.FieldTypeViewName = "FieldType.MyCustomField.cshtml";
         this.SortOrder = 10;
         this.SupportsRegex = true;
     }


### PR DESCRIPTION
I ran into a couple of issues trying to get a custom field type working in an old solution, so providing the fixes here for anyone else with the same problem. It's legacy documentation, but still something you need once in a while.

## 📋 Description

The example code didn't work as expected:
- the `FieldDataType.String` enum couldn't be found
- the renderer looks for a Razor view called "My Custom Field.cshtml" if not specified by the `FieldTypeViewName` property
- The `Guid()` class could not be found

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

This is a fix for the documentation for Umbraco Forms 7.x
