### PR TITLE
Security: Fix extension type for custom 2FA activation screen (16)

### DIFF
--- a/16/umbraco-cms/reference/security/two-factor-authentication.md
+++ b/16/umbraco-cms/reference/security/two-factor-authentication.md
@@ -697,7 +697,7 @@ To replace the default activation screen with the custom view, you need to regis
   "version": "1.0.0",
   "extensions": [
     {
-      "type": "mfaActivationProvider",
+      "type": "mfaLoginProvider",
       "alias": "UmbracoUserAppAuthenticator",
       "name": "UmbracoUserAppAuthenticator",
       "forProviderName": "UmbracoUserAppAuthenticator",
@@ -857,8 +857,10 @@ We need to register the custom view using a composer. This can be done on the `I
 
 {% code title="TwoFactorConfiguration.cs" lineNumbers="true" %}
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.Security;
 using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Web.BackOffice.Security;
+using Umbraco.Cms.Core.DependencyInjection;
 
 namespace My.Website;
 


### PR DESCRIPTION
## 📋 Description

Applies the same two fixes as umbraco/UmbracoDocs#8247 to the v16 *Two-Factor Authentication* article, which moved to the `umbraco-eol-versions` branch while that PR was open.

1. The custom activation screen extension type is `mfaLoginProvider` — `mfaActivationProvider` has never existed in the backoffice.
2. The `TwoFactorConfiguration` composer sample referenced the non-existent `Umbraco.Cms.Web.BackOffice.Security` namespace. `IBackOfficeTwoFactorOptions` lives in `Umbraco.Cms.Api.Management.Security`, and the missing usings for `IUmbracoBuilder` and `AddSingleton` are added.

This fix is AI-assisted (investigated and prepared with Claude Code, verified against the CMS source by @iOvergaard).

## 📎 Related Issues (if applicable)

* umbraco/Umbraco-CMS#23376 (closed by umbraco/UmbracoDocs#8247)

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco CMS 16.

## Deadline (if relevant)

Together with umbraco/UmbracoDocs#8247.
