### PR TITLE
Correct module permissions tracking consent wording

### DIFF
--- a/17/umbraco-engage/developers/introduction/the-umbraco-engage-cookie/module-permissions.md
+++ b/17/umbraco-engage/developers/introduction/the-umbraco-engage-cookie/module-permissions.md
@@ -73,9 +73,9 @@ namespace YourNamespace
 ## Tracking a visitor's Initial Pageview
 
 {% hint style="warning" %}
-By changing the default module permissions to false a visitor is be tracked until they give their consent to the Analytics module. In that case, the module permission `AnalyticsIsAllowed` will be set to `true`.
+By changing the default module permissions to false a visitor will not be tracked until they give their consent to the Analytics module. In that case, the module permission `AnalyticsIsAllowed` will be set to `true`.
 
-Is the module permission set to true it is required to reload the current page as soon as the visitor has given consent. This needs to happen to track the current page visit the visitor has given consent on.
+If the module permission is set to true it is required to reload the current page as soon as the visitor has given consent. This needs to happen to track the current page visit the visitor has given consent on.
 
 If no reload is performed the visitor's referrer and/or campaign information will not be tracked.
 

--- a/18/umbraco-engage/developers/introduction/the-umbraco-engage-cookie/module-permissions.md
+++ b/18/umbraco-engage/developers/introduction/the-umbraco-engage-cookie/module-permissions.md
@@ -73,9 +73,9 @@ namespace YourNamespace
 ## Tracking a visitor's Initial Pageview
 
 {% hint style="warning" %}
-By changing the default module permissions to false a visitor is be tracked until they give their consent to the Analytics module. In that case, the module permission `AnalyticsIsAllowed` will be set to `true`.
+By changing the default module permissions to false a visitor will not be tracked until they give their consent to the Analytics module. In that case, the module permission `AnalyticsIsAllowed` will be set to `true`.
 
-Is the module permission set to true it is required to reload the current page as soon as the visitor has given consent. This needs to happen to track the current page visit the visitor has given consent on.
+If the module permission is set to true it is required to reload the current page as soon as the visitor has given consent. This needs to happen to track the current page visit the visitor has given consent on.
 
 If no reload is performed the visitor's referrer and/or campaign information will not be tracked.
 


### PR DESCRIPTION
## 📋 Description

Corrects unclear wording on Engage settings and user tracking.

## 📎 Related Issues (if applicable)

https://github.com/umbraco/UmbracoDocs/issues/8083

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
