### PR TITLE
Add Deploy 17.2.0, 18.0.0 and Deploy Contrib 18.0.0 release notes

### DIFF
--- a/17/umbraco-deploy/release-notes.md
+++ b/17/umbraco-deploy/release-notes.md
@@ -16,6 +16,15 @@ If you are upgrading to a new major version, you can find the details about the 
 
 This section contains the release notes for Umbraco Deploy 17, including all changes for this version.
 
+### [17.2.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.0) (June 24th 2026)
+
+* All items from 17.2.0-rc1 and 17.2.0-rc2.
+
+### [17.2.0-rc2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.0-rc2) (June 19th 2026)
+
+* Support the `Umbraco:CMS:SignalR:ClientShouldSkipNegotiation` setting introduced in Umbraco CMS 17.5. Older CMS 17 versions continue to use the negotiate round-trip as before.
+* Throw a clear error when the API key or secret is not configured on the environment.
+
 ### [17.2.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.0-rc1) (June 4th 2026)
 
 * Prevent `ARRAffinity` cookie loss on load-balanced targets by disabling `HttpClient` handler rotation. Long-running transfers and restores now stay routed to the same target instance.

--- a/17/umbraco-deploy/release-notes.md
+++ b/17/umbraco-deploy/release-notes.md
@@ -16,7 +16,7 @@ If you are upgrading to a new major version, you can find the details about the 
 
 This section contains the release notes for Umbraco Deploy 17, including all changes for this version.
 
-### [17.2.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.0) (June 24th 2026)
+### [17.2.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.0) (June 25th 2026)
 
 * All items from 17.2.0-rc1 and 17.2.0-rc2.
 

--- a/18/umbraco-deploy/release-notes.md
+++ b/18/umbraco-deploy/release-notes.md
@@ -18,6 +18,21 @@ If you are upgrading to a new major version, you can find the details about the 
 
 This section contains the release notes for Umbraco Deploy 18, including all changes for this version.
 
+### [18.0.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.0) (June 24th 2026)
+
+* Compatibility with Umbraco CMS 18.0.0.
+* Fix `umbracodeploy` trigger route URLs broken by the Umbraco 18 routing migration. POST endpoints under `/umbraco/umbracodeploy/...` now resolve correctly.
+* Register Deploy routes and SignalR hubs during the Upgrading runtime level.
+* Fix the partial restore progress display and restore the work completion view.
+* Fix the partial restore modal not auto-selecting the only available restore environment.
+* Disambiguate queue root items by entity type, so each tree's root can be queued independently.
+* Gate the **Open Umbraco Cloud project** action to Cloud projects only, and link directly to the project URL.
+
+### [18.0.0-rc3](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.0) (June 19th 2026)
+
+* Compatibility with Umbraco CMS 18.0.0-rc3.
+* Throw a clear error when the API key or secret is not configured on the environment.
+
 ### [18.0.0-rc2](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.0) (June 5th 2026)
 
 * Compatibility with Umbraco CMS 18.0.0-rc2.
@@ -42,6 +57,16 @@ Version 18 introduces a redesigned Deploy experience in the backoffice:
 * A new sidebar workspace, launched from the environment name header app, replaces the transfer queue dashboard in the Content section. The workspace provides a single overview of the transfer queue, export queue, import, and restore environment operations.
 * Redesigned transfer, queue, restore, compare, and export modals with consistent styling, improved error surfacing, and a cleaner status and operation layout.
 * Refreshed status, schema, and configuration views in the management dashboard.
+
+## Umbraco.Deploy.Contrib
+
+### [18.0.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-18.0.0) (June 24th 2026)
+
+* Compatibility with Umbraco 18.0.0 and Deploy 18.0.0.
+
+### [18.0.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-18.0.0-rc1) (June 24th 2026)
+
+* Compatibility with Umbraco 18.0.0-rc3 and Deploy 18.0.0-rc3.
 
 ## Legacy release notes
 

--- a/18/umbraco-deploy/release-notes.md
+++ b/18/umbraco-deploy/release-notes.md
@@ -18,7 +18,7 @@ If you are upgrading to a new major version, you can find the details about the 
 
 This section contains the release notes for Umbraco Deploy 18, including all changes for this version.
 
-### [18.0.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.0) (June 24th 2026)
+### [18.0.0](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.0) (June 25th 2026)
 
 * Compatibility with Umbraco CMS 18.0.0.
 * Fix `umbracodeploy` trigger route URLs broken by the Umbraco 18 routing migration. POST endpoints under `/umbraco/umbracodeploy/...` now resolve correctly.
@@ -60,7 +60,7 @@ Version 18 introduces a redesigned Deploy experience in the backoffice:
 
 ## Umbraco.Deploy.Contrib
 
-### [18.0.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-18.0.0) (June 24th 2026)
+### [18.0.0](https://github.com/umbraco/Umbraco.Deploy.Contrib/releases/tag/release-18.0.0) (June 25th 2026)
 
 * Compatibility with Umbraco 18.0.0 and Deploy 18.0.0.
 


### PR DESCRIPTION
## 📋 Description

Adds release notes for the latest Umbraco Deploy and Deploy Contrib releases.

**Deploy 17.2.0-rc2 and 17.2.0** — bring Deploy's SignalR hubs in line with the `Umbraco:CMS:SignalR:ClientShouldSkipNegotiation` setting introduced in Umbraco CMS 17.5 (older CMS 17 versions remain unchanged), plus a clearer error when the API key/secret is not configured.

**Deploy 18.0.0-rc3 and 18.0.0** — final Umbraco CMS 18 compatibility, the clear API key/secret error, and a batch of fixes:

- `umbracodeploy` trigger route URLs broken by the Umbraco 18 routing migration now resolve.
- Deploy routes and SignalR hubs are registered during the Upgrading runtime level.
- Partial restore progress display and the work completion view are fixed.
- The partial restore modal auto-selects when only one restore environment is available.
- Queue root items are disambiguated by entity type so each tree's root can be queued independently.
- The **Open Umbraco Cloud project** action is now gated to Cloud projects and links directly to the project URL.

**Deploy Contrib 18.0.0-rc1 and 18.0.0** — compatibility releases against Umbraco 18 and Deploy 18 (no functional changes).

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Deploy 17.2.0, 18.0.0; Umbraco Deploy Contrib 18.0.0.

## Deadline (if relevant)

Alongside the 17.2.0, 18.0.0 and Contrib 18.0.0 releases.