### PR TITLE
Engage Release Notes - 02-06-2026

### DIFF
--- a/16/umbraco-engage/release-notes.md
+++ b/16/umbraco-engage/release-notes.md
@@ -16,6 +16,10 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 Below are the release notes for Umbraco Engage 16, detailing all changes in this version.
 
+#### [16.3.3](https://www.nuget.org/packages/Umbraco.Engage/16.3.3) (June 2nd 2026)
+
+* Resolved pageviews and associated data not getting flushed to the database on loadbalanced (subscriber) setups.
+
 #### [16.3.2](https://www.nuget.org/packages/Umbraco.Engage/16.3.2) (May 22nd 2026)
 
 * Resolved a unique-key collision that occurred when adding a second personalization to the same page ([Issue #66](https://github.com/umbraco/Umbraco.Engage.Issues/issues/66)).

--- a/16/umbraco-engage/release-notes.md
+++ b/16/umbraco-engage/release-notes.md
@@ -18,7 +18,7 @@ Below are the release notes for Umbraco Engage 16, detailing all changes in this
 
 #### [16.3.3](https://www.nuget.org/packages/Umbraco.Engage/16.3.3) (June 2nd 2026)
 
-* Resolved pageviews and associated data not getting flushed to the database on loadbalanced (subscriber) setups.
+* Resolved pageviews and associated data not getting flushed to the database on load-balanced (subscriber) setups.
 
 #### [16.3.2](https://www.nuget.org/packages/Umbraco.Engage/16.3.2) (May 22nd 2026)
 

--- a/17/umbraco-engage/release-notes.md
+++ b/17/umbraco-engage/release-notes.md
@@ -16,6 +16,10 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 Below are the release notes for Umbraco Engage 17, detailing all changes in this version.
 
+#### [17.2.3](https://www.nuget.org/packages/Umbraco.Engage/17.2.3) (June 2nd 2026)
+
+* Resolved pageviews and associated data not getting flushed to the database on loadbalanced (subscriber) setups.
+
 #### [17.2.2](https://www.nuget.org/packages/Umbraco.Engage/17.2.2) (May 22nd 2026)
 
 * Resolved a unique-key collision that occurred when adding a second personalization to the same page ([Issue #66](https://github.com/umbraco/Umbraco.Engage.Issues/issues/66)).

--- a/17/umbraco-engage/release-notes.md
+++ b/17/umbraco-engage/release-notes.md
@@ -18,7 +18,7 @@ Below are the release notes for Umbraco Engage 17, detailing all changes in this
 
 #### [17.2.3](https://www.nuget.org/packages/Umbraco.Engage/17.2.3) (June 2nd 2026)
 
-* Resolved pageviews and associated data not getting flushed to the database on loadbalanced (subscriber) setups.
+* Resolved pageviews and associated data not getting flushed to the database on load-balanced (subscriber) setups.
 
 #### [17.2.2](https://www.nuget.org/packages/Umbraco.Engage/17.2.2) (May 22nd 2026)
 


### PR DESCRIPTION
Added release notes for the Engage patch releases from 02-06-2026 