### PR TITLE
Add MCP version-match warning and fix compatibility tables

### DIFF
--- a/.github/styles/UmbracoDocs/Acronyms.yml
+++ b/.github/styles/UmbracoDocs/Acronyms.yml
@@ -74,6 +74,7 @@ exceptions:
   - LINK     # 
   - LINQ     # Language Integrated Query
   - LLM      # Large Language Model
+  - LTS      # Long-Term Support
   - MCP      # Mode Context Protocol
   - MIT      # Open-source software license developed at the Massachusetts Institute of Technology (MIT)
   - MDN      # Mozilla Developer Network

--- a/17/umbraco-in-ai/mcp/cms-developer-mcp/README.md
+++ b/17/umbraco-in-ai/mcp/cms-developer-mcp/README.md
@@ -185,7 +185,7 @@ The Umbraco MCP Server is designed to work with specific major versions of Umbra
 | ------------------ | -------------------------- | ---------------------------------- |
 | 15.x.x             | alpha                      | @umbraco-mcp/umbraco-mcp-cms@alpha |
 | 16.x.x             | 16.x                       | @umbraco-cms/mcp-dev@16            |
-| 17.x.x             | 17.x                       | @umbraco-cms/mcp-dev@lts-17         |
+| 17.x.x             | 17.x (LTS)                 | @umbraco-cms/mcp-dev@lts-17        |
 
 ### Version Checking
 

--- a/18/umbraco-in-ai/mcp/base-mcp/sdk/mcp-chaining.md
+++ b/18/umbraco-in-ai/mcp/base-mcp/sdk/mcp-chaining.md
@@ -32,7 +32,7 @@ const servers: McpServerConfig[] = [
   {
     name: "cms",
     command: "npx",
-    args: ["-y", "@umbraco-cms/mcp-dev@17.1"],
+    args: ["-y", "@umbraco-cms/mcp-dev@latest"],
     // Environment variables from the parent process are inherited automatically.
     // Only specify env here to override or add variables.
     proxyTools: true,

--- a/18/umbraco-in-ai/mcp/cms-developer-mcp/README.md
+++ b/18/umbraco-in-ai/mcp/cms-developer-mcp/README.md
@@ -101,6 +101,12 @@ Each MCP-compatible host application has its own setup process. Below you can fi
 
 Although the details vary slightly, the general pattern is the same across all hosts:
 
+{% hint style="warning" %}
+**Match the package version to your Umbraco site.** The example below uses `@latest`, which installs the newest release of the MCP Server. This may be a later major version than the one your site runs.
+
+If your site is on the current Long-Term Support (LTS) release, Umbraco 17, use the `@lts-17` tag instead, for example `@umbraco-cms/mcp-dev@lts-17`. A version mismatch causes the first tool request to fail. See [Version Compatibility](#version-compatibility) below for the full list of tags.
+{% endhint %}
+
 ```json
 {
   "umbraco-mcp": {
@@ -162,7 +168,7 @@ If you prefer, you can also install it globally with:
 
 ```bash
 
-@umbraco-cms/mcp-dev@17
+@umbraco-cms/mcp-dev@latest
 
 ```
 
@@ -185,7 +191,8 @@ The Umbraco MCP Server is designed to work with specific major versions of Umbra
 | ------------------ | -------------------------- | ---------------------------------- |
 | 15.x.x             | alpha                      | @umbraco-mcp/umbraco-mcp-cms@alpha |
 | 16.x.x             | 16.x                       | @umbraco-cms/mcp-dev@16            |
-| 17.x.x             | 17.x                       | @umbraco-cms/mcp-dev@17.1          |
+| 17.x.x             | 17.x (LTS)                 | @umbraco-cms/mcp-dev@lts-17        |
+| 18.x.x             | 18.x                       | @umbraco-cms/mcp-dev@latest        |
 
 ### Version Checking
 

--- a/18/umbraco-in-ai/mcp/cms-developer-mcp/best-practice/creating-media.md
+++ b/18/umbraco-in-ai/mcp/cms-developer-mcp/best-practice/creating-media.md
@@ -96,7 +96,7 @@ To use file path uploads, configure the allowed directories in your MCP server e
 {
   "umbraco-mcp": {
     "command": "npx",
-    "args": ["@umbraco-cms/mcp-dev@17.1"],
+    "args": ["@umbraco-cms/mcp-dev@latest"],
     "env": {
       "UMBRACO_CLIENT_ID": "your-client-id",
       "UMBRACO_CLIENT_SECRET": "your-client-secret",

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/README.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/README.md
@@ -6,6 +6,14 @@ description: "Connect a local Umbraco MCP server to your AI development environm
 
 These guides show how to connect a local Umbraco MCP server to each host application. The examples use the [Developer MCP](../cms-developer-mcp/README.md) package (`@umbraco-cms/mcp-dev`). If you are using a different Umbraco MCP server, replace the package name in the configuration.
 
+{% hint style="warning" %}
+**Match the package version to your Umbraco site.** The examples in these guides use `@latest`, which installs the newest release of the MCP Server. This may be a later major version than the one your site runs.
+
+If your site is on the current Long-Term Support (LTS) release, Umbraco 17, use the `@lts-17` tag instead, for example `@umbraco-cms/mcp-dev@lts-17`. A version mismatch causes the first tool request to fail.
+
+See [Version Compatibility](../cms-developer-mcp/README.md#version-compatibility) for the full list of tags.
+{% endhint %}
+
 ## Before You Start
 
 - **Node.js 22+** is required. Check your version by running `node -v` in your terminal.

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
@@ -10,6 +10,14 @@ description: "Host set up for Claude Code"
 The examples below use the Developer MCP package (`@umbraco-cms/mcp-dev`). Replace the package name if you are using a different Umbraco MCP server.
 {% endhint %}
 
+{% hint style="warning" %}
+**Match the package version to your Umbraco site.** The examples on this page use `@latest`, which installs the newest release of the MCP Server. This may be a later major version than the one your site runs.
+
+If your site is on the current Long-Term Support (LTS) release, Umbraco 17, use the `@lts-17` tag instead, for example `@umbraco-cms/mcp-dev@lts-17`. A version mismatch causes the first tool request to fail.
+
+See [Version Compatibility](../cms-developer-mcp/README.md#version-compatibility) for the full list of tags.
+{% endhint %}
+
 ## Getting started
 
 Installing Claude Code depends on your environment. For installation details, see the [Claude Code Quickstart Guide](https://code.claude.com/docs/en/quickstart).

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/claude-desktop.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/claude-desktop.md
@@ -10,6 +10,14 @@ description: Host set up for Claude Desktop
 The examples below use the Developer MCP package (`@umbraco-cms/mcp-dev`). Replace the package name if you are using a different Umbraco MCP server.
 {% endhint %}
 
+{% hint style="warning" %}
+**Match the package version to your Umbraco site.** The examples on this page use `@latest`, which installs the newest release of the MCP Server. This may be a later major version than the one your site runs.
+
+If your site is on the current Long-Term Support (LTS) release, Umbraco 17, use the `@lts-17` tag instead, for example `@umbraco-cms/mcp-dev@lts-17`. A version mismatch causes the first tool request to fail.
+
+See [Version Compatibility](../cms-developer-mcp/README.md#version-compatibility) for the full list of tags.
+{% endhint %}
+
 ## Getting started
 
 1. Download and install the [Claude.ai desktop app](https://claude.ai/download).

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/cursor.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/cursor.md
@@ -10,6 +10,14 @@ description: Host set up for Cursor
 The examples below use the Developer MCP package (`@umbraco-cms/mcp-dev`). Replace the package name if you are using a different Umbraco MCP server.
 {% endhint %}
 
+{% hint style="warning" %}
+**Match the package version to your Umbraco site.** The examples on this page use `@latest`, which installs the newest release of the MCP Server. This may be a later major version than the one your site runs.
+
+If your site is on the current Long-Term Support (LTS) release, Umbraco 17, use the `@lts-17` tag instead, for example `@umbraco-cms/mcp-dev@lts-17`. A version mismatch causes the first tool request to fail.
+
+See [Version Compatibility](../cms-developer-mcp/README.md#version-compatibility) for the full list of tags.
+{% endhint %}
+
 ## Getting started
 
 1. Go to **Cursor Settings** -> **Tools & MCP** -> **Add Custom MCP**.

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/github-copilot.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/github-copilot.md
@@ -10,6 +10,14 @@ description: Host set up for GitHub Copilot
 The examples below use the Developer MCP package (`@umbraco-cms/mcp-dev`). Replace the package name if you are using a different Umbraco MCP server.
 {% endhint %}
 
+{% hint style="warning" %}
+**Match the package version to your Umbraco site.** The examples on this page use `@latest`, which installs the newest release of the MCP Server. This may be a later major version than the one your site runs.
+
+If your site is on the current Long-Term Support (LTS) release, Umbraco 17, use the `@lts-17` tag instead, for example `@umbraco-cms/mcp-dev@lts-17`. A version mismatch causes the first tool request to fail.
+
+See [Version Compatibility](../cms-developer-mcp/README.md#version-compatibility) for the full list of tags.
+{% endhint %}
+
 ## Getting started
 
 ### Install MCP Server via Button

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/openai-codex.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/openai-codex.md
@@ -10,6 +10,14 @@ description: "Host setup for OpenAI Codex"
 The examples below use the Developer MCP package (`@umbraco-cms/mcp-dev`). Replace the package name if you are using a different Umbraco MCP server.
 {% endhint %}
 
+{% hint style="warning" %}
+**Match the package version to your Umbraco site.** The examples on this page use `@latest`, which installs the newest release of the MCP Server. This may be a later major version than the one your site runs.
+
+If your site is on the current Long-Term Support (LTS) release, Umbraco 17, use the `@lts-17` tag instead, for example `@umbraco-cms/mcp-dev@lts-17`. A version mismatch causes the first tool request to fail.
+
+See [Version Compatibility](../cms-developer-mcp/README.md#version-compatibility) for the full list of tags.
+{% endhint %}
+
 ## Getting started
 
 Option A: Install via npm:


### PR DESCRIPTION
## What this changes

Adds guidance to help first-time users of the CMS Developer MCP avoid a version mismatch between the MCP package and their Umbraco site — a problem [reported on the forum](https://forum.umbraco.com/t/umbraco-mcp-not-able-to-do-basic-operations/8327/3), where a Umbraco 17 site connected to a non-matching MCP version and tool calls failed on the first request.

### A — Version-match warning
Added a `warning` hint to every install-facing page in the `18/` tree that uses the `@latest` tag, explaining that `@latest` installs the newest release (which may be ahead of the site's version) and pointing LTS / Umbraco 17 users to `@umbraco-cms/mcp-dev@lts-17`, with a link to the Version Compatibility table:

- `local-mcp-setup/README.md` and all five host pages (Claude Code, Claude Desktop, Cursor, GitHub Copilot, OpenAI Codex)
- `cms-developer-mcp/README.md` (Host Setup section)

The `@latest` examples are left unchanged; the warning sits alongside them.

### B — Compatibility table & tag fixes
- **18-tree compatibility table:** corrected the 17.x row (`@17.1` → `@lts-17`), added the missing **18.x → `@latest`** row, and marked 17.x as `(LTS)`.
- **17-tree compatibility table:** fixed the `@lts-17` column misalignment and marked 17.x as `(LTS)`.
- Fixed the stray global-install snippet (`@17` → `@latest`).
- Standardised two leftover `@17.1` config examples in the 18 tree (`creating-media.md`, `mcp-chaining.md`) on `@latest`.

Tags verified against npm: `latest` = 18.0.1, `lts-17` = 17.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)