### PR TITLE
Removed updates block and smoothened text

### DIFF
--- a/18/umbraco-cms/get-started/upgrading-and-migrating/version-specific/README.md
+++ b/18/umbraco-cms/get-started/upgrading-and-migrating/version-specific/README.md
@@ -22,7 +22,9 @@ For details, see the entry on `EnableMediaRecycleBinProtection` further down.
 
 ### Implement `ITypedSingleBlockListProcessor` for custom block-list nesting property editors
 
-The single-mode block list migration — added in Umbraco 17 but disabled — now runs by default during the upgrade to Umbraco 18. Sites with custom property editors that nest block list values must implement and register an `ITypedSingleBlockListProcessor` before the upgrade runs. Without this, nested data in those property values will be left in the old format.
+The single-mode block list migration was added in Umbraco 17 but disabled by default. It now runs automatically during the upgrade to Umbraco 18.
+
+If your site has custom property editors that nest block list values, you must implement and register an `ITypedSingleBlockListProcessor` before upgrading. Without this, nested data in those property values will not be migrated and will remain in the old format.
 
 For details, see the [Single block migration](./single-block-migration.md) article.
 

--- a/18/umbraco-cms/get-started/upgrading-and-migrating/version-specific/single-block-migration.md
+++ b/18/umbraco-cms/get-started/upgrading-and-migrating/version-specific/single-block-migration.md
@@ -4,7 +4,7 @@ description: >-
   the new Single Block property editor.
 ---
 
-# Single Block Migration for Umbraco 18
+# Single Block Migration
 
 Version 17 introduced the single block property editor. Its purpose is to replace the "single mode" option that exists in the Block List property editor. This is part of the broader effort to ensure type consistency across core property editors.
 

--- a/18/umbraco-cms/get-started/upgrading-and-migrating/version-specific/single-block-migration.md
+++ b/18/umbraco-cms/get-started/upgrading-and-migrating/version-specific/single-block-migration.md
@@ -1,18 +1,14 @@
+---
+description: >-
+  Learn how to migrate Block List property editors configured in single mode to 
+  the new Single Block property editor.
+---
+
 # Single Block Migration for Umbraco 18
-
-{% updates format="full" %}
-{% update date="2025-10-27" tags="early-access" %}
-## Early Access - Umbraco 18
-
-This article describes a migration that will not be enabled by default until Umbraco version 18. The feature is available in Umbraco version 17 for early access only, meaning you can run it manually using your own migration plan ahead of the version 18 release.
-{% endupdate %}
-{% endupdates %}
-
-### Introduction
 
 Version 17 introduced the single block property editor. Its purpose is to replace the "single mode" option that exists in the Block List property editor. This is part of the broader effort to ensure type consistency across core property editors.
 
-### Included migration
+## Included migration
 
 Umbraco ships with a migration to:
 
@@ -21,7 +17,7 @@ Umbraco ships with a migration to:
 
 The migration was added in Umbraco 17 but disabled. It now runs by default during the upgrade to Umbraco 18.
 
-### Pre-running the migration
+## Pre-running the migration
 
 You can run the migration at any time by using your own migration plan, as shown in the example below. If you run this migration yourself, the default Umbraco migration won't update any data. It only changes data in the old format.
 
@@ -92,7 +88,7 @@ public class RunTestMigration : INotificationAsyncHandler<UmbracoApplicationStar
 
 ```
 
-### Extending the migration
+## Extending the migration
 
 If your non-core property editor nests content and stores it within its own value, you must extend the migration. To do this, create and register a class that implements `ITypedSingleBlockListProcessor` and register it. See how the built-in types are registered at `Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_18_0_0.SingleBlockList.MigrateSingleBlockListComposer`. The interface needs the following properties and methods:
 


### PR DESCRIPTION
## 📋 Description

As part of the restructure project, we noticed that the Single Block migration article has been added in v17 as early access, which should be available by default in v18. This PR:

- [x] Verifies the Single Block Migration article is included/mentioned in the version-specific upgrades for V18.
- [x] Smoothened the text (removed em dashes, maybe AI-generated content? not sure).
- [x] Removes the updates block.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS v18

## Deadline (if relevant)

Anytime

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
