### PR TITLE
Add Deploy 17.2.0-rc1, 18.0.0-rc1 and 18.0.0-rc2 release notes

### DIFF
--- a/17/umbraco-deploy/release-notes.md
+++ b/17/umbraco-deploy/release-notes.md
@@ -18,7 +18,7 @@ This section contains the release notes for Umbraco Deploy 17, including all cha
 
 ### [17.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.0-rc1) (June 4th 2026)
 
-* Prevent `ARRAffinity` cookie loss on load-balanced targets by disabling `HttpClient` handler rotation. Long-running transfers/restores now stay routed to the same target instance.
+* Prevent `ARRAffinity` cookie loss on load-balanced targets by disabling `HttpClient` handler rotation. Long-running transfers and restores now stay routed to the same target instance.
 * Add a cluster-wide Deploy worker lock to prevent concurrent deploys across load-balanced backoffice instances.
 * Process Deploy disk triggers on a single load-balanced server instead of racing on every node.
 

--- a/17/umbraco-deploy/release-notes.md
+++ b/17/umbraco-deploy/release-notes.md
@@ -16,6 +16,12 @@ If you are upgrading to a new major version, you can find the details about the 
 
 This section contains the release notes for Umbraco Deploy 17, including all changes for this version.
 
+### [17.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.0-rc1) (June 4th 2026)
+
+* Prevent `ARRAffinity` cookie loss on load-balanced targets by disabling `HttpClient` handler rotation. Long-running transfers/restores now stay routed to the same target instance.
+* Add a cluster-wide Deploy worker lock to prevent concurrent deploys across load-balanced backoffice instances.
+* Process Deploy disk triggers on a single load-balanced server instead of racing on every node.
+
 ### [17.1.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.1.0) (May 14th 2026)
 
 * All items from 17.1.0-rc1 and 17.1.0-rc2.

--- a/18/umbraco-deploy/release-notes.md
+++ b/18/umbraco-deploy/release-notes.md
@@ -18,6 +18,31 @@ If you are upgrading to a new major version, you can find the details about the 
 
 This section contains the release notes for Umbraco Deploy 18, including all changes for this version.
 
+### [18.0.0-rc2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.0) (June 5th 2026)
+
+* Compatibility with Umbraco CMS 18.0.0-rc2.
+* Restrict Deploy SignalR hubs to WebSockets when the `Umbraco:CMS:SignalR:ClientShouldSkipNegotiation` CMS setting is enabled.
+
+### [18.0.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.0) (June 5th 2026)
+
+* Compatibility with Umbraco CMS 18.0.0-rc1.
+  * See full details of breaking changes under the [Version-specific Upgrade Guide](upgrades/version-specific.md).
+* Add support for transferring, restoring, importing, and exporting elements (publishable, versioned content items in the new Library section).
+* Migrate Nested Content (when `MaxItems = 1`) and single-block-mode Block List configurations to the new `Umbraco.SingleBlock` editor at import time.
+* Major UI/UX overhaul of the Deploy experience in the backoffice. See [Backoffice UX refresh](#backoffice-ux-refresh) below for details.
+* Improved support for running Deploy on load-balanced backoffice instances:
+  * Prevent `ARRAffinity` cookie loss on load-balanced targets by disabling `HttpClient` handler rotation, so long-running restores stay routed to the same target instance.
+  * Add a cluster-wide Deploy worker lock to prevent concurrent deploys across load-balanced backoffice instances.
+  * Process Deploy disk triggers on a single load-balanced server instead of racing on every node.
+
+#### Backoffice UX refresh
+
+Version 18 introduces a redesigned Deploy experience in the backoffice:
+
+* A new sidebar/workspace, launched from the environment name header app, replaces the transfer queue dashboard in the Content section. The workspace provides a single overview of the transfer and export queue, import and restore environment operations.
+* Redesigned transfer/queue, restore, compare and export modals with consistent styling, improved error surfacing, and a cleaner status and operation layout.
+* Refreshed status, schema and configuration views in the management dashboard
+
 ## Legacy release notes
 
 You can find the release notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-deploy/release-notes.md) and [Umbraco Deploy Package page](https://our.umbraco.com/packages/developer-tools/umbraco-deploy/).

--- a/18/umbraco-deploy/release-notes.md
+++ b/18/umbraco-deploy/release-notes.md
@@ -26,7 +26,7 @@ This section contains the release notes for Umbraco Deploy 18, including all cha
 ### [18.0.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.0) (June 5th 2026)
 
 * Compatibility with Umbraco CMS 18.0.0-rc1.
-  * See full details of breaking changes under the [Version-specific Upgrade Guide](upgrades/version-specific.md).
+  * See full details of breaking changes under [Version Specific Upgrade Details](upgrades/version-specific.md).
 * Add support for transferring, restoring, importing, and exporting elements (publishable, versioned content items in the new Library section).
 * Migrate Nested Content (when `MaxItems = 1`) and single-block-mode Block List configurations to the new `Umbraco.SingleBlock` editor at import time.
 * Major UI/UX overhaul of the Deploy experience in the backoffice. See [Backoffice UX refresh](#backoffice-ux-refresh) below for details.
@@ -39,9 +39,9 @@ This section contains the release notes for Umbraco Deploy 18, including all cha
 
 Version 18 introduces a redesigned Deploy experience in the backoffice:
 
-* A new sidebar/workspace, launched from the environment name header app, replaces the transfer queue dashboard in the Content section. The workspace provides a single overview of the transfer and export queue, import and restore environment operations.
-* Redesigned transfer/queue, restore, compare and export modals with consistent styling, improved error surfacing, and a cleaner status and operation layout.
-* Refreshed status, schema and configuration views in the management dashboard
+* A new sidebar workspace, launched from the environment name header app, replaces the transfer queue dashboard in the Content section. The workspace provides a single overview of the transfer queue, export queue, import, and restore environment operations.
+* Redesigned transfer, queue, restore, compare, and export modals with consistent styling, improved error surfacing, and a cleaner status and operation layout.
+* Refreshed status, schema, and configuration views in the management dashboard.
 
 ## Legacy release notes
 


### PR DESCRIPTION
## 📋 Description

Adds release notes for Umbraco Deploy 17.2.0-rc1, 18.0.0-rc1, and 18.0.0-rc2.

**17.2.0-rc1** ships short-term fixes for running Deploy on load-balanced backoffice setups: `ARRAffinity` cookie preservation, a cluster-wide worker lock to prevent concurrent deploys, and single-node disk-trigger processing.

**18.0.0-rc1** provides Umbraco CMS 18 compatibility and is the first major Deploy release for v18. Highlights:

- Support for transferring, restoring, importing, and exporting Elements (publishable, versioned content items in the new Library section).
- Import-time migration of Nested Content (with `MaxItems = 1`) and single-block-mode Block List configurations to the new `Umbraco.SingleBlock` editor.
- Major UI/UX overhaul of the backoffice Deploy experience — new workspace launched from the environment header app, redesigned modals, refreshed schema and configuration views, and a cleaner integration surface for extension developers.
- The load-balancing improvements introduced in 17.2.0-rc1 are also included.

**18.0.0-rc2** restricts Deploy SignalR hubs to WebSockets when the `Umbraco:CMS:SignalR:ClientShouldSkipNegotiation` CMS setting is enabled, aligning Deploy with the v18 SignalR contract.

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Deploy 17.2.0-rc1, 18.0.0-rc1, and 18.0.0-rc2.

## Deadline (if relevant)

These versions are already available, so as soon as possible!