### PR TITLE
Update Umbraco AI embedding samples to use builder API

### DIFF
--- a/ai-in-umbraco/1/concepts/capabilities.md
+++ b/ai-in-umbraco/1/concepts/capabilities.md
@@ -54,6 +54,7 @@ The Embedding capability generates vector representations of text:
 
 ```csharp
 var embedding = await _embeddingService.GenerateEmbeddingAsync(
+    emb => emb.WithAlias("content-embedding"),
     "Umbraco is a content management system");
 
 // embedding.Vector contains the float array

--- a/ai-in-umbraco/1/using-the-api/README.md
+++ b/ai-in-umbraco/1/using-the-api/README.md
@@ -110,6 +110,7 @@ await foreach (var update in _chatService.StreamChatResponseAsync(
 
 ```csharp
 var embedding = await _embeddingService.GenerateEmbeddingAsync(
+    emb => emb.WithAlias("content-embedding"),
     "Umbraco is a content management system");
 
 float[] vector = embedding.Vector.ToArray();

--- a/ai-in-umbraco/1/using-the-api/embeddings/README.md
+++ b/ai-in-umbraco/1/using-the-api/embeddings/README.md
@@ -27,31 +27,19 @@ public interface IAIEmbeddingService
 {
     // Single embedding
     Task<Embedding<float>> GenerateEmbeddingAsync(
+        Action<AIEmbeddingBuilder> configure,
         string value,
-        EmbeddingGenerationOptions? options = null,
-        CancellationToken cancellationToken = default);
-
-    Task<Embedding<float>> GenerateEmbeddingAsync(
-        Guid profileId,
-        string value,
-        EmbeddingGenerationOptions? options = null,
         CancellationToken cancellationToken = default);
 
     // Multiple embeddings
     Task<GeneratedEmbeddings<Embedding<float>>> GenerateEmbeddingsAsync(
+        Action<AIEmbeddingBuilder> configure,
         IEnumerable<string> values,
-        EmbeddingGenerationOptions? options = null,
         CancellationToken cancellationToken = default);
 
-    Task<GeneratedEmbeddings<Embedding<float>>> GenerateEmbeddingsAsync(
-        Guid profileId,
-        IEnumerable<string> values,
-        EmbeddingGenerationOptions? options = null,
-        CancellationToken cancellationToken = default);
-
-    // Advanced: Get the underlying generator
-    Task<IEmbeddingGenerator<string, Embedding<float>>> GetEmbeddingGeneratorAsync(
-        Guid? profileId = null,
+    // Advanced: Get a configured generator
+    Task<IEmbeddingGenerator<string, Embedding<float>>> CreateEmbeddingGeneratorAsync(
+        Action<AIEmbeddingBuilder> configure,
         CancellationToken cancellationToken = default);
 }
 ```
@@ -77,7 +65,9 @@ public class SearchService
 
     public async Task<float[]> GetEmbedding(string text)
     {
-        var embedding = await _embeddingService.GenerateEmbeddingAsync(text);
+        var embedding = await _embeddingService.GenerateEmbeddingAsync(
+            emb => emb.WithAlias("content-search"),
+            text);
         return embedding.Vector.ToArray();
     }
 }
@@ -89,18 +79,24 @@ public class SearchService
 
 ### Default Profile
 
-Once you have [configured a default embedding profile](../../backoffice/managing-settings.md) in the backoffice, you can call without specifying a profile:
+Once you have [configured a default embedding profile](../../backoffice/managing-settings.md) in the backoffice, you can call without specifying a profile on the builder:
 
 ```csharp
-var embedding = await _embeddingService.GenerateEmbeddingAsync(text);
+var embedding = await _embeddingService.GenerateEmbeddingAsync(
+    emb => emb.WithAlias("content-search"),
+    text);
 ```
 
 ### Specific Profile
 
-Pass the profile ID:
+Select a profile by ID or alias on the builder:
 
 ```csharp
-var embedding = await _embeddingService.GenerateEmbeddingAsync(profileId, text);
+var embedding = await _embeddingService.GenerateEmbeddingAsync(
+    emb => emb
+        .WithAlias("content-search")
+        .WithProfile(profileId),
+    text);
 ```
 
 ## Common Use Cases
@@ -116,8 +112,12 @@ var embedding = await _embeddingService.GenerateEmbeddingAsync(profileId, text);
 Compare two pieces of content:
 
 ```csharp
-var embedding1 = await _embeddingService.GenerateEmbeddingAsync(content1);
-var embedding2 = await _embeddingService.GenerateEmbeddingAsync(content2);
+var embedding1 = await _embeddingService.GenerateEmbeddingAsync(
+    emb => emb.WithAlias("content-similarity"),
+    content1);
+var embedding2 = await _embeddingService.GenerateEmbeddingAsync(
+    emb => emb.WithAlias("content-similarity"),
+    content2);
 
 var similarity = CosineSimilarity(embedding1.Vector, embedding2.Vector);
 ```

--- a/ai-in-umbraco/1/using-the-api/embeddings/batch-embeddings.md
+++ b/ai-in-umbraco/1/using-the-api/embeddings/batch-embeddings.md
@@ -26,7 +26,9 @@ public class BatchEmbeddingExample
 
     public async Task<IList<float[]>> GenerateEmbeddings(IEnumerable<string> texts)
     {
-        var embeddings = await _embeddingService.GenerateEmbeddingsAsync(texts);
+        var embeddings = await _embeddingService.GenerateEmbeddingsAsync(
+            emb => emb.WithAlias("batch-embedding"),
+            texts);
 
         return embeddings.Select(e => e.Vector.ToArray()).ToList();
     }
@@ -49,7 +51,9 @@ public class BatchEmbeddingExample
 ```csharp
 var texts = new[] { "First document", "Second document", "Third document" };
 
-var embeddings = await _embeddingService.GenerateEmbeddingsAsync(texts);
+var embeddings = await _embeddingService.GenerateEmbeddingsAsync(
+    emb => emb.WithAlias("batch-embedding"),
+    texts);
 
 // Embeddings are in the same order as input
 for (int i = 0; i < texts.Length; i++)
@@ -99,7 +103,9 @@ public class BatchContentIndexer
             $"{c.Name} {c.GetValue<string>("bodyText")}").ToList();
 
         // Generate all embeddings in one request
-        var embeddings = await _embeddingService.GenerateEmbeddingsAsync(texts);
+        var embeddings = await _embeddingService.GenerateEmbeddingsAsync(
+            emb => emb.WithAlias("content-batch-index"),
+            texts);
 
         // Store each embedding with its content
         var documents = contentList.Zip(embeddings, (content, embedding) =>
@@ -151,8 +157,9 @@ public class ChunkedEmbeddingService
             var chunk = textList.Skip(i).Take(BatchSize);
 
             var embeddings = await _embeddingService.GenerateEmbeddingsAsync(
+                emb => emb.WithAlias("chunked-batch-embedding"),
                 chunk,
-                cancellationToken: cancellationToken);
+                cancellationToken);
 
             allEmbeddings.AddRange(embeddings);
         }
@@ -166,6 +173,8 @@ public class ChunkedEmbeddingService
 
 ## Using a Specific Profile
 
+Select a profile by ID or alias on the builder:
+
 {% code title="BatchWithProfile.cs" %}
 
 ```csharp
@@ -174,7 +183,9 @@ public async Task<IList<float[]>> GenerateBatchWithProfile(
     Guid profileId)
 {
     var embeddings = await _embeddingService.GenerateEmbeddingsAsync(
-        profileId,
+        emb => emb
+            .WithAlias("batch-embedding")
+            .WithProfile(profileId),
         texts);
 
     return embeddings.Select(e => e.Vector.ToArray()).ToList();

--- a/ai-in-umbraco/1/using-the-api/embeddings/generating-embeddings.md
+++ b/ai-in-umbraco/1/using-the-api/embeddings/generating-embeddings.md
@@ -26,7 +26,9 @@ public class EmbeddingExample
 
     public async Task<float[]> GenerateEmbedding(string text)
     {
-        var embedding = await _embeddingService.GenerateEmbeddingAsync(text);
+        var embedding = await _embeddingService.GenerateEmbeddingAsync(
+            emb => emb.WithAlias("content-embedding"),
+            text);
 
         // The vector is a ReadOnlyMemory<float>
         return embedding.Vector.ToArray();
@@ -49,7 +51,9 @@ The `Embedding<float>` type contains:
 {% code title="EmbeddingDetails.cs" %}
 
 ```csharp
-var embedding = await _embeddingService.GenerateEmbeddingAsync(text);
+var embedding = await _embeddingService.GenerateEmbeddingAsync(
+    emb => emb.WithAlias("content-embedding"),
+    text);
 
 // Access the vector
 ReadOnlyMemory<float> vector = embedding.Vector;
@@ -66,31 +70,28 @@ string? model = embedding.ModelId;
 
 ## Using a Specific Profile
 
+Select a profile by alias directly on the builder. The service resolves the alias for you.
+
 {% code title="WithProfile.cs" %}
 
 ```csharp
 public class ProfiledEmbeddingService
 {
     private readonly IAIEmbeddingService _embeddingService;
-    private readonly IAIProfileService _profileService;
 
-    public ProfiledEmbeddingService(
-        IAIEmbeddingService embeddingService,
-        IAIProfileService profileService)
+    public ProfiledEmbeddingService(IAIEmbeddingService embeddingService)
     {
         _embeddingService = embeddingService;
-        _profileService = profileService;
     }
 
     public async Task<float[]> GenerateWithProfile(string text, string profileAlias)
     {
-        var profile = await _profileService.GetProfileByAliasAsync(profileAlias);
-        if (profile is null)
-        {
-            throw new InvalidOperationException($"Profile '{profileAlias}' not found");
-        }
+        var embedding = await _embeddingService.GenerateEmbeddingAsync(
+            emb => emb
+                .WithAlias("content-embedding")
+                .WithProfile(profileAlias),
+            text);
 
-        var embedding = await _embeddingService.GenerateEmbeddingAsync(profile.Id, text);
         return embedding.Vector.ToArray();
     }
 }
@@ -107,7 +108,9 @@ public async Task<float[]?> SafeGenerateEmbedding(string text)
 {
     try
     {
-        var embedding = await _embeddingService.GenerateEmbeddingAsync(text);
+        var embedding = await _embeddingService.GenerateEmbeddingAsync(
+            emb => emb.WithAlias("content-embedding"),
+            text);
         return embedding.Vector.ToArray();
     }
     catch (InvalidOperationException ex) when (ex.Message.Contains("profile"))


### PR DESCRIPTION
## Summary

Users reported that the embedding code samples in [docs.umbraco.com/ai-in-umbraco/using-the-api/embeddings/generating-embeddings](https://docs.umbraco.com/ai-in-umbraco/using-the-api/embeddings/generating-embeddings) trigger obsolete warnings.

`IAIEmbeddingService` marks the following overloads obsolete (removal in v3):

- `GenerateEmbeddingAsync(string value, ...)`
- `GenerateEmbeddingAsync(Guid profileId, string value, ...)`
- `GenerateEmbeddingsAsync(IEnumerable<string> values, ...)`
- `GenerateEmbeddingsAsync(Guid profileId, IEnumerable<string> values, ...)`
- `GetEmbeddingGeneratorAsync(Guid? profileId, ...)`

The replacement is the builder overload (already documented on the [IAIEmbeddingService reference page](https://docs.umbraco.com/ai-in-umbraco/reference/services/ai-embedding-service)):

```csharp
var embedding = await _embeddingService.GenerateEmbeddingAsync(
    emb => emb.WithAlias("content-embedding"),
    text);
```

This PR updates all embedding code samples in the using-the-api section, the using-the-api landing page, and the capabilities concept page to use the new builder overload. The interface listing on the embeddings landing page is also updated to match the current `IAIEmbeddingService` shape.

### Files updated

- `ai-in-umbraco/1/using-the-api/embeddings/generating-embeddings.md`
- `ai-in-umbraco/1/using-the-api/embeddings/batch-embeddings.md`
- `ai-in-umbraco/1/using-the-api/embeddings/README.md`
- `ai-in-umbraco/1/using-the-api/README.md`
- `ai-in-umbraco/1/concepts/capabilities.md`

## Test plan

- [ ] Confirm code samples on the published page no longer reference obsolete overloads
- [ ] Confirm samples compile against the current `Umbraco.AI.Core` package
- [ ] Spot-check links/navigation are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)