### PR TITLE
docs(automate): document Workflow and UI Builder add-ons, config references

### DIFF
--- a/17/umbraco-automate/SUMMARY.md
+++ b/17/umbraco-automate/SUMMARY.md
@@ -59,6 +59,13 @@
   * [Installation](add-ons/deploy/installation.md)
   * [Triggers](add-ons/deploy/triggers.md)
   * [Transfer Automations](add-ons/deploy/transferring-automations.md)
+* [Workflow](add-ons/workflow/README.md)
+  * [Installation](add-ons/workflow/installation.md)
+  * [Triggers](add-ons/workflow/triggers.md)
+* [UI Builder](add-ons/uibuilder/README.md)
+  * [Installation](add-ons/uibuilder/installation.md)
+  * [Triggers](add-ons/uibuilder/triggers.md)
+  * [Actions](add-ons/uibuilder/actions.md)
 
 ## Extending
 

--- a/17/umbraco-automate/add-ons/README.md
+++ b/17/umbraco-automate/add-ons/README.md
@@ -18,6 +18,8 @@ Add-ons are NuGet packages that add new triggers and actions to Umbraco Automate
 | [Commerce](commerce/) | Triggers and actions for orders, payments, stock, discounts, and gift cards.                                                           |
 | [Engage](engage/)     | Triggers for A/B tests, segments, personas, and customer journeys. Actions for goals, persona scoring, and journey scoring.            |
 | [Deploy](deploy/)     | Deploy lifecycle triggers, plus Umbraco Deploy support for transferring automations, workspaces, and connections between environments. |
+| [Workflow](workflow/) | Triggers for the content approval lifecycle, task assignment, workflow emails, and content reviews.                                    |
+| [UI Builder](uibuilder/) | Triggers for entity changes in UI Builder collections. Actions for creating and deleting entities.                                 |
 
 ## Installing an Add-on
 

--- a/17/umbraco-automate/add-ons/uibuilder/README.md
+++ b/17/umbraco-automate/add-ons/uibuilder/README.md
@@ -1,0 +1,30 @@
+---
+description: >-
+  The UI Builder add-on adds triggers and actions for Umbraco UI Builder
+  entities to Umbraco Automate.
+---
+
+# UI Builder
+
+The UI Builder add-on lets your automations react to entity changes in Umbraco UI Builder collections. It also lets you create or delete entities from inside an automation.
+
+## What It Adds
+
+| Type     | Items                                          |
+| -------- | ----------------------------------------------- |
+| Triggers | Entity Saved, Entity Created, Entity Deleted    |
+| Actions  | Create Entity, Delete Entity                    |
+
+## In This Section
+
+{% content-ref url="installation.md" %}
+[Installation](installation.md)
+{% endcontent-ref %}
+
+{% content-ref url="triggers.md" %}
+[Triggers](triggers.md)
+{% endcontent-ref %}
+
+{% content-ref url="actions.md" %}
+[Actions](actions.md)
+{% endcontent-ref %}

--- a/17/umbraco-automate/add-ons/uibuilder/actions.md
+++ b/17/umbraco-automate/add-ons/uibuilder/actions.md
@@ -1,0 +1,18 @@
+---
+description: >-
+  Reference for the actions contributed by the Umbraco.UIBuilder.Automate
+  add-on.
+---
+
+# Actions
+
+The UI Builder add-on contributes the following actions.
+
+| Display Name  | Alias                          | Purpose                                                  |
+| -------------- | -------------------------------- | ----------------------------------------------------------- |
+| Create Entity  | `umbracoUIBuilder.createEntity`  | Create a new entity in a named collection from a JSON payload. |
+| Delete Entity  | `umbracoUIBuilder.deleteEntity`  | Delete an entity from a named collection by ID.               |
+
+{% hint style="info" %}
+Open the step in the canvas to see each action's settings and output fields. Both actions support bindings, so the collection alias, entity JSON, and entity ID can all come from an upstream trigger or step.
+{% endhint %}

--- a/17/umbraco-automate/add-ons/uibuilder/installation.md
+++ b/17/umbraco-automate/add-ons/uibuilder/installation.md
@@ -1,0 +1,27 @@
+---
+description: >-
+  Install the Umbraco.UIBuilder.Automate add-on alongside Umbraco UI Builder.
+---
+
+# Installation
+
+## Prerequisites
+
+* Umbraco Automate installed and configured
+* Umbraco UI Builder installed and configured, with at least one collection registered
+
+## Install the Package
+
+{% code title=".NET CLI" %}
+```bash
+dotnet add package Umbraco.UIBuilder.Automate
+```
+{% endcode %}
+
+Restart your Umbraco site. The UI Builder triggers and actions appear in the catalogue under the **UI Builder** group.
+
+## Next Steps
+
+{% content-ref url="triggers.md" %}
+[Triggers](triggers.md)
+{% endcontent-ref %}

--- a/17/umbraco-automate/add-ons/uibuilder/triggers.md
+++ b/17/umbraco-automate/add-ons/uibuilder/triggers.md
@@ -1,0 +1,21 @@
+---
+description: >-
+  Reference for the triggers contributed by the Umbraco.UIBuilder.Automate
+  add-on.
+---
+
+# Triggers
+
+The UI Builder add-on contributes the following triggers.
+
+| Display Name   | Alias                            |
+| --------------- | ---------------------------------- |
+| Entity Saved    | `umbracoUIBuilder.entitySaved`     |
+| Entity Created  | `umbracoUIBuilder.entityCreated`   |
+| Entity Deleted  | `umbracoUIBuilder.entityDeleted`   |
+
+**Entity Saved** fires whenever an entity is created or updated in any registered collection. **Entity Created** fires only the first time an entity is created, not on later updates. Each trigger has an optional **Collection Alias** setting to filter to a single collection; leave it blank to fire for every collection.
+
+{% hint style="info" %}
+Trigger output includes the collection alias, the entity ID, and the entity serialized as JSON. Properties configured as encrypted on the collection are omitted from the JSON, so decrypted secrets are never exposed to an automation. Inspect a real run in the **Runs** view to see the exact field names, then use the binding picker to reference them in downstream steps.
+{% endhint %}

--- a/17/umbraco-automate/add-ons/workflow/README.md
+++ b/17/umbraco-automate/add-ons/workflow/README.md
@@ -1,0 +1,29 @@
+---
+description: >-
+  The Workflow add-on adds triggers for Umbraco Workflow's content approval
+  lifecycle, tasks, emails, and content reviews.
+---
+
+# Workflow
+
+The Workflow add-on lets your automations react to Umbraco Workflow events, such as approvals, rejections, task assignments, and content reviews.
+
+## What It Adds
+
+| Type     | Items                                                                                          |
+| -------- | ---------------------------------------------------------------------------------------------- |
+| Triggers | Workflow lifecycle, task assignment, workflow emails, content reviews                          |
+
+{% hint style="info" %}
+The Workflow add-on contributes triggers only. It does not add any actions.
+{% endhint %}
+
+## In This Section
+
+{% content-ref url="installation.md" %}
+[Installation](installation.md)
+{% endcontent-ref %}
+
+{% content-ref url="triggers.md" %}
+[Triggers](triggers.md)
+{% endcontent-ref %}

--- a/17/umbraco-automate/add-ons/workflow/installation.md
+++ b/17/umbraco-automate/add-ons/workflow/installation.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Install the Umbraco.Forms.Automate add-on alongside Umbraco Forms.
+  Install the Umbraco.Workflow.Automate add-on alongside Umbraco Workflow.
 ---
 
 # Installation
@@ -8,17 +8,17 @@ description: >-
 ## Prerequisites
 
 * Umbraco Automate installed and configured
-* Umbraco Forms 18.0 or later installed
+* Umbraco Workflow installed and configured
 
 ## Install the Package
 
 {% code title=".NET CLI" %}
 ```bash
-dotnet add package Umbraco.Forms.Automate
+dotnet add package Umbraco.Workflow.Automate
 ```
 {% endcode %}
 
-Restart your Umbraco site. The Forms triggers and actions appear in the catalogue under the **Forms** group.
+Restart your Umbraco site. The Workflow triggers appear in the catalogue under the **Workflow** group.
 
 ## Next Steps
 

--- a/17/umbraco-automate/add-ons/workflow/triggers.md
+++ b/17/umbraco-automate/add-ons/workflow/triggers.md
@@ -1,0 +1,43 @@
+---
+description: >-
+  Reference for the triggers contributed by the Umbraco.Workflow.Automate
+  add-on.
+---
+
+# Triggers
+
+The Workflow add-on contributes the following triggers.
+
+## Workflow Lifecycle Triggers
+
+| Display Name          | Alias                          |
+| ---------------------- | ------------------------------- |
+| Workflow Started       | `umbracoWorkflow.started`       |
+| Workflow Completed     | `umbracoWorkflow.completed`     |
+| Workflow Approved      | `umbracoWorkflow.approved`      |
+| Workflow Rejected      | `umbracoWorkflow.rejected`      |
+| Workflow Cancelled     | `umbracoWorkflow.cancelled`     |
+| Workflow Resubmitted   | `umbracoWorkflow.resubmitted`   |
+
+## Task Triggers
+
+| Display Name  | Alias                        |
+| -------------- | ----------------------------- |
+| Task Assigned  | `umbracoWorkflow.taskAssigned` |
+
+## Email Triggers
+
+| Display Name          | Alias                              |
+| ---------------------- | ------------------------------------ |
+| Workflow Email Sent     | `umbracoWorkflow.emailSent`          |
+| Reminder Emails Sent    | `umbracoWorkflow.reminderEmailsSent` |
+
+## Content Review Triggers
+
+| Display Name              | Alias                                    |
+| --------------------------- | ------------------------------------------ |
+| Content Review Completed   | `umbracoWorkflow.contentReviewCompleted`   |
+
+{% hint style="info" %}
+Each Workflow trigger emits details about the workflow instance, task, or content review it fired on. Fields include the node ID, entity key, workflow type and status, author, and comment. Inspect a real run in the **Runs** view to see the exact field names, then use the binding picker to reference them in downstream steps.
+{% endhint %}

--- a/17/umbraco-automate/concepts/connections.md
+++ b/17/umbraco-automate/concepts/connections.md
@@ -33,6 +33,27 @@ Connections are stored globally but their use is scoped by workspace. Each works
 
 Most connection types implement a validation step. Click **Test connection** in the connection editor to check the credentials work before saving.
 
+## Configuration References
+
+Connection settings support configuration references. Values starting with `$` are resolved from configuration (`appsettings.json`, environment variables, Azure Key Vault, and so on) at runtime.
+
+References resolve from two dedicated configuration sections:
+
+* `Umbraco:Automate:Secrets` — for sensitive values such as API keys. These can only be referenced from settings fields marked sensitive (see [Create a Custom Connection Type](../extending/custom-connection-type.md)).
+* `Umbraco:Automate:Variables` — for non-sensitive per-environment values such as endpoints, IDs, or feature flags.
+
+Place the values you want to reference under these sections, then point the setting at them with the `$` prefix:
+
+{% code title="Connection Settings" %}
+```
+API Key: $Umbraco:Automate:Secrets:SlackToken
+```
+{% endcode %}
+
+{% hint style="info" %}
+See [Configuration](../getting-started/configuration.md#configuration-references) for the full syntax, the default allow-list, and how to expose additional configuration sections.
+{% endhint %}
+
 ## See Also
 
 * [Manage Connections](../backoffice/connections.md)

--- a/17/umbraco-automate/extending/custom-connection-type.md
+++ b/17/umbraco-automate/extending/custom-connection-type.md
@@ -30,12 +30,40 @@ public sealed class MyServiceConnectionSettings
 
     [Field(
         Label = "API key",
-        Description = "The API key issued by the service.",
+        Description = "The API key issued by the service. Supports config references like $Umbraco:Automate:Secrets:ApiKey.",
         IsSensitive = true)]
     public string ApiKey { get; set; } = string.Empty;
 }
 ```
 {% endcode %}
+
+## Configuration References
+
+Settings values starting with `$` are resolved from configuration. References resolve from `Umbraco:Automate:Secrets` (sensitive values) and `Umbraco:Automate:Variables` (non-sensitive values) by default.
+
+**In the UI:** enter `$Umbraco:Automate:Secrets:ApiKey`
+
+**In appsettings.json:**
+
+{% code title="appsettings.json" %}
+```json
+{
+  "Umbraco": {
+    "Automate": {
+      "Secrets": {
+        "ApiKey": "the-actual-key"
+      }
+    }
+  }
+}
+```
+{% endcode %}
+
+This keeps secrets out of the database and supports environment-specific values.
+
+{% hint style="info" %}
+Values under `Umbraco:Automate:Secrets` may only be referenced from fields marked `IsSensitive = true`. To reference values from other configuration sections, add their prefix to `Umbraco:Automate:AllowedConfigurationKeyPrefixes` — see [Configuration](../getting-started/configuration.md#configuration-references).
+{% endhint %}
 
 ## Connection Type Class
 

--- a/17/umbraco-automate/getting-started/configuration.md
+++ b/17/umbraco-automate/getting-started/configuration.md
@@ -89,6 +89,80 @@ The defaults are suitable for most sites:
 | `Execution`  | Default step timeout, concurrent run limit, maximum automation chain depth, and maximum HTTP response body size. |
 | `Governance` | Audit log retention and sensitive data masking.                                 |
 
+## Configuration References
+
+A settings field can reference a configuration value at run time with a `$Key:Path` syntax, instead of storing the value directly:
+
+```
+$Umbraco:Automate:Secrets:SlackToken
+```
+
+This lets administrators keep credentials and per-environment values in configuration — `appsettings.json`, environment variables, Azure Key Vault, and so on — rather than in the automation database.
+
+### Allowed Key Prefixes
+
+Automations run under an elevated service account, so configuration resolution is **default-deny**: a key only resolves when it falls under one of `AllowedConfigurationKeyPrefixes`. Any other key fails to resolve.
+
+Two prefixes are allowed by default:
+
+| Prefix                        | Intended for                                                          |
+| ------------------------------ | ---------------------------------------------------------------------- |
+| `Umbraco:Automate:Secrets`    | Sensitive values, such as API tokens.                                 |
+| `Umbraco:Automate:Variables`  | Non-sensitive per-environment values, such as base URLs or feature flags. |
+
+{% code title="appsettings.json" %}
+```json
+{
+  "Umbraco": {
+    "Automate": {
+      "Secrets": {
+        "SlackToken": "xoxb-..."
+      },
+      "Variables": {
+        "BaseUrl": "https://example.com"
+      }
+    }
+  }
+}
+```
+{% endcode %}
+
+Reference these values from a setting field with `$Umbraco:Automate:Secrets:SlackToken` or `$Umbraco:Automate:Variables:BaseUrl`.
+
+To expose an existing configuration section to automations without copying its values, add its prefix to `AllowedConfigurationKeyPrefixes`:
+
+{% code title="appsettings.json" %}
+```json
+{
+  "Umbraco": {
+    "Automate": {
+      "AllowedConfigurationKeyPrefixes": [
+        "Umbraco:Automate:Secrets",
+        "Umbraco:Automate:Variables",
+        "MyApp:ThirdPartyApi"
+      ]
+    }
+  }
+}
+```
+{% endcode %}
+
+{% hint style="warning" %}
+Everything under an added prefix becomes readable by anyone who can configure automation settings. Only add a prefix you are comfortable exposing to automation authors.
+{% endhint %}
+
+### Secret Key Prefixes
+
+Values under a prefix listed in `SecretConfigurationKeyPrefixes` (`Umbraco:Automate:Secrets` by default) can only be referenced from a settings field marked sensitive. See [Create a Custom Connection Type](../extending/custom-connection-type.md) for `IsSensitive`. Referencing a secret key from a non-sensitive field fails. A resolved secret can only land in a field the system already encrypts at rest and masks in run logs.
+
+`Umbraco:Automate:Variables` is deliberately left off `SecretConfigurationKeyPrefixes`, so non-secret values can be referenced from any field.
+
+Matching for both lists is segment-aware and case-insensitive: the prefix `Umbraco:Automate:Secrets` matches `Umbraco:Automate:Secrets:SlackToken` but not `Umbraco:Automate:SecretsBackup:X`.
+
+{% hint style="info" %}
+`AllowedConfigurationKeyPrefixes` and `SecretConfigurationKeyPrefixes` are configured in `appsettings.json` only — they are not editable from the backoffice.
+{% endhint %}
+
 ## Next Steps
 
 {% content-ref url="first-automation.md" %}

--- a/18/umbraco-automate/SUMMARY.md
+++ b/18/umbraco-automate/SUMMARY.md
@@ -59,6 +59,13 @@
   * [Installation](add-ons/deploy/installation.md)
   * [Triggers](add-ons/deploy/triggers.md)
   * [Transfer Automations](add-ons/deploy/transferring-automations.md)
+* [Workflow](add-ons/workflow/README.md)
+  * [Installation](add-ons/workflow/installation.md)
+  * [Triggers](add-ons/workflow/triggers.md)
+* [UI Builder](add-ons/uibuilder/README.md)
+  * [Installation](add-ons/uibuilder/installation.md)
+  * [Triggers](add-ons/uibuilder/triggers.md)
+  * [Actions](add-ons/uibuilder/actions.md)
 
 ## Extending
 

--- a/18/umbraco-automate/add-ons/README.md
+++ b/18/umbraco-automate/add-ons/README.md
@@ -18,6 +18,8 @@ Add-ons are NuGet packages that add new triggers and actions to Umbraco Automate
 | [Commerce](commerce/) | Triggers and actions for orders, payments, stock, discounts, and gift cards.                                                           |
 | [Engage](engage/)     | Triggers for A/B tests, segments, personas, and customer journeys. Actions for goals, persona scoring, and journey scoring.            |
 | [Deploy](deploy/)     | Deploy lifecycle triggers, plus Umbraco Deploy support for transferring automations, workspaces, and connections between environments. |
+| [Workflow](workflow/) | Triggers for the content approval lifecycle, task assignment, workflow emails, and content reviews.                                    |
+| [UI Builder](uibuilder/) | Triggers for entity changes in UI Builder collections. Actions for creating and deleting entities.                                 |
 
 ## Installing an Add-on
 

--- a/18/umbraco-automate/add-ons/uibuilder/README.md
+++ b/18/umbraco-automate/add-ons/uibuilder/README.md
@@ -1,0 +1,30 @@
+---
+description: >-
+  The UI Builder add-on adds triggers and actions for Umbraco UI Builder
+  entities to Umbraco Automate.
+---
+
+# UI Builder
+
+The UI Builder add-on lets your automations react to entity changes in Umbraco UI Builder collections. It also lets you create or delete entities from inside an automation.
+
+## What It Adds
+
+| Type     | Items                                          |
+| -------- | ----------------------------------------------- |
+| Triggers | Entity Saved, Entity Created, Entity Deleted    |
+| Actions  | Create Entity, Delete Entity                    |
+
+## In This Section
+
+{% content-ref url="installation.md" %}
+[Installation](installation.md)
+{% endcontent-ref %}
+
+{% content-ref url="triggers.md" %}
+[Triggers](triggers.md)
+{% endcontent-ref %}
+
+{% content-ref url="actions.md" %}
+[Actions](actions.md)
+{% endcontent-ref %}

--- a/18/umbraco-automate/add-ons/uibuilder/actions.md
+++ b/18/umbraco-automate/add-ons/uibuilder/actions.md
@@ -1,0 +1,18 @@
+---
+description: >-
+  Reference for the actions contributed by the Umbraco.UIBuilder.Automate
+  add-on.
+---
+
+# Actions
+
+The UI Builder add-on contributes the following actions.
+
+| Display Name  | Alias                          | Purpose                                                  |
+| -------------- | -------------------------------- | ----------------------------------------------------------- |
+| Create Entity  | `umbracoUIBuilder.createEntity`  | Create a new entity in a named collection from a JSON payload. |
+| Delete Entity  | `umbracoUIBuilder.deleteEntity`  | Delete an entity from a named collection by ID.               |
+
+{% hint style="info" %}
+Open the step in the canvas to see each action's settings and output fields. Both actions support bindings, so the collection alias, entity JSON, and entity ID can all come from an upstream trigger or step.
+{% endhint %}

--- a/18/umbraco-automate/add-ons/uibuilder/installation.md
+++ b/18/umbraco-automate/add-ons/uibuilder/installation.md
@@ -1,0 +1,27 @@
+---
+description: >-
+  Install the Umbraco.UIBuilder.Automate add-on alongside Umbraco UI Builder.
+---
+
+# Installation
+
+## Prerequisites
+
+* Umbraco Automate installed and configured
+* Umbraco UI Builder installed and configured, with at least one collection registered
+
+## Install the Package
+
+{% code title=".NET CLI" %}
+```bash
+dotnet add package Umbraco.UIBuilder.Automate
+```
+{% endcode %}
+
+Restart your Umbraco site. The UI Builder triggers and actions appear in the catalogue under the **UI Builder** group.
+
+## Next Steps
+
+{% content-ref url="triggers.md" %}
+[Triggers](triggers.md)
+{% endcontent-ref %}

--- a/18/umbraco-automate/add-ons/uibuilder/triggers.md
+++ b/18/umbraco-automate/add-ons/uibuilder/triggers.md
@@ -1,0 +1,21 @@
+---
+description: >-
+  Reference for the triggers contributed by the Umbraco.UIBuilder.Automate
+  add-on.
+---
+
+# Triggers
+
+The UI Builder add-on contributes the following triggers.
+
+| Display Name   | Alias                            |
+| --------------- | ---------------------------------- |
+| Entity Saved    | `umbracoUIBuilder.entitySaved`     |
+| Entity Created  | `umbracoUIBuilder.entityCreated`   |
+| Entity Deleted  | `umbracoUIBuilder.entityDeleted`   |
+
+**Entity Saved** fires whenever an entity is created or updated in any registered collection. **Entity Created** fires only the first time an entity is created, not on later updates. Each trigger has an optional **Collection Alias** setting to filter to a single collection; leave it blank to fire for every collection.
+
+{% hint style="info" %}
+Trigger output includes the collection alias, the entity ID, and the entity serialized as JSON. Properties configured as encrypted on the collection are omitted from the JSON, so decrypted secrets are never exposed to an automation. Inspect a real run in the **Runs** view to see the exact field names, then use the binding picker to reference them in downstream steps.
+{% endhint %}

--- a/18/umbraco-automate/add-ons/workflow/README.md
+++ b/18/umbraco-automate/add-ons/workflow/README.md
@@ -1,0 +1,29 @@
+---
+description: >-
+  The Workflow add-on adds triggers for Umbraco Workflow's content approval
+  lifecycle, tasks, emails, and content reviews.
+---
+
+# Workflow
+
+The Workflow add-on lets your automations react to Umbraco Workflow events, such as approvals, rejections, task assignments, and content reviews.
+
+## What It Adds
+
+| Type     | Items                                                                                          |
+| -------- | ---------------------------------------------------------------------------------------------- |
+| Triggers | Workflow lifecycle, task assignment, workflow emails, content reviews                          |
+
+{% hint style="info" %}
+The Workflow add-on contributes triggers only. It does not add any actions.
+{% endhint %}
+
+## In This Section
+
+{% content-ref url="installation.md" %}
+[Installation](installation.md)
+{% endcontent-ref %}
+
+{% content-ref url="triggers.md" %}
+[Triggers](triggers.md)
+{% endcontent-ref %}

--- a/18/umbraco-automate/add-ons/workflow/installation.md
+++ b/18/umbraco-automate/add-ons/workflow/installation.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Install the Umbraco.Forms.Automate add-on alongside Umbraco Forms.
+  Install the Umbraco.Workflow.Automate add-on alongside Umbraco Workflow.
 ---
 
 # Installation
@@ -8,17 +8,17 @@ description: >-
 ## Prerequisites
 
 * Umbraco Automate installed and configured
-* Umbraco Forms 18.0 or later installed
+* Umbraco Workflow installed and configured
 
 ## Install the Package
 
 {% code title=".NET CLI" %}
 ```bash
-dotnet add package Umbraco.Forms.Automate
+dotnet add package Umbraco.Workflow.Automate
 ```
 {% endcode %}
 
-Restart your Umbraco site. The Forms triggers and actions appear in the catalogue under the **Forms** group.
+Restart your Umbraco site. The Workflow triggers appear in the catalogue under the **Workflow** group.
 
 ## Next Steps
 

--- a/18/umbraco-automate/add-ons/workflow/triggers.md
+++ b/18/umbraco-automate/add-ons/workflow/triggers.md
@@ -1,0 +1,43 @@
+---
+description: >-
+  Reference for the triggers contributed by the Umbraco.Workflow.Automate
+  add-on.
+---
+
+# Triggers
+
+The Workflow add-on contributes the following triggers.
+
+## Workflow Lifecycle Triggers
+
+| Display Name          | Alias                          |
+| ---------------------- | ------------------------------- |
+| Workflow Started       | `umbracoWorkflow.started`       |
+| Workflow Completed     | `umbracoWorkflow.completed`     |
+| Workflow Approved      | `umbracoWorkflow.approved`      |
+| Workflow Rejected      | `umbracoWorkflow.rejected`      |
+| Workflow Cancelled     | `umbracoWorkflow.cancelled`     |
+| Workflow Resubmitted   | `umbracoWorkflow.resubmitted`   |
+
+## Task Triggers
+
+| Display Name  | Alias                        |
+| -------------- | ----------------------------- |
+| Task Assigned  | `umbracoWorkflow.taskAssigned` |
+
+## Email Triggers
+
+| Display Name          | Alias                              |
+| ---------------------- | ------------------------------------ |
+| Workflow Email Sent     | `umbracoWorkflow.emailSent`          |
+| Reminder Emails Sent    | `umbracoWorkflow.reminderEmailsSent` |
+
+## Content Review Triggers
+
+| Display Name              | Alias                                    |
+| --------------------------- | ------------------------------------------ |
+| Content Review Completed   | `umbracoWorkflow.contentReviewCompleted`   |
+
+{% hint style="info" %}
+Each Workflow trigger emits details about the workflow instance, task, or content review it fired on. Fields include the node ID, entity key, workflow type and status, author, and comment. Inspect a real run in the **Runs** view to see the exact field names, then use the binding picker to reference them in downstream steps.
+{% endhint %}

--- a/18/umbraco-automate/concepts/connections.md
+++ b/18/umbraco-automate/concepts/connections.md
@@ -33,6 +33,27 @@ Connections are stored globally but their use is scoped by workspace. Each works
 
 Most connection types implement a validation step. Click **Test connection** in the connection editor to check the credentials work before saving.
 
+## Configuration References
+
+Connection settings support configuration references. Values starting with `$` are resolved from configuration (`appsettings.json`, environment variables, Azure Key Vault, and so on) at runtime.
+
+References resolve from two dedicated configuration sections:
+
+* `Umbraco:Automate:Secrets` — for sensitive values such as API keys. These can only be referenced from settings fields marked sensitive (see [Create a Custom Connection Type](../extending/custom-connection-type.md)).
+* `Umbraco:Automate:Variables` — for non-sensitive per-environment values such as endpoints, IDs, or feature flags.
+
+Place the values you want to reference under these sections, then point the setting at them with the `$` prefix:
+
+{% code title="Connection Settings" %}
+```
+API Key: $Umbraco:Automate:Secrets:SlackToken
+```
+{% endcode %}
+
+{% hint style="info" %}
+See [Configuration](../getting-started/configuration.md#configuration-references) for the full syntax, the default allow-list, and how to expose additional configuration sections.
+{% endhint %}
+
 ## See Also
 
 * [Manage Connections](../backoffice/connections.md)

--- a/18/umbraco-automate/extending/custom-connection-type.md
+++ b/18/umbraco-automate/extending/custom-connection-type.md
@@ -30,12 +30,40 @@ public sealed class MyServiceConnectionSettings
 
     [Field(
         Label = "API key",
-        Description = "The API key issued by the service.",
+        Description = "The API key issued by the service. Supports config references like $Umbraco:Automate:Secrets:ApiKey.",
         IsSensitive = true)]
     public string ApiKey { get; set; } = string.Empty;
 }
 ```
 {% endcode %}
+
+## Configuration References
+
+Settings values starting with `$` are resolved from configuration. References resolve from `Umbraco:Automate:Secrets` (sensitive values) and `Umbraco:Automate:Variables` (non-sensitive values) by default.
+
+**In the UI:** enter `$Umbraco:Automate:Secrets:ApiKey`
+
+**In appsettings.json:**
+
+{% code title="appsettings.json" %}
+```json
+{
+  "Umbraco": {
+    "Automate": {
+      "Secrets": {
+        "ApiKey": "the-actual-key"
+      }
+    }
+  }
+}
+```
+{% endcode %}
+
+This keeps secrets out of the database and supports environment-specific values.
+
+{% hint style="info" %}
+Values under `Umbraco:Automate:Secrets` may only be referenced from fields marked `IsSensitive = true`. To reference values from other configuration sections, add their prefix to `Umbraco:Automate:AllowedConfigurationKeyPrefixes` — see [Configuration](../getting-started/configuration.md#configuration-references).
+{% endhint %}
 
 ## Connection Type Class
 

--- a/18/umbraco-automate/getting-started/configuration.md
+++ b/18/umbraco-automate/getting-started/configuration.md
@@ -89,6 +89,80 @@ The defaults are suitable for most sites:
 | `Execution`  | Default step timeout, concurrent run limit, maximum automation chain depth, and maximum HTTP response body size. |
 | `Governance` | Audit log retention and sensitive data masking.                                 |
 
+## Configuration References
+
+A settings field can reference a configuration value at run time with a `$Key:Path` syntax, instead of storing the value directly:
+
+```
+$Umbraco:Automate:Secrets:SlackToken
+```
+
+This lets administrators keep credentials and per-environment values in configuration — `appsettings.json`, environment variables, Azure Key Vault, and so on — rather than in the automation database.
+
+### Allowed Key Prefixes
+
+Automations run under an elevated service account, so configuration resolution is **default-deny**: a key only resolves when it falls under one of `AllowedConfigurationKeyPrefixes`. Any other key fails to resolve.
+
+Two prefixes are allowed by default:
+
+| Prefix                        | Intended for                                                          |
+| ------------------------------ | ---------------------------------------------------------------------- |
+| `Umbraco:Automate:Secrets`    | Sensitive values, such as API tokens.                                 |
+| `Umbraco:Automate:Variables`  | Non-sensitive per-environment values, such as base URLs or feature flags. |
+
+{% code title="appsettings.json" %}
+```json
+{
+  "Umbraco": {
+    "Automate": {
+      "Secrets": {
+        "SlackToken": "xoxb-..."
+      },
+      "Variables": {
+        "BaseUrl": "https://example.com"
+      }
+    }
+  }
+}
+```
+{% endcode %}
+
+Reference these values from a setting field with `$Umbraco:Automate:Secrets:SlackToken` or `$Umbraco:Automate:Variables:BaseUrl`.
+
+To expose an existing configuration section to automations without copying its values, add its prefix to `AllowedConfigurationKeyPrefixes`:
+
+{% code title="appsettings.json" %}
+```json
+{
+  "Umbraco": {
+    "Automate": {
+      "AllowedConfigurationKeyPrefixes": [
+        "Umbraco:Automate:Secrets",
+        "Umbraco:Automate:Variables",
+        "MyApp:ThirdPartyApi"
+      ]
+    }
+  }
+}
+```
+{% endcode %}
+
+{% hint style="warning" %}
+Everything under an added prefix becomes readable by anyone who can configure automation settings. Only add a prefix you are comfortable exposing to automation authors.
+{% endhint %}
+
+### Secret Key Prefixes
+
+Values under a prefix listed in `SecretConfigurationKeyPrefixes` (`Umbraco:Automate:Secrets` by default) can only be referenced from a settings field marked sensitive. See [Create a Custom Connection Type](../extending/custom-connection-type.md) for `IsSensitive`. Referencing a secret key from a non-sensitive field fails. A resolved secret can only land in a field the system already encrypts at rest and masks in run logs.
+
+`Umbraco:Automate:Variables` is deliberately left off `SecretConfigurationKeyPrefixes`, so non-secret values can be referenced from any field.
+
+Matching for both lists is segment-aware and case-insensitive: the prefix `Umbraco:Automate:Secrets` matches `Umbraco:Automate:Secrets:SlackToken` but not `Umbraco:Automate:SecretsBackup:X`.
+
+{% hint style="info" %}
+`AllowedConfigurationKeyPrefixes` and `SecretConfigurationKeyPrefixes` are configured in `appsettings.json` only — they are not editable from the backoffice.
+{% endhint %}
+
 ## Next Steps
 
 {% content-ref url="first-automation.md" %}


### PR DESCRIPTION
## 📋 Description

Documents three gaps found while auditing the `umbraco-automate` docs against recent changes to the `Umbraco.*.Automate` satellite repos:

- **Workflow add-on** had no docs at all (`add-ons/workflow/{README,installation,triggers}.md`), despite being one of the original five satellites. Content is sourced from the actual trigger set in `Umbraco.Workflow.Automate` (10 triggers, no actions).
- **UI Builder add-on** is new (shipped July 2026 as the sixth satellite) and had no docs (`add-ons/uibuilder/{README,installation,triggers,actions}.md`) — 3 triggers, 2 actions, sourced from `Umbraco.UIBuilder.Automate`.
- **Configuration references** (`$Key:Path` syntax, `AllowedConfigurationKeyPrefixes`/`SecretConfigurationKeyPrefixes`) were undocumented even though the underlying feature is code-identical to the already-documented `ai-in-umbraco` equivalent. Added to `getting-started/configuration.md`, `concepts/connections.md`, and `extending/custom-connection-type.md`, matching the ai-in-umbraco docs' structure and heading names as closely as possible.
- Fixed a stale prerequisite in `18/umbraco-automate/add-ons/forms/installation.md` ("Umbraco Forms 17.3 or later" left over in the v18 tree).

Applied identically to both the `/17` and `/18` doc trees. Vale linter passes clean (0 errors/warnings) on all changed/added files.

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Automate — v17 and v18 docs.

## Deadline (if relevant)

ASAP please!