### PR TITLE
Search: Clarify the boundaries for range facets

### DIFF
--- a/17/umbraco-search/getting-started/README.md
+++ b/17/umbraco-search/getting-started/README.md
@@ -204,6 +204,10 @@ facets:
 ```
 {% endcode %}
 
+{% hint style="info" %}
+Ranges include the lower interval and exclude the upper. The example above translates into: Facets for _`releaseYear` between 1950 and 1959 (both inclusive) and between 1980 and 1989 (both inclusive)_.
+{% endhint %}
+
 ## Sorting search results
 
 All fields can be used for sorting (ordering) search results, and sorting can be performed across multiple fields in a single query.
@@ -331,32 +335,6 @@ public class MySearchService(ISearcher searcher)
                 PrincipalId: principalId,
                 GroupIds: groupIds
             )
-        );
-    }
-}
-```
-{% endcode %}
-
-### Bypassing content protection in search queries
-
-Sometimes it's relevant to surface search results for protected content, regardless if a member is currently logged in. To this end you can pass `AccessContent.BypassProtection()` to the searcher:
-
-{% code title="MySearchService.cs" %}
-```csharp
-using Umbraco.Cms.Search.Core.Models.Searching;
-using Umbraco.Cms.Search.Core.Services;
-using Constants = Umbraco.Cms.Search.Core.Constants;
-
-namespace My.Site.Services;
-
-public class MySearchService(ISearcher searcher)
-{
-    public async Task<SearchResult> SearchWithBypassForProtectedContent()
-    {
-        return await searcher.SearchAsync(
-            indexAlias: Constants.IndexAliases.PublishedContent,
-            query: "pink",
-            accessContext: AccessContext.BypassProtection()
         );
     }
 }


### PR DESCRIPTION
## 📋 Description

The Search [docs for filtering](https://docs.umbraco.com/umbraco-search/getting-started/getting-started#search-by-filtering) explains how the boundaries for range filters behave. This explanation was omitted for range facets to reduce duplication. However, this has caused a bit of confusion, so here's a PR to add an explicit explanation for facets as well 😄 

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

N/A

## Deadline (if relevant)

N/A (whenever possible, no rush)

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
