### PR TITLE
chore: ignore .memsearch/ and docs/plans/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 settings.local.json
 .claude/eval-workspaces/
 node_modules/
+.memsearch/
+docs/plans/


### PR DESCRIPTION
Adds `.memsearch/` and `docs/plans/` to `.gitignore` so local tooling artifacts (memory search index and planning scratch files) don't get committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)