### PR TITLE
Added breaking change to appsettings.json in 17.4

### DIFF
--- a/17/umbraco-forms/upgrading/version-specific.md
+++ b/17/umbraco-forms/upgrading/version-specific.md
@@ -16,6 +16,23 @@ If you are upgrading to a minor or patch version, you can find the details about
 
 Version 17 of Umbraco Forms has a minimum dependency on Umbraco CMS core of `17.0.0`. It runs on .NET 10.
 
+### License Validation Configuration
+
+When upgrading to Umbraco Forms 17 (alongside Umbraco CMS 17+), there is a strict requirement for the `UmbracoApplicationUrl` to be explicitly configured in your environment's `appsettings.json`. 
+
+Without this setting, backoffice license validation for Umbraco Forms will fail (often returning a "Pending" or `ResultIsNull` status) because the application URL is no longer auto-detected from the host header by default. 
+
+Ensure the following configuration is added and properly set for each environment:
+
+```json
+"Umbraco": {
+  "CMS": {
+    "WebRouting": {
+      "UmbracoApplicationUrl": "[https://your-site-url.com/](https://your-site-url.com/)"
+    }
+  }
+}
+```
 
 ## Legacy version specific upgrade notes
 


### PR DESCRIPTION
## 📋 Description

Added breaking change that customer reported in 17.4 which is documented in other pages (https://docs.umbraco.com/umbraco-forms/developer/email-templates) , but specifically causes Umbraco Forms License to return a pending or resultisnull status

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x ] Code blocks are correctly formatted.
* [x ] Sentences are short and clear (preferably under 25 words).
* [x ] Passive voice and first-person language (“we”, “I”) are avoided.
* [x ] Relevant pages are linked.
* [x ] All links work and point to the correct resources.
* [ x] Screenshots or diagrams are included if useful.
* x[ ] Any code examples or instructions have been tested.
* [x ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Forms v17

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
