### PR TITLE
v17 Developer MCP docs: target the lts-17 dist-tag

### DIFF
--- a/17/umbraco-in-ai/mcp/base-mcp/sdk/mcp-chaining.md
+++ b/17/umbraco-in-ai/mcp/base-mcp/sdk/mcp-chaining.md
@@ -32,7 +32,7 @@ const servers: McpServerConfig[] = [
   {
     name: "cms",
     command: "npx",
-    args: ["-y", "@umbraco-cms/mcp-dev@17.1"],
+    args: ["-y", "@umbraco-cms/mcp-dev@lts-17"],
     // Environment variables from the parent process are inherited automatically.
     // Only specify env here to override or add variables.
     proxyTools: true,

--- a/17/umbraco-in-ai/mcp/cms-developer-mcp/README.md
+++ b/17/umbraco-in-ai/mcp/cms-developer-mcp/README.md
@@ -105,7 +105,7 @@ Although the details vary slightly, the general pattern is the same across all h
 {
   "umbraco-mcp": {
     "command": "npx",
-    "args": ["@umbraco-cms/mcp-dev@17.4.2"],
+    "args": ["@umbraco-cms/mcp-dev@lts-17"],
     "env": {
       "NODE_TLS_REJECT_UNAUTHORIZED": "0",
       "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",
@@ -162,7 +162,7 @@ If you prefer, you can also install it globally with:
 
 ```bash
 
-@umbraco-cms/mcp-dev@17
+@umbraco-cms/mcp-dev@lts-17
 
 ```
 
@@ -185,7 +185,7 @@ The Umbraco MCP Server is designed to work with specific major versions of Umbra
 | ------------------ | -------------------------- | ---------------------------------- |
 | 15.x.x             | alpha                      | @umbraco-mcp/umbraco-mcp-cms@alpha |
 | 16.x.x             | 16.x                       | @umbraco-cms/mcp-dev@16            |
-| 17.x.x             | 17.x                       | @umbraco-cms/mcp-dev@17.1          |
+| 17.x.x             | 17.x                       | @umbraco-cms/mcp-dev@lts-17         |
 
 ### Version Checking
 

--- a/17/umbraco-in-ai/mcp/cms-developer-mcp/best-practice/creating-media.md
+++ b/17/umbraco-in-ai/mcp/cms-developer-mcp/best-practice/creating-media.md
@@ -96,7 +96,7 @@ To use file path uploads, configure the allowed directories in your MCP server e
 {
   "umbraco-mcp": {
     "command": "npx",
-    "args": ["@umbraco-cms/mcp-dev@17.1"],
+    "args": ["@umbraco-cms/mcp-dev@lts-17"],
     "env": {
       "UMBRACO_CLIENT_ID": "your-client-id",
       "UMBRACO_CLIENT_SECRET": "your-client-secret",

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
@@ -20,7 +20,7 @@ Installing Claude Code depends on your environment. For installation details, se
 1. Add the Umbraco MCP server using the Claude CLI:
 
 ```bash
-claude mcp add umbraco-mcp npx @umbraco-cms/mcp-dev@17.4.2
+claude mcp add umbraco-mcp npx @umbraco-cms/mcp-dev@lts-17
 ```
 
 2. Define configuration values directly using this pattern:
@@ -28,7 +28,7 @@ claude mcp add umbraco-mcp npx @umbraco-cms/mcp-dev@17.4.2
 ```bash
 
 # Add with environment variables
-claude mcp add umbraco-mcp --env UMBRACO_CLIENT_ID="your-id" --env UMBRACO_CLIENT_SECRET="your-secret" --env UMBRACO_BASE_URL="https://your-domain.com" --env NODE_TLS_REJECT_UNAUTHORIZED="0" --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type" -- npx @umbraco-cms/mcp-dev@17.4.2
+claude mcp add umbraco-mcp --env UMBRACO_CLIENT_ID="your-id" --env UMBRACO_CLIENT_SECRET="your-secret" --env UMBRACO_BASE_URL="https://your-domain.com" --env NODE_TLS_REJECT_UNAUTHORIZED="0" --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type" -- npx @umbraco-cms/mcp-dev@lts-17
 ```
 
 Replace the following values with your local connection details:
@@ -75,7 +75,7 @@ Replace the `UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, `UMBRACO_BASE_URL` and
   "mcpServers": {
     "umbraco-mcp": {
       "command": "npx",
-      "args": ["@umbraco-cms/mcp-dev@17.4.2"],
+      "args": ["@umbraco-cms/mcp-dev@lts-17"],
     }
   }
 }

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/claude-desktop.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/claude-desktop.md
@@ -27,7 +27,7 @@ The examples below use the Developer MCP package (`@umbraco-cms/mcp-dev`). Repla
     "umbraco-mcp": 
     {
       "command": "npx",
-      "args": ["@umbraco-cms/mcp-dev@17.4.2"],
+      "args": ["@umbraco-cms/mcp-dev@lts-17"],
       "env": 
       {
         "NODE_TLS_REJECT_UNAUTHORIZED": "0",

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/cursor.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/cursor.md
@@ -23,7 +23,7 @@ The examples below use the Developer MCP package (`@umbraco-cms/mcp-dev`). Repla
   "mcpServers": {
     "umbraco-mcp": {
       "command": "npx", 
-      "args": ["@umbraco-cms/mcp-dev@17.4.2"],
+      "args": ["@umbraco-cms/mcp-dev@lts-17"],
       "env": {
         "NODE_TLS_REJECT_UNAUTHORIZED": "0",
         "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/github-copilot.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/github-copilot.md
@@ -33,7 +33,7 @@ Once you’ve added your MCP Server and updated the JSON configuration, restarti
   "servers": {
     "umbraco-mcp": {
       "command": "npx",
-      "args": ["@umbraco-cms/mcp-dev@17.4.2"],
+      "args": ["@umbraco-cms/mcp-dev@lts-17"],
       "env": {
         "NODE_TLS_REJECT_UNAUTHORIZED": "0",
         "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/openai-codex.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/openai-codex.md
@@ -29,7 +29,7 @@ brew install codex
 1. Add the Umbraco MCP server with the Codex CLI:
 
 ```bash
-codex mcp add umbraco-mcp -- npx -y @umbraco-cms/mcp-dev@17.4.2
+codex mcp add umbraco-mcp -- npx -y @umbraco-cms/mcp-dev@lts-17
 ```
 
 2. Define configuration values directly. If you prefer to keep secrets in your shell session, pass them as environment variables during registration:
@@ -41,7 +41,7 @@ codex mcp add umbraco-mcp \
   --env UMBRACO_BASE_URL="https://your-domain.com" \
   --env NODE_TLS_REJECT_UNAUTHORIZED="0" \
   --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type" \
-  -- npx -y @umbraco-cms/mcp-dev@17.4.2
+  -- npx -y @umbraco-cms/mcp-dev@lts-17
 ```
 
 Replace the following values with your local connection details:


### PR DESCRIPTION
## What
Updates the **v17** CMS Developer MCP docs to install `@umbraco-cms/mcp-dev@lts-17` instead of a specific pinned version.

- Replaces the previously pinned `@17.4.2` (added so v17 readers didn't pick up v18) across the local MCP setup guides and the Developer MCP README.
- Also updates older `@17.1` references — the mcp-chaining and creating-media install snippets, and the version compatibility table — to `@lts-17`.

## Why
The v17 line is published on npm under the **`lts-17`** dist-tag (per the release pipeline, which scopes the v17 line to `lts-17`). v17 users should track the latest 17.x release via that tag rather than a fixed version. The npm `latest` tag now points at `18.0.0`, so an unpinned install would otherwise jump to v18. Targeting `@lts-17` keeps v17 users on the latest compatible 17.x build.

Verified locally with Vale (`0 errors, 0 warnings`) on all changed files.