### PR TITLE
Update Amazon Bedrock docs for retired model access page

### DIFF
--- a/.github/styles/config/dictionaries/en_US.dic
+++ b/.github/styles/config/dictionaries/en_US.dic
@@ -34735,6 +34735,7 @@ emulsoid
 emunctory
 en/SM
 enable/EDSG
+enablement
 enabler/MS
 enact/ASLDG
 enactment/ASM

--- a/ai-in-umbraco/1/providers/amazon.md
+++ b/ai-in-umbraco/1/providers/amazon.md
@@ -45,7 +45,7 @@ dotnet add package Umbraco.AI.Amazon
 5. Copy the Access Key ID and Secret Access Key
 
 {% hint style="warning" %}
-Use IAM roles with least-privilege permissions. Attach the policy shown in [Required IAM Policy](#required-iam-policy) to the user or role.
+Use Identity Access Management (IAM) roles with least-privilege permissions. Attach the policy shown in [Required IAM Policy](#required-iam-policy) to the user or role.
 {% endhint %}
 
 ### Required IAM Policy

--- a/ai-in-umbraco/1/providers/amazon.md
+++ b/ai-in-umbraco/1/providers/amazon.md
@@ -45,10 +45,12 @@ dotnet add package Umbraco.AI.Amazon
 5. Copy the Access Key ID and Secret Access Key
 
 {% hint style="warning" %}
-Use IAM roles with least-privilege permissions. The user needs `bedrock:InvokeModel` permission.
+Use IAM roles with least-privilege permissions. Attach the policy shown in [Required IAM Policy](#required-iam-policy) to the user or role.
 {% endhint %}
 
 ### Required IAM Policy
+
+The IAM principal needs permission to invoke Bedrock models and to subscribe to AWS Marketplace products. The Marketplace actions are used by Bedrock to auto-enable foundation models on first use.
 
 {% code title="bedrock-policy.json" %}
 
@@ -58,8 +60,20 @@ Use IAM roles with least-privilege permissions. The user needs `bedrock:InvokeMo
     "Statement": [
         {
             "Effect": "Allow",
-            "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
+            "Action": [
+                "bedrock:InvokeModel",
+                "bedrock:InvokeModelWithResponseStream"
+            ],
             "Resource": "arn:aws:bedrock:*::foundation-model/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "aws-marketplace:Subscribe",
+                "aws-marketplace:Unsubscribe",
+                "aws-marketplace:ViewSubscriptions"
+            ],
+            "Resource": "*"
         }
     ]
 }
@@ -67,15 +81,23 @@ Use IAM roles with least-privilege permissions. The user needs `bedrock:InvokeMo
 
 {% endcode %}
 
+The AWS managed policy [AmazonBedrockFullAccess](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonBedrockFullAccess.html) covers all of these actions if you prefer to attach a managed policy.
+
 ### Enabling Models
 
-Before using a model, you must enable it in your AWS account:
+In commercial AWS regions, foundation model access is enabled automatically. The first time you invoke a third-party model in an account, Amazon Bedrock initiates the subscription in the background. Auto-enablement can take up to 15 minutes, during which calls may return `AccessDeniedException`.
 
-1. Go to **Amazon Bedrock** in the AWS Console
-2. Navigate to **Model access**
-3. Click **Manage model access**
-4. Select the models you want to use
-5. Submit the request (some models require approval)
+{% hint style="info" %}
+The **Manage model access** page in the Bedrock console was retired in October 2025. You no longer need to opt-in to individual models before using them.
+{% endhint %}
+
+#### Anthropic models
+
+Anthropic models require a one-time use-case form per AWS account or organization. Submit the form by selecting an Anthropic model from the model catalog in the Bedrock console, or by calling the [PutUseCaseForModelAccess](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_PutUseCaseForModelAccess.html) API. Access is granted immediately after submission.
+
+#### AWS GovCloud (US)
+
+GovCloud accounts in `us-gov-west-1` still use the **Model access** page in the Bedrock console for manual enablement. Third-party models also need to be enabled in the linked commercial account. For full details, see the AWS guide on [Request access to models](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html#model-access-govcloud).
 
 ![Amazon Bedrock connection detail showing Region and Access Key fields](../.gitbook/assets/amazon-bedrock-create-connection.png)
 

--- a/ai-in-umbraco/1/providers/amazon.md
+++ b/ai-in-umbraco/1/providers/amazon.md
@@ -50,7 +50,7 @@ Use Identity Access Management (IAM) roles with least-privilege permissions. Att
 
 ### Required IAM Policy
 
-The IAM principal needs permission to invoke Bedrock models and to subscribe to AWS Marketplace products. The Marketplace actions are used by Bedrock to auto-enable foundation models on first use.
+The IAM principal needs permission to invoke Bedrock models and to subscribe to Amazon Web Services (AWS) Marketplace products. The Marketplace actions are used by Bedrock to auto-enable foundation models on first use.
 
 {% code title="bedrock-policy.json" %}
 


### PR DESCRIPTION
## 📋 Description

User feedback flagged that the Amazon Bedrock provider docs are out of date: the **Manage model access** page in the AWS console was [retired in October 2025](https://aws.amazon.com/blogs/security/simplified-amazon-bedrock-model-access/) and the existing instructions no longer match the AWS console.

Foundation model access is now enabled automatically on first invocation, via AWS Marketplace auto-subscription. This PR updates `ai-in-umbraco/1/providers/amazon.md` to reflect the new flow:

- Add `aws-marketplace:Subscribe`, `aws-marketplace:Unsubscribe`, and `aws-marketplace:ViewSubscriptions` to the required IAM policy (needed for the auto-subscription to succeed), plus a pointer to `AmazonBedrockFullAccess` for users who prefer the managed policy.
- Replace the obsolete "Go to Model access → Manage model access → submit request" steps with the automatic enablement flow, and add an info hint stating the page was retired.
- Document the one-time use-case form that Anthropic models still require (submitted via the console or `PutUseCaseForModelAccess` API).
- Document the GovCloud (`us-gov-west-1`) exception, where the **Model access** page is still used.

**Not covered in this PR:** the user also reported that only "Cohere V4" appears in the embeddings dropdown and "it doesn't work". That's a `Umbraco.AI.Amazon` package-side concern, not a docs change — flagging it for the AI team.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful. _(N/A — the obsolete screenshot was for a retired UI; no replacement needed.)_
* [x] Any code examples or instructions have been tested. _(IAM policy verified against AWS docs.)_
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco.AI v1 — `ai-in-umbraco/1/providers/amazon.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)