### PR TITLE
Align content version cleanup policy example with default settings

### DIFF
--- a/13/umbraco-cms/fundamentals/data/content-version-cleanup.md
+++ b/13/umbraco-cms/fundamentals/data/content-version-cleanup.md
@@ -6,8 +6,8 @@ A new version is created whenever you save and publish a content item in Umbraco
 
 The default cleanup policy will:
 
-* Not delete any versions created over the previous 4 days. The recent version history is preserved. See the `KeepAllVersionsNewerThanDays` setting.
-* 'Prune' versions 4 days after they are created. The last version of a content item saved on a particular day will be kept but earlier versions from that day will be deleted.
+* Not delete any versions created over the previous 7 days. The recent version history is preserved. See the `KeepAllVersionsNewerThanDays` setting.
+* 'Prune' versions 7 days after they are created. The last version of a content item saved on a particular day will be kept but earlier versions from that day will be deleted.
 * Delete all versions older than 90 days. See the `KeepLatestVersionPerDayForDays` setting.
 * Never delete any versions that are currently 'published'.
 * Never delete any specific versions marked as 'Prevent Cleanup' in the Backoffice version history.
@@ -31,7 +31,7 @@ The feature can be configured in the `appSettings.json`:
         "ContentVersionCleanupPolicy": {
           "EnableCleanup": true,
           "KeepLatestVersionPerDayForDays": 90,
-          "KeepAllVersionsNewerThanDays": 4
+          "KeepAllVersionsNewerThanDays": 7
         }
       }
     }

--- a/16/umbraco-cms/fundamentals/data/content-version-cleanup.md
+++ b/16/umbraco-cms/fundamentals/data/content-version-cleanup.md
@@ -6,8 +6,8 @@ A new version is created whenever you save and publish a content item in Umbraco
 
 The default cleanup policy will:
 
-* Not delete any versions created over the previous 4 days. The recent version history is preserved. See the `KeepAllVersionsNewerThanDays` setting.
-* 'Prune' versions 4 days after they are created. The last version of a content item saved on a particular day will be kept but earlier versions from that day will be deleted.
+* Not delete any versions created over the previous 7 days. The recent version history is preserved. See the `KeepAllVersionsNewerThanDays` setting.
+* 'Prune' versions 7 days after they are created. The last version of a content item saved on a particular day will be kept but earlier versions from that day will be deleted.
 * Delete all versions older than 90 days. See the `KeepLatestVersionPerDayForDays` setting.
 * Never delete any versions that are currently 'published'.
 * Never delete any specific versions marked as 'Prevent Cleanup' in the Backoffice version history.
@@ -31,7 +31,7 @@ The feature can be configured in the `appSettings.json`:
         "ContentVersionCleanupPolicy": {
           "EnableCleanup": true,
           "KeepLatestVersionPerDayForDays": 90,
-          "KeepAllVersionsNewerThanDays": 4
+          "KeepAllVersionsNewerThanDays": 7
         }
       }
     }

--- a/17/umbraco-cms/develop-with-umbraco/configuration/content-version-cleanup.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/content-version-cleanup.md
@@ -6,8 +6,8 @@ A new version is created whenever you save and publish a content item in Umbraco
 
 The default cleanup policy will:
 
-* Not delete any versions created over the previous 4 days. The recent version history is preserved. See the `KeepAllVersionsNewerThanDays` setting.
-* 'Prune' versions 4 days after they are created. The last version of a content item saved on a particular day will be kept but earlier versions from that day will be deleted.
+* Not delete any versions created over the previous 7 days. The recent version history is preserved. See the `KeepAllVersionsNewerThanDays` setting.
+* 'Prune' versions 7 days after they are created. The last version of a content item saved on a particular day will be kept but earlier versions from that day will be deleted.
 * Delete all versions older than 90 days. See the `KeepLatestVersionPerDayForDays` setting.
 * Never delete any versions that are currently 'published'.
 * Never delete any specific versions marked as 'Prevent Cleanup' in the Backoffice version history.
@@ -31,7 +31,7 @@ The feature can be configured in the `appSettings.json`:
         "ContentVersionCleanupPolicy": {
           "EnableCleanup": true,
           "KeepLatestVersionPerDayForDays": 90,
-          "KeepAllVersionsNewerThanDays": 4
+          "KeepAllVersionsNewerThanDays": 7
         }
       }
     }

--- a/18/umbraco-cms/develop-with-umbraco/configuration/content-version-cleanup.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/content-version-cleanup.md
@@ -6,8 +6,8 @@ A new version is created whenever you save and publish a content item in Umbraco
 
 The default cleanup policy will:
 
-* Not delete any versions created over the previous 4 days. The recent version history is preserved. See the `KeepAllVersionsNewerThanDays` setting.
-* 'Prune' versions 4 days after they are created. The last version of a content item saved on a particular day will be kept but earlier versions from that day will be deleted.
+* Not delete any versions created over the previous 7 days. The recent version history is preserved. See the `KeepAllVersionsNewerThanDays` setting.
+* 'Prune' versions 7 days after they are created. The last version of a content item saved on a particular day will be kept but earlier versions from that day will be deleted.
 * Delete all versions older than 90 days. See the `KeepLatestVersionPerDayForDays` setting.
 * Never delete any versions that are currently 'published'.
 * Never delete any specific versions marked as 'Prevent Cleanup' in the Backoffice version history.
@@ -31,7 +31,7 @@ The feature can be configured in the `appSettings.json`:
         "ContentVersionCleanupPolicy": {
           "EnableCleanup": true,
           "KeepLatestVersionPerDayForDays": 90,
-          "KeepAllVersionsNewerThanDays": 4
+          "KeepAllVersionsNewerThanDays": 7
         }
       }
     }


### PR DESCRIPTION
## 📋 Description

The documentation is now aligned with the default settings in `ContentVersionCleanupPolicySettings`.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [X] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [X] Relevant pages are linked.
* [X] All links work and point to the correct resources.
* [X] Screenshots or diagrams are included if useful.
* [X] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

This is relevant all the way down to v13. Can it be merged down to the historic branches?