### PR TITLE
Adds UFM Member Name component (due in CMS 17.6)

### DIFF
--- a/17/umbraco-cms/model-your-content/property-editors/umbraco-flavored-markdown.md
+++ b/17/umbraco-cms/model-your-content/property-editors/umbraco-flavored-markdown.md
@@ -122,6 +122,7 @@ The following UFM components are available to use.
 | Label Value  | `{umbValue: headline}`                 |
 | Localize     | `{umbLocalize: general_name}`          |
 | Content Name | `{umbContentName: pickerAlias}`        |
+| Member Name  | `{umbMemberName: pickerAlias}`         |
 | Link Title   | `{umbLink: pickerAlias}`               |
 | Form Name    | `{umbFormName: formAlias}`             | 
 
@@ -149,7 +150,14 @@ The Content Name component will render the name of a content item, (either Docum
 
 The alias prefix is `umbContentName`. An example of the syntax is `{umbContentName: pickerAlias}`, which would render the component as `<ufm-content-name alias="pickerAlias"></ufm-content-name>`.
 
-The Content Name component supports content-based pickers, such as the Document Picker, Content Picker (formerly known as Multinode Treepicker), and Member Picker. Support for the advanced Media Picker will be available in an upcoming Umbraco release.
+The Content Name component supports content-based pickers, such as the Document Picker, Content Picker (formerly known as Multinode Treepicker) and Media Picker.
+
+#### Member Name
+
+The Member Name component will render the name of a member from the value of a given Member Picker property editor. Multiple values will render the names as a comma-separated list.
+
+The alias prefix is `umbMemberName`. An example of the syntax is `{umbMemberName: pickerAlias}`, which would render the component as `<ufm-member-name alias="pickerAlias"></ufm-member-name>`.
+
 
 #### Link Title
 

--- a/18/umbraco-cms/model-your-content/property-editors/umbraco-flavored-markdown.md
+++ b/18/umbraco-cms/model-your-content/property-editors/umbraco-flavored-markdown.md
@@ -122,6 +122,7 @@ The following UFM components are available to use.
 | Label Value  | `{umbValue: headline}`                 |
 | Localize     | `{umbLocalize: general_name}`          |
 | Content Name | `{umbContentName: pickerAlias}`        |
+| Member Name  | `{umbMemberName: pickerAlias}`         |
 | Link Title   | `{umbLink: pickerAlias}`               |
 | Form Name    | `{umbFormName: formAlias}`             | 
 
@@ -150,6 +151,12 @@ The Content Name component will render the name of a content item, (either Docum
 The alias prefix is `umbContentName`. An example of the syntax is `{umbContentName: pickerAlias}`, which would render the component as `<ufm-content-name alias="pickerAlias"></ufm-content-name>`.
 
 The Content Name component supports content-based pickers, such as the Document Picker, Content Picker (formerly known as Multinode Treepicker), and Member Picker. Support for the advanced Media Picker will be available in an upcoming Umbraco release.
+
+#### Member Name
+
+The Member Name component will render the name of a member from the value of a given Member Picker property editor. Multiple values will render the names as a comma-separated list.
+
+The alias prefix is `umbMemberName`. An example of the syntax is `{umbMemberName: pickerAlias}`, which would render the component as `<ufm-member-name alias="pickerAlias"></ufm-member-name>`.
 
 #### Link Title
 

--- a/18/umbraco-cms/model-your-content/property-editors/umbraco-flavored-markdown.md
+++ b/18/umbraco-cms/model-your-content/property-editors/umbraco-flavored-markdown.md
@@ -122,6 +122,7 @@ The following UFM components are available to use.
 | Label Value  | `{umbValue: headline}`                 |
 | Localize     | `{umbLocalize: general_name}`          |
 | Content Name | `{umbContentName: pickerAlias}`        |
+| Element Name | `{umbElementName: pickerAlias}`        |
 | Member Name  | `{umbMemberName: pickerAlias}`         |
 | Link Title   | `{umbLink: pickerAlias}`               |
 | Form Name    | `{umbFormName: formAlias}`             | 
@@ -150,7 +151,13 @@ The Content Name component will render the name of a content item, (either Docum
 
 The alias prefix is `umbContentName`. An example of the syntax is `{umbContentName: pickerAlias}`, which would render the component as `<ufm-content-name alias="pickerAlias"></ufm-content-name>`.
 
-The Content Name component supports content-based pickers, such as the Document Picker, Content Picker (formerly known as Multinode Treepicker), and Member Picker. Support for the advanced Media Picker will be available in an upcoming Umbraco release.
+The Content Name component supports content-based pickers, such as the Document Picker, Content Picker (formerly known as Multinode Treepicker) and Media Picker.
+
+#### Element Name
+
+The Element Name component will render the name of an element from the value of a given Element Picker property editor. Multiple values will render the names as a comma-separated list.
+
+The alias prefix is `umbElementName`. An example of the syntax is `{umbElementName: pickerAlias}`, which would render the component as `<ufm-element-name alias="pickerAlias"></ufm-element-name>`.
 
 #### Member Name
 


### PR DESCRIPTION
## 📋 Description

Adds an entry to the [UFM documentation](https://docs.umbraco.com/umbraco-cms/model-your-content/property-editors/umbraco-flavored-markdown) for a new **Member Name** component.

Also corrected the details on the **Content Name** entry, (as it didn't work with the Member Picker editor), but Media Picker support was added a while ago (I can't recall which v17 version).

## 📎 Related Issues (if applicable)

- https://github.com/umbraco/Umbraco-CMS/pull/23165

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17.6.0

## Deadline (if relevant)

Should be published on 23<sup>rd</sup> July 2026, along with the related release candidates.
