### PR TITLE
Document AI configuration reference sections

### DIFF
--- a/ai-in-umbraco/1/add-ons/deploy/README.md
+++ b/ai-in-umbraco/1/add-ons/deploy/README.md
@@ -62,7 +62,7 @@ See [Installation](installation.md) for detailed setup instructions.
 
 Deploy automatically filters sensitive data like API keys to prevent secrets from being committed to version control.
 
-Use configuration references (e.g., `$OpenAI:ApiKey`) instead of hardcoded values to keep secrets safe. See [Configuration](configuration.md) for details.
+Use configuration references (e.g., `$Umbraco:AI:Secrets:OpenAIApiKey`) instead of hardcoded values to keep secrets safe. See [Configuration](configuration.md) for details.
 
 ### Dependency Resolution
 

--- a/ai-in-umbraco/1/add-ons/deploy/best-practices.md
+++ b/ai-in-umbraco/1/add-ons/deploy/best-practices.md
@@ -20,10 +20,10 @@ API Key: sk-prod-abc123def456...
 
 ✅ **Good:**
 ```
-API Key: $OpenAI:ApiKey
+API Key: $Umbraco:AI:Secrets:OpenAIApiKey
 ```
 
-Configuration references ensure secrets stay in configuration files, not in version control.
+Configuration references ensure secrets stay in configuration files, not in version control. References resolve from the `Umbraco:AI:Secrets` and `Umbraco:AI:Variables` sections by default - see [Configuration References](../../concepts/connections.md#configuration-references).
 
 ### 2. Separate Configuration by Environment
 
@@ -47,15 +47,7 @@ For production environments, use a secret management solution:
 - **Environment Variables** - For container deployments
 - **Kubernetes Secrets** - For Kubernetes deployments
 
-Example with Azure Key Vault:
-
-```json
-{
-  "OpenAI": {
-    "ApiKey": "$KeyVault:OpenAI:ApiKey"
-  }
-}
-```
+These providers surface their values through `IConfiguration`, so name the entries to land under the allow-listed `Umbraco:AI:Secrets` section. For example, an Azure Key Vault secret named `Umbraco--AI--Secrets--OpenAIApiKey` (Key Vault uses `--` as the section separator) can then be referenced from a connection as `$Umbraco:AI:Secrets:OpenAIApiKey`.
 
 ### 4. Review Deployment Files Before Committing
 
@@ -156,39 +148,55 @@ Feature branches allow peer review before deploying to production.
 
 ### 1. Group Related Settings
 
-Organize configuration by provider and environment:
+Keep sensitive values under `Umbraco:AI:Secrets` and non-sensitive values under `Umbraco:AI:Variables`:
 
 ```json
 {
-  "OpenAI": {
-    "ApiKey": "sk-dev-abc123...",
-    "Organization": "org-123"
-  },
-  "Anthropic": {
-    "ApiKey": "sk-ant-dev-xyz789..."
+  "Umbraco": {
+    "AI": {
+      "Secrets": {
+        "OpenAIApiKey": "sk-dev-abc123...",
+        "AnthropicApiKey": "sk-ant-dev-xyz789..."
+      },
+      "Variables": {
+        "OpenAIOrganization": "org-123"
+      }
+    }
   }
 }
 ```
 
 ### 2. Use Consistent Key Paths
 
-Use consistent configuration key paths across providers:
+Use consistent configuration key names across providers:
 
 ✅ **Good:**
 ```json
 {
-  "OpenAI": { "ApiKey": "..." },
-  "Anthropic": { "ApiKey": "..." },
-  "Google": { "ApiKey": "..." }
+  "Umbraco": {
+    "AI": {
+      "Secrets": {
+        "OpenAIApiKey": "...",
+        "AnthropicApiKey": "...",
+        "GoogleApiKey": "..."
+      }
+    }
+  }
 }
 ```
 
 ❌ **Bad:**
 ```json
 {
-  "OpenAI": { "Key": "..." },
-  "Anthropic": { "ApiKey": "..." },
-  "Google": { "API_KEY": "..." }
+  "Umbraco": {
+    "AI": {
+      "Secrets": {
+        "OpenAIKey": "...",
+        "AnthropicApiKey": "...",
+        "Google_API_KEY": "..."
+      }
+    }
+  }
 }
 ```
 
@@ -198,10 +206,13 @@ Add comments to configuration files (where supported):
 
 ```jsonc
 {
-  // OpenAI configuration
-  // Get API key from: https://platform.openai.com/api-keys
-  "OpenAI": {
-    "ApiKey": "$KeyVault:OpenAI:ApiKey"
+  "Umbraco": {
+    "AI": {
+      "Secrets": {
+        // OpenAI API key. Get it from: https://platform.openai.com/api-keys
+        "OpenAIApiKey": "sk-..."
+      }
+    }
   }
 }
 ```
@@ -236,7 +247,7 @@ Maintain documentation of your AI configuration:
 ### OpenAI Production
 - **Purpose:** Production chat and embeddings
 - **Model:** gpt-4o
-- **Configuration:** `$OpenAI:ApiKey`
+- **Configuration:** `$Umbraco:AI:Secrets:OpenAIApiKey`
 
 ## Profiles
 
@@ -336,7 +347,7 @@ dotnet run --project ConfigTest
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
-var apiKey = builder.Configuration["OpenAI:ApiKey"];
+var apiKey = builder.Configuration["Umbraco:AI:Secrets:OpenAIApiKey"];
 Console.WriteLine($"OpenAI API Key: {apiKey}");
 ```
 

--- a/ai-in-umbraco/1/add-ons/deploy/configuration.md
+++ b/ai-in-umbraco/1/add-ons/deploy/configuration.md
@@ -12,7 +12,7 @@ Deploy support provides configuration options to control how sensitive data is h
 By default, Deploy:
 
 - **Excludes encrypted values** - Values starting with `ENC:` are not deployed
-- **Allows configuration references** - Values starting with `$` (e.g., `$OpenAI:ApiKey`) are deployed
+- **Allows configuration references** - Values starting with `$` (e.g., `$Umbraco:AI:Secrets:OpenAIApiKey`) are deployed
 - **Allows sensitive fields** - Fields marked as sensitive (via `[AIField(IsSensitive = true)]`) are treated like any other field and can be deployed
 
 Encrypted values stay safe while configuration references for sensitive fields are still deployed. To further restrict sensitive fields, enable `IgnoreSensitive` or list specific fields in `IgnoreSettings`.
@@ -55,7 +55,7 @@ When `true`, blocks encrypted values (starting with `ENC:`) from being deployed,
 
 | Value in Database | Deployed? |
 |-------------------|-----------|
-| `$OpenAI:ApiKey` | ✅ Yes (configuration reference) |
+| `$Umbraco:AI:Secrets:OpenAIApiKey` | ✅ Yes (configuration reference) |
 | `ENC:abc123...` | ❌ No (encrypted value) |
 | `https://api.openai.com` | ✅ Yes (plain value) |
 
@@ -77,7 +77,7 @@ For a field marked as sensitive (e.g., `ApiKey`):
 
 | Value in Database | Deployed? |
 |-------------------|-----------|
-| `$OpenAI:ApiKey` | ✅ Yes (configuration reference allowed) |
+| `$Umbraco:AI:Secrets:OpenAIApiKey` | ✅ Yes (configuration reference allowed) |
 | `ENC:abc123...` | ❌ No (blocked by IgnoreEncrypted) |
 | `sk-abc123...` | ✅ Yes (plain value allowed - not recommended) |
 
@@ -176,8 +176,12 @@ To safely deploy API keys and secrets, use configuration references:
 
 ```json
 {
-  "OpenAI": {
-    "ApiKey": "sk-dev-abc123..."
+  "Umbraco": {
+    "AI": {
+      "Secrets": {
+        "OpenAIApiKey": "sk-dev-abc123..."
+      }
+    }
   }
 }
 ```
@@ -188,8 +192,12 @@ To safely deploy API keys and secrets, use configuration references:
 
 ```json
 {
-  "OpenAI": {
-    "ApiKey": "sk-prod-xyz789..."
+  "Umbraco": {
+    "AI": {
+      "Secrets": {
+        "OpenAIApiKey": "sk-prod-xyz789..."
+      }
+    }
   }
 }
 ```
@@ -200,7 +208,7 @@ To safely deploy API keys and secrets, use configuration references:
 
 When creating a Connection in the backoffice, use `$` syntax:
 
-- **API Key field:** `$OpenAI:ApiKey`
+- **API Key field:** `$Umbraco:AI:Secrets:OpenAIApiKey`
 
 Deploy saves the reference in the deployment file. Each environment resolves the value from its own configuration.
 
@@ -211,7 +219,7 @@ Check the deployment file (`.uda`) to ensure it contains the reference, not the 
 ```json
 {
   "Settings": {
-    "ApiKey": "$OpenAI:ApiKey"
+    "ApiKey": "$Umbraco:AI:Secrets:OpenAIApiKey"
   }
 }
 ```

--- a/ai-in-umbraco/1/add-ons/deploy/deploying-entities.md
+++ b/ai-in-umbraco/1/add-ons/deploy/deploying-entities.md
@@ -158,7 +158,7 @@ Standard agent `UserGroupPermissions` are keyed by user group GUID. Referenced u
 5. Enter details:
    - **Name:** "OpenAI Production"
    - **Alias:** "openai-production"
-   - **API Key:** `$OpenAI:ApiKey` (configuration reference)
+   - **API Key:** `$Umbraco:AI:Secrets:OpenAIApiKey` (configuration reference)
    - **Organization ID:** (optional)
 6. Click **Save**
 
@@ -176,7 +176,7 @@ Open the file and verify it contains the configuration reference, not the actual
 ```json
 {
   "Settings": {
-    "ApiKey": "$OpenAI:ApiKey"
+    "ApiKey": "$Umbraco:AI:Secrets:OpenAIApiKey"
   }
 }
 ```
@@ -196,8 +196,12 @@ Before deploying, ensure the target environment has the configuration:
 **appsettings.Production.json:**
 ```json
 {
-  "OpenAI": {
-    "ApiKey": "sk-prod-xyz789..."
+  "Umbraco": {
+    "AI": {
+      "Secrets": {
+        "OpenAIApiKey": "sk-prod-xyz789..."
+      }
+    }
   }
 }
 ```
@@ -208,7 +212,7 @@ When you deploy to the target environment (via Umbraco Cloud, Azure DevOps, or o
 
 1. Umbraco Deploy detects the new deployment file
 2. Creates the Connection in the target environment
-3. Resolves `$OpenAI:ApiKey` from the target's `appsettings.json`
+3. Resolves `$Umbraco:AI:Secrets:OpenAIApiKey` from the target's `appsettings.json`
 4. Activates the Connection
 
 ## Step-by-Step: Deploying a Profile
@@ -259,8 +263,12 @@ Here's how the same configuration deploys to different environments:
 **appsettings.Development.json:**
 ```json
 {
-  "OpenAI": {
-    "ApiKey": "sk-dev-abc123..."
+  "Umbraco": {
+    "AI": {
+      "Secrets": {
+        "OpenAIApiKey": "sk-dev-abc123..."
+      }
+    }
   }
 }
 ```
@@ -270,8 +278,12 @@ Here's how the same configuration deploys to different environments:
 **appsettings.Staging.json:**
 ```json
 {
-  "OpenAI": {
-    "ApiKey": "sk-staging-def456..."
+  "Umbraco": {
+    "AI": {
+      "Secrets": {
+        "OpenAIApiKey": "sk-staging-def456..."
+      }
+    }
   }
 }
 ```
@@ -281,8 +293,12 @@ Here's how the same configuration deploys to different environments:
 **appsettings.Production.json:**
 ```json
 {
-  "OpenAI": {
-    "ApiKey": "sk-prod-xyz789..."
+  "Umbraco": {
+    "AI": {
+      "Secrets": {
+        "OpenAIApiKey": "sk-prod-xyz789..."
+      }
+    }
   }
 }
 ```
@@ -296,12 +312,12 @@ Here's how the same configuration deploys to different environments:
   "Alias": "openai-production",
   "ProviderId": "openai",
   "Settings": {
-    "ApiKey": "$OpenAI:ApiKey"
+    "ApiKey": "$Umbraco:AI:Secrets:OpenAIApiKey"
   }
 }
 ```
 
-Each environment resolves `$OpenAI:ApiKey` from its own configuration, so the same deployment file works everywhere.
+Each environment resolves `$Umbraco:AI:Secrets:OpenAIApiKey` from its own configuration, so the same deployment file works everywhere.
 
 ## Deployment Order
 

--- a/ai-in-umbraco/1/add-ons/deploy/installation.md
+++ b/ai-in-umbraco/1/add-ons/deploy/installation.md
@@ -87,7 +87,7 @@ If deployment files aren't created when you save entities:
 
 If deployment files contain API keys or other sensitive data:
 
-1. Use configuration references instead of hardcoded values (e.g., `$OpenAI:ApiKey`)
+1. Use configuration references instead of hardcoded values (e.g., `$Umbraco:AI:Secrets:OpenAIApiKey`)
 2. Configure sensitive data filtering in `appsettings.json` (see [Configuration](configuration.md))
 
 ## Next Steps

--- a/ai-in-umbraco/1/backoffice/managing-connections.md
+++ b/ai-in-umbraco/1/backoffice/managing-connections.md
@@ -47,23 +47,27 @@ When using the OpenAI provider:
 
 Instead of storing API keys directly in the database, use configuration references:
 
-1. Add your API key to `appsettings.json`:
+1. Add your API key to `appsettings.json` under the `Umbraco:AI:Secrets` section:
 
 {% code title="appsettings.json" %}
 
 ```json
 {
-    "OpenAI": {
-        "ApiKey": "sk-your-api-key-here"
+    "Umbraco": {
+        "AI": {
+            "Secrets": {
+                "OpenAIApiKey": "sk-your-api-key-here"
+            }
+        }
     }
 }
 ```
 
 {% endcode %}
 
-2. In the connection settings, enter `$OpenAI:ApiKey` as the API Key value.
+2. In the connection settings, enter `$Umbraco:AI:Secrets:OpenAIApiKey` as the API Key value.
 
-The `$` prefix tells Umbraco.AI to resolve the value from configuration at runtime.
+The `$` prefix tells Umbraco.AI to resolve the value from configuration at runtime. References resolve from the `Umbraco:AI:Secrets` and `Umbraco:AI:Variables` sections by default - see [Configuration References](../concepts/connections.md#configuration-references) for details.
 
 {% hint style="success" %}
 Configuration references keep sensitive values out of the database and allow different values per environment.

--- a/ai-in-umbraco/1/concepts/connections.md
+++ b/ai-in-umbraco/1/concepts/connections.md
@@ -41,12 +41,19 @@ You can create and manage connections through the backoffice. See [Managing Conn
 
 ## Configuration References
 
-Connection settings support configuration references. Values starting with `$` are resolved from `appsettings.json` at runtime.
+Connection settings support configuration references. Values starting with `$` are resolved from configuration (`appsettings.json`, environment variables, Azure Key Vault, and so on) at runtime.
+
+References resolve from two dedicated configuration sections:
+
+- `Umbraco:AI:Secrets` - for sensitive values such as API keys. These can only be referenced from settings fields marked as sensitive (see [Provider Settings](../extending/providers/provider-settings.md)).
+- `Umbraco:AI:Variables` - for non-sensitive per-environment values such as endpoints, organization IDs, or feature flags.
+
+Place the values you want to reference under these sections, then point the setting at them with the `$` prefix:
 
 {% code title="Connection Settings" %}
 
 ```
-API Key: $OpenAI:ApiKey
+API Key: $Umbraco:AI:Secrets:OpenAIApiKey
 ```
 
 {% endcode %}
@@ -55,8 +62,12 @@ API Key: $OpenAI:ApiKey
 
 ```json
 {
-    "OpenAI": {
-        "ApiKey": "sk-your-actual-key"
+    "Umbraco": {
+        "AI": {
+            "Secrets": {
+                "OpenAIApiKey": "sk-your-actual-key"
+            }
+        }
     }
 }
 ```
@@ -68,6 +79,10 @@ Benefits of configuration references:
 - Sensitive values stay out of the database.
 - Different values per environment (dev/staging/prod)
 - Works with Azure Key Vault, environment variables, and more.
+
+{% hint style="info" %}
+To reference values that already live in another configuration section, add that section's prefix to `Umbraco:AI:AllowedConfigurationKeyPrefixes`. See [AIOptions](../reference/configuration/ai-options.md#configuration-references).
+{% endhint %}
 
 ## Accessing Connections in Code
 

--- a/ai-in-umbraco/1/extending/providers/creating-a-provider.md
+++ b/ai-in-umbraco/1/extending/providers/creating-a-provider.md
@@ -43,7 +43,7 @@ public class MyProviderSettings
 {
     [AIField(
         Label = "API Key",
-        Description = "Your MyProvider API key. Use $Config:Key for config reference.",
+        Description = "Your MyProvider API key. Use $Umbraco:AI:Secrets:MyProviderApiKey for a config reference.",
         IsSensitive = true,
         SortOrder = 1)]
     [Required]

--- a/ai-in-umbraco/1/extending/providers/provider-settings.md
+++ b/ai-in-umbraco/1/extending/providers/provider-settings.md
@@ -60,7 +60,7 @@ public class MyProviderSettings
 {
     [AIField(
         Label = "API Key",
-        Description = "Your API key. Supports config references like $MyProvider:ApiKey",
+        Description = "Your API key. Supports config references like $Umbraco:AI:Secrets:MyProviderApiKey",
         SortOrder = 1)]
     [Required]
     public required string ApiKey { get; set; }
@@ -128,17 +128,21 @@ Non-nullable properties without `[Required]` automatically have a required valid
 
 ## Configuration References
 
-Settings values starting with `$` are resolved from `appsettings.json`:
+Settings values starting with `$` are resolved from configuration. References resolve from the `Umbraco:AI:Secrets` section (sensitive values) and `Umbraco:AI:Variables` section (non-sensitive values) by default.
 
-**In the UI:** Enter `$MyProvider:ApiKey`
+**In the UI:** Enter `$Umbraco:AI:Secrets:MyProviderApiKey`
 
 **In appsettings.json:**
 {% code title="appsettings.json" %}
 
 ```json
 {
-    "MyProvider": {
-        "ApiKey": "sk-actual-key-here"
+    "Umbraco": {
+        "AI": {
+            "Secrets": {
+                "MyProviderApiKey": "sk-actual-key-here"
+            }
+        }
     }
 }
 ```
@@ -146,6 +150,10 @@ Settings values starting with `$` are resolved from `appsettings.json`:
 {% endcode %}
 
 This keeps secrets out of the database and supports environment-specific values.
+
+{% hint style="info" %}
+Values under `Umbraco:AI:Secrets` may only be referenced from fields marked `IsSensitive = true` (see [Sensitive Settings](#sensitive-settings)). Mark any field that should accept a secret reference as sensitive. To reference values from other configuration sections, add their prefix to `Umbraco:AI:AllowedConfigurationKeyPrefixes` - see [AIOptions](../../reference/configuration/ai-options.md#configuration-references).
+{% endhint %}
 
 ## Sensitive Settings
 

--- a/ai-in-umbraco/1/getting-started/first-connection.md
+++ b/ai-in-umbraco/1/getting-started/first-connection.md
@@ -36,10 +36,10 @@ Fill in the connection details:
 | **Name**     | A display name for this connection          | "OpenAI Production"          |
 | **Alias**    | A unique identifier for programmatic access | "openai-prod"                |
 | **Provider** | The AI provider to use                      | "OpenAI"                     |
-| **API Key**  | Your provider API key                       | "sk-..." or "$OpenAI:ApiKey" |
+| **API Key**  | Your provider API key                       | "sk-..." or "$Umbraco:AI:Secrets:OpenAIApiKey" |
 
 {% hint style="info" %}
-Use a configuration reference like `$OpenAI:ApiKey` to read the API key from `appsettings.json` instead of storing it in the database.
+Use a configuration reference like `$Umbraco:AI:Secrets:OpenAIApiKey` to read the API key from configuration instead of storing it in the database. See [Configuration References](../concepts/connections.md#configuration-references) for how the referenced sections work.
 {% endhint %}
 
 ## Connection Properties

--- a/ai-in-umbraco/1/management-api/connections/create.md
+++ b/ai-in-umbraco/1/management-api/connections/create.md
@@ -61,7 +61,7 @@ POST /umbraco/ai/management/api/v1/connections
 
 ### Settings with Configuration References
 
-Use `$` prefix to reference values from `appsettings.json`:
+Use `$` prefix to reference values from configuration. References resolve from the `Umbraco:AI:Secrets` and `Umbraco:AI:Variables` sections by default:
 
 {% code title="Request with Config Reference" %}
 
@@ -71,7 +71,7 @@ Use `$` prefix to reference values from `appsettings.json`:
     "name": "OpenAI Production",
     "providerId": "openai",
     "settings": {
-        "apiKey": "$OpenAI:ApiKey"
+        "apiKey": "$Umbraco:AI:Secrets:OpenAIApiKey"
     }
 }
 ```
@@ -203,7 +203,7 @@ const connection = await createConnection({
     name: "OpenAI Production",
     providerId: "openai",
     settings: {
-        apiKey: "$OpenAI:ApiKey",
+        apiKey: "$Umbraco:AI:Secrets:OpenAIApiKey",
     },
 });
 ```

--- a/ai-in-umbraco/1/management-api/connections/update.md
+++ b/ai-in-umbraco/1/management-api/connections/update.md
@@ -36,7 +36,7 @@ PUT /umbraco/ai/management/api/v1/connections/{id}
     "name": "OpenAI Production (Updated)",
     "isActive": true,
     "settings": {
-        "apiKey": "$OpenAI:ApiKey",
+        "apiKey": "$Umbraco:AI:Secrets:OpenAIApiKey",
         "organization": "org-123"
     }
 }
@@ -120,7 +120,7 @@ curl -X PUT "https://your-site.com/umbraco/ai/management/api/v1/connections/3fa8
     "name": "OpenAI Production (Updated)",
     "isActive": true,
     "settings": {
-      "apiKey": "$OpenAI:ApiKey"
+      "apiKey": "$Umbraco:AI:Secrets:OpenAIApiKey"
     }
   }'
 ```

--- a/ai-in-umbraco/1/management-api/providers/get.md
+++ b/ai-in-umbraco/1/management-api/providers/get.md
@@ -229,5 +229,5 @@ public bool ValidateSettings(ProviderResponseModel provider, Dictionary<string, 
 ## Notes
 
 - Settings schema is defined by the provider using `[AIField]` attributes
-- Sensitive settings (like API keys) should support config references (`$Config:Path`)
+- Sensitive settings (like API keys) should support config references (`$Umbraco:AI:Secrets:Key`)
 - The schema enables dynamic UI generation without hardcoding provider details

--- a/ai-in-umbraco/1/reference/configuration/README.md
+++ b/ai-in-umbraco/1/reference/configuration/README.md
@@ -192,18 +192,22 @@ Thread directories whose files have not been modified within this period are cle
 
 ## Provider Credentials
 
-Store provider credentials in configuration and reference them in connections:
+Store provider credentials in configuration and reference them in connections. Place sensitive values under `Umbraco:AI:Secrets` and non-sensitive per-environment values under `Umbraco:AI:Variables`:
 
 {% code title="appsettings.json" %}
 
 ```json
 {
-    "OpenAI": {
-        "ApiKey": "sk-your-api-key-here"
-    },
-    "Azure": {
-        "ApiKey": "your-azure-key",
-        "Endpoint": "https://your-resource.openai.azure.com"
+    "Umbraco": {
+        "AI": {
+            "Secrets": {
+                "OpenAIApiKey": "sk-your-api-key-here",
+                "AzureApiKey": "your-azure-key"
+            },
+            "Variables": {
+                "AzureEndpoint": "https://your-resource.openai.azure.com"
+            }
+        }
     }
 }
 ```
@@ -212,8 +216,10 @@ Store provider credentials in configuration and reference them in connections:
 
 Reference these in connection settings using the `$` prefix:
 
-- `$OpenAI:ApiKey` - Resolves to the OpenAI API key
-- `$Azure:Endpoint` - Resolves to the Azure endpoint
+- `$Umbraco:AI:Secrets:OpenAIApiKey` - Resolves to the OpenAI API key
+- `$Umbraco:AI:Variables:AzureEndpoint` - Resolves to the Azure endpoint
+
+Secret values may only be referenced from fields marked as sensitive. To reference an existing section instead, add its prefix to `Umbraco:AI:AllowedConfigurationKeyPrefixes`. See [AIOptions](ai-options.md#configuration-references) for details.
 
 ## Environment-Specific Configuration
 

--- a/ai-in-umbraco/1/reference/configuration/ai-options.md
+++ b/ai-in-umbraco/1/reference/configuration/ai-options.md
@@ -32,6 +32,17 @@ public class AIOptions
     public string? DefaultEmbeddingProfileAlias { get; set; }
     public string? ClassifierChatProfileAlias { get; set; }
     public string? DefaultSpeechToTextProfileAlias { get; set; }
+
+    public IList<string> AllowedConfigurationKeyPrefixes { get; set; } = new List<string>
+    {
+        "Umbraco:AI:Secrets",
+        "Umbraco:AI:Variables",
+    };
+
+    public IList<string> SecretConfigurationKeyPrefixes { get; set; } = new List<string>
+    {
+        "Umbraco:AI:Secrets",
+    };
 }
 ```
 
@@ -45,6 +56,8 @@ public class AIOptions
 | `DefaultEmbeddingProfileAlias`    | `string?` | Fallback default profile alias for embeddings           |
 | `ClassifierChatProfileAlias`      | `string?` | Fallback profile alias for classification tasks         |
 | `DefaultSpeechToTextProfileAlias` | `string?` | Fallback default profile alias for speech-to-text       |
+| `AllowedConfigurationKeyPrefixes` | `IList<string>` | Configuration sections that settings may resolve via `$` references. Defaults to `Umbraco:AI:Secrets` and `Umbraco:AI:Variables` |
+| `SecretConfigurationKeyPrefixes`  | `IList<string>` | The subset of allowed prefixes treated as secret. Values under these may only be referenced from sensitive fields. Defaults to `Umbraco:AI:Secrets` |
 
 ## Configuration
 
@@ -64,6 +77,60 @@ public class AIOptions
 ```
 
 {% endcode %}
+
+## Configuration References
+
+Editable model settings (such as connection API keys) support a `$Key:Path` syntax that resolves to a configuration value at runtime, letting you keep credentials and per-environment values in configuration rather than the database. For example, a connection's API Key field set to `$Umbraco:AI:Secrets:OpenAIApiKey` reads from:
+
+{% code title="appsettings.json" %}
+
+```json
+{
+    "Umbraco": {
+        "AI": {
+            "Secrets": {
+                "OpenAIApiKey": "sk-your-actual-key"
+            },
+            "Variables": {
+                "OpenAIEndpoint": "https://api.openai.com/v1"
+            }
+        }
+    }
+}
+```
+
+{% endcode %}
+
+References resolve only from the sections listed in `AllowedConfigurationKeyPrefixes`. Two sections are allowed by default:
+
+- `Umbraco:AI:Secrets` - for sensitive values (API keys, tokens). Listed in `SecretConfigurationKeyPrefixes`, so these values may only be referenced from settings fields marked `[AIField(IsSensitive = true)]`.
+- `Umbraco:AI:Variables` - for non-sensitive per-environment values (endpoints, IDs, flags). These may be referenced from any field.
+
+Prefix matching is segment-aware and case-insensitive: `Umbraco:AI:Secrets` permits `Umbraco:AI:Secrets:OpenAIApiKey` but not `Umbraco:AI:SecretsBackup:Key`.
+
+To reference values that already live in another configuration section, add that section's prefix to `AllowedConfigurationKeyPrefixes`:
+
+{% code title="appsettings.json" %}
+
+```json
+{
+    "Umbraco": {
+        "AI": {
+            "AllowedConfigurationKeyPrefixes": [
+                "Umbraco:AI:Secrets",
+                "Umbraco:AI:Variables",
+                "OpenAI"
+            ]
+        }
+    }
+}
+```
+
+{% endcode %}
+
+{% hint style="info" %}
+`AllowedConfigurationKeyPrefixes` and `SecretConfigurationKeyPrefixes` are configured in `appsettings.json` only - they are not editable from the backoffice.
+{% endhint %}
 
 ## Precedence
 

--- a/ai-in-umbraco/1/reference/models/ai-connection.md
+++ b/ai-in-umbraco/1/reference/models/ai-connection.md
@@ -89,7 +89,7 @@ var connection = new AIConnection
     ProviderId = "openai",
     Settings = new
     {
-        ApiKey = "$OpenAI:ApiKey"  // Resolved from appsettings.json
+        ApiKey = "$Umbraco:AI:Secrets:OpenAIApiKey"  // Resolved from configuration
     }
 };
 ```
@@ -100,13 +100,19 @@ var connection = new AIConnection
 
 ```json
 {
-    "OpenAI": {
-        "ApiKey": "sk-actual-key-here"
+    "Umbraco": {
+        "AI": {
+            "Secrets": {
+                "OpenAIApiKey": "sk-actual-key-here"
+            }
+        }
     }
 }
 ```
 
 {% endcode %}
+
+References resolve from the `Umbraco:AI:Secrets` and `Umbraco:AI:Variables` sections by default. See [Configuration References](../configuration/ai-options.md#configuration-references).
 
 ## Creating a Connection
 
@@ -122,7 +128,7 @@ var connection = new AIConnection
     ProviderId = "openai",
     Settings = new
     {
-        ApiKey = "$OpenAI:ApiKey",
+        ApiKey = "$Umbraco:AI:Secrets:OpenAIApiKey",
         OrganizationId = "org-123"
     },
     IsActive = true

--- a/ai-in-umbraco/1/reference/services/ai-connection-service.md
+++ b/ai-in-umbraco/1/reference/services/ai-connection-service.md
@@ -142,7 +142,7 @@ var connection = new AIConnection
     Alias = "my-openai",
     Name = "My OpenAI Connection",
     ProviderId = "openai",
-    Settings = new { ApiKey = "$OpenAI:ApiKey" },
+    Settings = new { ApiKey = "$Umbraco:AI:Secrets:OpenAIApiKey" },
     IsActive = true
 };
 


### PR DESCRIPTION
## Description

Updates the Umbraco AI documentation to cover the new configuration reference resolution behavior.

### Changes

- Documents the new `AllowedConfigurationKeyPrefixes` and `SecretConfigurationKeyPrefixes` options on `AIOptions`, including defaults and how prefix matching works
- Adds a **Configuration References** section to the AIOptions reference article explaining the `Umbraco:AI:Secrets` and `Umbraco:AI:Variables` sections
- Updates all configuration reference examples across the AI docs (connections, providers, Deploy add-on, Management API) to use the default `Umbraco:AI:Secrets` / `Umbraco:AI:Variables` sections
- Cross-links related articles (concepts, backoffice, provider settings, Deploy best practices) to the new reference documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
