### PR TITLE
UI Builder: load-balanced/multi-node guidance for repositories

### DIFF
--- a/17/umbraco-ui-builder/advanced/efcore-repositories.md
+++ b/17/umbraco-ui-builder/advanced/efcore-repositories.md
@@ -38,6 +38,10 @@ The NPoco-based repository remains the default when the feature flag is not set 
 
 When using EF Core, your entity models use standard data annotation attributes from `System.ComponentModel.DataAnnotations` and `System.ComponentModel.DataAnnotations.Schema` instead of NPoco attributes.
 
+{% hint style="info" %}
+Umbraco UI Builder does not create or migrate the EF Core tables for you. Provision the database schema through your own deployment or migration process before the collections are used. This requirement applies to every environment, including load-balanced setups where all nodes share a single database.
+{% endhint %}
+
 ### Defining Entity Models
 
 ```csharp

--- a/17/umbraco-ui-builder/advanced/efcore-repositories.md
+++ b/17/umbraco-ui-builder/advanced/efcore-repositories.md
@@ -36,7 +36,7 @@ The NPoco-based repository remains the default when the feature flag is not set 
 
 ## Database Setup
 
-When using EF Core, your entity models use standard data annotation attributes from `System.ComponentModel.DataAnnotations` and `System.ComponentModel.DataAnnotations.Schema` instead of NPoco attributes.
+When using EF Core, your entity models use standard data annotation attributes from `System.ComponentModel.DataAnnotations` and `System.ComponentModel.DataAnnotations.Schema` instead of NPoco attributes. 
 
 {% hint style="info" %}
 Umbraco UI Builder does not create or migrate the EF Core tables for you. Provision the database schema through your own deployment or migration process before the collections are used. This requirement applies to every environment, including load-balanced setups where all nodes share a single database.

--- a/17/umbraco-ui-builder/advanced/repositories.md
+++ b/17/umbraco-ui-builder/advanced/repositories.md
@@ -60,6 +60,12 @@ public class PersonRepository : Repository<Person, int> {
 
 \{% hint style="info" %\} `Impl` methods have public alternatives without the suffix. Separate implementation methods ensure repositories trigger Umbraco UI Builder events, whether actions originate from the UI or not. \{% endhint %\}
 
+{% hint style="warning" %}
+
+When running in a load-balanced or multi-node environment, a custom repository must read and write through a shared, centralized data store. Backing a repository with in-memory collections or the local file system causes data to diverge between nodes. Use the shared site database, a distributed cache, or an external service that all nodes can reach.
+
+{% endhint %}
+
 ## Changing the Repository Implementation of a Collection
 
 ### Using the `SetRepositoryType()` Method

--- a/18/umbraco-ui-builder/advanced/efcore-repositories.md
+++ b/18/umbraco-ui-builder/advanced/efcore-repositories.md
@@ -38,6 +38,10 @@ The NPoco-based repository remains the default when the feature flag is not set 
 
 When using EF Core, your entity models use standard data annotation attributes from `System.ComponentModel.DataAnnotations` and `System.ComponentModel.DataAnnotations.Schema` instead of NPoco attributes.
 
+{% hint style="info" %}
+Umbraco UI Builder does not create or migrate the EF Core tables for you. Provision the database schema through your own deployment or migration process before the collections are used. This requirement applies to every environment, including load-balanced setups where all nodes share a single database.
+{% endhint %}
+
 ### Defining Entity Models
 
 ```csharp

--- a/18/umbraco-ui-builder/advanced/repositories.md
+++ b/18/umbraco-ui-builder/advanced/repositories.md
@@ -60,6 +60,12 @@ public class PersonRepository : Repository<Person, int> {
 
 \{% hint style="info" %\} `Impl` methods have public alternatives without the suffix. Separate implementation methods ensure repositories trigger Umbraco UI Builder events, whether actions originate from the UI or not. \{% endhint %\}
 
+{% hint style="warning" %}
+
+When running in a load-balanced or multi-node environment, a custom repository must read and write through a shared, centralized data store. Backing a repository with in-memory collections or the local file system causes data to diverge between nodes. Use the shared site database, a distributed cache, or an external service that all nodes can reach.
+
+{% endhint %}
+
 ## Changing the Repository Implementation of a Collection
 
 ### Using the `SetRepositoryType()` Method

--- a/18/umbraco-ui-builder/advanced/repositories.md
+++ b/18/umbraco-ui-builder/advanced/repositories.md
@@ -58,11 +58,15 @@ public class PersonRepository : Repository<Person, int> {
 }
 ```
 
-\{% hint style="info" %\} `Impl` methods have public alternatives without the suffix. Separate implementation methods ensure repositories trigger Umbraco UI Builder events, whether actions originate from the UI or not. \{% endhint %\}
+{% hint style="info" %}
+
+`Impl` methods have public alternatives without the suffix. Separate implementation methods ensure repositories trigger Umbraco UI Builder events, whether actions originate from the UI or not.
+
+{% endhint %}
 
 {% hint style="warning" %}
 
-When running in a load-balanced or multi-node environment, a custom repository must read and write through a shared, centralized data store. Backing a repository with in-memory collections or the local file system causes data to diverge between nodes. Use the shared site database, a distributed cache, or an external service that all nodes can reach.
+When running in a load-balanced or multi-node environment, a custom repository must read and write through a shared, centralized data store. Backing a repository with in-memory collections or the local file system causes data to diverge between nodes. Use the shared site database, a distributed cache, or an external service that all nodes can reach. 
 
 {% endhint %}
 


### PR DESCRIPTION
## 📋 Description

Adds multi-node / load-balancing guidance to the Umbraco UI Builder **Advanced** documentation. There is currently no load-balancing guidance anywhere in the UI Builder docs.

This was prompted by reviewing UI Builder against Umbraco Cloud's new stateless, non-sticky, multi-node topology. The library's own behaviour is compatible (built-in repositories use the shared database, list/filter state is request-carried, configuration is startup-deterministic, there are no background jobs, and licensing self-heals per node). The one consumer-facing gap was that the custom-repository contract permits — and the docs previously listed — local or in-memory backing stores, which are unsafe without sticky sessions.

Changes (v17 and v18):

* `advanced/repositories.md` — warning hint: a custom `Repository<TEntity, TId>` must persist to a shared, centralized store in load-balanced or multi-node environments. Backing it with in-memory collections or the local file system causes data to diverge between nodes.
* `advanced/efcore-repositories.md` — info hint: UI Builder does not auto-create or migrate the EF Core tables. The schema must be provisioned through your own deployment or migration process. This is also why there is no cross-node startup schema race.

Edits to existing articles only — no `SUMMARY.md` or `.gitbook.yaml` changes needed.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

Vale passes clean (0 errors, 0 warnings, 0 suggestions) on all four changed files.

## Product & Version (if relevant)

Umbraco UI Builder — versions 17 and 18 (both ship EF Core support; 16 and 13 predate it).

## Deadline (if relevant)

When approved