### PR TITLE
Engage: Clarify async/defer support for client-side scripts

### DIFF
--- a/13/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/additional-measurements-with-the-analytics-scripts.md
+++ b/13/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/additional-measurements-with-the-analytics-scripts.md
@@ -13,7 +13,7 @@ You can add the Umbraco Engage Analytics JavaScript file to your website by plac
 ```
 
 {% hint style="info" %}
-The following client-side tracking script loading types are currently not supported: "async" or "defer".
+Support for the "async" and "defer" script loading types was added in Umbraco Engage 13.6.0.
 {% endhint %}
 
 When this file is included, Umbraco Engage sends the following data to the server before the visitor navigates to another page:

--- a/13/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-analytics.md
+++ b/13/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-analytics.md
@@ -15,7 +15,7 @@ Add a reference to `umbracoEngage.analytics.ga4-bridge.min.js`:
 ```
 
 {% hint style="info" %}
-The following Google Analytics bridging script loading types are currently not supported: "async" or "defer".
+Support for the "async" and "defer" script loading types was added in Umbraco Engage 13.6.0.
 {% endhint %}
 
 ### Excluded events

--- a/13/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-tag-manager.md
+++ b/13/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-tag-manager.md
@@ -13,5 +13,5 @@ To include the file add the following code before the closing `body` tag in your
 ```
 
 {% hint style="info" %}
-The "async" or "defer" Google Analytics bridging script loading types are currently not supported.
+Support for the "async" and "defer" script loading types was added in Umbraco Engage 13.6.0.
 {% endhint %}

--- a/13/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/google-analytics-blocker-detection.md
+++ b/13/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/google-analytics-blocker-detection.md
@@ -13,7 +13,7 @@ This is made possible by a JavaScript file that you can include before the closi
 ```
 
 {% hint style="info" %}
-The following Google Analytics blocker detection script loading types are currently not supported: "async" or "defer".
+Support for the "async" and "defer" script loading types was added in Umbraco Engage 13.6.0.
 {% endhint %}
 
 If you include the script one of the following events is sent:

--- a/13/umbraco-engage/developers/analytics/forms.md
+++ b/13/umbraco-engage/developers/analytics/forms.md
@@ -11,7 +11,7 @@ To track Umbraco Forms submissions, you need to install [Umbraco Forms](https://
 Umbraco Engage measures interactions with Umbraco Forms on your website automatically if you include the Umbraco Engage [analytics JavaScript file](client-side-events-and-additional-javascript-files/additional-measurements-with-the-analytics-scripts.md). No additional configuration is needed. The data is visualized in the backoffice in Engage > Analytics > Forms.
 
 {% hint style="info" %}
-The following Umbraco Forms script loading types are currently not supported: "async" or "defer".
+Support for the "async" and "defer" script loading types was added in Umbraco Engage 13.6.0.
 {% endhint %}
 
 The following is measured:

--- a/13/umbraco-engage/installation/installation.md
+++ b/13/umbraco-engage/installation/installation.md
@@ -97,7 +97,7 @@ To capture events that happen on the clientside (frontend) of your website, you 
 ```
 
 {% hint style="info" %}
-The following client-side tracking script loading types are currently not supported: "async" or "defer".
+Support for the "async" and "defer" script loading types was added in Umbraco Engage 13.6.0.
 {% endhint %}
 
 ### Cockpit
@@ -129,7 +129,7 @@ Here are some optional extras you can do to improve your experience with Umbraco
 ```
 
 {% hint style="info" %}
-The following Google Analytics bridging or blocker script loading types are currently not supported: "async" or "defer".
+Support for the "async" and "defer" script loading types was added in Umbraco Engage 13.6.0.
 {% endhint %}
 
 ### Cookie consent

--- a/16/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/additional-measurements-with-the-analytics-scripts.md
+++ b/16/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/additional-measurements-with-the-analytics-scripts.md
@@ -13,7 +13,7 @@ You can add the Umbraco Engage Analytics JavaScript file to your website by plac
 ```
 
 {% hint style="info" %}
-The following client-side tracking script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 When this file is included, Umbraco Engage sends the following data to the server before the visitor navigates to another page:

--- a/16/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-analytics.md
+++ b/16/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-analytics.md
@@ -15,7 +15,7 @@ Add a reference to `umbracoEngage.analytics.ga4-bridge.min.js`:
 ```
 
 {% hint style="info" %}
-The following Google Analytics bridging script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 ### Excluded events

--- a/16/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-tag-manager.md
+++ b/16/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-tag-manager.md
@@ -13,5 +13,5 @@ To include the file add the following code before the closing `body` tag in your
 ```
 
 {% hint style="info" %}
-The "async" or "defer" Google Analytics bridging script loading types are currently not supported.
+Includes support for "async" and "defer" keywords.
 {% endhint %}

--- a/16/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/google-analytics-blocker-detection.md
+++ b/16/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/google-analytics-blocker-detection.md
@@ -13,7 +13,7 @@ This is made possible by a JavaScript file that you can include before the closi
 ```
 
 {% hint style="info" %}
-The following Google Analytics blocker detection script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 If you include the script one of the following events is sent:

--- a/16/umbraco-engage/developers/analytics/forms.md
+++ b/16/umbraco-engage/developers/analytics/forms.md
@@ -11,7 +11,7 @@ To track Umbraco Forms submissions, you need to install [Umbraco Forms](https://
 Umbraco Engage measures interactions with Umbraco Forms on your website automatically if you include the Umbraco Engage [analytics JavaScript file](client-side-events-and-additional-javascript-files/additional-measurements-with-the-analytics-scripts.md). No additional configuration is needed. The data is visualized in the backoffice in Engage > Analytics > Forms.
 
 {% hint style="info" %}
-The following Umbraco Forms script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 The following is measured:

--- a/16/umbraco-engage/installation/installation.md
+++ b/16/umbraco-engage/installation/installation.md
@@ -92,7 +92,7 @@ To capture events that happen on the clientside (frontend) of your website, you 
 ```
 
 {% hint style="info" %}
-The following client-side tracking script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 ### Cockpit
@@ -124,7 +124,7 @@ Here are some optional extras you can do to improve your experience with Umbraco
 ```
 
 {% hint style="info" %}
-The following Google Analytics bridging or blocker script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 ### Cookie consent

--- a/17/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/additional-measurements-with-the-analytics-scripts.md
+++ b/17/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/additional-measurements-with-the-analytics-scripts.md
@@ -13,7 +13,7 @@ You can add the Umbraco Engage Analytics JavaScript file to your website by plac
 ```
 
 {% hint style="info" %}
-The following client-side tracking script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 When this file is included, Umbraco Engage sends the following data to the server before the visitor navigates to another page:

--- a/17/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-analytics.md
+++ b/17/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-analytics.md
@@ -15,7 +15,7 @@ Add a reference to `umbracoEngage.analytics.ga4-bridge.min.js`:
 ```
 
 {% hint style="info" %}
-The following Google Analytics bridging script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 ### Excluded events

--- a/17/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-tag-manager.md
+++ b/17/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-tag-manager.md
@@ -13,5 +13,5 @@ To include the file add the following code before the closing `body` tag in your
 ```
 
 {% hint style="info" %}
-The "async" or "defer" Google Analytics bridging script loading types are currently not supported.
+Includes support for "async" and "defer" keywords.
 {% endhint %}

--- a/17/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/google-analytics-blocker-detection.md
+++ b/17/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/google-analytics-blocker-detection.md
@@ -13,7 +13,7 @@ This is made possible by a JavaScript file that you can include before the closi
 ```
 
 {% hint style="info" %}
-The following Google Analytics blocker detection script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 If you include the script one of the following events is sent:

--- a/17/umbraco-engage/developers/analytics/forms.md
+++ b/17/umbraco-engage/developers/analytics/forms.md
@@ -11,7 +11,7 @@ To track Umbraco Forms submissions, you need to install [Umbraco Forms](https://
 Umbraco Engage measures interactions with Umbraco Forms on your website automatically if you include the Umbraco Engage [analytics JavaScript file](client-side-events-and-additional-javascript-files/additional-measurements-with-the-analytics-scripts.md). No additional configuration is needed. The data is visualized in the backoffice in Engage > Analytics > Forms.
 
 {% hint style="info" %}
-The following Umbraco Forms script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 The following is measured:

--- a/17/umbraco-engage/installation/installation.md
+++ b/17/umbraco-engage/installation/installation.md
@@ -114,7 +114,7 @@ To capture events that happen on the clientside (frontend) of your website, you 
 ```
 
 {% hint style="info" %}
-The following client-side tracking script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 ### Cockpit
@@ -146,7 +146,7 @@ Here are some optional extras you can do to improve your experience with Umbraco
 ```
 
 {% hint style="info" %}
-The following Google Analytics bridging or blocker script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 ### Cookie consent

--- a/18/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/additional-measurements-with-the-analytics-scripts.md
+++ b/18/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/additional-measurements-with-the-analytics-scripts.md
@@ -13,7 +13,7 @@ You can add the Umbraco Engage Analytics JavaScript file to your website by plac
 ```
 
 {% hint style="info" %}
-The following client-side tracking script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 When this file is included, Umbraco Engage sends the following data to the server before the visitor navigates to another page:

--- a/18/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-analytics.md
+++ b/18/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-analytics.md
@@ -15,7 +15,7 @@ Add a reference to `umbracoEngage.analytics.ga4-bridge.min.js`:
 ```
 
 {% hint style="info" %}
-The following Google Analytics bridging script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 ### Excluded events

--- a/18/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-tag-manager.md
+++ b/18/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/bridging-library-for-google-tag-manager.md
@@ -13,5 +13,5 @@ To include the file add the following code before the closing `body` tag in your
 ```
 
 {% hint style="info" %}
-The "async" or "defer" Google Analytics bridging script loading types are currently not supported.
+Includes support for "async" and "defer" keywords.
 {% endhint %}

--- a/18/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/google-analytics-blocker-detection.md
+++ b/18/umbraco-engage/developers/analytics/client-side-events-and-additional-javascript-files/google-analytics-blocker-detection.md
@@ -13,7 +13,7 @@ This is made possible by a JavaScript file that you can include before the closi
 ```
 
 {% hint style="info" %}
-The following Google Analytics blocker detection script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 If you include the script one of the following events is sent:

--- a/18/umbraco-engage/developers/analytics/forms.md
+++ b/18/umbraco-engage/developers/analytics/forms.md
@@ -11,7 +11,7 @@ To track Umbraco Forms submissions, you need to install [Umbraco Forms](https://
 Umbraco Engage measures interactions with Umbraco Forms on your website automatically if you include the Umbraco Engage [analytics JavaScript file](client-side-events-and-additional-javascript-files/additional-measurements-with-the-analytics-scripts.md). No additional configuration is needed. The data is visualized in the backoffice in Engage > Analytics > Forms.
 
 {% hint style="info" %}
-The following Umbraco Forms script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 The following is measured:

--- a/18/umbraco-engage/installation/installation.md
+++ b/18/umbraco-engage/installation/installation.md
@@ -114,7 +114,7 @@ To capture events that happen on the clientside (frontend) of your website, you 
 ```
 
 {% hint style="info" %}
-The following client-side tracking script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 ### Cockpit
@@ -146,7 +146,7 @@ Here are some optional extras you can do to improve your experience with Umbraco
 ```
 
 {% hint style="info" %}
-The following Google Analytics bridging or blocker script loading types are currently not supported: "async" or "defer".
+Includes support for "async" and "defer" keywords.
 {% endhint %}
 
 ### Cookie consent


### PR DESCRIPTION
## 📋 Description

Updates documentation to reflect that 'async' and 'defer' script loading attributes are now supported by Umbraco Engage client-side scripts, introduced in version 13.6.0.

## 📎 Related Issues (if applicable)


## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)
v13, v16, v17 and v18

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
