### PR TITLE
Added example for contenservice - Getting date values programmatically

### DIFF
--- a/17/umbraco-cms/extend-your-project/server-side-extensions/management/using-services/contentservice.md
+++ b/17/umbraco-cms/extend-your-project/server-side-extensions/management/using-services/contentservice.md
@@ -63,8 +63,11 @@ For information on how to retrieve multilingual languages, see the [Retrieving l
 
 
 ### Getting date values programmatically
+
 When creating content programmatically, you may need to read back date values stored on a content node. This could be to validate, transform, or pass them to another service. The `IContentService` returns date property values as raw JSON, which must be deserialized into a `DateTimeDto` before use.
+
 The following example retrieves a date property from an existing content node and converts it to a `DateOnly` value:
+
 ```csharp
 using System.Text.Json;
 using Umbraco.Cms.Core.Services;
@@ -98,7 +101,7 @@ public class GetDateValueDemo
 	}
 }
 ```
-(generated with the help of Claude)
+_(generated with the help of Claude)_
 
 ## Publishing content programmatically
 

--- a/17/umbraco-cms/extend-your-project/server-side-extensions/management/using-services/contentservice.md
+++ b/17/umbraco-cms/extend-your-project/server-side-extensions/management/using-services/contentservice.md
@@ -99,3 +99,39 @@ The `PublishBranchFilter` option can include one or more of the following flags:
 - `ForceRepublish` - republishes all nodes, even if unchanged.
 - `All` - combines `IncludeUnpublished` and `ForceRepublish`.
 - For multilingual content, replace `"*"` with the array of cultures, for example, `new[] { "en-us", "da" }`.
+
+
+## Getting date values programmatically
+```csharp
+using System.Text.Json;
+using Umbraco.Cms.Core.Services;
+using static Umbraco.Cms.Core.PropertyEditors.ValueConverters.DateTimeValueConverterBase;
+
+namespace Umbraco.Cms.Web.UI.Custom;
+public class GetDateValueDemo
+{
+	private readonly IContentService _contentService;
+
+	public GetDateValueDemo(IContentService contentService) => _contentService = contentService;
+
+	public void GetDate(Guid key)
+	{
+		var content = _contentService.GetById(key);
+
+		if (content is not null)
+		{
+			var rawValue = content.GetValue("myDateProperty");
+
+			if (string.IsNullOrEmpty(rawValue?.ToString()) is false)
+			{
+				var dto = JsonSerializer.Deserialize<DateTimeDto>(rawValue.ToString()!);
+
+				if (dto is not null)
+				{
+					var dateOnly = DateOnly.FromDateTime(dto.Date.Date);
+				}
+			}
+		}
+	}
+}
+```

--- a/17/umbraco-cms/extend-your-project/server-side-extensions/management/using-services/contentservice.md
+++ b/17/umbraco-cms/extend-your-project/server-side-extensions/management/using-services/contentservice.md
@@ -64,7 +64,7 @@ For information on how to retrieve multilingual languages, see the [Retrieving l
 
 ### Getting date values programmatically
 
-When creating content programmatically, you may need to read back date values stored on a content node. This could be to validate, transform, or pass them to another service. The `IContentService` returns date property values as raw JSON, which must be deserialized into a `DateTimeDto` before use.
+When creating content programmatically, you may need to read back date values stored on a content node. This could be to validate, transform, or pass them to another service. The `IContentService` returns date property values as raw JSON, which must be deserialized into a `DateTimeDto` before use. 
 
 The following example retrieves a date property from an existing content node and converts it to a `DateOnly` value:
 

--- a/17/umbraco-cms/extend-your-project/server-side-extensions/management/using-services/contentservice.md
+++ b/17/umbraco-cms/extend-your-project/server-side-extensions/management/using-services/contentservice.md
@@ -61,6 +61,45 @@ demoProduct.SetCultureName("Mikrofon", "da"); // this will set the danish name
 
 For information on how to retrieve multilingual languages, see the [Retrieving languages](localizationservice.md) article.
 
+
+### Getting date values programmatically
+When creating content programmatically, you may need to read back date values stored on a content node. This could be to validate, transform, or pass them to another service. The `IContentService` returns date property values as raw JSON, which must be deserialized into a `DateTimeDto` before use.
+The following example retrieves a date property from an existing content node and converts it to a `DateOnly` value:
+```csharp
+using System.Text.Json;
+using Umbraco.Cms.Core.Services;
+using static Umbraco.Cms.Core.PropertyEditors.ValueConverters.DateTimeValueConverterBase;
+
+namespace Umbraco.Cms.Web.UI.Custom;
+public class GetDateValueDemo
+{
+	private readonly IContentService _contentService;
+
+	public GetDateValueDemo(IContentService contentService) => _contentService = contentService;
+
+	public void GetDate(Guid key)
+	{
+		var content = _contentService.GetById(key);
+
+		if (content is not null)
+		{
+			var rawValue = content.GetValue("myDateProperty");
+
+			if (string.IsNullOrEmpty(rawValue?.ToString()) is false)
+			{
+				var dto = JsonSerializer.Deserialize<DateTimeDto>(rawValue.ToString()!);
+
+				if (dto is not null)
+				{
+					var dateOnly = DateOnly.FromDateTime(dto.Date.Date);
+				}
+			}
+		}
+	}
+}
+```
+(generated with the help of Claude)
+
 ## Publishing content programmatically
 
 The `IContentService` is also used for publishing existing content. The following example shows how to publish a page and all its descendants.
@@ -100,38 +139,3 @@ The `PublishBranchFilter` option can include one or more of the following flags:
 - `All` - combines `IncludeUnpublished` and `ForceRepublish`.
 - For multilingual content, replace `"*"` with the array of cultures, for example, `new[] { "en-us", "da" }`.
 
-
-## Getting date values programmatically
-```csharp
-using System.Text.Json;
-using Umbraco.Cms.Core.Services;
-using static Umbraco.Cms.Core.PropertyEditors.ValueConverters.DateTimeValueConverterBase;
-
-namespace Umbraco.Cms.Web.UI.Custom;
-public class GetDateValueDemo
-{
-	private readonly IContentService _contentService;
-
-	public GetDateValueDemo(IContentService contentService) => _contentService = contentService;
-
-	public void GetDate(Guid key)
-	{
-		var content = _contentService.GetById(key);
-
-		if (content is not null)
-		{
-			var rawValue = content.GetValue("myDateProperty");
-
-			if (string.IsNullOrEmpty(rawValue?.ToString()) is false)
-			{
-				var dto = JsonSerializer.Deserialize<DateTimeDto>(rawValue.ToString()!);
-
-				if (dto is not null)
-				{
-					var dateOnly = DateOnly.FromDateTime(dto.Date.Date);
-				}
-			}
-		}
-	}
-}
-```

--- a/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/date-only.md
+++ b/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/date-only.md
@@ -114,3 +114,7 @@ The property editor handles date-only values. Time is set to 00:00:00 and offset
     // Save the change
     _contentService.Save(content);
     ```
+
+### Getting values programmatically
+
+For an example on how to work with `DateOnly` property using `IContentService` see the [Getting date values programmatically](../../../../extend-your-project/server-side-extensions/management/using-services/contentservice.md#getting-date-values-programmatically) article.

--- a/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/date-time-unspecified.md
+++ b/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/date-time-unspecified.md
@@ -117,3 +117,7 @@ The property editor handles unspecified date and time values without time zone i
     // Save the change
     _contentService.Save(content);
     ```
+
+### Getting values programmatically
+
+For an example on how to work with a date property using `IContentService` see the [Getting date values programmatically](../../../../extend-your-project/server-side-extensions/management/using-services/contentservice.md#getting-date-values-programmatically) article.

--- a/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/date-time-with-time-zone.md
+++ b/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/date-time-with-time-zone.md
@@ -163,3 +163,7 @@ The property editor stores values in this JSON format:
     // Save the change
     _contentService.Save(content);
     ```
+
+### Getting values programmatically
+
+For an example on how to work with a date property using `IContentService` see the [Getting date values programmatically](../../../../extend-your-project/server-side-extensions/management/using-services/contentservice.md#getting-date-values-programmatically) article.

--- a/18/umbraco-cms/extend-your-project/server-side-extensions/management/using-services/contentservice.md
+++ b/18/umbraco-cms/extend-your-project/server-side-extensions/management/using-services/contentservice.md
@@ -61,6 +61,48 @@ demoProduct.SetCultureName("Mikrofon", "da"); // this will set the danish name
 
 For information on how to retrieve multilingual languages, see the [Retrieving languages](localizationservice.md) article.
 
+
+### Getting date values programmatically
+
+When creating content programmatically, you may need to read back date values stored on a content node. This could be to validate, transform, or pass them to another service. The `IContentService` returns date property values as raw JSON, which must be deserialized into a `DateTimeDto` before use.
+
+The following example retrieves a date property from an existing content node and converts it to a `DateOnly` value:
+
+```csharp
+using System.Text.Json;
+using Umbraco.Cms.Core.Services;
+using static Umbraco.Cms.Core.PropertyEditors.ValueConverters.DateTimeValueConverterBase;
+
+namespace Umbraco.Cms.Web.UI.Custom;
+public class GetDateValueDemo
+{
+	private readonly IContentService _contentService;
+
+	public GetDateValueDemo(IContentService contentService) => _contentService = contentService;
+
+	public void GetDate(Guid key)
+	{
+		var content = _contentService.GetById(key);
+
+		if (content is not null)
+		{
+			var rawValue = content.GetValue("myDateProperty");
+
+			if (string.IsNullOrEmpty(rawValue?.ToString()) is false)
+			{
+				var dto = JsonSerializer.Deserialize<DateTimeDto>(rawValue.ToString()!);
+
+				if (dto is not null)
+				{
+					var dateOnly = DateOnly.FromDateTime(dto.Date.Date);
+				}
+			}
+		}
+	}
+}
+```
+_(generated with the help of Claude)_
+
 ## Publishing content programmatically
 
 The `IContentService` is also used for publishing existing content. The following example shows how to publish a page and all its descendants.

--- a/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/date-only.md
+++ b/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/date-only.md
@@ -114,3 +114,7 @@ The property editor handles date-only values. Time is set to 00:00:00 and offset
     // Save the change
     _contentService.Save(content);
     ```
+    
+### Getting values programmatically
+
+For an example on how to work with `DateOnly` property using `IContentService` see the [Getting date values programmatically](../../../../extend-your-project/server-side-extensions/management/using-services/contentservice.md#getting-date-values-programmatically) article.

--- a/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/date-time-unspecified.md
+++ b/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/date-time-unspecified.md
@@ -117,3 +117,7 @@ The property editor handles unspecified date and time values without time zone i
     // Save the change
     _contentService.Save(content);
     ```
+
+### Getting values programmatically
+
+For an example on how to work with a date property using `IContentService` see the [Getting date values programmatically](../../../../extend-your-project/server-side-extensions/management/using-services/contentservice.md#getting-date-values-programmatically) article.

--- a/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/date-time-with-time-zone.md
+++ b/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/date-time-editor/date-time-with-time-zone.md
@@ -163,3 +163,7 @@ The property editor stores values in this JSON format:
     // Save the change
     _contentService.Save(content);
     ```
+
+### Getting values programmatically
+
+For an example on how to work with a date property using `IContentService` see the [Getting date values programmatically](../../../../extend-your-project/server-side-extensions/management/using-services/contentservice.md#getting-date-values-programmatically) article.


### PR DESCRIPTION
## 📋 Description

Added a code example for working with dates using content service.

(Unsure if I should add comments to it)

## 📎 Related Issues (if applicable)

Code example for #8031 

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [X] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
