### PR TITLE
Enhance User Mapping Claim Name explanation

### DIFF
--- a/umbraco-cloud/begin-your-cloud-journey/the-cloud-portal/organizations/organization-login-providers.md
+++ b/umbraco-cloud/begin-your-cloud-journey/the-cloud-portal/organizations/organization-login-providers.md
@@ -271,7 +271,13 @@ Using the "Use Default Access Level" option, all users in your Login Provider wi
 
 ### User Mapping Claim Name
 
-This is used for the name of your provider's default or custom Role claim name. Use this if you want to override the one already entered in the Login Provider configuration.
+Your provider may assign users to specific roles (For example: Admin, Editor, Viewer).
+
+The User Group Claim Name is the field in the authentication token (claim) that identifies these roles. The system reads this claim to determine a user’s permissions.
+
+Example: If your provider sends roles in a claim named user_roles, you would set the User Group Claim Name to user_roles so the system can properly recognize user permissions.
+
+NOTE: If the field is left blank, the system will default to use http://schemas.microsoft.com/ws/2008/06/identity/claims/role as the claim name.
 
 ### Project User Mappings
 


### PR DESCRIPTION
Clarify the User Mapping Claim Name section with examples and details on role assignments.

## 📋 Description

Expanded the User Mapping Claim Name section to provide additional context on how role claims are used during authentication.

Added:

A clearer explanation of the purpose of the setting.
An example showing how a custom role claim (for example, user_roles) can be configured.
Details about how role assignments are mapped to user permissions and user groups.
A note describing the default behavior when the field is left blank.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x ] Code blocks are correctly formatted.
* [x ] Sentences are short and clear (preferably under 25 words).
* [x ] Passive voice and first-person language (“we”, “I”) are avoided.
* [x ] Relevant pages are linked.
* [ x] All links work and point to the correct resources.
* [x ] Screenshots or diagrams are included if useful.
* [x ] Any code examples or instructions have been tested.
* [ x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Cloud - External login providers

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
