### PR TITLE
Mention umbracoAIAuditLog database table in audit logs docs

### DIFF
--- a/17/ai-in-umbraco/backoffice/audit-logs.md
+++ b/17/ai-in-umbraco/backoffice/audit-logs.md
@@ -7,6 +7,10 @@ description: >-
 
 Every AI operation (chat completion, embedding generation) is logged with detailed information about the request, response, timing, and outcome. Use audit logs for monitoring, debugging, and compliance.
 
+{% hint style="info" %}
+Audit logs are stored in the `umbracoAIAuditLog` database table.
+{% endhint %}
+
 ## Accessing Audit Logs
 
 1. Navigate to the **AI** section in the main navigation.

--- a/18/ai-in-umbraco/backoffice/audit-logs.md
+++ b/18/ai-in-umbraco/backoffice/audit-logs.md
@@ -7,6 +7,10 @@ description: >-
 
 Every AI operation (chat completion, embedding generation) is logged with detailed information about the request, response, timing, and outcome. Use audit logs for monitoring, debugging, and compliance.
 
+{% hint style="info" %}
+Audit logs are stored in the `umbracoAIAuditLog` database table.
+{% endhint %}
+
 ## Accessing Audit Logs
 
 1. Navigate to the **AI** section in the main navigation.


### PR DESCRIPTION
## 📋 Description

Adds a note to the audit logs page mentioning that AI audit logs are stored in the umbracoAIAuditLog database table.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

v17 and v18