### PR TITLE
Document version-specific Backoffice Skills marketplace install

### DIFF
--- a/17/umbraco-in-ai/agents-skills/backoffice-skills/README.md
+++ b/17/umbraco-in-ai/agents-skills/backoffice-skills/README.md
@@ -15,12 +15,25 @@ Skills use the open [`SKILL.md`](https://agentskills.io/home) format. They load 
 
 ### Claude Code
 
-Add the marketplace and install the plugins:
+Add the marketplace for your Umbraco version, then install the plugins.
+
+Add the marketplace:
 
 ```bash
-# Add the marketplace
-/plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills
+# Umbraco 17
+/plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#v17/main
 
+# Umbraco 18
+/plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#main
+```
+
+{% hint style="info" %}
+The `#v17/main` and `#main` suffixes pin the marketplace to the branch that matches your Umbraco version. For Umbraco 18 you can also use the shorthand `/plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills`, which tracks the repository's default branch (`main`). `/plugin marketplace update` follows the pinned branch, or the default branch when you use the shorthand.
+{% endhint %}
+
+Install the plugins:
+
+```bash
 # Install backoffice extension skills (58 skills)
 /plugin install umbraco-cms-backoffice-skills@umbraco-backoffice-marketplace
 

--- a/17/umbraco-in-ai/agents-skills/backoffice-skills/README.md
+++ b/17/umbraco-in-ai/agents-skills/backoffice-skills/README.md
@@ -15,20 +15,16 @@ Skills use the open [`SKILL.md`](https://agentskills.io/home) format. They load 
 
 ### Claude Code
 
-Add the marketplace for your Umbraco version, then install the plugins.
+Add the marketplace, then install the plugins.
 
 Add the marketplace:
 
 ```bash
-# Umbraco 17
 /plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#v17/main
-
-# Umbraco 18
-/plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#main
 ```
 
 {% hint style="info" %}
-The `#v17/main` and `#main` suffixes pin the marketplace to the branch that matches your Umbraco version. For Umbraco 18 you can also use the shorthand `/plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills`, which tracks the repository's default branch (`main`). `/plugin marketplace update` follows the pinned branch, or the default branch when you use the shorthand.
+The `#v17/main` suffix pins the marketplace to the branch for this Umbraco version. `/plugin marketplace update` follows that branch.
 {% endhint %}
 
 Install the plugins:

--- a/18/umbraco-in-ai/agents-skills/backoffice-skills/README.md
+++ b/18/umbraco-in-ai/agents-skills/backoffice-skills/README.md
@@ -15,20 +15,16 @@ Skills use the open [`SKILL.md`](https://agentskills.io/home) format. They load 
 
 ### Claude Code
 
-Add the marketplace for your Umbraco version, then install the plugins.
+Add the marketplace, then install the plugins.
 
 Add the marketplace:
 
 ```bash
-# Umbraco 18
 /plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#main
-
-# Umbraco 17
-/plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#v17/main
 ```
 
 {% hint style="info" %}
-The `#main` and `#v17/main` suffixes pin the marketplace to the branch that matches your Umbraco version. For Umbraco 18 you can also use the shorthand `/plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills`, which tracks the repository's default branch (`main`). `/plugin marketplace update` follows the pinned branch, or the default branch when you use the shorthand.
+The `#main` suffix pins the marketplace to the branch for this Umbraco version. You can also use the shorthand `/plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills`, which tracks the repository's default branch (`main`). `/plugin marketplace update` follows the pinned branch, or the default branch when you use the shorthand.
 {% endhint %}
 
 Install the plugins:

--- a/18/umbraco-in-ai/agents-skills/backoffice-skills/README.md
+++ b/18/umbraco-in-ai/agents-skills/backoffice-skills/README.md
@@ -15,12 +15,25 @@ Skills use the open [`SKILL.md`](https://agentskills.io/home) format. They load 
 
 ### Claude Code
 
-Add the marketplace and install the plugins:
+Add the marketplace for your Umbraco version, then install the plugins.
+
+Add the marketplace:
 
 ```bash
-# Add the marketplace
-/plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills
+# Umbraco 18
+/plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#main
 
+# Umbraco 17
+/plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#v17/main
+```
+
+{% hint style="info" %}
+The `#main` and `#v17/main` suffixes pin the marketplace to the branch that matches your Umbraco version. For Umbraco 18 you can also use the shorthand `/plugin marketplace add umbraco/Umbraco-CMS-Backoffice-Skills`, which tracks the repository's default branch (`main`). `/plugin marketplace update` follows the pinned branch, or the default branch when you use the shorthand.
+{% endhint %}
+
+Install the plugins:
+
+```bash
 # Install backoffice extension skills (58 skills)
 /plugin install umbraco-cms-backoffice-skills@umbraco-backoffice-marketplace
 


### PR DESCRIPTION
## What

Updates the **Claude Code** install section on the Backoffice Skills pages for both Umbraco 17 and 18 to give a version-specific `/plugin marketplace add` command.

Previously both pages used the bare shorthand (`umbraco/Umbraco-CMS-Backoffice-Skills`), which always tracks the marketplace repo's default branch and can't target the correct version line.

## Commands documented

```bash
# Umbraco 18
/plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#main

# Umbraco 17
/plugin marketplace add https://github.com/umbraco/Umbraco-CMS-Backoffice-Skills.git#v17/main
```

- Uses the full Git URL + `#ref` form (unambiguous, officially documented branch pinning).
- Each page leads with its own version and shows both for reference.
- The bare shorthand is documented for **Umbraco 18 only**, since it tracks the default branch (`main`) — and `/plugin marketplace update` follows that default.

## Note for reviewers

The Umbraco 18 `#main` command is correct once the marketplace repo's `upgrade/v18` branch is merged into `main` (the default branch). Until then `main` still serves v17-era content.

## Files changed

- `17/umbraco-in-ai/agents-skills/backoffice-skills/README.md`
- `18/umbraco-in-ai/agents-skills/backoffice-skills/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)