### PR TITLE
Document HTTP Request response body size limit (Automate v17 & v18)

### DIFF
--- a/17/umbraco-automate/concepts/actions.md
+++ b/17/umbraco-automate/concepts/actions.md
@@ -60,6 +60,10 @@ ${ steps.callApi.responseBody }
 
 The step's alias (`callApi` in the example) is set in the step settings panel.
 
+{% hint style="warning" %}
+The HTTP Request action rejects responses larger than `Execution:MaxHttpResponseBodyBytes` (10 MB by default). The step fails with a terminal error that names the response size and the limit. Raise the limit in [Configuration](../getting-started/configuration.md) for larger payloads.
+{% endhint %}
+
 ## Step Behaviour
 
 Each step has additional execution settings on the canvas:

--- a/17/umbraco-automate/getting-started/configuration.md
+++ b/17/umbraco-automate/getting-started/configuration.md
@@ -68,7 +68,8 @@ The defaults are suitable for most sites:
       "Execution": {
         "DefaultTimeout": "00:05:00",
         "MaxConcurrentRuns": 10,
-        "MaxChainDepth": 5
+        "MaxChainDepth": 5,
+        "MaxHttpResponseBodyBytes": 10485760
       },
       "Governance": {
         "AuditLogEnabled": true,
@@ -85,7 +86,7 @@ The defaults are suitable for most sites:
 | ------------ | ------------------------------------------------------------------------------- |
 | `Enabled`    | Master switch for the automation engine.                                        |
 | `Webhook`    | Maximum payload size and per-automation rate limit for incoming webhooks.       |
-| `Execution`  | Default step timeout, concurrent run limit, and maximum automation chain depth. |
+| `Execution`  | Default step timeout, concurrent run limit, maximum automation chain depth, and maximum HTTP response body size. |
 | `Governance` | Audit log retention and sensitive data masking.                                 |
 
 ## Next Steps

--- a/18/umbraco-automate/concepts/actions.md
+++ b/18/umbraco-automate/concepts/actions.md
@@ -60,6 +60,10 @@ ${ steps.callApi.responseBody }
 
 The step's alias (`callApi` in the example) is set in the step settings panel.
 
+{% hint style="warning" %}
+The HTTP Request action rejects responses larger than `Execution:MaxHttpResponseBodyBytes` (10 MB by default). The step fails with a terminal error that names the response size and the limit. Raise the limit in [Configuration](../getting-started/configuration.md) for larger payloads.
+{% endhint %}
+
 ## Step Behaviour
 
 Each step has additional execution settings on the canvas:

--- a/18/umbraco-automate/getting-started/configuration.md
+++ b/18/umbraco-automate/getting-started/configuration.md
@@ -68,7 +68,8 @@ The defaults are suitable for most sites:
       "Execution": {
         "DefaultTimeout": "00:05:00",
         "MaxConcurrentRuns": 10,
-        "MaxChainDepth": 5
+        "MaxChainDepth": 5,
+        "MaxHttpResponseBodyBytes": 10485760
       },
       "Governance": {
         "AuditLogEnabled": true,
@@ -85,7 +86,7 @@ The defaults are suitable for most sites:
 | ------------ | ------------------------------------------------------------------------------- |
 | `Enabled`    | Master switch for the automation engine.                                        |
 | `Webhook`    | Maximum payload size and per-automation rate limit for incoming webhooks.       |
-| `Execution`  | Default step timeout, concurrent run limit, and maximum automation chain depth. |
+| `Execution`  | Default step timeout, concurrent run limit, maximum automation chain depth, and maximum HTTP response body size. |
 | `Governance` | Audit log retention and sensitive data masking.                                 |
 
 ## Next Steps


### PR DESCRIPTION
## 📋 Description

Documents the `MaxHttpResponseBodyBytes` execution setting introduced in Umbraco Automate 18.0.0 (also present on the v17 line).

The HTTP Request action now caps response bodies at a configurable limit (default 10 MB / `10485760` bytes). Responses over the limit fail the step with a terminal error. This was previously undocumented.

Changes (applied to both `17/` and `18/` doc trees):

- **`getting-started/configuration.md`** — add `MaxHttpResponseBodyBytes` to the `Execution` settings example and the settings table.
- **`concepts/actions.md`** — add a hint explaining the HTTP Request action's oversized-response failure behaviour and how to raise the limit.

## Product & Version (if relevant)

Automate v17 and v18

## ✅ Contributor Checklist

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful. (not applicable — settings reference)
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.