### PR TITLE
Security: Fix extension type for custom 2FA activation screen (17, 18)

### DIFF
--- a/17/umbraco-cms/run-in-production/security/two-factor-authentication.md
+++ b/17/umbraco-cms/run-in-production/security/two-factor-authentication.md
@@ -861,8 +861,10 @@ We need to register the custom view using a composer. This can be done on the `I
 
 {% code title="TwoFactorConfiguration.cs" lineNumbers="true" %}
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.Security;
 using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Web.BackOffice.Security;
+using Umbraco.Cms.Core.DependencyInjection;
 
 namespace My.Website;
 

--- a/17/umbraco-cms/run-in-production/security/two-factor-authentication.md
+++ b/17/umbraco-cms/run-in-production/security/two-factor-authentication.md
@@ -701,7 +701,7 @@ To replace the default activation screen with the custom view, you need to regis
   "version": "1.0.0",
   "extensions": [
     {
-      "type": "mfaActivationProvider",
+      "type": "mfaLoginProvider",
       "alias": "UmbracoUserAppAuthenticator",
       "name": "UmbracoUserAppAuthenticator",
       "forProviderName": "UmbracoUserAppAuthenticator",

--- a/18/umbraco-cms/run-in-production/security/two-factor-authentication.md
+++ b/18/umbraco-cms/run-in-production/security/two-factor-authentication.md
@@ -861,8 +861,10 @@ We need to register the custom view using a composer. This can be done on the `I
 
 {% code title="TwoFactorConfiguration.cs" lineNumbers="true" %}
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.Security;
 using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Web.BackOffice.Security;
+using Umbraco.Cms.Core.DependencyInjection;
 
 namespace My.Website;
 

--- a/18/umbraco-cms/run-in-production/security/two-factor-authentication.md
+++ b/18/umbraco-cms/run-in-production/security/two-factor-authentication.md
@@ -701,7 +701,7 @@ To replace the default activation screen with the custom view, you need to regis
   "version": "1.0.0",
   "extensions": [
     {
-      "type": "mfaActivationProvider",
+      "type": "mfaLoginProvider",
       "alias": "UmbracoUserAppAuthenticator",
       "name": "UmbracoUserAppAuthenticator",
       "forProviderName": "UmbracoUserAppAuthenticator",


### PR DESCRIPTION
## 📋 Description

Fixes two errors in the *Two-Factor Authentication* article for CMS 17 and 18. The same fixes for the v16 article, which moved to the `umbraco-eol-versions` branch while this PR was open, are in umbraco/UmbracoDocs#8249.

**1. Wrong extension type for the custom activation screen.** The article instructs readers to register a custom 2FA activation screen using the extension type `mfaActivationProvider`. That extension type has never existed in the backoffice — the correct type is `mfaLoginProvider`, which the same article already uses in the initial registration step. The wrong name was introduced in the v14 rewrite of the article (commit 8ddf196ea, May 2024) and has been copied forward since. With the wrong type, the manifest is registered but never consumed, so the custom activation element silently never loads and the default screen is shown instead.

**2. Broken code sample in "Customizing the login screen".** The `TwoFactorConfiguration` composer sample referenced `Umbraco.Cms.Web.BackOffice.Security`, a namespace that no longer exists. `IBackOfficeTwoFactorOptions` lives in `Umbraco.Cms.Api.Management.Security`. The sample was also missing the usings for `IUmbracoBuilder` and `AddSingleton`. The corrected sample compile-tests clean against `Umbraco.Cms.Api.Management` 17.x. The v13 article is unaffected, as the old namespace is correct there.

This fix is AI-assisted (investigated and prepared with Claude Code, verified against the CMS source by @iOvergaard).

## 📎 Related Issues (if applicable)

* Fixes umbraco/Umbraco-CMS#23376
* Forum report: https://forum.umbraco.com/t/customizing-the-2fa-activation-screen-is-not-working/8313

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco CMS 17 and 18 (16 in umbraco/UmbracoDocs#8249).

## Deadline (if relevant)

As soon as possible — the wrong extension type is actively confusing users (see linked issue and forum thread).
