### PR TITLE
Documented stable machine identifier for hosting (due in CMS 17.6 and 18.1)

### DIFF
--- a/17/umbraco-cms/develop-with-umbraco/configuration/hostingsettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/hostingsettings.md
@@ -16,7 +16,8 @@ A full configuration with default values can be seen here:
       "LocalTempStorageLocation": "Default",
       "TemporaryFileUploadLocation"
       "Debug": false,
-      "SiteName"
+      "SiteName",
+      "MachineIdentifier"
     }
   }
 }
@@ -48,3 +49,13 @@ This setting allows you to run Umbraco in debug mode, by setting the value to tr
 ### Site name
 
 Gets or sets a value specifying the name of the site. The [IWebHostEnvironment.ApplicationName](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.ihostenvironment.applicationname?view=dotnet-plat-ext-6.0) is used if not specified
+
+### Machine identifier
+
+Set `MachineIdentifier` to a stable value that identifies this server instance. Umbraco uses the value to track cache synchronization state per server. The state determines whether a restart can resume from the last sync or must rebuild caches and indexes.
+
+Set this property in environments where the OS hostname is not stable across restarts, such as Docker or Kubernetes.
+
+{% hint style="info" %}
+`MachineIdentifier` is available from Umbraco 17.6.
+{% endhint %}

--- a/17/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/azure-web-apps.md
+++ b/17/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/azure-web-apps.md
@@ -92,6 +92,14 @@ The quickest way to get to your logs is using the following URL template and rep
 
 You can also find this in the KUDU console by clicking **Advanced Tools** > **Log Stream** on the Web App in the Azure Portal.
 
+## Preventing cold boots on container restarts
+
+On Azure App Service on Linux, the container hostname changes on every container recycle. In earlier versions, Umbraco derived its machine identifier from the hostname and rebuilt its Examine indexes and published content cache on every restart.
+
+From Umbraco 17.6, Umbraco reads the `WEBSITE_INSTANCE_ID` environment variable instead. The environment variable stays stable across container recycles and is unique per instance, so no configuration is needed.
+
+To take full control of the identifier, set `Hosting:MachineIdentifier` explicitly with a value that is unique per instance. See [Hosting Settings](../../../develop-with-umbraco/configuration/hostingsettings.md) for the full property reference.
+
 ## Web App secret management
 
 Consult the [Azure Key Vault documentation](../../security/key-vault.md) if you would like to directly reference Azure Key Vault Secrets to your Azure Web App.

--- a/17/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/load-balancing/flexible-advanced.md
+++ b/17/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/load-balancing/flexible-advanced.md
@@ -104,3 +104,22 @@ Options:
 * `TimeBetweenPruneOperations` - The timespan to wait between each prune operation
 
 These setting would normally be applied to all environments as they are added to the global app settings. If you need these settings to be environment specific, we recommend using [environment specific `appSetting` files](../../../../develop-with-umbraco/configuration/README.md).
+
+## Custom machine identity providers
+
+Umbraco resolves the machine identifier through an ordered collection of `IMachineIdentityProvider` implementations. The first provider to return a non-null value wins.
+
+Three built-in providers cover configuration, Azure App Service, and `Environment.MachineName`, in that priority order.
+
+To customize identifier resolution, implement `IMachineIdentityProvider` and register it through `IUmbracoBuilder.MachineIdentityProviders()` in a [Composer](../../../../model-your-content/content-types-and-structure/composing.md). A custom provider can, for example, read a Kubernetes pod label or a custom environment variable. Return `null` from your provider to pass through to the next provider in the collection.
+
+```csharp
+public class MyComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+        => builder.MachineIdentityProviders()
+            .Insert<CustomIdentityProvider>();
+}
+```
+
+To ensure your custom provider is used before the built-in providers, insert it at the start of the collection. You can also remove the built-in providers if you want to fully control identifier resolution.

--- a/17/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/running-umbraco-in-docker.md
+++ b/17/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/running-umbraco-in-docker.md
@@ -52,7 +52,7 @@ Your solution may require some specific files to run, such as license files. You
 
 ## Preventing cold boots on container restarts
 
-Container hostnames are typically regenerated on every container start. Umbraco derives its machine identifier from the hostname by default, so each restart looks like a new server and rebuilds the Examine indexes and published content cache.
+Container hostnames are typically regenerated on every container start. Umbraco derives its machine identifier from the hostname by default. Each restart then looks like a new server, so Umbraco rebuilds the Examine indexes and published content cache.
 
 From Umbraco 17.6, set `Hosting:MachineIdentifier` to a stable, instance-unique value to prevent the rebuild. Use a StatefulSet ordinal, a node label, or any other string that does not change between restarts:
 

--- a/17/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/running-umbraco-in-docker.md
+++ b/17/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/running-umbraco-in-docker.md
@@ -50,6 +50,27 @@ One solution is to use bind mounts. The ideal setup, though, is to store the med
 
 Your solution may require some specific files to run, such as license files. You will need to pass these files into the container at build time, or mount them externally.
 
+## Preventing cold boots on container restarts
+
+Container hostnames are typically regenerated on every container start. Umbraco derives its machine identifier from the hostname by default, so each restart looks like a new server and rebuilds the Examine indexes and published content cache.
+
+From Umbraco 17.6, set `Hosting:MachineIdentifier` to a stable, instance-unique value to prevent the rebuild. Use a StatefulSet ordinal, a node label, or any other string that does not change between restarts:
+
+```yaml
+services:
+  umbraco:
+    environment:
+      - UMBRACO__CMS__HOSTING__MACHINEIDENTIFIER=umbraco-pod-1
+```
+
+See [Hosting Settings](../../../develop-with-umbraco/configuration/hostingsettings.md) for the full property reference.
+
+{% hint style="info" %}
+On Azure App Service, Umbraco derives the identifier from the `WEBSITE_INSTANCE_ID` environment variable instead, which is stable across container recycles. No configuration is needed there.
+{% endhint %}
+
+For advanced scenarios, implement `IMachineIdentityProvider` to read the stable identifier from wherever your infrastructure exposes it. Examples include an environment variable, a mounted file, or a metadata API. See [Advanced Techniques With Flexible Load Balancing](load-balancing/flexible-advanced.md#custom-machine-identity-providers) for details.
+
 ## HTTPS
 
 When running websites in Docker, it's common to do so behind a reverse proxy or load balancer. In these scenarios you will likely handle SSL termination at the reverse proxy. This means that Umbraco will not be aware of the SSL termination, and will complain about not using HTTPS.

--- a/18/umbraco-cms/develop-with-umbraco/configuration/hostingsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/hostingsettings.md
@@ -16,7 +16,8 @@ A full configuration with default values can be seen here:
       "LocalTempStorageLocation": "Default",
       "TemporaryFileUploadLocation"
       "Debug": false,
-      "SiteName"
+      "SiteName",
+      "MachineIdentifier"
     }
   }
 }
@@ -48,3 +49,14 @@ This setting allows you to run Umbraco in debug mode, by setting the value to tr
 ### Site name
 
 Gets or sets a value specifying the name of the site. The [IWebHostEnvironment.ApplicationName](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.ihostenvironment.applicationname?view=dotnet-plat-ext-6.0) is used if not specified
+
+### Machine identifier
+
+Set `MachineIdentifier` to a stable value that identifies this server instance. Umbraco uses the value to track cache synchronization state per server. The state determines whether a restart can resume from the last sync or must rebuild caches and indexes.
+
+Set this property in environments where the OS hostname is not stable across restarts, such as Docker or Kubernetes.
+
+{% hint style="info" %}
+`MachineIdentifier` is available from Umbraco 18.1.
+{% endhint %}
+

--- a/18/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/azure-web-apps.md
+++ b/18/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/azure-web-apps.md
@@ -92,6 +92,14 @@ The quickest way to get to your logs is using the following URL template and rep
 
 You can also find this in the KUDU console by clicking **Advanced Tools** > **Log Stream** on the Web App in the Azure Portal.
 
+## Preventing cold boots on container restarts
+
+On Azure App Service on Linux, the container hostname changes on every container recycle. In earlier versions, Umbraco derived its machine identifier from the hostname and rebuilt its Examine indexes and published content cache on every restart.
+
+From Umbraco 18.1, Umbraco reads the `WEBSITE_INSTANCE_ID` environment variable instead. The environment variable stays stable across container recycles and is unique per instance, so no configuration is needed.
+
+To take full control of the identifier, set `Hosting:MachineIdentifier` explicitly with a value that is unique per instance. See [Hosting Settings](../../../develop-with-umbraco/configuration/hostingsettings.md) for the full property reference.
+
 ## Web App secret management
 
 Consult the [Azure Key Vault documentation](../../security/key-vault.md) if you would like to directly reference Azure Key Vault Secrets to your Azure Web App.

--- a/18/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/load-balancing/flexible-advanced.md
+++ b/18/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/load-balancing/flexible-advanced.md
@@ -104,3 +104,22 @@ Options:
 * `TimeBetweenPruneOperations` - The timespan to wait between each prune operation
 
 These setting would normally be applied to all environments as they are added to the global app settings. If you need these settings to be environment specific, we recommend using [environment specific `appSetting` files](../../../../develop-with-umbraco/configuration/README.md).
+
+## Custom machine identity providers
+
+Umbraco resolves the machine identifier through an ordered collection of `IMachineIdentityProvider` implementations. The first provider to return a non-null value wins.
+
+Three built-in providers cover configuration, Azure App Service, and `Environment.MachineName`, in that priority order.
+
+To customize identifier resolution, implement `IMachineIdentityProvider` and register it through `IUmbracoBuilder.MachineIdentityProviders()` in a [Composer](../../../../model-your-content/content-types-and-structure/composing.md). A custom provider can, for example, read a Kubernetes pod label or a custom environment variable. Return `null` from your provider to pass through to the next provider in the collection.
+
+```csharp
+public class MyComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+        => builder.MachineIdentityProviders()
+            .Insert<CustomIdentityProvider>();
+}
+```
+
+To ensure your custom provider is used before the built-in providers, insert it at the start of the collection. You can also remove the built-in providers if you want to fully control identifier resolution.

--- a/18/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/running-umbraco-in-docker.md
+++ b/18/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/running-umbraco-in-docker.md
@@ -50,6 +50,27 @@ One solution is to use bind mounts. The ideal setup, though, is to store the med
 
 Your solution may require some specific files to run, such as license files. You will need to pass these files into the container at build time, or mount them externally.
 
+## Preventing cold boots on container restarts
+
+Container hostnames are typically regenerated on every container start. Umbraco derives its machine identifier from the hostname by default, so each restart looks like a new server and rebuilds the Examine indexes and published content cache.
+
+From Umbraco 18.1, set `Hosting:MachineIdentifier` to a stable, instance-unique value to prevent the rebuild. Use a StatefulSet ordinal, a node label, or any other string that does not change between restarts:
+
+```yaml
+services:
+  umbraco:
+    environment:
+      - UMBRACO__CMS__HOSTING__MACHINEIDENTIFIER=umbraco-pod-1
+```
+
+See [Hosting Settings](../../../develop-with-umbraco/configuration/hostingsettings.md) for the full property reference.
+
+{% hint style="info" %}
+On Azure App Service, Umbraco derives the identifier from the `WEBSITE_INSTANCE_ID` environment variable instead, which is stable across container recycles. No configuration is needed there.
+{% endhint %}
+
+For advanced scenarios, implement `IMachineIdentityProvider` to read the stable identifier from wherever your infrastructure exposes it. Examples include an environment variable, a mounted file, or a metadata API. See [Advanced Techniques With Flexible Load Balancing](load-balancing/flexible-advanced.md#custom-machine-identity-providers) for details.
+
 ## HTTPS
 
 When running websites in Docker, it's common to do so behind a reverse proxy or load balancer. In these scenarios you will likely handle SSL termination at the reverse proxy. This means that Umbraco will not be aware of the SSL termination, and will complain about not using HTTPS.

--- a/18/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/running-umbraco-in-docker.md
+++ b/18/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/running-umbraco-in-docker.md
@@ -52,7 +52,7 @@ Your solution may require some specific files to run, such as license files. You
 
 ## Preventing cold boots on container restarts
 
-Container hostnames are typically regenerated on every container start. Umbraco derives its machine identifier from the hostname by default, so each restart looks like a new server and rebuilds the Examine indexes and published content cache.
+Container hostnames are typically regenerated on every container start. Umbraco derives its machine identifier from the hostname by default. Each restart then looks like a new server, so Umbraco rebuilds the Examine indexes and published content cache.
 
 From Umbraco 18.1, set `Hosting:MachineIdentifier` to a stable, instance-unique value to prevent the rebuild. Use a StatefulSet ordinal, a node label, or any other string that does not change between restarts:
 


### PR DESCRIPTION
## 📋 Description

Documented the stable machine identifier for hosting (due in CMS 17.6 and 18.1)

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/pull/23233
https://github.com/umbraco/Umbraco-CMS/issues/22947

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [X] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [X] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17.6 and 18.1

## Deadline (if relevant)

Should be published on 23rd July, along with the related release candidates.

## AI
I've used AI for initial generation, but have then corrected it and validated the code example. 