### PR TITLE
Add backoffice extension guidance for Umbraco Forms

### DIFF
--- a/17/umbraco-forms/SUMMARY.md
+++ b/17/umbraco-forms/SUMMARY.md
@@ -47,6 +47,8 @@
 * [Working With Record Data](developer/working-with-data.md)
 * [Umbraco Forms in the Database](developer/forms-in-the-database.md)
 * [Extending](developer/extending/README.md)
+  * [Backoffice Extension Points](developer/extending/backoffice-extension-points.md)
+    * [Working with the Form Workspace Context](developer/extending/working-with-the-form-workspace-context.md)
   * [Adding A Type To The Provider Model](developer/extending/adding-a-type.md)
     * [Setting Types](developer/extending/setting-types.md)
   * [Adding A Field Type To Umbraco Forms](developer/extending/adding-a-fieldtype.md)

--- a/17/umbraco-forms/developer/extending/README.md
+++ b/17/umbraco-forms/developer/extending/README.md
@@ -60,6 +60,14 @@ This ensures that the Umbraco Backoffice packages are not bundled with your pack
 
 Read more about using Vite with Umbraco in the [Vite Package Setup](https://docs.umbraco.com/umbraco-cms/customizing/development-flow/vite-package-setup) article.
 
+### [Backoffice Extension Points](backoffice-extension-points.md)
+
+Forms exposes several backoffice extension points on top of the Umbraco CMS extension system. These include property editors, field previews, and setting value converters.
+
+### [Working with the Form Workspace Context](working-with-the-form-workspace-context.md)
+
+When your extension needs access to the open form, consume the Form Workspace Context. This is the supported way to read a form's pages, fields, and other structure from a property editor or other backoffice element.
+
 ## Developing Custom Providers
 
 Although the Forms package comes with many fields, workflows and other built-in types, you can still create and develop your own if needed.

--- a/17/umbraco-forms/developer/extending/README.md
+++ b/17/umbraco-forms/developer/extending/README.md
@@ -62,7 +62,7 @@ Read more about using Vite with Umbraco in the [Vite Package Setup](https://docs
 
 ### [Backoffice Extension Points](backoffice-extension-points.md)
 
-Forms exposes several backoffice extension points on top of the Umbraco CMS extension system. These include property editors, field previews, and setting value converters.
+Forms exposes backoffice extension points on top of the Umbraco CMS extension system. These include property editors, field previews, and setting value converters.
 
 ### [Working with the Form Workspace Context](working-with-the-form-workspace-context.md)
 

--- a/17/umbraco-forms/developer/extending/backoffice-extension-points.md
+++ b/17/umbraco-forms/developer/extending/backoffice-extension-points.md
@@ -1,0 +1,156 @@
+---
+description: >-
+  Overview of the backoffice extension points that Umbraco Forms exposes,
+  including property editors, field previews, and setting value converters.
+---
+
+# Backoffice Extension Points
+
+The Umbraco Forms backoffice is built on the [Umbraco CMS extension system](https://docs.umbraco.com/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-types). You extend it by registering manifests, each with a `type` that tells Umbraco what kind of extension it is.
+
+This article lists the extension points that Forms adds on top of the CMS. Use it as a map: each point links to the detailed guidance for that scenario.
+
+Before you start, install and configure the `@umbraco-forms/backoffice` package as described in the [Extending](README.md#extending-the-backoffice) article.
+
+## Overview
+
+| Extension point        | Manifest type                                | Use it to                                                       |
+| ---------------------- | -------------------------------------------- | -------------------------------------------------------------- |
+| Property editor UI     | `propertyEditorUi`                           | Render the settings UI for a field type or workflow type.      |
+| Field preview          | `formsFieldPreview`                          | Render a preview of a field type in the form designer.         |
+| Setting value converter| `formsSettingValueConverter`                 | Convert a setting value between the editor and storage.        |
+
+Server-side providers, such as field types and workflow types, are registered in C#. These are covered in [Adding A Type To The Provider Model](adding-a-type.md).
+
+## Registering extensions
+
+Forms uses the same registration mechanism as the CMS. You declare your manifests and register them through your package's entry point.
+
+{% code title="manifests.ts" %}
+```typescript
+import { manifests as fieldPreviewManifests } from "./field-preview/manifests.js";
+import { manifests as settingValueConverterManifests } from "./setting-value-converter/manifests.js";
+
+const manifests = [...fieldPreviewManifests, ...settingValueConverterManifests];
+
+export const onInit = (host, extensionRegistry) => {
+  extensionRegistry.registerMany(manifests);
+};
+```
+{% endcode %}
+
+For the full setup, including the `umbraco-package.json` manifest that points to this entry, see the [Register an Extension](https://docs.umbraco.com/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-registry/register-extensions) article.
+
+## Property editor UIs for settings
+
+Field types and workflow types expose their settings through a standard CMS `propertyEditorUi`. You register a property editor UI and reference its alias from the type's `EditView` or setting definition.
+
+A common requirement is to read the open form from a settings editor. For example, to list the form's fields in a mapping grid. Consume the Form Workspace Context to do this.
+
+{% content-ref url="working-with-the-form-workspace-context.md" %}
+[working-with-the-form-workspace-context.md](working-with-the-form-workspace-context.md)
+{% endcontent-ref %}
+
+For full examples of field and setting editors, see [Adding A Field Type To Umbraco Forms](adding-a-fieldtype.md) and [Adding A Workflow Type To Umbraco Forms](adding-a-workflowtype.md).
+
+## Field previews
+
+A field preview renders a representation of a field type in the form designer. The preview receives the field's `settings` and `prevalues`. Extend `FormsFieldPreviewBaseElement` and read settings with `getSettingValue(alias)`.
+
+{% code title="slider-field-preview.element.ts" %}
+```typescript
+import { customElement, html } from "@umbraco-cms/backoffice/external/lit";
+import { FormsFieldPreviewBaseElement } from "@umbraco-forms/backoffice";
+
+const elementName = "my-slider-field-preview";
+
+@customElement(elementName)
+export class MySliderFieldPreviewElement extends FormsFieldPreviewBaseElement {
+  render() {
+    return html`
+      <uui-slider
+        .min=${parseInt(this.getSettingValue("Min"))}
+        .max=${parseInt(this.getSettingValue("Max"))}
+        .value=${this.getSettingValue("DefaultValue")}
+      ></uui-slider>
+    `;
+  }
+}
+
+export default MySliderFieldPreviewElement;
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [elementName]: MySliderFieldPreviewElement;
+  }
+}
+```
+{% endcode %}
+
+Register the preview with a `formsFieldPreview` manifest:
+
+{% code title="manifests.ts" %}
+```typescript
+import type { ManifestFormsFieldPreview } from "@umbraco-forms/backoffice";
+
+const sliderPreview: ManifestFormsFieldPreview = {
+  type: "formsFieldPreview",
+  alias: "My.FieldPreview.Slider",
+  name: "Slider Field Preview",
+  element: () => import("./slider-field-preview.element.js"),
+};
+
+export const manifests = [sliderPreview];
+```
+{% endcode %}
+
+{% hint style="info" %}
+The manifest `alias` must match the `PreviewView` property on your C# field type. This is how Forms knows which preview to render. See [Adding A Field Type To Umbraco Forms](adding-a-fieldtype.md) for the full example.
+{% endhint %}
+
+## Setting value converters
+
+A setting value converter converts a setting value between the format used by the editor and the format stored with the form. Implement `FormsSettingValueConverterApi` and tie it to a property editor UI through `propertyEditorUiAlias`.
+
+{% code title="slider-setting-value-converter.api.ts" %}
+```typescript
+import type { FormsSettingValueConverterApi, Setting } from "@umbraco-forms/backoffice";
+import type { UmbPropertyValueData } from "@umbraco-cms/backoffice/property";
+
+export class SliderSettingValueConverter implements FormsSettingValueConverterApi {
+  async getSettingValueForEditor(setting: Setting, alias: string, value: string) {
+    return value;
+  }
+
+  async getSettingValueForPersistence(setting: Setting, valueData: UmbPropertyValueData) {
+    return valueData.value?.toString() ?? "";
+  }
+
+  async getSettingPropertyConfig(setting: Setting, alias: string, values: Array<UmbPropertyValueData>) {
+    return [];
+  }
+
+  destroy() {}
+}
+
+export default SliderSettingValueConverter;
+```
+{% endcode %}
+
+{% code title="manifests.ts" %}
+```typescript
+import type { ManifestFormsSettingValueConverterPreview } from "@umbraco-forms/backoffice";
+
+const sliderConverter: ManifestFormsSettingValueConverterPreview = {
+  type: "formsSettingValueConverter",
+  alias: "My.SettingValueConverter.Slider",
+  name: "Slider Setting Value Converter",
+  propertyEditorUiAlias: "My.PropertyEditorUi.Slider",
+  api: () => import("./slider-setting-value-converter.api.js"),
+};
+
+export const manifests = [sliderConverter];
+```
+{% endcode %}
+
+For more on settings and converters, see [Adding A Field Type To Umbraco Forms](adding-a-fieldtype.md).

--- a/17/umbraco-forms/developer/extending/working-with-the-form-workspace-context.md
+++ b/17/umbraco-forms/developer/extending/working-with-the-form-workspace-context.md
@@ -6,7 +6,7 @@ description: >-
 
 # Working with the Form Workspace Context
 
-When you build a backoffice extension for Umbraco Forms, you often need access to the form that is currently open. A common example is a [property editor](https://docs.umbraco.com/umbraco-cms/customizing/property-editors) that lets an editor map to or pick one of the form's fields.
+When you build a backoffice extension for Umbraco Forms, you often need access to the form that is currently open. A common example is a [property editor](https://docs.umbraco.com/umbraco-cms/extend-your-project/backoffice-extensions/property-editors) that lets an editor map to or pick one of the form's fields.
 
 Umbraco Forms exposes the open form through the **Form Workspace Context**. This article explains how to consume the context, how to read the form's structure, and how to register a property editor that uses it.
 

--- a/17/umbraco-forms/developer/extending/working-with-the-form-workspace-context.md
+++ b/17/umbraco-forms/developer/extending/working-with-the-form-workspace-context.md
@@ -1,0 +1,226 @@
+---
+description: >-
+  Learn how to consume the Form Workspace Context in a backoffice extension to
+  read a form's pages, fields, and other structure.
+---
+
+# Working with the Form Workspace Context
+
+When you build a backoffice extension for Umbraco Forms, you often need access to the form that is currently open. A common example is a [property editor](https://docs.umbraco.com/umbraco-cms/customizing/property-editors) that lets an editor map to or pick one of the form's fields.
+
+Umbraco Forms exposes the open form through the **Form Workspace Context**. This article explains how to consume the context, how to read the form's structure, and how to register a property editor that uses it.
+
+Before you start, install and configure the `@umbraco-forms/backoffice` package as described in the [Extending](README.md#extending-the-backoffice) article. For an overview of the available extension points, see [Backoffice Extension Points](backoffice-extension-points.md).
+
+## Consuming the Form Workspace Context
+
+The Form Workspace Context is published through the `FORMS_FORM_WORKSPACE_CONTEXT` context token. Import the token from `@umbraco-forms/backoffice` and consume it in your element's constructor.
+
+{% code title="my-field-picker.element.ts" %}
+```typescript
+import { html, customElement } from "@umbraco-cms/backoffice/external/lit";
+import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
+import type { UmbPropertyEditorUiElement } from "@umbraco-cms/backoffice/property-editor";
+import { FORMS_FORM_WORKSPACE_CONTEXT } from "@umbraco-forms/backoffice";
+
+const elementName = "my-field-picker";
+
+@customElement(elementName)
+export class MyFieldPickerElement
+  extends UmbLitElement
+  implements UmbPropertyEditorUiElement
+{
+  #workspaceContext?: typeof FORMS_FORM_WORKSPACE_CONTEXT.TYPE;
+
+  constructor() {
+    super();
+
+    this.consumeContext(FORMS_FORM_WORKSPACE_CONTEXT, (context) => {
+      this.#workspaceContext = context;
+    }).passContextAliasMatches();
+  }
+
+  render() {
+    return html`<p>Field picker</p>`;
+  }
+}
+
+export default MyFieldPickerElement;
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [elementName]: MyFieldPickerElement;
+  }
+}
+```
+{% endcode %}
+
+### Why `passContextAliasMatches()` is required
+
+The `FORMS_FORM_WORKSPACE_CONTEXT` token is registered under the shared `UmbWorkspaceContext` alias. A type-guard narrows the alias to the form workspace by checking the entity type.
+
+By default, the Context API stops at the first context that matches the alias. This avoids consuming unrelated descending contexts. Inside a modal, such as the field or workflow settings dialog, the nearest `UmbWorkspaceContext` is the modal's own workspace. That context fails the type-guard, so consumption stops and your callback never receives the form workspace.
+
+Calling `passContextAliasMatches()` tells the consumer to pass beyond alias matches that fail the type-guard. The consumer then keeps looking up the tree until it finds the form workspace.
+
+{% hint style="warning" %}
+Omit `passContextAliasMatches()` only when your element is rendered directly in the form workspace and not inside a modal. When in doubt, add it. Field and workflow settings are rendered in modals, so they always need it.
+{% endhint %}
+
+## Reading the form structure
+
+A form is organized into pages, fieldsets, containers, and fields. The Form Workspace Context provides helper methods so you do not have to traverse this structure yourself.
+
+| Method                     | Returns                                                  |
+| -------------------------- | ------------------------------------------------------- |
+| `getAllPages()`            | All pages on the form.                                  |
+| `getAllContainers()`       | All containers across every page and fieldset.          |
+| `getAllFields()`           | All fields across the whole form.                       |
+| `getAllFieldAliases()`     | The alias of every field on the form.                   |
+| `getField(id)`             | A single field by its ID, or `null` when not found.     |
+
+Each field is a `Field` object. The properties used most often are `id`, `alias`, and `caption`.
+
+The following snippet reads the form's fields from the consumed context and maps them to a list of options. The `Field` type is also exported from `@umbraco-forms/backoffice`:
+
+{% code title="my-field-picker.element.ts" %}
+```typescript
+import type { Field } from "@umbraco-forms/backoffice";
+
+// this.#workspaceContext is the consumed FORMS_FORM_WORKSPACE_CONTEXT.
+const fields = this.#workspaceContext?.getAllFields() ?? [];
+const options = fields.map((field: Field) => ({
+  name: field.caption,
+  value: field.id,
+}));
+```
+{% endcode %}
+
+{% hint style="info" %}
+The methods read the form's current in-memory state. Call them inside the context callback, or after it has run, so the workspace is available.
+{% endhint %}
+
+## Example: a property editor that picks a form field
+
+This example registers a property editor that lets an editor select one of the current form's fields. The selected field ID is stored as the property value.
+
+The example uses two files: the element and its manifest.
+
+{% code title="field-picker.element.ts" %}
+```typescript
+import { html, customElement, property, state } from "@umbraco-cms/backoffice/external/lit";
+import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
+import { UmbChangeEvent } from "@umbraco-cms/backoffice/event";
+import type { UmbPropertyEditorUiElement } from "@umbraco-cms/backoffice/property-editor";
+import type { UUISelectEvent, UUISelectOption } from "@umbraco-cms/backoffice/external/uui";
+import { FORMS_FORM_WORKSPACE_CONTEXT } from "@umbraco-forms/backoffice";
+import type { Field } from "@umbraco-forms/backoffice";
+
+const elementName = "my-forms-field-picker";
+
+@customElement(elementName)
+export class MyFormsFieldPickerElement
+  extends UmbLitElement
+  implements UmbPropertyEditorUiElement
+{
+  #workspaceContext?: typeof FORMS_FORM_WORKSPACE_CONTEXT.TYPE;
+
+  // The selected field ID, stored as the property value.
+  @property({ type: String })
+  value = "";
+
+  @state()
+  private _options: Array<UUISelectOption> = [];
+
+  constructor() {
+    super();
+
+    // passContextAliasMatches() is required so the context resolves inside modals.
+    this.consumeContext(FORMS_FORM_WORKSPACE_CONTEXT, (context) => {
+      this.#workspaceContext = context;
+      this.#buildOptions();
+    }).passContextAliasMatches();
+  }
+
+  #buildOptions() {
+    const fields = this.#workspaceContext?.getAllFields() ?? [];
+    this._options = fields.map((field: Field) => ({
+      name: field.caption,
+      value: field.id,
+      selected: field.id === this.value,
+    }));
+  }
+
+  #onChange(event: UUISelectEvent) {
+    this.value = event.target.value as string;
+    // Notify the backoffice that the property value changed.
+    this.dispatchEvent(new UmbChangeEvent());
+  }
+
+  render() {
+    return html`
+      <uui-select
+        label="Form field"
+        placeholder="Select a field"
+        .options=${this._options}
+        @change=${this.#onChange}
+      ></uui-select>
+    `;
+  }
+}
+
+export default MyFormsFieldPickerElement;
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [elementName]: MyFormsFieldPickerElement;
+  }
+}
+```
+{% endcode %}
+
+Register the element as a property editor UI through a manifest:
+
+{% code title="manifests.ts" %}
+```typescript
+import type { ManifestPropertyEditorUi } from "@umbraco-cms/backoffice/property-editor";
+
+const fieldPickerManifest: ManifestPropertyEditorUi = {
+  type: "propertyEditorUi",
+  alias: "My.PropertyEditorUi.FormsFieldPicker",
+  name: "Forms Field Picker Property Editor UI",
+  element: () => import("./field-picker.element.js"),
+  meta: {
+    label: "Forms Field Picker",
+    icon: "icon-checkbox",
+    group: "common",
+  },
+};
+
+export const manifests = [fieldPickerManifest];
+```
+{% endcode %}
+
+You can now use the property editor UI in a field or workflow setting. The dropdown lists every field on the open form.
+
+## Other building blocks
+
+The `@umbraco-forms/backoffice` package exposes more than the workspace context. The types and base classes below help you build common extensions:
+
+* `ManifestFormsFieldPreview` and `FormsFieldPreviewBaseElement` for rendering a custom field preview in the form designer.
+* `FormsSettingValueConverterApi` and `ManifestFormsSettingValueConverterPreview` for converting setting values between the editor and storage.
+* `Field`, `Page`, `FieldsetContainer`, and `Setting` types for working with the form model.
+
+Most server-side providers, such as field types and workflow types, are documented separately:
+
+* [Adding A Field Type To Umbraco Forms](adding-a-fieldtype.md)
+* [Adding A Workflow Type To Umbraco Forms](adding-a-workflowtype.md)
+* [Setting Types](setting-types.md)
+
+## Versioning
+
+The client-side extension API is still evolving. Methods and context shapes can change between minor releases.
+
+{% hint style="warning" %}
+Install the version of `@umbraco-forms/backoffice` that matches your Umbraco Forms installation. Pin the version, then review the [Release Notes](../../release-notes.md) before upgrading. You can find compatible versions on the [`@umbraco-forms/backoffice` npm page](https://www.npmjs.com/package/@umbraco-forms/backoffice).
+{% endhint %}

--- a/18/umbraco-forms/SUMMARY.md
+++ b/18/umbraco-forms/SUMMARY.md
@@ -47,6 +47,8 @@
 * [Working With Record Data](developer/working-with-data.md)
 * [Umbraco Forms in the Database](developer/forms-in-the-database.md)
 * [Extending](developer/extending/README.md)
+  * [Backoffice Extension Points](developer/extending/backoffice-extension-points.md)
+    * [Working with the Form Workspace Context](developer/extending/working-with-the-form-workspace-context.md)
   * [Adding A Type To The Provider Model](developer/extending/adding-a-type.md)
     * [Setting Types](developer/extending/setting-types.md)
   * [Adding A Field Type To Umbraco Forms](developer/extending/adding-a-fieldtype.md)

--- a/18/umbraco-forms/developer/extending/README.md
+++ b/18/umbraco-forms/developer/extending/README.md
@@ -60,6 +60,14 @@ This ensures that the Umbraco Backoffice packages are not bundled with your pack
 
 Read more about using Vite with Umbraco in the [Vite Package Setup](https://docs.umbraco.com/umbraco-cms/customizing/development-flow/vite-package-setup) article.
 
+### [Backoffice Extension Points](backoffice-extension-points.md)
+
+Forms exposes several backoffice extension points on top of the Umbraco CMS extension system. These include property editors, field previews, and setting value converters.
+
+### [Working with the Form Workspace Context](working-with-the-form-workspace-context.md)
+
+When your extension needs access to the open form, consume the Form Workspace Context. This is the supported way to read a form's pages, fields, and other structure from a property editor or other backoffice element.
+
 ## Developing Custom Providers
 
 Although the Forms package comes with many fields, workflows and other built-in types, you can still create and develop your own if needed.

--- a/18/umbraco-forms/developer/extending/README.md
+++ b/18/umbraco-forms/developer/extending/README.md
@@ -62,7 +62,7 @@ Read more about using Vite with Umbraco in the [Vite Package Setup](https://docs
 
 ### [Backoffice Extension Points](backoffice-extension-points.md)
 
-Forms exposes several backoffice extension points on top of the Umbraco CMS extension system. These include property editors, field previews, and setting value converters.
+Forms exposes backoffice extension points on top of the Umbraco CMS extension system. These include property editors, field previews, and setting value converters.
 
 ### [Working with the Form Workspace Context](working-with-the-form-workspace-context.md)
 

--- a/18/umbraco-forms/developer/extending/backoffice-extension-points.md
+++ b/18/umbraco-forms/developer/extending/backoffice-extension-points.md
@@ -1,0 +1,156 @@
+---
+description: >-
+  Overview of the backoffice extension points that Umbraco Forms exposes,
+  including property editors, field previews, and setting value converters.
+---
+
+# Backoffice Extension Points
+
+The Umbraco Forms backoffice is built on the [Umbraco CMS extension system](https://docs.umbraco.com/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-types). You extend it by registering manifests, each with a `type` that tells Umbraco what kind of extension it is.
+
+This article lists the extension points that Forms adds on top of the CMS. Use it as a map: each point links to the detailed guidance for that scenario.
+
+Before you start, install and configure the `@umbraco-forms/backoffice` package as described in the [Extending](README.md#extending-the-backoffice) article.
+
+## Overview
+
+| Extension point        | Manifest type                                | Use it to                                                       |
+| ---------------------- | -------------------------------------------- | -------------------------------------------------------------- |
+| Property editor UI     | `propertyEditorUi`                           | Render the settings UI for a field type or workflow type.      |
+| Field preview          | `formsFieldPreview`                          | Render a preview of a field type in the form designer.         |
+| Setting value converter| `formsSettingValueConverter`                 | Convert a setting value between the editor and storage.        |
+
+Server-side providers, such as field types and workflow types, are registered in C#. These are covered in [Adding A Type To The Provider Model](adding-a-type.md).
+
+## Registering extensions
+
+Forms uses the same registration mechanism as the CMS. You declare your manifests and register them through your package's entry point.
+
+{% code title="manifests.ts" %}
+```typescript
+import { manifests as fieldPreviewManifests } from "./field-preview/manifests.js";
+import { manifests as settingValueConverterManifests } from "./setting-value-converter/manifests.js";
+
+const manifests = [...fieldPreviewManifests, ...settingValueConverterManifests];
+
+export const onInit = (host, extensionRegistry) => {
+  extensionRegistry.registerMany(manifests);
+};
+```
+{% endcode %}
+
+For the full setup, including the `umbraco-package.json` manifest that points to this entry, see the [Register an Extension](https://docs.umbraco.com/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-registry/register-extensions) article.
+
+## Property editor UIs for settings
+
+Field types and workflow types expose their settings through a standard CMS `propertyEditorUi`. You register a property editor UI and reference its alias from the type's `EditView` or setting definition.
+
+A common requirement is to read the open form from a settings editor. For example, to list the form's fields in a mapping grid. Consume the Form Workspace Context to do this.
+
+{% content-ref url="working-with-the-form-workspace-context.md" %}
+[working-with-the-form-workspace-context.md](working-with-the-form-workspace-context.md)
+{% endcontent-ref %}
+
+For full examples of field and setting editors, see [Adding A Field Type To Umbraco Forms](adding-a-fieldtype.md) and [Adding A Workflow Type To Umbraco Forms](adding-a-workflowtype.md).
+
+## Field previews
+
+A field preview renders a representation of a field type in the form designer. The preview receives the field's `settings` and `prevalues`. Extend `FormsFieldPreviewBaseElement` and read settings with `getSettingValue(alias)`.
+
+{% code title="slider-field-preview.element.ts" %}
+```typescript
+import { customElement, html } from "@umbraco-cms/backoffice/external/lit";
+import { FormsFieldPreviewBaseElement } from "@umbraco-forms/backoffice";
+
+const elementName = "my-slider-field-preview";
+
+@customElement(elementName)
+export class MySliderFieldPreviewElement extends FormsFieldPreviewBaseElement {
+  render() {
+    return html`
+      <uui-slider
+        .min=${parseInt(this.getSettingValue("Min"))}
+        .max=${parseInt(this.getSettingValue("Max"))}
+        .value=${this.getSettingValue("DefaultValue")}
+      ></uui-slider>
+    `;
+  }
+}
+
+export default MySliderFieldPreviewElement;
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [elementName]: MySliderFieldPreviewElement;
+  }
+}
+```
+{% endcode %}
+
+Register the preview with a `formsFieldPreview` manifest:
+
+{% code title="manifests.ts" %}
+```typescript
+import type { ManifestFormsFieldPreview } from "@umbraco-forms/backoffice";
+
+const sliderPreview: ManifestFormsFieldPreview = {
+  type: "formsFieldPreview",
+  alias: "My.FieldPreview.Slider",
+  name: "Slider Field Preview",
+  element: () => import("./slider-field-preview.element.js"),
+};
+
+export const manifests = [sliderPreview];
+```
+{% endcode %}
+
+{% hint style="info" %}
+The manifest `alias` must match the `PreviewView` property on your C# field type. This is how Forms knows which preview to render. See [Adding A Field Type To Umbraco Forms](adding-a-fieldtype.md) for the full example.
+{% endhint %}
+
+## Setting value converters
+
+A setting value converter converts a setting value between the format used by the editor and the format stored with the form. Implement `FormsSettingValueConverterApi` and tie it to a property editor UI through `propertyEditorUiAlias`.
+
+{% code title="slider-setting-value-converter.api.ts" %}
+```typescript
+import type { FormsSettingValueConverterApi, Setting } from "@umbraco-forms/backoffice";
+import type { UmbPropertyValueData } from "@umbraco-cms/backoffice/property";
+
+export class SliderSettingValueConverter implements FormsSettingValueConverterApi {
+  async getSettingValueForEditor(setting: Setting, alias: string, value: string) {
+    return value;
+  }
+
+  async getSettingValueForPersistence(setting: Setting, valueData: UmbPropertyValueData) {
+    return valueData.value?.toString() ?? "";
+  }
+
+  async getSettingPropertyConfig(setting: Setting, alias: string, values: Array<UmbPropertyValueData>) {
+    return [];
+  }
+
+  destroy() {}
+}
+
+export default SliderSettingValueConverter;
+```
+{% endcode %}
+
+{% code title="manifests.ts" %}
+```typescript
+import type { ManifestFormsSettingValueConverterPreview } from "@umbraco-forms/backoffice";
+
+const sliderConverter: ManifestFormsSettingValueConverterPreview = {
+  type: "formsSettingValueConverter",
+  alias: "My.SettingValueConverter.Slider",
+  name: "Slider Setting Value Converter",
+  propertyEditorUiAlias: "My.PropertyEditorUi.Slider",
+  api: () => import("./slider-setting-value-converter.api.js"),
+};
+
+export const manifests = [sliderConverter];
+```
+{% endcode %}
+
+For more on settings and converters, see [Adding A Field Type To Umbraco Forms](adding-a-fieldtype.md).

--- a/18/umbraco-forms/developer/extending/working-with-the-form-workspace-context.md
+++ b/18/umbraco-forms/developer/extending/working-with-the-form-workspace-context.md
@@ -6,7 +6,7 @@ description: >-
 
 # Working with the Form Workspace Context
 
-When you build a backoffice extension for Umbraco Forms, you often need access to the form that is currently open. A common example is a [property editor](https://docs.umbraco.com/umbraco-cms/customizing/property-editors) that lets an editor map to or pick one of the form's fields.
+When you build a backoffice extension for Umbraco Forms, you often need access to the form that is currently open. A common example is a [property editor](https://docs.umbraco.com/umbraco-cms/extend-your-project/backoffice-extensions/property-editors) that lets an editor map to or pick one of the form's fields.
 
 Umbraco Forms exposes the open form through the **Form Workspace Context**. This article explains how to consume the context, how to read the form's structure, and how to register a property editor that uses it.
 

--- a/18/umbraco-forms/developer/extending/working-with-the-form-workspace-context.md
+++ b/18/umbraco-forms/developer/extending/working-with-the-form-workspace-context.md
@@ -1,0 +1,226 @@
+---
+description: >-
+  Learn how to consume the Form Workspace Context in a backoffice extension to
+  read a form's pages, fields, and other structure.
+---
+
+# Working with the Form Workspace Context
+
+When you build a backoffice extension for Umbraco Forms, you often need access to the form that is currently open. A common example is a [property editor](https://docs.umbraco.com/umbraco-cms/customizing/property-editors) that lets an editor map to or pick one of the form's fields.
+
+Umbraco Forms exposes the open form through the **Form Workspace Context**. This article explains how to consume the context, how to read the form's structure, and how to register a property editor that uses it.
+
+Before you start, install and configure the `@umbraco-forms/backoffice` package as described in the [Extending](README.md#extending-the-backoffice) article. For an overview of the available extension points, see [Backoffice Extension Points](backoffice-extension-points.md).
+
+## Consuming the Form Workspace Context
+
+The Form Workspace Context is published through the `FORMS_FORM_WORKSPACE_CONTEXT` context token. Import the token from `@umbraco-forms/backoffice` and consume it in your element's constructor.
+
+{% code title="my-field-picker.element.ts" %}
+```typescript
+import { html, customElement } from "@umbraco-cms/backoffice/external/lit";
+import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
+import type { UmbPropertyEditorUiElement } from "@umbraco-cms/backoffice/property-editor";
+import { FORMS_FORM_WORKSPACE_CONTEXT } from "@umbraco-forms/backoffice";
+
+const elementName = "my-field-picker";
+
+@customElement(elementName)
+export class MyFieldPickerElement
+  extends UmbLitElement
+  implements UmbPropertyEditorUiElement
+{
+  #workspaceContext?: typeof FORMS_FORM_WORKSPACE_CONTEXT.TYPE;
+
+  constructor() {
+    super();
+
+    this.consumeContext(FORMS_FORM_WORKSPACE_CONTEXT, (context) => {
+      this.#workspaceContext = context;
+    }).passContextAliasMatches();
+  }
+
+  render() {
+    return html`<p>Field picker</p>`;
+  }
+}
+
+export default MyFieldPickerElement;
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [elementName]: MyFieldPickerElement;
+  }
+}
+```
+{% endcode %}
+
+### Why `passContextAliasMatches()` is required
+
+The `FORMS_FORM_WORKSPACE_CONTEXT` token is registered under the shared `UmbWorkspaceContext` alias. A type-guard narrows the alias to the form workspace by checking the entity type.
+
+By default, the Context API stops at the first context that matches the alias. This avoids consuming unrelated descending contexts. Inside a modal, such as the field or workflow settings dialog, the nearest `UmbWorkspaceContext` is the modal's own workspace. That context fails the type-guard, so consumption stops and your callback never receives the form workspace.
+
+Calling `passContextAliasMatches()` tells the consumer to pass beyond alias matches that fail the type-guard. The consumer then keeps looking up the tree until it finds the form workspace.
+
+{% hint style="warning" %}
+Omit `passContextAliasMatches()` only when your element is rendered directly in the form workspace and not inside a modal. When in doubt, add it. Field and workflow settings are rendered in modals, so they always need it.
+{% endhint %}
+
+## Reading the form structure
+
+A form is organized into pages, fieldsets, containers, and fields. The Form Workspace Context provides helper methods so you do not have to traverse this structure yourself.
+
+| Method                     | Returns                                                  |
+| -------------------------- | ------------------------------------------------------- |
+| `getAllPages()`            | All pages on the form.                                  |
+| `getAllContainers()`       | All containers across every page and fieldset.          |
+| `getAllFields()`           | All fields across the whole form.                       |
+| `getAllFieldAliases()`     | The alias of every field on the form.                   |
+| `getField(id)`             | A single field by its ID, or `null` when not found.     |
+
+Each field is a `Field` object. The properties used most often are `id`, `alias`, and `caption`.
+
+The following snippet reads the form's fields from the consumed context and maps them to a list of options. The `Field` type is also exported from `@umbraco-forms/backoffice`:
+
+{% code title="my-field-picker.element.ts" %}
+```typescript
+import type { Field } from "@umbraco-forms/backoffice";
+
+// this.#workspaceContext is the consumed FORMS_FORM_WORKSPACE_CONTEXT.
+const fields = this.#workspaceContext?.getAllFields() ?? [];
+const options = fields.map((field: Field) => ({
+  name: field.caption,
+  value: field.id,
+}));
+```
+{% endcode %}
+
+{% hint style="info" %}
+The methods read the form's current in-memory state. Call them inside the context callback, or after it has run, so the workspace is available.
+{% endhint %}
+
+## Example: a property editor that picks a form field
+
+This example registers a property editor that lets an editor select one of the current form's fields. The selected field ID is stored as the property value.
+
+The example uses two files: the element and its manifest.
+
+{% code title="field-picker.element.ts" %}
+```typescript
+import { html, customElement, property, state } from "@umbraco-cms/backoffice/external/lit";
+import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
+import { UmbChangeEvent } from "@umbraco-cms/backoffice/event";
+import type { UmbPropertyEditorUiElement } from "@umbraco-cms/backoffice/property-editor";
+import type { UUISelectEvent, UUISelectOption } from "@umbraco-cms/backoffice/external/uui";
+import { FORMS_FORM_WORKSPACE_CONTEXT } from "@umbraco-forms/backoffice";
+import type { Field } from "@umbraco-forms/backoffice";
+
+const elementName = "my-forms-field-picker";
+
+@customElement(elementName)
+export class MyFormsFieldPickerElement
+  extends UmbLitElement
+  implements UmbPropertyEditorUiElement
+{
+  #workspaceContext?: typeof FORMS_FORM_WORKSPACE_CONTEXT.TYPE;
+
+  // The selected field ID, stored as the property value.
+  @property({ type: String })
+  value = "";
+
+  @state()
+  private _options: Array<UUISelectOption> = [];
+
+  constructor() {
+    super();
+
+    // passContextAliasMatches() is required so the context resolves inside modals.
+    this.consumeContext(FORMS_FORM_WORKSPACE_CONTEXT, (context) => {
+      this.#workspaceContext = context;
+      this.#buildOptions();
+    }).passContextAliasMatches();
+  }
+
+  #buildOptions() {
+    const fields = this.#workspaceContext?.getAllFields() ?? [];
+    this._options = fields.map((field: Field) => ({
+      name: field.caption,
+      value: field.id,
+      selected: field.id === this.value,
+    }));
+  }
+
+  #onChange(event: UUISelectEvent) {
+    this.value = event.target.value as string;
+    // Notify the backoffice that the property value changed.
+    this.dispatchEvent(new UmbChangeEvent());
+  }
+
+  render() {
+    return html`
+      <uui-select
+        label="Form field"
+        placeholder="Select a field"
+        .options=${this._options}
+        @change=${this.#onChange}
+      ></uui-select>
+    `;
+  }
+}
+
+export default MyFormsFieldPickerElement;
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [elementName]: MyFormsFieldPickerElement;
+  }
+}
+```
+{% endcode %}
+
+Register the element as a property editor UI through a manifest:
+
+{% code title="manifests.ts" %}
+```typescript
+import type { ManifestPropertyEditorUi } from "@umbraco-cms/backoffice/property-editor";
+
+const fieldPickerManifest: ManifestPropertyEditorUi = {
+  type: "propertyEditorUi",
+  alias: "My.PropertyEditorUi.FormsFieldPicker",
+  name: "Forms Field Picker Property Editor UI",
+  element: () => import("./field-picker.element.js"),
+  meta: {
+    label: "Forms Field Picker",
+    icon: "icon-checkbox",
+    group: "common",
+  },
+};
+
+export const manifests = [fieldPickerManifest];
+```
+{% endcode %}
+
+You can now use the property editor UI in a field or workflow setting. The dropdown lists every field on the open form.
+
+## Other building blocks
+
+The `@umbraco-forms/backoffice` package exposes more than the workspace context. The types and base classes below help you build common extensions:
+
+* `ManifestFormsFieldPreview` and `FormsFieldPreviewBaseElement` for rendering a custom field preview in the form designer.
+* `FormsSettingValueConverterApi` and `ManifestFormsSettingValueConverterPreview` for converting setting values between the editor and storage.
+* `Field`, `Page`, `FieldsetContainer`, and `Setting` types for working with the form model.
+
+Most server-side providers, such as field types and workflow types, are documented separately:
+
+* [Adding A Field Type To Umbraco Forms](adding-a-fieldtype.md)
+* [Adding A Workflow Type To Umbraco Forms](adding-a-workflowtype.md)
+* [Setting Types](setting-types.md)
+
+## Versioning
+
+The client-side extension API is still evolving. Methods and context shapes can change between minor releases.
+
+{% hint style="warning" %}
+Install the version of `@umbraco-forms/backoffice` that matches your Umbraco Forms installation. Pin the version, then review the [Release Notes](../../release-notes.md) before upgrading. You can find compatible versions on the [`@umbraco-forms/backoffice` npm page](https://www.npmjs.com/package/@umbraco-forms/backoffice).
+{% endhint %}


### PR DESCRIPTION
## What

Adds developer guidance for extending the Umbraco Forms backoffice, addressing [umbraco/Umbraco.Forms.Issues#1724](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1724) ("Guidance for extensions").

Two new articles under `developer/extending/`, applied to **17** and **18**:

### Backoffice Extension Points (overview)
A map of the extension points Forms exposes on top of the CMS extension system:
- **Property editor UIs** for field/workflow settings
- **Field previews** (`formsFieldPreview`)
- **Setting value converters** (`formsSettingValueConverter`)

Links to the existing field-type and provider-model articles rather than duplicating their examples.

### Working with the Form Workspace Context
The concrete answer to the issue's main ask — the official way to read a form's structure from a backoffice extension:
- Consuming `FORMS_FORM_WORKSPACE_CONTEXT` from `@umbraco-forms/backoffice`
- **Why `passContextAliasMatches()` is required** (the token shares the `UmbWorkspaceContext` alias; inside a settings modal the consumer otherwise stops at an inner workspace that fails the type-guard)
- Reading fields/pages/containers via `getAllFields()`, `getAllPages()`, etc.
- A complete field-picker property editor example
- A versioning note (pin the package to your Forms version)

Both articles are linked from the Extending `README.md` and `SUMMARY.md`.

## Verification
- All code examples, manifest types, and APIs checked against the Forms source.
- CMS cross-links verified against the live docs.
- Vale: 0 errors. Internal links resolve.

## Out of scope
The issue also raised a **client-side API breaking-changes policy** question. That is a product/governance decision and is not authored here — only a factual versioning note is included. The "context naming inconsistency" point is product feedback, not a docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)