### PR TITLE
Allow UMBRACO__STORAGE prefix in Secret Management

### DIFF
--- a/umbraco-cloud/begin-your-cloud-journey/project-features/secrets-management.md
+++ b/umbraco-cloud/begin-your-cloud-journey/project-features/secrets-management.md
@@ -159,7 +159,7 @@ The following prefixes are allowed for Secrets on Umbraco Cloud:
 
 * `Umbraco__CMS__Global__Smtp__`
 * `Umbraco__Forms__Security__FormsApiKey__`
-* `Umbraco__Forms__FieldTypes__Recaptcha__`
+* `Umbraco__Forms__FieldTypes__Recaptcha`
 * `Umbraco__CMS__Integrations__`
 * `Umbraco__CMS__DeliveryAPI__`
 * `UMBRACO__LICENSES__`
@@ -167,7 +167,8 @@ The following prefixes are allowed for Secrets on Umbraco Cloud:
 * `UMBRACO__COMMERCE__`,
 * `UMBRACO__AI__`,
 * `UMBRACO__CMS__IMAGING__HMACSECRETKEY`,
-* `UMBRACO__CMS__HEALTHCHECKS__`
+* `UMBRACO__CMS__HEALTHCHECKS__`,
+* `UMBRACO__STORAGE__`
 
 You can also use secrets to store API keys, passwords, and reCAPTCHA keys for Umbraco products on Umbraco Cloud.
 


### PR DESCRIPTION
On Umbraco Cloud the Secret Management feature now allows the `UMBRACO__STORAGE__` prefix

Also the `Umbraco__Forms__FieldTypes__Recaptcha` is less trict now a days, allowing `Umbraco__Forms__FieldTypes__Recaptcha3__` and `Umbraco__Forms__FieldTypes__Recaptcha2__`  values

## 📋 Description

<!-- A clear and concise description of what this PR changes or adds. Include context if necessary. -->

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
