### PR TITLE
Packages: Add App_Plugins cache-busting documentation (17.6 & 18.1)

### DIFF
--- a/.github/styles/config/dictionaries/umbraco.dic
+++ b/.github/styles/config/dictionaries/umbraco.dic
@@ -78,7 +78,9 @@ browsable
 buildable
 bundleId
 bundler
+bundlers
 cacheable
+Cachebuster
 camelCase
 camelcase
 cancellationToken

--- a/17/umbraco-cms/develop-with-umbraco/configuration/pluginssettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/pluginssettings.md
@@ -31,7 +31,7 @@ This setting allows you to customize what file types plugins are allowed to use 
 ```
 {% endcode %}
 
-As you can see above, by default, markup, styles, scripts, source maps, images, fonts, configurations, and license type are included. If you were to, for example, remove the ".html" entry, then plugins would no longer be allowed to use HTML files.
+By default, plugins can serve markup, styles, scripts, source maps, images, fonts, configuration files, and license files. If you remove the `.html` entry, plugins cannot serve HTML files.
 
 ## Cachebuster
 

--- a/17/umbraco-cms/develop-with-umbraco/configuration/pluginssettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/pluginssettings.md
@@ -23,7 +23,8 @@ This setting allows you to customize what file types plugins are allowed to use 
         ".eot", ".ttf", ".woff", ".woff2",
         ".xml", ".json", ".config",
         ".lic",
-        ".map"]
+        ".map"
+      ]
     }
   }
 }

--- a/17/umbraco-cms/develop-with-umbraco/configuration/pluginssettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/pluginssettings.md
@@ -4,8 +4,13 @@ description: Information on the plugins settings section
 
 # Plugins settings
 
-The Plugins settings allow you to configure how Umbraco handles plugins. Currently, you can only configure browsable file extensions, which allows you to customize what file types plugins are allowed to use for the front end. The default configuration looks like this:
+The Plugins settings allow you to configure how Umbraco handles plugins. You can configure which file extensions plugins are allowed to serve, and a cache buster for plugin assets.
 
+## Browsable file extensions
+
+This setting allows you to customize what file types plugins are allowed to use for the front end. The default configuration looks like this:
+
+{% code title="appsettings.json" %}
 ```json
 "Umbraco": {
   "CMS": {
@@ -17,10 +22,38 @@ The Plugins settings allow you to configure how Umbraco handles plugins. Current
         ".jpg", ".jpeg", ".gif", ".png", ".svg",
         ".eot", ".ttf", ".woff", ".woff2",
         ".xml", ".json", ".config",
-        ".lic"]
+        ".lic",
+        ".map"]
     }
   }
 }
 ```
+{% endcode %}
 
-As you can see above, by default, markup, styles, scripts, images, fonts, configurations, and license type are included. If you were to, for example, remove the ".html" entry, then plugins would no longer be allowed to use HTML files.
+As you can see above, by default, markup, styles, scripts, source maps, images, fonts, configurations, and license type are included. If you were to, for example, remove the ".html" entry, then plugins would no longer be allowed to use HTML files.
+
+## Cachebuster
+
+{% hint style="info" %}
+The `Cachebuster` setting is available from Umbraco 17.6.
+{% endhint %}
+
+This setting lets you force browsers to re-fetch all package assets served from `/App_Plugins`. It is empty by default and has no effect until you set it.
+
+Set it to a value that changes with each deployment, for example a build number or a git commit hash:
+
+{% code title="appsettings.json" %}
+```json
+"Umbraco": {
+  "CMS": {
+    "Plugins": {
+      "Cachebuster": "build-20260713.1"
+    }
+  }
+}
+```
+{% endcode %}
+
+A short hash of the value is included in the cache-busting query string that Umbraco appends to package asset URLs. When the value changes, the asset URLs of every package change at once. The value is resolved on the server, so it stays consistent across servers in a load-balanced setup.
+
+Read more about how packages are cache busted in the [Umbraco Package](../../extend-your-project/backoffice-extensions/umbraco-package.md#cache-busting) article.

--- a/17/umbraco-cms/extend-your-project/backoffice-extensions/development-flow/vite-package-setup.md
+++ b/17/umbraco-cms/extend-your-project/backoffice-extensions/development-flow/vite-package-setup.md
@@ -188,7 +188,7 @@ export default class MyElement extends LitElement {
 Learn more about the abilities of the manifest file in the [Umbraco Package Manifest](../umbraco-package.md) article.
 
 {% hint style="info" %}
-From Umbraco 17.6, the `version` field is used to cache bust your package's assets. Bump it whenever you release changed assets. The content-hashed chunks that Vite generates bust their own cache. Read more in the [Umbraco Package](../umbraco-package.md#cache-busting) article.
+Umbraco uses the `version` field to cache bust your package's assets. Bump it whenever you release changed assets. The content-hashed chunks that Vite generates bust their own cache. Read more in the [Umbraco Package](../umbraco-package.md#cache-busting) article.
 {% endhint %}
 
 #### Testing your package

--- a/17/umbraco-cms/extend-your-project/backoffice-extensions/development-flow/vite-package-setup.md
+++ b/17/umbraco-cms/extend-your-project/backoffice-extensions/development-flow/vite-package-setup.md
@@ -187,6 +187,10 @@ export default class MyElement extends LitElement {
 
 Learn more about the abilities of the manifest file in the [Umbraco Package Manifest](../umbraco-package.md) article.
 
+{% hint style="info" %}
+From Umbraco 17.6, the `version` field is used to cache bust your package's assets. Bump it whenever you release changed assets. The content-hashed chunks that Vite generates bust their own cache. Read more in the [Umbraco Package](../umbraco-package.md#cache-busting) article.
+{% endhint %}
+
 #### Testing your package
 
 To test your package, run your site.

--- a/17/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-registry/register-extensions.md
+++ b/17/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-registry/register-extensions.md
@@ -48,13 +48,16 @@ When writing the Umbraco Package Manifest, you can use the JSON schema located i
 ```
 {% endcode %}
 
-There are two additional, optional properties that can be useful:
+Two additional, optional properties are particularly useful:
 
 * `id` - a unique identifier of the package. If you are creating a NuGet package, use this value as the id.
-* `version` - the version of the package that is displayed in the backoffice in the overview of installed packages. This is also used for package migrations.
+* `version` - the version of the package that is displayed in the backoffice in the overview of installed packages. This is also used for package migrations. From Umbraco 17.6, the version is also used to cache bust the package's assets, as described in the [Umbraco Package](../../umbraco-package.md#cache-busting) article.
+
+You can find all available properties in the [Umbraco Package](../../umbraco-package.md#root-fields) article.
 
 This is an example of a full `umbraco-package.json` that registers two localization extensions:
 
+{% code title="umbraco-package.json" %}
 ```json
 {
   "$schema": "../../umbraco-package-schema.json",
@@ -83,6 +86,7 @@ This is an example of a full `umbraco-package.json` that registers two localizat
   ]
 }
 ```
+{% endcode %}
 
 ## Advanced Registration
 

--- a/17/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-registry/register-extensions.md
+++ b/17/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-registry/register-extensions.md
@@ -51,7 +51,7 @@ When writing the Umbraco Package Manifest, you can use the JSON schema located i
 Two additional, optional properties are particularly useful:
 
 * `id` - a unique identifier of the package. If you are creating a NuGet package, use this value as the id.
-* `version` - the version of the package that is displayed in the backoffice in the overview of installed packages. This is also used for package migrations. From Umbraco 17.6, the version is also used to cache bust the package's assets, as described in the [Umbraco Package](../../umbraco-package.md#cache-busting) article.
+* `version` - the version of the package that is displayed in the backoffice in the overview of installed packages. This is also used for package migrations.
 
 You can find all available properties in the [Umbraco Package](../../umbraco-package.md#root-fields) article.
 

--- a/17/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
+++ b/17/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
@@ -219,7 +219,7 @@ You can also take control of the versioning yourself. There are two alternatives
 
 Umbraco leaves URLs that already contain a query string untouched. You can therefore version an asset yourself:
 
-{% code title="umbraco-package.json" %}
+{% code title="umbraco-package.json (snippet)" %}
 ```json
 {
     "type": "propertyEditorUi",

--- a/17/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
+++ b/17/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
@@ -49,6 +49,7 @@ The `umbraco-package` accepts these fields:
     "version": "",
     "allowTelemetry": true,
     "allowPublicAccess": false,
+    "allowCacheBusting": true,
     "importmap": {
         "imports": {
             "": ""
@@ -73,6 +74,8 @@ Allows you to specify a friendly name for your package that will be used for tel
 
 The version of your package, if this is not specified there will be no version-specific information for your package. This is used for telemetry and to help users understand what version of your package they are using. It is also used for package migrations. The version should follow the [Semantic Versioning](https://semver.org/) format.
 
+From Umbraco 17.6, the version also acts as the cache key for your package's `/App_Plugins` assets. Read more in the [Cache busting](#cache-busting) section.
+
 ### Allow Telemetry
 
 With this field, you can control the telemetry of this package, this will provide Umbraco with the knowledge of how many installations use this package.
@@ -86,6 +89,12 @@ Also known as: `allowPackageTelemetry`
 This field is used to allow public access to the package. If set to `true`, the package will be available for anonymous usage, for example on the login screen. If set to `false`, the package will only be available to logged-in users.
 
 The default is `false`.
+
+### Allow Cache Busting
+
+This field controls whether Umbraco appends a cache-busting query string to the package's `/App_Plugins` assets. Set it to `false` to opt out. Read more in the [Cache busting](#cache-busting) section.
+
+The default is `true`.
 
 ### Importmap
 
@@ -160,6 +169,153 @@ Common aliases include:
 * `Umb.Condition.UserPermission.Document`.
 
 For a full list and details, see the [Extension Conditions](extending-overview/extension-types/condition.md) article.
+
+## Cache busting
+
+{% hint style="info" %}
+Automatic cache busting for package assets is available from Umbraco 17.6.
+{% endhint %}
+
+Browsers cache the assets that your package serves from `/App_Plugins`. Without cache busting, users can keep running old JavaScript and CSS after you ship an update. To prevent this, Umbraco appends a cache-busting query string to your package's asset URLs.
+
+The value is derived from the `version` field in your `umbraco-package.json` file. Umbraco appends it as `?umb__rnd={value}` to:
+
+* Import map entries pointing to `/App_Plugins` in the server-rendered import map.
+* Asset URLs of your registered extensions, for example `element` and `js` paths. The Backoffice appends the value when the extensions are loaded. This also covers the login screen and the preview pane.
+
+For example, with `"version": "1.2.3"` an asset URL is rendered as `/App_Plugins/MyPackage/dist/index.js?umb__rnd=1.2.3`.
+
+The host can configure a `Cachebuster` value as described in the [Plugins settings](../../develop-with-umbraco/configuration/pluginssettings.md) article. When set, a short hash of that value is appended to the version, for example `?umb__rnd=1.2.3-7bb8e1f`.
+
+### The version is your cache key
+
+The cache-busting value works both ways. As long as the version is unchanged, browsers keep reusing the assets they already downloaded. When the version changes, all asset URLs change with it, and browsers fetch the new files. Bump the `version` field whenever the assets you ship change.
+
+{% hint style="warning" %}
+If you change assets without bumping the version, the asset URLs stay the same. Browsers can then keep serving the old files from their cache. Treat a version bump as mandatory for every release that changes assets.
+{% endhint %}
+
+If your package has no `version`, the cache-busting value falls back to a hash of the host's `Cachebuster` value. That hash only changes when the host changes the setting, described in the [Plugins settings](../../develop-with-umbraco/configuration/pluginssettings.md) article. If neither is set, no query string is appended at all. Set a version to control cache busting yourself.
+
+### What is not stamped
+
+Umbraco leaves these URLs untouched:
+
+* URLs that already contain a query string. You manage the caching of these yourself.
+* URLs outside `/App_Plugins`, for example absolute URLs to a Content Delivery Network (CDN).
+* Bare module specifiers, for example `@umbraco-cms/backoffice/extension-api`.
+
+### Bundle your assets
+
+The cache buster covers the entry points that you declare in your manifest and import map. Files that those entry points import at runtime, for example code-split chunks, are requested without the query string.
+
+Use a bundler such as Vite to build your package. Bundlers add a content hash to the file names of generated chunks by default. A content-hashed file name changes whenever the file content changes, so those files bust their own cache.
+
+### Manage the version yourself
+
+You can also take control of the versioning yourself. There are two alternatives.
+
+#### Add your own query string
+
+Umbraco leaves URLs that already contain a query string untouched. You can therefore version an asset yourself:
+
+{% code title="umbraco-package.json" %}
+```json
+{
+    "type": "propertyEditorUi",
+    "alias": "My.PropertyEditorUi",
+    "name": "My Property Editor UI",
+    "element": "/App_Plugins/MyPackage/dist/my-editor.js?v=1.2.3"
+}
+```
+{% endcode %}
+
+You take over the responsibility with this approach. Remember to update the value whenever the file changes.
+
+#### Read the version from your assembly
+
+You can provide the package manifest from code instead of a `umbraco-package.json` file. Implement the `IPackageManifestReader` interface and read the version from your assembly. This keeps the manifest version in sync with your NuGet package version on every release.
+
+{% code title="MyPackageManifestReader.cs" %}
+```csharp
+using Umbraco.Cms.Core.Manifest;
+using Umbraco.Cms.Infrastructure.Manifest;
+
+namespace MyPackage;
+
+public class MyPackageManifestReader : IPackageManifestReader
+{
+    public Task<IEnumerable<PackageManifest>> ReadPackageManifestsAsync()
+    {
+        var version = typeof(MyPackageManifestReader).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
+
+        PackageManifest manifest = new()
+        {
+            Id = "My.Package",
+            Name = "My Package",
+            Version = version,
+            Extensions =
+            [
+                new Dictionary<string, object>
+                {
+                    ["type"] = "propertyEditorUi",
+                    ["alias"] = "My.PropertyEditorUi",
+                    ["name"] = "My Property Editor UI",
+                    ["element"] = "/App_Plugins/MyPackage/dist/my-editor.js",
+                },
+            ],
+        };
+
+        return Task.FromResult<IEnumerable<PackageManifest>>([manifest]);
+    }
+}
+```
+{% endcode %}
+
+Register the reader in a composer:
+
+{% code title="MyPackageComposer.cs" %}
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Infrastructure.Manifest;
+
+namespace MyPackage;
+
+public class MyPackageComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.Services.AddSingleton<IPackageManifestReader, MyPackageManifestReader>();
+    }
+}
+```
+{% endcode %}
+
+{% hint style="info" %}
+The manifest reader replaces the `umbraco-package.json` file. Remove the file from your package to avoid registering the extensions twice.
+{% endhint %}
+
+### Opting out
+
+Set `allowCacheBusting` to `false` in your `umbraco-package.json` file to opt out of the automatic stamping:
+
+{% code title="umbraco-package.json" %}
+```json
+{
+    "name": "My Package",
+    "version": "1.2.3",
+    "allowCacheBusting": false
+}
+```
+{% endcode %}
+
+Omitting the `version` field also stops the version-based cache busting. This is not recommended, as the version is also used for package migrations and telemetry. Keep in mind that the host's `Cachebuster` value is still applied when set.
+
+{% hint style="warning" %}
+The legacy `%CACHE_BUSTER%` token still resolves to Umbraco's global cache-busting hash. That hash only changes when Umbraco itself is updated. The token is deprecated and is scheduled for removal in Umbraco 20. Rely on the automatic stamping instead.
+{% endhint %}
 
 ## Package Manifest IntelliSense
 

--- a/17/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
+++ b/17/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
@@ -185,11 +185,11 @@ The value is derived from the `version` field in your `umbraco-package.json` fil
 
 For example, with `"version": "1.2.3"` an asset URL is rendered as `/App_Plugins/MyPackage/dist/index.js?umb__rnd=1.2.3`.
 
-The host can configure a `Cachebuster` value as described in the [Plugins settings](../../develop-with-umbraco/configuration/pluginssettings.md) article. When set, a short hash of that value is appended to the version, for example `?umb__rnd=1.2.3-7bb8e1f`.
+The host can configure a `Cachebuster` value as described in the [Plugins settings](../../develop-with-umbraco/configuration/pluginssettings.md) article. When set, Umbraco appends a short hash of that value to the version (for example, `?umb__rnd=1.2.3-7bb8e1f`).
 
 ### The version is your cache key
 
-The cache-busting value works both ways. As long as the version is unchanged, browsers keep reusing the assets they already downloaded. When the version changes, all asset URLs change with it, and browsers fetch the new files. Bump the `version` field whenever the assets you ship change.
+The cache-busting value works both ways. When the version stays the same, browsers reuse the assets they already downloaded. When the version changes, browsers fetch the new files. Bump the `version` field whenever the assets you ship change.
 
 {% hint style="warning" %}
 If you change assets without bumping the version, the asset URLs stay the same. Browsers can then keep serving the old files from their cache. Treat a version bump as mandatory for every release that changes assets.

--- a/17/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
+++ b/17/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
@@ -213,7 +213,7 @@ Use a bundler such as Vite to build your package. Bundlers add a content hash to
 
 ### Manage the version yourself
 
-You can also take control of the versioning yourself. There are two alternatives.
+You can also take control of the versioning yourself. There are two alternatives:
 
 #### Add your own query string
 

--- a/17/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
+++ b/17/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
@@ -74,7 +74,7 @@ Allows you to specify a friendly name for your package that will be used for tel
 
 The version of your package, if this is not specified there will be no version-specific information for your package. This is used for telemetry and to help users understand what version of your package they are using. It is also used for package migrations. The version should follow the [Semantic Versioning](https://semver.org/) format.
 
-From Umbraco 17.6, the version also acts as the cache key for your package's `/App_Plugins` assets. Read more in the [Cache busting](#cache-busting) section.
+The version also acts as the cache key for your package's `/App_Plugins` assets. Read more in the [Cache busting](#cache-busting) section.
 
 ### Allow Telemetry
 

--- a/17/umbraco-cms/extend-your-project/packages/good-practice-and-defaults.md
+++ b/17/umbraco-cms/extend-your-project/packages/good-practice-and-defaults.md
@@ -18,6 +18,8 @@ Files in the `App_Plugins` folder will be publicly available on the website even
 
 Files in the `App_Plugins` folder should be considered immutable. This means that they are not something a user of your package is expected to change on their site.
 
+Set the `version` field in your `umbraco-package.json` file and bump it in every release. From Umbraco 17.6, Umbraco uses the version to cache bust your package's assets. If you release changed assets without bumping the version, browsers can keep serving the old files. Read more in the [Umbraco Package](../backoffice-extensions/umbraco-package.md#cache-busting) article.
+
 The default delivery method for files to the `App_Plugins` folder is via a `.targets` file within a package. This means when a website is built, the files in this folder are copied over from the NuGet cache. When this happens, any changes a user might have made to these files will be lost. Equally, if the user performs a `dotnet clean` on a solution, all files in the `App_Plugins` folder will be deleted.
 
 {% hint style="info" %}

--- a/17/umbraco-cms/extend-your-project/packages/good-practice-and-defaults.md
+++ b/17/umbraco-cms/extend-your-project/packages/good-practice-and-defaults.md
@@ -18,7 +18,7 @@ Files in the `App_Plugins` folder will be publicly available on the website even
 
 Files in the `App_Plugins` folder should be considered immutable. This means that they are not something a user of your package is expected to change on their site.
 
-Set the `version` field in your `umbraco-package.json` file and bump it in every release. From Umbraco 17.6, Umbraco uses the version to cache bust your package's assets. If you release changed assets without bumping the version, browsers can keep serving the old files. Read more in the [Umbraco Package](../backoffice-extensions/umbraco-package.md#cache-busting) article.
+Set the `version` field in your `umbraco-package.json` file and bump it in every release. Read more about what the version is used for in the [Umbraco Package](../backoffice-extensions/umbraco-package.md#version) article.
 
 The default delivery method for files to the `App_Plugins` folder is via a `.targets` file within a package. This means when a website is built, the files in this folder are copied over from the NuGet cache. When this happens, any changes a user might have made to these files will be lost. Equally, if the user performs a `dotnet clean` on a solution, all files in the `App_Plugins` folder will be deleted.
 

--- a/17/umbraco-cms/extend-your-project/tutorials/creating-your-first-extension.md
+++ b/17/umbraco-cms/extend-your-project/tutorials/creating-your-first-extension.md
@@ -56,6 +56,10 @@ We consider it best practice to use at least TypeScript and some kind of build t
 This code sets up a basic package with a dashboard extension.
 
 {% hint style="info" %}
+The `version` field does more than describe your package. From Umbraco 17.6, Umbraco uses it to cache bust your package's assets. Bump it whenever the assets change. Read more in the [Umbraco Package](../backoffice-extensions/umbraco-package.md#cache-busting) article.
+{% endhint %}
+
+{% hint style="info" %}
 Adding `$schema` to `umbraco-package.json` will give you IntelliSense for this file to help you see different options for your package.
 {% endhint %}
 

--- a/17/umbraco-cms/extend-your-project/tutorials/creating-your-first-extension.md
+++ b/17/umbraco-cms/extend-your-project/tutorials/creating-your-first-extension.md
@@ -56,7 +56,7 @@ We consider it best practice to use at least TypeScript and some kind of build t
 This code sets up a basic package with a dashboard extension.
 
 {% hint style="info" %}
-The `version` field does more than describe your package. From Umbraco 17.6, Umbraco uses it to cache bust your package's assets. Bump it whenever the assets change. Read more in the [Umbraco Package](../backoffice-extensions/umbraco-package.md#cache-busting) article.
+The `version` field does more than describe your package. Umbraco uses it to cache bust your package's assets. Bump it whenever the assets change. Read more in the [Umbraco Package](../backoffice-extensions/umbraco-package.md#cache-busting) article.
 {% endhint %}
 
 {% hint style="info" %}

--- a/18/umbraco-cms/develop-with-umbraco/configuration/pluginssettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/pluginssettings.md
@@ -30,7 +30,7 @@ This setting allows you to customize what file types plugins are allowed to use 
 ```
 {% endcode %}
 
-As you can see above, by default, markup, styles, scripts, source maps, images, fonts, configurations, and license type are included. If you were to, for example, remove the ".html" entry, then plugins would no longer be allowed to use HTML files.
+By default, plugins can serve markup, styles, scripts, source maps, images, fonts, configuration files, and license files. If you remove the `.html` entry, plugins cannot serve HTML files.
 
 ## Cachebuster
 

--- a/18/umbraco-cms/develop-with-umbraco/configuration/pluginssettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/pluginssettings.md
@@ -23,7 +23,8 @@ This setting allows you to customize what file types plugins are allowed to use 
         ".eot", ".ttf", ".woff", ".woff2",
         ".xml", ".json", ".config",
         ".lic",
-        ".map"]
+        ".map"
+      ]
     }
   }
 }

--- a/18/umbraco-cms/develop-with-umbraco/configuration/pluginssettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/pluginssettings.md
@@ -4,8 +4,13 @@ description: Information on the plugins settings section
 
 # Plugins settings
 
-The Plugins settings allow you to configure how Umbraco handles plugins. Currently, you can only configure browsable file extensions, which allows you to customize what file types plugins are allowed to use for the front end. The default configuration looks like this:
+The Plugins settings allow you to configure how Umbraco handles plugins. You can configure which file extensions plugins are allowed to serve, and a cache buster for plugin assets.
 
+## Browsable file extensions
+
+This setting allows you to customize what file types plugins are allowed to use for the front end. The default configuration looks like this:
+
+{% code title="appsettings.json" %}
 ```json
 "Umbraco": {
   "CMS": {
@@ -17,10 +22,38 @@ The Plugins settings allow you to configure how Umbraco handles plugins. Current
         ".jpg", ".jpeg", ".gif", ".png", ".svg",
         ".eot", ".ttf", ".woff", ".woff2",
         ".xml", ".json", ".config",
-        ".lic"]
+        ".lic",
+        ".map"]
     }
   }
 }
 ```
+{% endcode %}
 
-As you can see above, by default, markup, styles, scripts, images, fonts, configurations, and license type are included. If you were to, for example, remove the ".html" entry, then plugins would no longer be allowed to use HTML files.
+As you can see above, by default, markup, styles, scripts, source maps, images, fonts, configurations, and license type are included. If you were to, for example, remove the ".html" entry, then plugins would no longer be allowed to use HTML files.
+
+## Cachebuster
+
+{% hint style="info" %}
+The `Cachebuster` setting is available from Umbraco 18.1.
+{% endhint %}
+
+This setting lets you force browsers to re-fetch all package assets served from `/App_Plugins`. It is empty by default and has no effect until you set it.
+
+Set it to a value that changes with each deployment, for example a build number or a git commit hash:
+
+{% code title="appsettings.json" %}
+```json
+"Umbraco": {
+  "CMS": {
+    "Plugins": {
+      "Cachebuster": "build-20260713.1"
+    }
+  }
+}
+```
+{% endcode %}
+
+A short hash of the value is included in the cache-busting query string that Umbraco appends to package asset URLs. When the value changes, the asset URLs of every package change at once. The value is resolved on the server, so it stays consistent across servers in a load-balanced setup.
+
+Read more about how packages are cache busted in the [Umbraco Package](../../extend-your-project/backoffice-extensions/umbraco-package.md#cache-busting) article.

--- a/18/umbraco-cms/extend-your-project/backoffice-extensions/development-flow/vite-package-setup.md
+++ b/18/umbraco-cms/extend-your-project/backoffice-extensions/development-flow/vite-package-setup.md
@@ -188,7 +188,7 @@ export default class MyElement extends LitElement {
 Learn more about the abilities of the manifest file in the [Umbraco Package Manifest](../umbraco-package.md) article.
 
 {% hint style="info" %}
-From Umbraco 18.1, the `version` field is used to cache bust your package's assets. Bump it whenever you release changed assets. The content-hashed chunks that Vite generates bust their own cache. Read more in the [Umbraco Package](../umbraco-package.md#cache-busting) article.
+Umbraco uses the `version` field to cache bust your package's assets. Bump it whenever you release changed assets. The content-hashed chunks that Vite generates bust their own cache. Read more in the [Umbraco Package](../umbraco-package.md#cache-busting) article.
 {% endhint %}
 
 #### Testing your package

--- a/18/umbraco-cms/extend-your-project/backoffice-extensions/development-flow/vite-package-setup.md
+++ b/18/umbraco-cms/extend-your-project/backoffice-extensions/development-flow/vite-package-setup.md
@@ -187,6 +187,10 @@ export default class MyElement extends LitElement {
 
 Learn more about the abilities of the manifest file in the [Umbraco Package Manifest](../umbraco-package.md) article.
 
+{% hint style="info" %}
+From Umbraco 18.1, the `version` field is used to cache bust your package's assets. Bump it whenever you release changed assets. The content-hashed chunks that Vite generates bust their own cache. Read more in the [Umbraco Package](../umbraco-package.md#cache-busting) article.
+{% endhint %}
+
 #### Testing your package
 
 To test your package, run your site.

--- a/18/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-registry/register-extensions.md
+++ b/18/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-registry/register-extensions.md
@@ -51,7 +51,7 @@ When writing the Umbraco Package Manifest, you can use the JSON schema located i
 Two additional, optional properties are particularly useful:
 
 * `id` - a unique identifier of the package. If you are creating a NuGet package, use this value as the id.
-* `version` - the version of the package that is displayed in the backoffice in the overview of installed packages. This is also used for package migrations. From Umbraco 18.1, the version is also used to cache bust the package's assets, as described in the [Umbraco Package](../../umbraco-package.md#cache-busting) article.
+* `version` - the version of the package that is displayed in the backoffice in the overview of installed packages. This is also used for package migrations.
 
 You can find all available properties in the [Umbraco Package](../../umbraco-package.md#root-fields) article.
 

--- a/18/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-registry/register-extensions.md
+++ b/18/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-registry/register-extensions.md
@@ -48,13 +48,16 @@ When writing the Umbraco Package Manifest, you can use the JSON schema located i
 ```
 {% endcode %}
 
-There are two additional, optional properties that can be useful:
+Two additional, optional properties are particularly useful:
 
 * `id` - a unique identifier of the package. If you are creating a NuGet package, use this value as the id.
-* `version` - the version of the package that is displayed in the backoffice in the overview of installed packages. This is also used for package migrations.
+* `version` - the version of the package that is displayed in the backoffice in the overview of installed packages. This is also used for package migrations. From Umbraco 18.1, the version is also used to cache bust the package's assets, as described in the [Umbraco Package](../../umbraco-package.md#cache-busting) article.
+
+You can find all available properties in the [Umbraco Package](../../umbraco-package.md#root-fields) article.
 
 This is an example of a full `umbraco-package.json` that registers two localization extensions:
 
+{% code title="umbraco-package.json" %}
 ```json
 {
   "$schema": "../../umbraco-package-schema.json",
@@ -83,6 +86,7 @@ This is an example of a full `umbraco-package.json` that registers two localizat
   ]
 }
 ```
+{% endcode %}
 
 ## Advanced Registration
 

--- a/18/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
+++ b/18/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
@@ -219,7 +219,7 @@ You can also take control of the versioning yourself. There are two alternatives
 
 Umbraco leaves URLs that already contain a query string untouched. You can therefore version an asset yourself:
 
-{% code title="umbraco-package.json" %}
+{% code title="umbraco-package.json (snippet)" %}
 ```json
 {
     "type": "propertyEditorUi",

--- a/18/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
+++ b/18/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
@@ -74,7 +74,7 @@ Allows you to specify a friendly name for your package that will be used for tel
 
 The version of your package, if this is not specified there will be no version-specific information for your package. This is used for telemetry and to help users understand what version of your package they are using. It is also used for package migrations. The version should follow the [Semantic Versioning](https://semver.org/) format.
 
-From Umbraco 18.1, the version also acts as the cache key for your package's `/App_Plugins` assets. Read more in the [Cache busting](#cache-busting) section.
+The version also acts as the cache key for your package's `/App_Plugins` assets. Read more in the [Cache busting](#cache-busting) section.
 
 ### Allow Telemetry
 

--- a/18/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
+++ b/18/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
@@ -49,6 +49,7 @@ The `umbraco-package` accepts these fields:
     "version": "",
     "allowTelemetry": true,
     "allowPublicAccess": false,
+    "allowCacheBusting": true,
     "importmap": {
         "imports": {
             "": ""
@@ -73,6 +74,8 @@ Allows you to specify a friendly name for your package that will be used for tel
 
 The version of your package, if this is not specified there will be no version-specific information for your package. This is used for telemetry and to help users understand what version of your package they are using. It is also used for package migrations. The version should follow the [Semantic Versioning](https://semver.org/) format.
 
+From Umbraco 18.1, the version also acts as the cache key for your package's `/App_Plugins` assets. Read more in the [Cache busting](#cache-busting) section.
+
 ### Allow Telemetry
 
 With this field, you can control the telemetry of this package, this will provide Umbraco with the knowledge of how many installations use this package.
@@ -86,6 +89,12 @@ Also known as: `allowPackageTelemetry`
 This field is used to allow public access to the package. If set to `true`, the package will be available for anonymous usage, for example on the login screen. If set to `false`, the package will only be available to logged-in users.
 
 The default is `false`.
+
+### Allow Cache Busting
+
+This field controls whether Umbraco appends a cache-busting query string to the package's `/App_Plugins` assets. Set it to `false` to opt out. Read more in the [Cache busting](#cache-busting) section.
+
+The default is `true`.
 
 ### Importmap
 
@@ -160,6 +169,153 @@ Common aliases include:
 * `Umb.Condition.UserPermission.Document`.
 
 For a full list and details, see the [Extension Conditions](extending-overview/extension-types/condition.md) article.
+
+## Cache busting
+
+{% hint style="info" %}
+Automatic cache busting for package assets is available from Umbraco 18.1.
+{% endhint %}
+
+Browsers cache the assets that your package serves from `/App_Plugins`. Without cache busting, users can keep running old JavaScript and CSS after you ship an update. To prevent this, Umbraco appends a cache-busting query string to your package's asset URLs.
+
+The value is derived from the `version` field in your `umbraco-package.json` file. Umbraco appends it as `?umb__rnd={value}` to:
+
+* Import map entries pointing to `/App_Plugins` in the server-rendered import map.
+* Asset URLs of your registered extensions, for example `element` and `js` paths. The Backoffice appends the value when the extensions are loaded. This also covers the login screen and the preview pane.
+
+For example, with `"version": "1.2.3"` an asset URL is rendered as `/App_Plugins/MyPackage/dist/index.js?umb__rnd=1.2.3`.
+
+The host can configure a `Cachebuster` value as described in the [Plugins settings](../../develop-with-umbraco/configuration/pluginssettings.md) article. When set, a short hash of that value is appended to the version, for example `?umb__rnd=1.2.3-7bb8e1f`.
+
+### The version is your cache key
+
+The cache-busting value works both ways. As long as the version is unchanged, browsers keep reusing the assets they already downloaded. When the version changes, all asset URLs change with it, and browsers fetch the new files. Bump the `version` field whenever the assets you ship change.
+
+{% hint style="warning" %}
+If you change assets without bumping the version, the asset URLs stay the same. Browsers can then keep serving the old files from their cache. Treat a version bump as mandatory for every release that changes assets.
+{% endhint %}
+
+If your package has no `version`, the cache-busting value falls back to a hash of the host's `Cachebuster` value. That hash only changes when the host changes the setting, described in the [Plugins settings](../../develop-with-umbraco/configuration/pluginssettings.md) article. If neither is set, no query string is appended at all. Set a version to control cache busting yourself.
+
+### What is not stamped
+
+Umbraco leaves these URLs untouched:
+
+* URLs that already contain a query string. You manage the caching of these yourself.
+* URLs outside `/App_Plugins`, for example absolute URLs to a Content Delivery Network (CDN).
+* Bare module specifiers, for example `@umbraco-cms/backoffice/extension-api`.
+
+### Bundle your assets
+
+The cache buster covers the entry points that you declare in your manifest and import map. Files that those entry points import at runtime, for example code-split chunks, are requested without the query string.
+
+Use a bundler such as Vite to build your package. Bundlers add a content hash to the file names of generated chunks by default. A content-hashed file name changes whenever the file content changes, so those files bust their own cache.
+
+### Manage the version yourself
+
+You can also take control of the versioning yourself. There are two alternatives.
+
+#### Add your own query string
+
+Umbraco leaves URLs that already contain a query string untouched. You can therefore version an asset yourself:
+
+{% code title="umbraco-package.json" %}
+```json
+{
+    "type": "propertyEditorUi",
+    "alias": "My.PropertyEditorUi",
+    "name": "My Property Editor UI",
+    "element": "/App_Plugins/MyPackage/dist/my-editor.js?v=1.2.3"
+}
+```
+{% endcode %}
+
+You take over the responsibility with this approach. Remember to update the value whenever the file changes.
+
+#### Read the version from your assembly
+
+You can provide the package manifest from code instead of a `umbraco-package.json` file. Implement the `IPackageManifestReader` interface and read the version from your assembly. This keeps the manifest version in sync with your NuGet package version on every release.
+
+{% code title="MyPackageManifestReader.cs" %}
+```csharp
+using Umbraco.Cms.Core.Manifest;
+using Umbraco.Cms.Infrastructure.Manifest;
+
+namespace MyPackage;
+
+public class MyPackageManifestReader : IPackageManifestReader
+{
+    public Task<IEnumerable<PackageManifest>> ReadPackageManifestsAsync()
+    {
+        var version = typeof(MyPackageManifestReader).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
+
+        PackageManifest manifest = new()
+        {
+            Id = "My.Package",
+            Name = "My Package",
+            Version = version,
+            Extensions =
+            [
+                new Dictionary<string, object>
+                {
+                    ["type"] = "propertyEditorUi",
+                    ["alias"] = "My.PropertyEditorUi",
+                    ["name"] = "My Property Editor UI",
+                    ["element"] = "/App_Plugins/MyPackage/dist/my-editor.js",
+                },
+            ],
+        };
+
+        return Task.FromResult<IEnumerable<PackageManifest>>([manifest]);
+    }
+}
+```
+{% endcode %}
+
+Register the reader in a composer:
+
+{% code title="MyPackageComposer.cs" %}
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Infrastructure.Manifest;
+
+namespace MyPackage;
+
+public class MyPackageComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.Services.AddSingleton<IPackageManifestReader, MyPackageManifestReader>();
+    }
+}
+```
+{% endcode %}
+
+{% hint style="info" %}
+The manifest reader replaces the `umbraco-package.json` file. Remove the file from your package to avoid registering the extensions twice.
+{% endhint %}
+
+### Opting out
+
+Set `allowCacheBusting` to `false` in your `umbraco-package.json` file to opt out of the automatic stamping:
+
+{% code title="umbraco-package.json" %}
+```json
+{
+    "name": "My Package",
+    "version": "1.2.3",
+    "allowCacheBusting": false
+}
+```
+{% endcode %}
+
+Omitting the `version` field also stops the version-based cache busting. This is not recommended, as the version is also used for package migrations and telemetry. Keep in mind that the host's `Cachebuster` value is still applied when set.
+
+{% hint style="warning" %}
+The legacy `%CACHE_BUSTER%` token still resolves to Umbraco's global cache-busting hash. That hash only changes when Umbraco itself is updated. The token is deprecated and is scheduled for removal in Umbraco 20. Rely on the automatic stamping instead.
+{% endhint %}
 
 ## Package Manifest IntelliSense
 

--- a/18/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
+++ b/18/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
@@ -185,11 +185,11 @@ The value is derived from the `version` field in your `umbraco-package.json` fil
 
 For example, with `"version": "1.2.3"` an asset URL is rendered as `/App_Plugins/MyPackage/dist/index.js?umb__rnd=1.2.3`.
 
-The host can configure a `Cachebuster` value as described in the [Plugins settings](../../develop-with-umbraco/configuration/pluginssettings.md) article. When set, a short hash of that value is appended to the version, for example `?umb__rnd=1.2.3-7bb8e1f`.
+The host can configure a `Cachebuster` value as described in the [Plugins settings](../../develop-with-umbraco/configuration/pluginssettings.md) article. When set, Umbraco appends a short hash of that value to the version (for example, `?umb__rnd=1.2.3-7bb8e1f`).
 
 ### The version is your cache key
 
-The cache-busting value works both ways. As long as the version is unchanged, browsers keep reusing the assets they already downloaded. When the version changes, all asset URLs change with it, and browsers fetch the new files. Bump the `version` field whenever the assets you ship change.
+The cache-busting value works both ways. When the version stays the same, browsers reuse the assets they already downloaded. When the version changes, browsers fetch the new files. Bump the `version` field whenever the assets you ship change.
 
 {% hint style="warning" %}
 If you change assets without bumping the version, the asset URLs stay the same. Browsers can then keep serving the old files from their cache. Treat a version bump as mandatory for every release that changes assets.

--- a/18/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
+++ b/18/umbraco-cms/extend-your-project/backoffice-extensions/umbraco-package.md
@@ -213,7 +213,7 @@ Use a bundler such as Vite to build your package. Bundlers add a content hash to
 
 ### Manage the version yourself
 
-You can also take control of the versioning yourself. There are two alternatives.
+You can also take control of the versioning yourself. There are two alternatives:
 
 #### Add your own query string
 

--- a/18/umbraco-cms/extend-your-project/packages/good-practice-and-defaults.md
+++ b/18/umbraco-cms/extend-your-project/packages/good-practice-and-defaults.md
@@ -18,7 +18,7 @@ Files in the `App_Plugins` folder will be publicly available on the website even
 
 Files in the `App_Plugins` folder should be considered immutable. This means that they are not something a user of your package is expected to change on their site.
 
-Set the `version` field in your `umbraco-package.json` file and bump it in every release. From Umbraco 18.1, Umbraco uses the version to cache bust your package's assets. If you release changed assets without bumping the version, browsers can keep serving the old files. Read more in the [Umbraco Package](../backoffice-extensions/umbraco-package.md#cache-busting) article.
+Set the `version` field in your `umbraco-package.json` file and bump it in every release. Read more about what the version is used for in the [Umbraco Package](../backoffice-extensions/umbraco-package.md#version) article.
 
 The default delivery method for files to the `App_Plugins` folder is via a `.targets` file within a package. This means when a website is built, the files in this folder are copied over from the NuGet cache. When this happens, any changes a user might have made to these files will be lost. Equally, if the user performs a `dotnet clean` on a solution, all files in the `App_Plugins` folder will be deleted.
 

--- a/18/umbraco-cms/extend-your-project/packages/good-practice-and-defaults.md
+++ b/18/umbraco-cms/extend-your-project/packages/good-practice-and-defaults.md
@@ -18,6 +18,8 @@ Files in the `App_Plugins` folder will be publicly available on the website even
 
 Files in the `App_Plugins` folder should be considered immutable. This means that they are not something a user of your package is expected to change on their site.
 
+Set the `version` field in your `umbraco-package.json` file and bump it in every release. From Umbraco 18.1, Umbraco uses the version to cache bust your package's assets. If you release changed assets without bumping the version, browsers can keep serving the old files. Read more in the [Umbraco Package](../backoffice-extensions/umbraco-package.md#cache-busting) article.
+
 The default delivery method for files to the `App_Plugins` folder is via a `.targets` file within a package. This means when a website is built, the files in this folder are copied over from the NuGet cache. When this happens, any changes a user might have made to these files will be lost. Equally, if the user performs a `dotnet clean` on a solution, all files in the `App_Plugins` folder will be deleted.
 
 {% hint style="info" %}

--- a/18/umbraco-cms/extend-your-project/tutorials/creating-your-first-extension.md
+++ b/18/umbraco-cms/extend-your-project/tutorials/creating-your-first-extension.md
@@ -56,7 +56,7 @@ We consider it best practice to use at least TypeScript and some kind of build t
 This code sets up a basic package with a dashboard extension.
 
 {% hint style="info" %}
-The `version` field does more than describe your package. From Umbraco 18.1, Umbraco uses it to cache bust your package's assets. Bump it whenever the assets change. Read more in the [Umbraco Package](../backoffice-extensions/umbraco-package.md#cache-busting) article.
+The `version` field does more than describe your package. Umbraco uses it to cache bust your package's assets. Bump it whenever the assets change. Read more in the [Umbraco Package](../backoffice-extensions/umbraco-package.md#cache-busting) article.
 {% endhint %}
 
 {% hint style="info" %}

--- a/18/umbraco-cms/extend-your-project/tutorials/creating-your-first-extension.md
+++ b/18/umbraco-cms/extend-your-project/tutorials/creating-your-first-extension.md
@@ -56,6 +56,10 @@ We consider it best practice to use at least TypeScript and some kind of build t
 This code sets up a basic package with a dashboard extension.
 
 {% hint style="info" %}
+The `version` field does more than describe your package. From Umbraco 18.1, Umbraco uses it to cache bust your package's assets. Bump it whenever the assets change. Read more in the [Umbraco Package](../backoffice-extensions/umbraco-package.md#cache-busting) article.
+{% endhint %}
+
+{% hint style="info" %}
 Adding `$schema` to `umbraco-package.json` will give you IntelliSense for this file to help you see different options for your package.
 {% endhint %}
 


### PR DESCRIPTION
## 📋 Description

> **AI disclosure:** AI-assisted — drafted with Claude Code using the repo's `umbraco-docs-content` skill. I supplied the source PR, corrections, and review; content is verified against the shipped code and the C# samples are compile-tested against `Umbraco.Infrastructure`.

Documents the per-package cache busting for `/App_Plugins` assets shipped in umbraco/Umbraco-CMS#23094. All changes are mirrored in `17/` and `18/` with matching "available from Umbraco 17.6 / 18.1" hints.

**Umbraco Package** article — new *Cache busting* section:

* `version` acts as the cache key: `?umb__rnd=<version>` is stamped on clean `/App_Plugins` URLs (importmap server-side, extension assets client-side, including the login screen and preview pane).
* The stale-asset warning: bump `version` on every release that changes assets.
* What is never stamped: existing query strings, CDN URLs, bare specifiers.
* Bundling guidance: content-hashed chunks bust their own cache; the buster covers entry points.
* Managing versioning yourself: own query string, or `IPackageManifestReader` reading the assembly version.
* `allowCacheBusting: false` opt-out and the `%CACHE_BUSTER%` deprecation (removal in Umbraco 20).
* New `allowCacheBusting` root field added to the reference.

**Plugins settings** article — the new `Umbraco:CMS:Plugins:Cachebuster` host setting ("bust everything" lever, load-balance safe).

**Pointers** added to the first-extension tutorial, Vite package setup, register-extensions, and package good-practice articles, all linking to the canonical section.

**Also fixed while scanning:**

* `pluginssettings.md`: the default `BrowsableFileExtensions` list was missing `".map"` (a CMS default since v10).
* `register-extensions.md`: understated the optional root fields; now links to the full list.
* Vale dictionary: added `Cachebuster` and `bundlers`.

**Notes for review:**

* The sibling work item AB#69068 (`assetCaching` tiers / central Cache-Control) has **not** shipped and is deliberately not documented here.
* Two places where the shipped code differs from the original task description (docs follow the code): versionless packages fall back to a hash of the host's `Cachebuster` value, and `%CACHE_BUSTER%` still resolves to the global hash.
* On the 10-file cap from the [AI contribution guidelines](https://docs.umbraco.com/contributing/documentation/ai-guidelines): the diff touches 12 article files, but it is 6 unique articles mirrored across `17/` and `18/`. Kept as one PR so the two versions stay in sync.

## 📎 Related Issues (if applicable)

* AB#69069
* umbraco/Umbraco-CMS#23094 (the documented feature)

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

Vale passes clean on all 12 markdown files, and both C# samples compile against `Umbraco.Infrastructure`.

## Product & Version (if relevant)

Umbraco CMS 17.6.0 and 18.1.0.

## Deadline (if relevant)

Publish after 17.6.0 / 18.1.0 are released — the feature is merged but not yet shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)