### PR TITLE
Document Fallback.ToDefaultLanguage in IPublishedContent properties

### DIFF
--- a/13/umbraco-cms/reference/querying/ipublishedcontent/properties.md
+++ b/13/umbraco-cms/reference/querying/ipublishedcontent/properties.md
@@ -266,6 +266,14 @@ If working with variants - fallback to a different language value - if perhaps t
 @(Model.Value(PublishedValueFallback, "pageTitle", "fr", fallback: Fallback.ToLanguage))
 ```
 
+### Fallback to Default Language
+
+If working with variants - fallback to the value from the default language - if the value hasn't been populated yet for the current language. Unlike `Fallback.ToLanguage`, this doesn't require a specific culture to be specified, as it always falls back to the site's default language:
+
+```csharp
+@(Model.Value(PublishedValueFallback, "pageTitle", fallback: Fallback.ToDefaultLanguage))
+```
+
 ### Combining the Fallback options
 
 Use Fallback.To() to 'combine' Fallback options.

--- a/16/umbraco-cms/reference/querying/ipublishedcontent/properties.md
+++ b/16/umbraco-cms/reference/querying/ipublishedcontent/properties.md
@@ -266,6 +266,14 @@ If working with variants - fallback to a different language value - if perhaps t
 @(Model.Value(PublishedValueFallback, "pageTitle", "fr", fallback: Fallback.ToLanguage))
 ```
 
+### Fallback to Default Language
+
+If working with variants - fallback to the value from the default language - if the value hasn't been populated yet for the current language. Unlike `Fallback.ToLanguage`, this doesn't require a specific culture to be specified, as it always falls back to the site's default language:
+
+```csharp
+@(Model.Value(PublishedValueFallback, "pageTitle", fallback: Fallback.ToDefaultLanguage))
+```
+
 ### Combining the Fallback options
 
 Use Fallback.To() to 'combine' Fallback options.

--- a/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/ipublishedcontent/properties.md
+++ b/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/ipublishedcontent/properties.md
@@ -266,6 +266,14 @@ If working with variants - fallback to a different language value - if perhaps t
 @(Model.Value(PublishedValueFallback, "pageTitle", "fr", fallback: Fallback.ToLanguage))
 ```
 
+### Fallback to Default Language
+
+If working with variants - fallback to the value from the default language - if the value hasn't been populated yet for the current language. Unlike `Fallback.ToLanguage`, this doesn't require a specific culture to be specified, as it always falls back to the site's default language:
+
+```csharp
+@(Model.Value(PublishedValueFallback, "pageTitle", fallback: Fallback.ToDefaultLanguage))
+```
+
 ### Combining the Fallback options
 
 Use Fallback.To() to 'combine' Fallback options.

--- a/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/ipublishedcontent/properties.md
+++ b/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/ipublishedcontent/properties.md
@@ -265,6 +265,14 @@ If working with variants - fallback to a different language value - if perhaps t
 @(Model.Value(PublishedValueFallback, "pageTitle", "fr", fallback: Fallback.ToLanguage))
 ```
 
+### Fallback to Default Language
+
+If working with variants - fallback to the value from the default language - if the value hasn't been populated yet for the current language. Unlike `Fallback.ToLanguage`, this doesn't require a specific culture to be specified, as it always falls back to the site's default language:
+
+```csharp
+@(Model.Value(PublishedValueFallback, "pageTitle", fallback: Fallback.ToDefaultLanguage))
+```
+
 ### Combining the Fallback options
 
 Use Fallback.To() to 'combine' Fallback options.


### PR DESCRIPTION
## Description

The [Fallbacks section of the IPublishedContent properties documentation](https://docs.umbraco.com/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/ipublishedcontent/properties#fallbacks) was missing the `Fallback.ToDefaultLanguage` option.

This fallback policy (`Fallback.DefaultLanguage` enum value / `Fallback.ToDefaultLanguage` helper) was added in [umbraco/Umbraco-CMS#13814](https://github.com/umbraco/Umbraco-CMS/pull/13814) and shipped in Umbraco 11.3.0. It falls back to the value from the site's default language without requiring a specific culture to be specified.

## Changes

Added a new `### Fallback to Default Language` subsection to the Fallbacks section in all currently supported versions:

- `13/umbraco-cms/reference/querying/ipublishedcontent/properties.md`
- `16/umbraco-cms/reference/querying/ipublishedcontent/properties.md`
- `17/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/ipublishedcontent/properties.md`
- `18/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/ipublishedcontent/properties.md`

The API naming was verified against the `Fallback` struct in the CMS source.