### PR TITLE
Updated application URL health check with warning and error states for CMS 17.5 (and 18.0)

### DIFF
--- a/17/umbraco-cms/run-in-production/infrastructure-and-ops/health-check/guides/fixedapplicationurl.md
+++ b/17/umbraco-cms/run-in-production/infrastructure-and-ops/health-check/guides/fixedapplicationurl.md
@@ -1,6 +1,6 @@
 # Fixed Application Url
 
-_Checks that an application URL is available. This URL is used by features that need an absolute URL, such as password-reset and user-invitation emails sent from the backoffice._
+Checks that an application URL is available. This URL is used by features that need an absolute URL, such as password-reset and user-invitation emails sent from the backoffice.
 
 The check has three possible outcomes:
 
@@ -8,9 +8,9 @@ The check has three possible outcomes:
 | --- | --- |
 | `UmbracoApplicationUrl` is set | **Success** |
 | `UmbracoApplicationUrl` is not set, but `ApplicationUrlDetection` is `FirstRequest` or `EveryRequest` | **Warning** — the application URL is detected from incoming requests. Setting it explicitly is recommended. |
-| `UmbracoApplicationUrl` is not set **and** `ApplicationUrlDetection` is `None` | **Error** — no URL is configured and none will ever be detected. |
+| `UmbracoApplicationUrl` is not set **and** `ApplicationUrlDetection` is `None` | **Error** — no URL is configured, and none will ever be detected. |
 
-When the check returns an **Error**, no application URL is available and nothing will detect one. Features that require an absolute URL - such as password-reset and user-invitation emails - will not work until the configuration is corrected.
+When the check returns an **Error**, no application URL is available, and nothing will detect one. Features that require an absolute URL - such as password-reset and user-invitation emails - will not work until the configuration is corrected.
 
 ## How to fix this health check
 
@@ -20,11 +20,11 @@ There are two ways to resolve this health check. Setting the application URL exp
 
 Provide configuration on the following path: `Umbraco:CMS:WebRouting:UmbracoApplicationUrl`.
 
-This configuration can be setup in a configuration source of your choice. This guide shows how to set it up in one of the JSON file sources.
+This configuration can be set up in a configuration source of your choice. This guide shows how to set it up in one of the JSON file sources.
 
 #### Updating the JSON configuration
 
-The following JSON needs to be merged into one of your JSON sources. By default the following JSON sources are used: `appSettings.json` and `appSettings.<environment>.json`, e.g. `appSettings.Development.json` or `appSettings.Production.json`.
+The following JSON needs to be merged into one of your JSON sources. By default, the following JSON sources are used: `appSettings.json` and `appSettings.<environment>.json` (`appSettings.Development.json` or `appSettings.Production.json`).
 
 ```json
 {
@@ -53,7 +53,7 @@ One example that can be used in production
 ```
 
 {% hint style="info" %}
-If the site is hosted on Umbraco Cloud, changing the above configuration will have no effect. The site will always use the URL set in the\`umbraco-cloud.json\` file, which can not be changed.
+If the site is hosted on Umbraco Cloud, changing the above configuration will have no effect. The site will always use the URL set in the `umbraco-cloud.json` file, which can not be changed.
 {% endhint %}
 
 ### Option 2: Enable application URL detection

--- a/17/umbraco-cms/run-in-production/infrastructure-and-ops/health-check/guides/fixedapplicationurl.md
+++ b/17/umbraco-cms/run-in-production/infrastructure-and-ops/health-check/guides/fixedapplicationurl.md
@@ -1,15 +1,28 @@
 # Fixed Application Url
 
-_Check to make sure a fixed application URL is specified. This URL is for example used when sending emails from backoffice._\
-&#xNAN;_&#x49;f this is not specified in configuration, Umbraco gets the application URL from last host used to request the application_
+_Checks that an application URL is available. This URL is used by features that need an absolute URL, such as password-reset and user-invitation emails sent from the backoffice._
+
+The check has three possible outcomes:
+
+| Condition | Result |
+| --- | --- |
+| `UmbracoApplicationUrl` is set | **Success** |
+| `UmbracoApplicationUrl` is not set, but `ApplicationUrlDetection` is `FirstRequest` or `EveryRequest` | **Warning** — the application URL is detected from incoming requests. Setting it explicitly is recommended. |
+| `UmbracoApplicationUrl` is not set **and** `ApplicationUrlDetection` is `None` | **Error** — no URL is configured and none will ever be detected. |
+
+When the check returns an **Error**, no application URL is available and nothing will detect one. Features that require an absolute URL - such as password-reset and user-invitation emails - will not work until the configuration is corrected.
 
 ## How to fix this health check
 
-This health check can be fixed by providing configuration on the following path: `Umbraco:CMS:WebRouting:UmbracoApplicationUrl`.
+There are two ways to resolve this health check. Setting the application URL explicitly is the recommended approach for production environments.
+
+### Option 1: Set the application URL explicitly (recommended)
+
+Provide configuration on the following path: `Umbraco:CMS:WebRouting:UmbracoApplicationUrl`.
 
 This configuration can be setup in a configuration source of your choice. This guide shows how to set it up in one of the JSON file sources.
 
-### Updating the JSON configuration
+#### Updating the JSON configuration
 
 The following JSON needs to be merged into one of your JSON sources. By default the following JSON sources are used: `appSettings.json` and `appSettings.<environment>.json`, e.g. `appSettings.Development.json` or `appSettings.Production.json`.
 
@@ -42,3 +55,21 @@ One example that can be used in production
 {% hint style="info" %}
 If the site is hosted on Umbraco Cloud, changing the above configuration will have no effect. The site will always use the URL set in the\`umbraco-cloud.json\` file, which can not be changed.
 {% endhint %}
+
+### Option 2: Enable application URL detection
+
+Alternatively, set `Umbraco:CMS:WebRouting:ApplicationUrlDetection` to `FirstRequest` or `EveryRequest`, so that the application URL is detected automatically from incoming requests. This resolves the **Error** to a **Warning**.
+
+```json
+{
+    "Umbraco": {
+        "CMS": {
+            "WebRouting": {
+                "ApplicationUrlDetection": "FirstRequest"
+            }
+        }
+    }
+}
+```
+
+For details on the available detection modes and their security implications, see [Application URL detection](../../../../develop-with-umbraco/configuration/webroutingsettings.md#application-url-detection) in the WebRouting settings documentation.

--- a/18/umbraco-cms/run-in-production/infrastructure-and-ops/health-check/guides/fixedapplicationurl.md
+++ b/18/umbraco-cms/run-in-production/infrastructure-and-ops/health-check/guides/fixedapplicationurl.md
@@ -1,6 +1,6 @@
 # Fixed Application Url
 
-_Checks that an application URL is available. This URL is used by features that need an absolute URL, such as password-reset and user-invitation emails sent from the backoffice._
+Checks that an application URL is available. This URL is used by features that need an absolute URL, such as password-reset and user-invitation emails sent from the backoffice.
 
 The check has three possible outcomes:
 
@@ -8,9 +8,9 @@ The check has three possible outcomes:
 | --- | --- |
 | `UmbracoApplicationUrl` is set | **Success** |
 | `UmbracoApplicationUrl` is not set, but `ApplicationUrlDetection` is `FirstRequest` or `EveryRequest` | **Warning** — the application URL is detected from incoming requests. Setting it explicitly is recommended. |
-| `UmbracoApplicationUrl` is not set **and** `ApplicationUrlDetection` is `None` | **Error** — no URL is configured and none will ever be detected. |
+| `UmbracoApplicationUrl` is not set **and** `ApplicationUrlDetection` is `None` | **Error** — no URL is configured, and none will ever be detected. |
 
-When the check returns an **Error**, no application URL is available and nothing will detect one. Features that require an absolute URL - such as password-reset and user-invitation emails - will not work until the configuration is corrected.
+When the check returns an **Error**, no application URL is available, and nothing will detect one. Features that require an absolute URL - such as password-reset and user-invitation emails - will not work until the configuration is corrected.
 
 ## How to fix this health check
 
@@ -20,11 +20,11 @@ There are two ways to resolve this health check. Setting the application URL exp
 
 Provide configuration on the following path: `Umbraco:CMS:WebRouting:UmbracoApplicationUrl`.
 
-This configuration can be setup in a configuration source of your choice. This guide shows how to set it up in one of the JSON file sources.
+This configuration can be set up in a configuration source of your choice. This guide shows how to set it up in one of the JSON file sources.
 
 #### Updating the JSON configuration
 
-The following JSON needs to be merged into one of your JSON sources. By default the following JSON sources are used: `appSettings.json` and `appSettings.<environment>.json`, e.g. `appSettings.Development.json` or `appSettings.Production.json`.
+The following JSON needs to be merged into one of your JSON sources. By default, the following JSON sources are used: `appSettings.json` and `appSettings.<environment>.json` (`appSettings.Development.json` or `appSettings.Production.json`).
 
 ```json
 {
@@ -53,7 +53,7 @@ One example that can be used in production
 ```
 
 {% hint style="info" %}
-If the site is hosted on Umbraco Cloud, changing the above configuration will have no effect. The site will always use the URL set in the\`umbraco-cloud.json\` file, which can not be changed.
+If the site is hosted on Umbraco Cloud, changing the above configuration will have no effect. The site will always use the URL set in the `umbraco-cloud.json` file, which can not be changed.
 {% endhint %}
 
 ### Option 2: Enable application URL detection

--- a/18/umbraco-cms/run-in-production/infrastructure-and-ops/health-check/guides/fixedapplicationurl.md
+++ b/18/umbraco-cms/run-in-production/infrastructure-and-ops/health-check/guides/fixedapplicationurl.md
@@ -1,15 +1,28 @@
 # Fixed Application Url
 
-_Check to make sure a fixed application URL is specified. This URL is for example used when sending emails from backoffice._\
-&#xNAN;_&#x49;f this is not specified in configuration, Umbraco gets the application URL from last host used to request the application_
+_Checks that an application URL is available. This URL is used by features that need an absolute URL, such as password-reset and user-invitation emails sent from the backoffice._
+
+The check has three possible outcomes:
+
+| Condition | Result |
+| --- | --- |
+| `UmbracoApplicationUrl` is set | **Success** |
+| `UmbracoApplicationUrl` is not set, but `ApplicationUrlDetection` is `FirstRequest` or `EveryRequest` | **Warning** — the application URL is detected from incoming requests. Setting it explicitly is recommended. |
+| `UmbracoApplicationUrl` is not set **and** `ApplicationUrlDetection` is `None` | **Error** — no URL is configured and none will ever be detected. |
+
+When the check returns an **Error**, no application URL is available and nothing will detect one. Features that require an absolute URL - such as password-reset and user-invitation emails - will not work until the configuration is corrected.
 
 ## How to fix this health check
 
-This health check can be fixed by providing configuration on the following path: `Umbraco:CMS:WebRouting:UmbracoApplicationUrl`.
+There are two ways to resolve this health check. Setting the application URL explicitly is the recommended approach for production environments.
+
+### Option 1: Set the application URL explicitly (recommended)
+
+Provide configuration on the following path: `Umbraco:CMS:WebRouting:UmbracoApplicationUrl`.
 
 This configuration can be setup in a configuration source of your choice. This guide shows how to set it up in one of the JSON file sources.
 
-### Updating the JSON configuration
+#### Updating the JSON configuration
 
 The following JSON needs to be merged into one of your JSON sources. By default the following JSON sources are used: `appSettings.json` and `appSettings.<environment>.json`, e.g. `appSettings.Development.json` or `appSettings.Production.json`.
 
@@ -42,3 +55,21 @@ One example that can be used in production
 {% hint style="info" %}
 If the site is hosted on Umbraco Cloud, changing the above configuration will have no effect. The site will always use the URL set in the\`umbraco-cloud.json\` file, which can not be changed.
 {% endhint %}
+
+### Option 2: Enable application URL detection
+
+Alternatively, set `Umbraco:CMS:WebRouting:ApplicationUrlDetection` to `FirstRequest` or `EveryRequest`, so that the application URL is detected automatically from incoming requests. This resolves the **Error** to a **Warning**.
+
+```json
+{
+    "Umbraco": {
+        "CMS": {
+            "WebRouting": {
+                "ApplicationUrlDetection": "FirstRequest"
+            }
+        }
+    }
+}
+```
+
+For details on the available detection modes and their security implications, see [Application URL detection](../../../../develop-with-umbraco/configuration/webroutingsettings.md#application-url-detection) in the WebRouting settings documentation.


### PR DESCRIPTION
## 📋 Description

Updates the documentation on the application URL health check for CMS 17.5 (and 18.0)

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/pull/23033

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17.5 and 18.0

## Deadline (if relevant)

I suggest this goes live with CMS 17.5-rc due on 11th June. Strictly speaking it's in the 18.0-rc1 that's released earlier, but I think it'll be less confusing if we update this with 17.5 availability.

