### PR TITLE
Documented `SessionIdLogging` setting (due in CMS 17.6 and 18.1)

### DIFF
--- a/17/umbraco-cms/develop-with-umbraco/configuration/loggingsettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/loggingsettings.md
@@ -15,7 +15,8 @@ The following configuration is available in the Logging settings:
       "MaxLogAge": "2.00:00:00",
       "Directory": "~/CustomLogFileLocation",
       "FileNameFormat": "UmbracoTraceLog.{0}..json",
-      "FileNameFormatArguments": "MachineName"
+      "FileNameFormatArguments": "MachineName",
+      "SessionIdLogging": "SessionId"
     }
   }
 }
@@ -51,3 +52,15 @@ Other or additional arguments can be provided via the `FileNameFormatArguments` 
 So for example, to provide both supported arguments you would configure `MachineName,EnvironmentName`.
 
 The number of arguments provided should match the placeholders in the configured `FileNameFormat`.
+
+## SessionIdLogging
+
+This setting determines how log events are enriched with a session identifier, used to correlate the log entries produced while handling requests from the same session.
+
+The available options are:
+
+- `SessionId` (default) - Enriches log events with the actual ASP.NET Core session id. This matches the historical behavior. Reading the session id forces the session to be loaded from its store, which is a blocking round-trip per request when the session is backed by an `IDistributedCache` (for example, on a load-balanced setup or when using a standalone L2 cache).
+- `CookieHash` - Enriches log events with a one-way hash of the session cookie value. This provides the same per-session correlation as `SessionId` without loading the session from its store, so it never incurs a distributed-cache round-trip.
+- `None` - Does not enrich log events with a session identifier.
+
+If your session is backed by an `IDistributedCache`, consider setting this to `CookieHash` or `None` to avoid the blocking session-store load that resolving the actual session id incurs on each request.

--- a/17/umbraco-cms/develop-with-umbraco/configuration/loggingsettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/loggingsettings.md
@@ -55,7 +55,7 @@ The number of arguments provided should match the placeholders in the configured
 
 ## SessionIdLogging
 
-This setting determines how log events are enriched with a session identifier, used to correlate the log entries produced while handling requests from the same session.
+This setting determines how log events are enriched with a session identifier. The identifier correlates the log entries produced while handling requests from the same session.
 
 The available options are:
 
@@ -63,4 +63,4 @@ The available options are:
 - `CookieHash` - Enriches log events with a one-way hash of the session cookie value. This provides the same per-session correlation as `SessionId` without loading the session from its store, so it never incurs a distributed-cache round-trip.
 - `None` - Does not enrich log events with a session identifier.
 
-If your session is backed by an `IDistributedCache`, consider setting this to `CookieHash` or `None` to avoid the blocking session-store load that resolving the actual session id incurs on each request.
+If your session is backed by an `IDistributedCache`, consider setting this to `CookieHash` or `None`. This avoids the blocking session-store load that resolving the actual session id incurs on each request.

--- a/17/umbraco-cms/develop-with-umbraco/configuration/loggingsettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/loggingsettings.md
@@ -59,7 +59,7 @@ This setting determines how log events are enriched with a session identifier. T
 
 The available options are:
 
-- `SessionId` (default) - Enriches log events with the actual ASP.NET Core session id. This matches the historical behavior. Reading the session id forces the session to be loaded from its store, which is a blocking round-trip per request when the session is backed by an `IDistributedCache` (for example, on a load-balanced setup or when using a standalone L2 cache).
+- `SessionId` (default) - Enriches log events with the actual ASP.NET Core session ID. This matches the historical behavior. Reading the session ID forces the session to be loaded from its store, which is a blocking round-trip per request when the session is backed by an `IDistributedCache` (for example, on a load-balanced setup or when using a standalone L2 cache).
 - `CookieHash` - Enriches log events with a one-way hash of the session cookie value. This provides the same per-session correlation as `SessionId` without loading the session from its store, so it never incurs a distributed-cache round-trip.
 - `None` - Does not enrich log events with a session identifier.
 

--- a/18/umbraco-cms/develop-with-umbraco/configuration/loggingsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/loggingsettings.md
@@ -15,7 +15,8 @@ The following configuration is available in the Logging settings:
       "MaxLogAge": "2.00:00:00",
       "Directory": "~/CustomLogFileLocation",
       "FileNameFormat": "UmbracoTraceLog.{0}..json",
-      "FileNameFormatArguments": "MachineName"
+      "FileNameFormatArguments": "MachineName",
+      "SessionIdLogging": "SessionId"
     }
   }
 }
@@ -51,3 +52,15 @@ Other or additional arguments can be provided via the `FileNameFormatArguments` 
 So for example, to provide both supported arguments you would configure `MachineName,EnvironmentName`.
 
 The number of arguments provided should match the placeholders in the configured `FileNameFormat`.
+
+## SessionIdLogging
+
+This setting determines how log events are enriched with a session identifier, used to correlate the log entries produced while handling requests from the same session.
+
+The available options are:
+
+- `SessionId` (default) - Enriches log events with the actual ASP.NET Core session id. This matches the historical behavior. Reading the session id forces the session to be loaded from its store, which is a blocking round-trip per request when the session is backed by an `IDistributedCache` (for example, on a load-balanced setup or when using a standalone L2 cache).
+- `CookieHash` - Enriches log events with a one-way hash of the session cookie value. This provides the same per-session correlation as `SessionId` without loading the session from its store, so it never incurs a distributed-cache round-trip.
+- `None` - Does not enrich log events with a session identifier.
+
+If your session is backed by an `IDistributedCache`, consider setting this to `CookieHash` or `None` to avoid the blocking session-store load that resolving the actual session id incurs on each request.

--- a/18/umbraco-cms/develop-with-umbraco/configuration/loggingsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/loggingsettings.md
@@ -55,7 +55,7 @@ The number of arguments provided should match the placeholders in the configured
 
 ## SessionIdLogging
 
-This setting determines how log events are enriched with a session identifier, used to correlate the log entries produced while handling requests from the same session.
+This setting determines how log events are enriched with a session identifier. The identifier correlates the log entries produced while handling requests from the same session.
 
 The available options are:
 
@@ -63,4 +63,4 @@ The available options are:
 - `CookieHash` - Enriches log events with a one-way hash of the session cookie value. This provides the same per-session correlation as `SessionId` without loading the session from its store, so it never incurs a distributed-cache round-trip.
 - `None` - Does not enrich log events with a session identifier.
 
-If your session is backed by an `IDistributedCache`, consider setting this to `CookieHash` or `None` to avoid the blocking session-store load that resolving the actual session id incurs on each request.
+If your session is backed by an `IDistributedCache`, consider setting this to `CookieHash` or `None`. This avoids the blocking session-store load that resolving the actual session id incurs on each request.

--- a/18/umbraco-cms/develop-with-umbraco/configuration/loggingsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/loggingsettings.md
@@ -59,7 +59,7 @@ This setting determines how log events are enriched with a session identifier. T
 
 The available options are:
 
-- `SessionId` (default) - Enriches log events with the actual ASP.NET Core session id. This matches the historical behavior. Reading the session id forces the session to be loaded from its store, which is a blocking round-trip per request when the session is backed by an `IDistributedCache` (for example, on a load-balanced setup or when using a standalone L2 cache).
+- `SessionId` (default) - Enriches log events with the actual ASP.NET Core session ID. This matches the historical behavior. Reading the session ID forces the session to be loaded from its store, which is a blocking round-trip per request when the session is backed by an `IDistributedCache` (for example, on a load-balanced setup or when using a standalone L2 cache).
 - `CookieHash` - Enriches log events with a one-way hash of the session cookie value. This provides the same per-session correlation as `SessionId` without loading the session from its store, so it never incurs a distributed-cache round-trip.
 - `None` - Does not enrich log events with a session identifier.
 


### PR DESCRIPTION
## 📋 Description

Documents a new configuration setting for session ID log enrichment, due in 17.6 and 18.1.

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/pull/23083

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17.6 and 18.1

## Deadline (if relevant)

Should be published on 23rd July, along with the related release candidates.
