### PR TITLE
Documented scheduled publishing settings (due in CMS 17.6 and 18.1)

### DIFF
--- a/17/umbraco-cms/SUMMARY.md
+++ b/17/umbraco-cms/SUMMARY.md
@@ -275,6 +275,7 @@
   * [Plugins Settings](develop-with-umbraco/configuration/pluginssettings.md)
   * [Request Handler Settings](develop-with-umbraco/configuration/requesthandlersettings.md)
   * [Runtime Settings](develop-with-umbraco/configuration/runtimesettings.md)
+  * [Scheduled Publishing Settings](develop-with-umbraco/configuration/scheduledpublishingsettings.md)
   * [Security Settings](develop-with-umbraco/configuration/securitysettings.md)
   * [Serilog Settings](develop-with-umbraco/configuration/serilog.md)
   * [Type Finder Settings](develop-with-umbraco/configuration/typefindersettings.md)

--- a/17/umbraco-cms/develop-with-umbraco/configuration/scheduledpublishingsettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/scheduledpublishingsettings.md
@@ -2,7 +2,7 @@
 description: "Information on the scheduled publishing settings section."
 ---
 
-# Scheduled publishing settings
+# Scheduled Publishing Settings
 
 The scheduled publishing settings control how often Umbraco checks for content scheduled to be published or unpublished. They also control whether those checks are aligned to clock boundaries.
 

--- a/17/umbraco-cms/develop-with-umbraco/configuration/scheduledpublishingsettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/scheduledpublishingsettings.md
@@ -1,0 +1,46 @@
+---
+description: "Information on the scheduled publishing settings section."
+---
+
+# Scheduled publishing settings
+
+The scheduled publishing settings control how often Umbraco checks for content scheduled to be published or unpublished. They also control whether those checks are aligned to clock boundaries.
+
+By default, scheduled publishing runs once a minute. An item scheduled to go live at a specific time is therefore published at some point in the following minute. It is not published exactly at the configured time. These settings let you tune that cadence and optionally snap it to wall-clock boundaries.
+
+## Configuration
+
+```json
+"Umbraco": {
+  "CMS": {
+    "ScheduledPublishing": {
+      "Period": "00:01:00",
+      "AlignToClock": false
+    }
+  }
+}
+```
+
+## Settings
+
+### Period
+
+**Default:** `00:01:00` (1 minute)
+
+Specifies how often scheduled publishing runs.
+
+A shorter period means scheduled content is published closer to its configured time, but increases the processing overhead. Reducing the period too far is not recommended, as each run has a performance cost and publishing itself takes some time.
+
+### AlignToClock
+
+**Default:** `false`
+
+Determines whether scheduled publishing runs are aligned to clock boundaries derived from `Period`, rather than drifting based on when the previous run completed.
+
+When `false` (the default), each run is scheduled relative to the completion of the previous run. This means the time of day at which publishing occurs gradually drifts forward.
+
+When `true`, runs are aligned to clock boundaries that are a multiple of `Period`. For example, with a `Period` of `00:00:10`, runs are aligned to the `:00`, `:10`, `:20`, `:30`, `:40`, and `:50` seconds of each minute. This makes the time at which scheduled content is published more predictable.
+
+When `AlignToClock` is enabled, `Period` must be a whole number of seconds that divides evenly into one hour (3600 seconds). For example, 10, 12, 15, 20, 30, or 60 seconds. If this condition is not met, the configuration fails validation on startup.
+
+This does not guarantee publishing to the exact second, as publishing still takes a little time to run. It does, however, narrow the range of when scheduled content goes live.

--- a/17/umbraco-cms/develop-with-umbraco/configuration/scheduledpublishingsettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/scheduledpublishingsettings.md
@@ -37,6 +37,10 @@ A shorter period means scheduled content is published closer to its configured t
 
 Determines whether scheduled publishing runs are aligned to clock boundaries derived from `Period`, rather than drifting based on when the previous run completed.
 
+{% hint style="info" %}
+The default is `false` in Umbraco 17 and 18 to preserve the existing behaviour. It is due to change to `true` in Umbraco 19.
+{% endhint %}
+
 When `false` (the default), each run is scheduled relative to the completion of the previous run. This means the time of day at which publishing occurs gradually drifts forward.
 
 When `true`, runs are aligned to clock boundaries that are a multiple of `Period`. For example, with a `Period` of `00:00:10`, runs are aligned to the `:00`, `:10`, `:20`, `:30`, `:40`, and `:50` seconds of each minute. This makes the time at which scheduled content is published more predictable.

--- a/18/umbraco-cms/SUMMARY.md
+++ b/18/umbraco-cms/SUMMARY.md
@@ -277,6 +277,7 @@
   * [Plugins Settings](develop-with-umbraco/configuration/pluginssettings.md)
   * [Request Handler Settings](develop-with-umbraco/configuration/requesthandlersettings.md)
   * [Runtime Settings](develop-with-umbraco/configuration/runtimesettings.md)
+  * [Scheduled Publishing Settings](develop-with-umbraco/configuration/scheduledpublishingsettings.md)
   * [Security Settings](develop-with-umbraco/configuration/securitysettings.md)
   * [Serilog Settings](develop-with-umbraco/configuration/serilog.md)
   * [Type Finder Settings](develop-with-umbraco/configuration/typefindersettings.md)

--- a/18/umbraco-cms/develop-with-umbraco/configuration/scheduledpublishingsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/scheduledpublishingsettings.md
@@ -2,7 +2,7 @@
 description: "Information on the scheduled publishing settings section."
 ---
 
-# Scheduled publishing settings
+# Scheduled Publishing Settings
 
 The scheduled publishing settings control how often Umbraco checks for content scheduled to be published or unpublished. They also control whether those checks are aligned to clock boundaries.
 

--- a/18/umbraco-cms/develop-with-umbraco/configuration/scheduledpublishingsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/scheduledpublishingsettings.md
@@ -1,0 +1,46 @@
+---
+description: "Information on the scheduled publishing settings section."
+---
+
+# Scheduled publishing settings
+
+The scheduled publishing settings control how often Umbraco checks for content scheduled to be published or unpublished. They also control whether those checks are aligned to clock boundaries.
+
+By default, scheduled publishing runs once a minute. An item scheduled to go live at a specific time is therefore published at some point in the following minute. It is not published exactly at the configured time. These settings let you tune that cadence and optionally snap it to wall-clock boundaries.
+
+## Configuration
+
+```json
+"Umbraco": {
+  "CMS": {
+    "ScheduledPublishing": {
+      "Period": "00:01:00",
+      "AlignToClock": false
+    }
+  }
+}
+```
+
+## Settings
+
+### Period
+
+**Default:** `00:01:00` (1 minute)
+
+Specifies how often scheduled publishing runs.
+
+A shorter period means scheduled content is published closer to its configured time, but increases the processing overhead. Reducing the period too far is not recommended, as each run has a performance cost and publishing itself takes some time.
+
+### AlignToClock
+
+**Default:** `false`
+
+Determines whether scheduled publishing runs are aligned to clock boundaries derived from `Period`, rather than drifting based on when the previous run completed.
+
+When `false` (the default), each run is scheduled relative to the completion of the previous run. This means the time of day at which publishing occurs gradually drifts forward.
+
+When `true`, runs are aligned to clock boundaries that are a multiple of `Period`. For example, with a `Period` of `00:00:10`, runs are aligned to the `:00`, `:10`, `:20`, `:30`, `:40`, and `:50` seconds of each minute. This makes the time at which scheduled content is published more predictable.
+
+When `AlignToClock` is enabled, `Period` must be a whole number of seconds that divides evenly into one hour (3600 seconds). For example, 10, 12, 15, 20, 30, or 60 seconds. If this condition is not met, the configuration fails validation on startup.
+
+This does not guarantee publishing to the exact second, as publishing still takes a little time to run. It does, however, narrow the range of when scheduled content goes live.

--- a/18/umbraco-cms/develop-with-umbraco/configuration/scheduledpublishingsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/scheduledpublishingsettings.md
@@ -37,6 +37,10 @@ A shorter period means scheduled content is published closer to its configured t
 
 Determines whether scheduled publishing runs are aligned to clock boundaries derived from `Period`, rather than drifting based on when the previous run completed.
 
+{% hint style="info" %}
+The default is `false` in Umbraco 17 and 18 to preserve the existing behaviour. It is due to change to `true` in Umbraco 19.
+{% endhint %}
+
 When `false` (the default), each run is scheduled relative to the completion of the previous run. This means the time of day at which publishing occurs gradually drifts forward.
 
 When `true`, runs are aligned to clock boundaries that are a multiple of `Period`. For example, with a `Period` of `00:00:10`, runs are aligned to the `:00`, `:10`, `:20`, `:30`, `:40`, and `:50` seconds of each minute. This makes the time at which scheduled content is published more predictable.


### PR DESCRIPTION
## 📋 Description

Documents a new configuration setting for scheduled publishing log enrichment, due in 17.6 and 18.1.

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/pull/23127

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [X] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [X] Relevant pages are linked.
* [X] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17.6 and 18.1

## Deadline (if relevant)

Should be published on 23rd July, along with the related release candidates.
