### PR TITLE
Revert direct-to-main commit of UmbracoApplicationUrl Forms notes

### DIFF
--- a/17/umbraco-forms/developer/email-templates.md
+++ b/17/umbraco-forms/developer/email-templates.md
@@ -20,28 +20,6 @@ You now have a model that contains your Form fields which can be used in your em
 
 Below is an example of an email template from the `~/Views/Partials/Forms/Emails/` folder:
 
-{% hint style="warning" %}
-**Absolute URLs in load-balanced or proxied environments**
-
-The example below builds an absolute domain from `Context.Request.Scheme` and `Context.Request.Host`. This relies on the incoming request's `Host` header, which is fine when an email is rendered during a normal front-end form submission. It can produce empty or incorrect links when the email is generated **outside** of that request. Examples include re-running a workflow from the backoffice, or running it from a background or scheduled job. On a different node, or behind a load balancer or reverse proxy, the `Host` header may not match your site's public address.
-
-From Umbraco 17, the `Host` header is no longer used to auto-detect the application URL by default. In load-balanced, proxied, or multi-node setups, set the application URL explicitly. This ensures absolute links - including the `FormPageUrl` exposed on the email model - resolve consistently on every node:
-
-```json
-{
-  "Umbraco": {
-    "CMS": {
-      "WebRouting": {
-        "UmbracoApplicationUrl": "https://www.your-site.com/"
-      }
-    }
-  }
-}
-```
-
-See [Web Routing Settings](https://docs.umbraco.com/umbraco-cms/develop-with-umbraco/configuration/webroutingsettings) for details. When you need the public site URL inside a template, prefer reading it from this configuration (or `IHostingEnvironment.ApplicationMainUrl`) rather than from `Context.Request.Host`.
-{% endhint %}
-
 ```csharp
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Forms.Core.Models.FormsHtmlModel>
 

--- a/17/umbraco-forms/editor/attaching-workflows/workflow-types.md
+++ b/17/umbraco-forms/editor/attaching-workflows/workflow-types.md
@@ -163,10 +163,6 @@ Sends the Form to a URL either as a HTTP POST or GET. The following configuratio
 * User
 * Password
 
-{% hint style="warning" %}
-The **page URL** standard field is rendered as an absolute URL. This applies in a load-balanced, proxied, or multi-node environment. It also applies when this workflow runs outside a front-end request, such as re-running it from the backoffice. Set `Umbraco:CMS:WebRouting:UmbracoApplicationUrl` to your site's public URL so the page URL resolves correctly on every node. See [Web Routing Settings](https://docs.umbraco.com/umbraco-cms/develop-with-umbraco/configuration/webroutingsettings).
-{% endhint %}
-
 When mapping fields, if any are selected, only those chosen will be sent in the request to the configured URL. If no fields are mapped, all will be sent.
 
 The receiving endpoint extracts form fields and values using GET for querystrings and POST for form collections.

--- a/18/umbraco-forms/developer/email-templates.md
+++ b/18/umbraco-forms/developer/email-templates.md
@@ -20,28 +20,6 @@ You now have a model that contains your Form fields which can be used in your em
 
 Below is an example of an email template from the `~/Views/Partials/Forms/Emails/` folder:
 
-{% hint style="warning" %}
-**Absolute URLs in load-balanced or proxied environments**
-
-The example below builds an absolute domain from `Context.Request.Scheme` and `Context.Request.Host`. This relies on the incoming request's `Host` header, which is fine when an email is rendered during a normal front-end form submission. It can produce empty or incorrect links when the email is generated **outside** of that request. Examples include re-running a workflow from the backoffice, or running it from a background or scheduled job. On a different node, or behind a load balancer or reverse proxy, the `Host` header may not match your site's public address.
-
-From Umbraco 17, the `Host` header is no longer used to auto-detect the application URL by default. In load-balanced, proxied, or multi-node setups, set the application URL explicitly. This ensures absolute links - including the `FormPageUrl` exposed on the email model - resolve consistently on every node:
-
-```json
-{
-  "Umbraco": {
-    "CMS": {
-      "WebRouting": {
-        "UmbracoApplicationUrl": "https://www.your-site.com/"
-      }
-    }
-  }
-}
-```
-
-See [Web Routing Settings](https://docs.umbraco.com/umbraco-cms/develop-with-umbraco/configuration/webroutingsettings) for details. When you need the public site URL inside a template, prefer reading it from this configuration (or `IHostingEnvironment.ApplicationMainUrl`) rather than from `Context.Request.Host`.
-{% endhint %}
-
 ```csharp
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Forms.Core.Models.FormsHtmlModel>
 

--- a/18/umbraco-forms/editor/attaching-workflows/workflow-types.md
+++ b/18/umbraco-forms/editor/attaching-workflows/workflow-types.md
@@ -163,10 +163,6 @@ Sends the Form to a URL either as a HTTP POST or GET. The following configuratio
 * User
 * Password
 
-{% hint style="warning" %}
-The **page URL** standard field is rendered as an absolute URL. This applies in a load-balanced, proxied, or multi-node environment. It also applies when this workflow runs outside a front-end request, such as re-running it from the backoffice. Set `Umbraco:CMS:WebRouting:UmbracoApplicationUrl` to your site's public URL so the page URL resolves correctly on every node. See [Web Routing Settings](https://docs.umbraco.com/umbraco-cms/develop-with-umbraco/configuration/webroutingsettings).
-{% endhint %}
-
 When mapping fields, if any are selected, only those chosen will be sent in the request to the configured URL. If no fields are mapped, all will be sent.
 
 The receiving endpoint extracts form fields and values using GET for querystrings and POST for form collections.


### PR DESCRIPTION
## 📋 Description

This reverts commit `712bb20b9` ("Forms: Note UmbracoApplicationUrl for absolute URLs in load-balanced setups"), which was pushed directly to `main` as a fast-forward rather than going through a pull request.

The content itself is good — it adds guidance on setting `Umbraco:CMS:WebRouting:UmbracoApplicationUrl` for absolute URLs in load-balanced, proxied, and multi-node setups (Forms email templates and the page-URL workflow field, for both v17 and v18). The only issue is process: it bypassed review.

Merging this revert removes those additions from `main` so the change can be re-introduced properly via a PR from `forms/load-balancing-application-url-notes`.

This is a pure revert (52 line deletions, the exact inverse of the original commit) — no content authoring, so the style checklist below is not applicable.

## 📎 Related Issues (if applicable)

N/A

## Product & Version (if relevant)

Umbraco Forms — docs for v17 and v18 (revert only).