### PR TITLE
Move note from members to users article

### DIFF
--- a/17/umbraco-cms/run-in-production/tutorials/add-google-authentication.md
+++ b/17/umbraco-cms/run-in-production/tutorials/add-google-authentication.md
@@ -8,6 +8,15 @@ description: >-
 
 The Umbraco Backoffice supports external login providers (OAuth) for performing authentication of your users. This could be any OpenIDConnect provider such as Entra ID/Azure Active Directory, Identity Server, Google, or Facebook.
 
+{% hint style="success" %}
+**Note for Umbraco Cloud users**
+
+Umbraco Cloud supports External Identity Providers, including Google Authentication.
+If you're working on a Cloud project, see the [External Login Providers](https://docs.umbraco.com/umbraco-cloud/begin-your-cloud-journey/project-features/external-login-providers) article in the Umbraco Cloud documentation.
+
+The following tutorial is intended only for non-Cloud (on-premises or self-hosted) projects.
+{% endhint %}
+
 In this tutorial, we will take you through the steps of setting up a Google login for the Umbraco CMS backoffice.
 
 ## What is a Google Login?

--- a/17/umbraco-cms/run-in-production/tutorials/add-microsoft-entra-id-authentication.md
+++ b/17/umbraco-cms/run-in-production/tutorials/add-microsoft-entra-id-authentication.md
@@ -8,15 +8,6 @@ description: >-
 
 This tutorial takes you through configuring Microsoft Entra ID (Azure Active Directory/Azure AD) for the member login on your Umbraco CMS website.
 
-{% hint style="success" %}
-**Note for Umbraco Cloud users**
-
-Umbraco Cloud supports External Identity Providers, including Entra ID (formerly Azure AD).\
-If you're working on a Cloud project, see the [External Login Providers](https://docs.umbraco.com/umbraco-cloud/begin-your-cloud-journey/project-features/external-login-providers) article in the Umbraco Cloud documentation.
-
-On Umbraco Cloud, Entra ID is configured via settings rather than custom code. So, this tutorial is intended for non-Cloud (on-premises or self-hosted) projects.
-{% endhint %}
-
 ## Prerequisites
 
 * A project with a setup for Members.

--- a/18/umbraco-cms/run-in-production/tutorials/add-google-authentication.md
+++ b/18/umbraco-cms/run-in-production/tutorials/add-google-authentication.md
@@ -8,6 +8,15 @@ description: >-
 
 The Umbraco Backoffice supports external login providers (OAuth) for performing authentication of your users. This could be any OpenIDConnect provider such as Entra ID/Azure Active Directory, Identity Server, Google, or Facebook.
 
+{% hint style="success" %}
+**Note for Umbraco Cloud users**
+
+Umbraco Cloud supports External Identity Providers, including Google Authentication.
+If you're working on a Cloud project, see the [External Login Providers](https://docs.umbraco.com/umbraco-cloud/begin-your-cloud-journey/project-features/external-login-providers) article in the Umbraco Cloud documentation.
+
+The following tutorial is intended only for non-Cloud (on-premises or self-hosted) projects.
+{% endhint %}
+
 In this tutorial, we will take you through the steps of setting up a Google login for the Umbraco CMS backoffice.
 
 ## What is a Google Login?

--- a/18/umbraco-cms/run-in-production/tutorials/add-microsoft-entra-id-authentication.md
+++ b/18/umbraco-cms/run-in-production/tutorials/add-microsoft-entra-id-authentication.md
@@ -8,15 +8,6 @@ description: >-
 
 This tutorial takes you through configuring Microsoft Entra ID (Azure Active Directory/Azure AD) for the member login on your Umbraco CMS website.
 
-{% hint style="success" %}
-**Note for Umbraco Cloud users**
-
-Umbraco Cloud supports External Identity Providers, including Entra ID (formerly Azure AD).\
-If you're working on a Cloud project, see the [External Login Providers](https://docs.umbraco.com/umbraco-cloud/begin-your-cloud-journey/project-features/external-login-providers) article in the Umbraco Cloud documentation.
-
-On Umbraco Cloud, Entra ID is configured via settings rather than custom code. So, this tutorial is intended for non-Cloud (on-premises or self-hosted) projects.
-{% endhint %}
-
 ## Prerequisites
 
 * A project with a setup for Members.


### PR DESCRIPTION
## 📋 Description

#8108 reports that the note about external login providers has been placed in the Member Authentication tutorial, and not in the User Authentication tutorial, where it should be.

This PR fixes that.

## 📎 Related Issues (if applicable)

Fixes #8108 
