### PR TITLE
Add CodeEditor to setting types documentation

### DIFF
--- a/17/umbraco-forms/developer/extending/setting-types.md
+++ b/17/umbraco-forms/developer/extending/setting-types.md
@@ -26,6 +26,7 @@ Some are defined with the Umbraco CMS and some ship with the Forms package.
 | Name                                           | Source | Description                                               | Used in                                       |
 | ---------------------------------------------- | ------ | --------------------------------------------------------- | --------------------------------------------- |
 | Umb.PropertyEditorUi.CheckBoxList              | CMS    | Uses multiple checkboxes for entry                        |                                               |
+| Umb.PropertyEditorUi.CodeEditor                | CMS    | Uses a code editor                                        |                                               |
 | Umb.PropertyEditorUi.ContentPicker.Source      | CMS    | Uses a content picker with the option for XPath entry     | The "Save as Umbraco node" workflow           |
 | Umb.PropertyEditorUi.DocumentPicker            | CMS    | Uses a content picker                                     |                                               |
 | Umb.PropertyEditorUi.Dropdown                  | CMS    | Used for selection from a list of options                 |                                               |

--- a/18/umbraco-forms/developer/extending/setting-types.md
+++ b/18/umbraco-forms/developer/extending/setting-types.md
@@ -26,6 +26,7 @@ Some are defined with the Umbraco CMS and some ship with the Forms package.
 | Name                                           | Source | Description                                               | Used in                                       |
 | ---------------------------------------------- | ------ | --------------------------------------------------------- | --------------------------------------------- |
 | Umb.PropertyEditorUi.CheckBoxList              | CMS    | Uses multiple checkboxes for entry                        |                                               |
+| Umb.PropertyEditorUi.CodeEditor                | CMS    | Uses a code editor                                        |                                               |
 | Umb.PropertyEditorUi.ContentPicker.Source      | CMS    | Uses a content picker with the option for XPath entry     | The "Save as Umbraco node" workflow           |
 | Umb.PropertyEditorUi.DocumentPicker            | CMS    | Uses a content picker                                     |                                               |
 | Umb.PropertyEditorUi.Dropdown                  | CMS    | Used for selection from a list of options                 |                                               |


### PR DESCRIPTION
## 📋 Description

Documented usage of `Umb.PropertyEditorUi.CodeEditor` as property editor UI in a settings type as we have used this in a specific project for a math expression and with monospace font it improved the readability of the expression instead of a regular textarea.
It may be useful to other developers to know about, when implementing custom field types and extending existing.

Not sure if it possible to handle configuration of this, e.g. as a JSON editor.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
