### PR TITLE
docs(cloud): clarify purpose of the two static outbound IP pages

### DIFF
--- a/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
+++ b/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
@@ -1,9 +1,9 @@
 # External Services
 
 {% hint style="info" %}
-This page covers **your project's own outbound IP addresses** - the addresses your website sends traffic *from*. Share these with an external service so it can allowlist requests coming from your Cloud project.
+This page covers **your project's own outbound IP addresses** - the addresses your website sends traffic *from*. Share these with an external service to allowlist requests coming from your Cloud project.
 
-Looking for the IP addresses of Umbraco Cloud's own services so you can allowlist them in your firewall? See [Static Outbound IP Addresses for Umbraco Cloud](static-outbound-ip-addresses.md).
+Are you looking for the IP addresses of Umbraco Cloud's own services to allowlist them in your firewall? See [Static Outbound IP Addresses for Umbraco Cloud](static-outbound-ip-addresses.md).
 {% endhint %}
 
 In some cases, Umbraco Cloud might not be the only service you are working with. You might need to work with other services as well. This could be either internal or third-party services. In either case, it will be serviced externally to Umbraco Cloud.
@@ -14,7 +14,7 @@ For example, to retrieve information from an external service that is located be
 
 ## Enabling static outbound IP addresses
 
-For projects on a Standard, Professional, and Enterprise plan you can enable static outbound IP addresses.
+For projects on a Standard, Professional, and Enterprise plan, you can enable static outbound IP addresses.
 
 On the **Advanced** page of your project, you can turn on the static outbound IP address feature to ensure persistent communication. This opt-in feature can be switched on for **Standard**, **Professional**, and **Enterprise** Cloud projects.
 
@@ -60,6 +60,6 @@ For projects on a Starter plan, you can see the current dynamic outbound IP addr
 
 ## Umbraco Cloud service IP addresses
 
-The IP addresses above are your project's *own* outbound addresses. These are different from the addresses used by Umbraco Cloud's internal services that connect to your environment. The internal services include both global and regional services.
+The IP addresses above are your project's **own** outbound addresses. These are different from the addresses used by Umbraco Cloud's internal services that connect to your environment. The internal services include both global and regional services.
 
 If you need to allowlist those services in your firewall, see [Static Outbound IP Addresses for Umbraco Cloud](static-outbound-ip-addresses.md).

--- a/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
+++ b/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
@@ -60,6 +60,6 @@ For projects on a Starter plan, you can see the current dynamic outbound IP addr
 
 ## Umbraco Cloud service IP addresses
 
-The IP addresses above are your project's *own* outbound addresses. These are different from the addresses used by Umbraco Cloud's internal services that connect to your environment. These services include both global and regional services.
+The IP addresses above are your project's *own* outbound addresses. These are different from the addresses used by Umbraco Cloud's internal services that connect to your environment. The services include both global and regional services.
 
 If you need to allowlist those services in your firewall, see [Static Outbound IP Addresses for Umbraco Cloud](static-outbound-ip-addresses.md).

--- a/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
+++ b/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
@@ -60,6 +60,6 @@ For projects on a Starter plan, you can see the current dynamic outbound IP addr
 
 ## Umbraco Cloud service IP addresses
 
-The IP addresses above are your project's *own* outbound addresses. These are different from the addresses used by Umbraco Cloud's internal services that connect to your environment. The services include both global and regional services.
+The IP addresses above are your project's *own* outbound addresses. These are different from the addresses used by Umbraco Cloud's internal services that connect to your environment. The internal services include both global and regional services.
 
 If you need to allowlist those services in your firewall, see [Static Outbound IP Addresses for Umbraco Cloud](static-outbound-ip-addresses.md).

--- a/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
+++ b/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
@@ -1,5 +1,11 @@
 # External Services
 
+{% hint style="info" %}
+This page covers **your project's own outbound IP addresses** - the addresses your website sends traffic *from*. Share these with an external service so it can allowlist requests coming from your Cloud project.
+
+Looking for the IP addresses of Umbraco Cloud's own services so you can allowlist them in your firewall? See [Static Outbound IP Addresses for Umbraco Cloud](static-outbound-ip-addresses.md).
+{% endhint %}
+
 In some cases, Umbraco Cloud might not be the only service you are working with. You might need to work with other services as well. This could be either internal or third-party services. In either case, it will be serviced externally to Umbraco Cloud.
 
 If an external service behind a firewall needs to communicate with your Umbraco Cloud project, allow Umbraco Cloud Server IPs to bypass the firewall.
@@ -52,6 +58,8 @@ If you need to use a CIDR Range for the IPs: `40.113.173.32/28`
 For projects on a Starter plan, you can see the current dynamic outbound IP addresses. The IP addresses for starter projects are dynamic and may change due to Azure or Umbraco optimizing resources.
 {% endhint %}
 
-## Complete IP Address Reference
+## Umbraco Cloud service IP addresses
 
-For a comprehensive list of all static outbound IP addresses used by Umbraco Cloud services across all regions, including both global and regional services, see [Static Outbound IP Addresses for Umbraco Cloud](static-outbound-ip-addresses.md).
+The IP addresses above are your project's *own* outbound addresses. These are different from the addresses used by Umbraco Cloud's internal services that connect to your environment.
+
+If you need to allowlist those services in your firewall, see [Static Outbound IP Addresses for Umbraco Cloud](static-outbound-ip-addresses.md).

--- a/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
+++ b/umbraco-cloud/expand-your-projects-capabilities/external-services/README.md
@@ -60,6 +60,6 @@ For projects on a Starter plan, you can see the current dynamic outbound IP addr
 
 ## Umbraco Cloud service IP addresses
 
-The IP addresses above are your project's *own* outbound addresses. These are different from the addresses used by Umbraco Cloud's internal services that connect to your environment.
+The IP addresses above are your project's *own* outbound addresses. These are different from the addresses used by Umbraco Cloud's internal services that connect to your environment. These services include both global and regional services.
 
 If you need to allowlist those services in your firewall, see [Static Outbound IP Addresses for Umbraco Cloud](static-outbound-ip-addresses.md).

--- a/umbraco-cloud/expand-your-projects-capabilities/external-services/static-outbound-ip-addresses.md
+++ b/umbraco-cloud/expand-your-projects-capabilities/external-services/static-outbound-ip-addresses.md
@@ -7,9 +7,9 @@ description: >-
 # Static Outbound IP Addresses for Umbraco Cloud
 
 {% hint style="info" %}
-This page covers the IP addresses used by **Umbraco Cloud's own services** that connect to your environment. Allowlist these in your firewall so Umbraco Cloud services can keep reaching your site.
+This page covers the IP addresses used by **Umbraco Cloud's own services** that connect to your environment. Allowlist these in your firewall to enable Umbraco Cloud services to keep reaching your site.
 
-Looking for your project's own outbound IP addresses to share with an external service? See [External Services](README.md).
+Are you looking for your project's own outbound IP addresses to share with an external service? See [External Services](README.md).
 {% endhint %}
 
 Umbraco Cloud services access external applications using static outbound IP addresses. This enables you to allowlist Cloud services in IP-based firewalls. This is particularly useful if you wish to control access to your website based on IP addresses.

--- a/umbraco-cloud/expand-your-projects-capabilities/external-services/static-outbound-ip-addresses.md
+++ b/umbraco-cloud/expand-your-projects-capabilities/external-services/static-outbound-ip-addresses.md
@@ -6,6 +6,12 @@ description: >-
 
 # Static Outbound IP Addresses for Umbraco Cloud
 
+{% hint style="info" %}
+This page covers the IP addresses used by **Umbraco Cloud's own services** that connect to your environment. Allowlist these in your firewall so those services can keep reaching your site.
+
+Looking for your project's own outbound IP addresses to share with an external service? See [External Services](README.md).
+{% endhint %}
+
 Umbraco Cloud services access external applications using static outbound IP addresses. This enables you to allowlist Cloud services in IP-based firewalls. This is particularly useful if you wish to control access to your website based on IP addresses.
 
 ## Allowlisting IP Addresses

--- a/umbraco-cloud/expand-your-projects-capabilities/external-services/static-outbound-ip-addresses.md
+++ b/umbraco-cloud/expand-your-projects-capabilities/external-services/static-outbound-ip-addresses.md
@@ -7,7 +7,7 @@ description: >-
 # Static Outbound IP Addresses for Umbraco Cloud
 
 {% hint style="info" %}
-This page covers the IP addresses used by **Umbraco Cloud's own services** that connect to your environment. Allowlist these in your firewall so those services can keep reaching your site.
+This page covers the IP addresses used by **Umbraco Cloud's own services** that connect to your environment. Allowlist these in your firewall so Umbraco Cloud services can keep reaching your site.
 
 Looking for your project's own outbound IP addresses to share with an external service? See [External Services](README.md).
 {% endhint %}


### PR DESCRIPTION
## 📋 Description

We have 2 pages that have a list of static IPs that can be confusing for users.
This PR adds a bit more information that clears up the confusion between the two, and adds references to the other page so navigating is easier.

## 📎 Related Issues (if applicable)



## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Cloud

## Deadline (if relevant)

No deadline 😄 

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
