### PR TITLE
Added details for content type filters relating to elements (due in CMS 18.1)

### DIFF
--- a/17/umbraco-cms/extend-your-project/server-side-extensions/content-type-filters.md
+++ b/17/umbraco-cms/extend-your-project/server-side-extensions/content-type-filters.md
@@ -19,10 +19,10 @@ To create a Content Type Filter you use a class that implements the `IContentTyp
 
 There are two methods you can implement:
 
-* One for filtering the content types allowed at the content root
-* One for the content types allowed below a given parent node.
+* `FilterAllowedAtRootAsync` for the content types allowed at the content root.
+* `FilterAllowedChildrenAsync` for the content types allowed below a given parent node. The method receives the parent content type key and the parent content key, so you can filter based on the parent node.
 
-If you don't want to filter using one of the two approaches, you can return the provided collection unmodified.
+Each method has a default implementation that returns the provided collection unmodified. You only implement the methods relevant to your use case.
 
 ### Example Use Case
 

--- a/18/umbraco-cms/extend-your-project/server-side-extensions/content-type-filters.md
+++ b/18/umbraco-cms/extend-your-project/server-side-extensions/content-type-filters.md
@@ -17,12 +17,17 @@ This is possible using Content Type Filters.
 
 To create a Content Type Filter you use a class that implements the `IContentTypeFilter` interface (found in the `Umbraco.Cms.Core.Services.Filters` namespace).
 
-There are two methods you can implement:
+There are three methods you can implement:
 
-* One for filtering the content types allowed at the content root
-* One for the content types allowed below a given parent node.
+* `FilterAllowedAtRootAsync` for the content types allowed at the content root.
+* `FilterAllowedChildrenAsync` for the content types allowed below a given parent node. The method receives the parent content type key and the parent content key, so you can filter based on the parent node.
+* `FilterAllowedInLibraryAsync` for the content types allowed when creating Elements in the library. The method receives the parent container key, which is `null` at the library root or the key of the folder the Element is created within. You can filter based on where in the library the Element is being created.
 
-If you don't want to filter using one of the two approaches, you can return the provided collection unmodified.
+Each method has a default implementation that returns the provided collection unmodified. You only implement the methods relevant to your use case.
+
+{% hint style="info" %}
+Content Type Filters are enforced on the server. A content type excluded by a filter cannot be created, moved, or restored under the restricted location, even if a request bypasses the backoffice UI.
+{% endhint %}
 
 ### Example Use Case
 


### PR DESCRIPTION
## 📋 Description

Added details for content type filters relating to elements (due in CMS 18.1)

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/pull/23161

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17.6 and 18.1

## Deadline (if relevant)

Should be published on 23rd July, along with the related release candidates.

