### PR TITLE
docs(ui-builder): release notes for 17.2.3/17.2.4 and 18.0.0/18.0.1/18.0.2

### DIFF
--- a/17/umbraco-ui-builder/release-notes.md
+++ b/17/umbraco-ui-builder/release-notes.md
@@ -18,6 +18,23 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 Below are the release notes for Umbraco UI Builder, detailing all changes in this version.
 
+### [**17.2.4**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.4) **(July 16th 2026)**
+
+* Fixed read-only fields displaying JSON as `[object Object]`; JSON values now render as formatted text [#222](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/222)
+
+### [**17.2.3**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.3) **(July 13th 2026)**
+
+* Fixed the editor modal not closing when the entity being edited is deleted [#228](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/228)
+* Fixed the summary dashboard showing incorrect totals [#227](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/227)
+* Fixed the MultipleChoice filter editor failing to render [#226](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/226)
+* Fixed the Entity Picker showing nothing when `maxItems` is set to 0 [#225](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/225)
+* Fixed repository save methods on new-entity insert with the NPoco backend (regression in 17.1.0) [#224](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/224)
+* Fixed a 403 `insufficient_access` error on the data-type endpoint for users without Content/Media section access [#218](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/218)
+* Fixed `FileActionResult` not showing an error notification when an exception occurs [#217](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/217)
+* Fixed the Entity Picker missing when the foreign key is non-nullable [#187](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/187)
+* Fixed the Import Action not working with a custom data type [#178](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/178)
+* Fixed Block List throwing an error on save [#123](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/123)
+
 ### [**17.2.2**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.2) **(May 1st 2026)**
 
 * Fixed issue with section dashboard collections [#221](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/221)

--- a/17/umbraco-ui-builder/release-notes.md
+++ b/17/umbraco-ui-builder/release-notes.md
@@ -29,10 +29,10 @@ Below are the release notes for Umbraco UI Builder, detailing all changes in thi
 * Fixed the MultipleChoice filter editor failing to render [#226](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/226)
 * Fixed the Entity Picker showing nothing when `maxItems` is set to 0 [#225](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/225)
 * Fixed repository save methods on new-entity insert with the NPoco backend (regression in 17.1.0) [#224](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/224)
-* Fixed a 403 `insufficient_access` error on the data-type endpoint for users without Content/Media section access [#218](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/218)
+* Fixed a 403 `insufficient_access` error on the Data Type endpoint for users without Content/Media section access [#218](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/218)
 * Fixed `FileActionResult` not showing an error notification when an exception occurs [#217](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/217)
 * Fixed the Entity Picker missing when the foreign key is non-nullable [#187](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/187)
-* Fixed the Import Action not working with a custom data type [#178](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/178)
+* Fixed the Import Action not working with a custom Data Type [#178](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/178)
 * Fixed Block List throwing an error on save [#123](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/123)
 
 ### [**17.2.2**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.2) **(May 1st 2026)**

--- a/18/umbraco-ui-builder/release-notes.md
+++ b/18/umbraco-ui-builder/release-notes.md
@@ -29,10 +29,10 @@ Below are the release notes for Umbraco UI Builder, detailing all changes in thi
 * Fixed the MultipleChoice filter editor failing to render [#226](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/226)
 * Fixed the Entity Picker showing nothing when `maxItems` is set to 0 [#225](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/225)
 * Fixed repository save methods on new-entity insert with the NPoco backend (regression in 17.1.0) [#224](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/224)
-* Fixed a 403 `insufficient_access` error on the data-type endpoint for users without Content/Media section access [#218](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/218)
+* Fixed a 403 `insufficient_access` error on the Data Type endpoint for users without Content/Media section access [#218](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/218)
 * Fixed `FileActionResult` not showing an error notification when an exception occurs [#217](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/217)
 * Fixed the Entity Picker missing when the foreign key is non-nullable [#187](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/187)
-* Fixed the Import Action not working with a custom data type [#178](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/178)
+* Fixed the Import Action not working with a custom Data Type [#178](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/178)
 * Fixed Block List throwing an error on save [#123](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/123)
 
 ### **18.0.0** **(June 23rd 2026)**

--- a/18/umbraco-ui-builder/release-notes.md
+++ b/18/umbraco-ui-builder/release-notes.md
@@ -18,6 +18,27 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 Below are the release notes for Umbraco UI Builder, detailing all changes in this version.
 
-#### 18.0.0-rc1 (04th Jun 2026)
+### [**18.0.2**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.2) **(July 16th 2026)**
+
+* Fixed read-only fields displaying JSON as `[object Object]`; JSON values now render as formatted text [#222](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/222)
+
+### [**18.0.1**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.1) **(July 13th 2026)**
+
+* Fixed the editor modal not closing when the entity being edited is deleted [#228](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/228)
+* Fixed the summary dashboard showing incorrect totals [#227](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/227)
+* Fixed the MultipleChoice filter editor failing to render [#226](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/226)
+* Fixed the Entity Picker showing nothing when `maxItems` is set to 0 [#225](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/225)
+* Fixed repository save methods on new-entity insert with the NPoco backend (regression in 17.1.0) [#224](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/224)
+* Fixed a 403 `insufficient_access` error on the data-type endpoint for users without Content/Media section access [#218](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/218)
+* Fixed `FileActionResult` not showing an error notification when an exception occurs [#217](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/217)
+* Fixed the Entity Picker missing when the foreign key is non-nullable [#187](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/187)
+* Fixed the Import Action not working with a custom data type [#178](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/178)
+* Fixed Block List throwing an error on save [#123](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/123)
+
+### **18.0.0** **(June 23rd 2026)**
+
+* First stable release of Umbraco UI Builder for Umbraco 18.
+
+### 18.0.0-rc1 (June 4th 2026)
 
 * Initial release candidate for Umbraco v18. 


### PR DESCRIPTION
## What

Adds the missing Umbraco UI Builder release notes for the releases published since the docs were last updated:

**v17** (`17/umbraco-ui-builder/release-notes.md`) — last documented was `17.2.2`:
- **17.2.4** (16 Jul 2026) — read-only JSON `[object Object]` fix ([#222](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/222))
- **17.2.3** (13 Jul 2026) — 10 bug fixes (#228, #227, #226, #225, #224, #218, #217, #187, #178, #123)

**v18** (`18/umbraco-ui-builder/release-notes.md`) — only `18.0.0-rc1` was documented:
- **18.0.2** (16 Jul 2026) — read-only JSON `[object Object]` fix ([#222](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/222))
- **18.0.1** (13 Jul 2026) — same 10 bug fixes as 17.2.3
- **18.0.0** (23 Jun 2026) — first stable release for Umbraco 18

## Notes

- Entries follow the existing format (version heading linking to the `release/{version}` issue-tracker filter, dated, with per-issue links). Content is derived from the issues labelled `release/{version}` in the [issue tracker](https://github.com/umbraco/Umbraco.UIBuilder.Issues).
- Normalised the v18 `18.0.0-rc1` heading from `####` to `###` for consistency with the rest of the list.
- No content changes outside the two release-notes files.
