### PR TITLE
Documented sort children notification settings (due in CMS 17.6 and 18.1)

### DIFF
--- a/17/umbraco-cms/develop-with-umbraco/configuration/contentsettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/contentsettings.md
@@ -47,6 +47,7 @@ The following snippet will give an overview of the keys and values in the conten
       },
       "PreviewBadge": "<![CDATA[<b>My HTML here</b>]]>",
       "ResolveUrlsFromTextString": false,
+      "SortChildrenByFieldFiresNotifications": false,
       "ShowDeprecatedPropertyEditors": false,
       "ShowDomainWarnings": true,
       "ShowUnroutableContentWarnings": true,
@@ -159,6 +160,14 @@ This allows you to customize the preview badge being shown when you're previewin
 ### Resolve urls from text string
 
 This setting is used when you're running Umbraco in virtual directories. Setting this to true can increase render time for pages with a large number of links. However, this is required if Umbraco is running in a virtual directory.
+
+### Sort children by field fires notifications
+
+This setting controls how sorting the children of a node by a field is persisted. Sorting by a field is available through the Management API, which can reorder a node's entire set of children in a single operation.
+
+By default (`false`), the children are reordered with a single set-based database update and a single branch cache refresh. A single audit entry is written, but no per-item save/sort notifications are fired. As a result, webhooks that depend on those notifications are not triggered. This keeps the operation efficient on nodes with many children.
+
+Set this to `true` to restore per-item save/sort notifications (and the webhooks that depend on them). This routes the field sort through the standard per-item sort path, accepting the additional performance cost on nodes with many children.
 
 ### Show deprecated property editors
 

--- a/17/umbraco-cms/develop-with-umbraco/configuration/contentsettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/contentsettings.md
@@ -163,11 +163,11 @@ This setting is used when you're running Umbraco in virtual directories. Setting
 
 ### Sort children by field fires notifications
 
-This setting controls how sorting the children of a node by a field is persisted. Sorting by a field is available through the Management API, which can reorder a node's entire set of children in a single operation.
+Sorting by a field is available through the Management API, which can reorder a node's entire set of children in a single operation. This is an alternative mechanism to the per-item sort currently supported via the backoffice.
 
-By default (`false`), the children are reordered with a single set-based database update and a single branch cache refresh. A single audit entry is written, but no per-item save/sort notifications are fired. As a result, webhooks that depend on those notifications are not triggered. This keeps the operation efficient on nodes with many children.
+By default (`false`), the children are reordered in a performant "set-based" operation. A single audit entry is written, but no per-item save/sort notifications are fired. As a result, webhooks that depend on notifications are not triggered.
 
-Set this to `true` to restore per-item save/sort notifications (and the webhooks that depend on them). This routes the field sort through the standard per-item sort path, accepting the additional performance cost on nodes with many children.
+Set this to `true` to restore per-item save/sort notifications (and the webhooks that depend on them). This follows the per-item sort path, accepting the additional performance cost on nodes with many children.
 
 ### Show deprecated property editors
 

--- a/18/umbraco-cms/develop-with-umbraco/configuration/contentsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/contentsettings.md
@@ -46,6 +46,7 @@ The following snippet will give an overview of the keys and values in the conten
       },
       "PreviewBadge": "<![CDATA[<b>My HTML here</b>]]>",
       "ResolveUrlsFromTextString": false,
+      "SortChildrenByFieldFiresNotifications": false,
       "ShowDeprecatedPropertyEditors": false,
       "ShowDomainWarnings": true,
       "ShowUnroutableContentWarnings": true,
@@ -154,6 +155,14 @@ This allows you to customize the preview badge being shown when you're previewin
 ### Resolve urls from text string
 
 This setting is used when you're running Umbraco in virtual directories. Setting this to true can increase render time for pages with a large number of links. However, this is required if Umbraco is running in a virtual directory.
+
+### Sort children by field fires notifications
+
+This setting controls how sorting the children of a node by a field is persisted. Sorting by a field is available through the Management API, which can reorder a node's entire set of children in a single operation.
+
+By default (`false`), the children are reordered with a single set-based database update and a single branch cache refresh. A single audit entry is written, but no per-item save/sort notifications are fired. As a result, webhooks that depend on those notifications are not triggered. This keeps the operation efficient on nodes with many children.
+
+Set this to `true` to restore per-item save/sort notifications (and the webhooks that depend on them). This routes the field sort through the standard per-item sort path, accepting the additional performance cost on nodes with many children.
 
 ### Show deprecated property editors
 

--- a/18/umbraco-cms/develop-with-umbraco/configuration/contentsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/contentsettings.md
@@ -158,11 +158,11 @@ This setting is used when you're running Umbraco in virtual directories. Setting
 
 ### Sort children by field fires notifications
 
-This setting controls how sorting the children of a node by a field is persisted. Sorting by a field is available through the Management API, which can reorder a node's entire set of children in a single operation.
+Sorting by a field is available through the Management API, which can reorder a node's entire set of children in a single operation. This is an alternative mechanism to the per-item sort currently supported via the backoffice.
 
-By default (`false`), the children are reordered with a single set-based database update and a single branch cache refresh. A single audit entry is written, but no per-item save/sort notifications are fired. As a result, webhooks that depend on those notifications are not triggered. This keeps the operation efficient on nodes with many children.
+By default (`false`), the children are reordered in a performant "set-based" operation. A single audit entry is written, but no per-item save/sort notifications are fired. As a result, webhooks that depend on notifications are not triggered.
 
-Set this to `true` to restore per-item save/sort notifications (and the webhooks that depend on them). This routes the field sort through the standard per-item sort path, accepting the additional performance cost on nodes with many children.
+Set this to `true` to restore per-item save/sort notifications (and the webhooks that depend on them). This follows the per-item sort path, accepting the additional performance cost on nodes with many children.
 
 ### Show deprecated property editors
 


### PR DESCRIPTION
## 📋 Description

Adds details of the `SortChildrenByFieldFiresNotifications` setting added in CMS 17.6 and 18.1.

For now I've only referenced calling this from the management API, but we should update to reference the backoffice feature that calls the API when it's ready.

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/pull/23077

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17.6 and 18.1

## Deadline (if relevant)

Should be published on 23rd July, along with the related release candidates.
