### PR TITLE
Documented maximum global timeout value (due in CMS 17.6 and 18.1)

### DIFF
--- a/17/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
@@ -86,7 +86,7 @@ Adding additional values to the Reserved URLs and Reserved Paths will overwrite 
 
 Key: `TimeOut` Type: `string` (default: `00:20:00`)
 
-Configure the session timeout to determine how much time without a request being made can pass before the user is required to log in again. The session timeout format needs to be set as `HH:MM:SS`. Any activity within the backoffice will reset the timer.
+Configure the session timeout to determine how much time without a request being made can pass before the user is required to log in again. The session timeout format needs to be set as `HH:MM:SS`. Any activity within the backoffice will reset the timer. The value must not exceed 24 days, the maximum the backoffice timer supports. Larger values are rejected at startup. Use `KeepUserLoggedIn` for longer-lived sessions.
 
 {% hint style="info" %}
 Long session timeouts raise data exposure and unauthorized access risks. Thus, it's vital to establish a reasonable timeout to mitigate security risks.

--- a/18/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
@@ -86,7 +86,7 @@ Adding additional values to the Reserved URLs and Reserved Paths will overwrite 
 
 Key: `TimeOut` Type: `string` (default: `00:20:00`)
 
-Configure the session timeout to determine how much time without a request being made can pass before the user is required to log in again. The session timeout format needs to be set as `HH:MM:SS`. Any activity within the backoffice will reset the timer.
+Configure the session timeout to determine how much time without a request being made can pass before the user is required to log in again. The session timeout format needs to be set as `HH:MM:SS`. Any activity within the backoffice will reset the timer. The value must not exceed 24 days, the maximum the backoffice timer supports. Larger values are rejected at startup. Use `KeepUserLoggedIn` for longer-lived sessions.
 
 {% hint style="info" %}
 Long session timeouts raise data exposure and unauthorized access risks. Thus, it's vital to establish a reasonable timeout to mitigate security risks.


### PR DESCRIPTION
## 📋 Description

Documented maximum global timeout value (due in CMS 17.6 and 18.1).

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/issues/23246
https://github.com/umbraco/Umbraco-CMS/pull/23283

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17.6 and 18.1

## Deadline (if relevant)

Should be published on 23rd July, along with the related release candidates.

