### PR TITLE
Add Umbraco Commerce v17.1.6/17.1.7 and v18.0.0/18.0.1/18.0.2 release notes

### DIFF
--- a/17/umbraco-commerce/release-notes/README.md
+++ b/17/umbraco-commerce/release-notes/README.md
@@ -18,6 +18,25 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 This section contains the release notes for Umbraco Commerce 17 including all changes for this version.
 
+#### [17.1.7](https://github.com/umbraco/Umbraco.Commerce.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.1.7) (15th Jul 2026)
+* Fix cart conversion "Reached Checkout" and "Purchased" totals drifting for past periods [#835](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/835)
+* Fix the product picker in the discount rule editor losing store context
+* Tolerate legacy member group names in discount rule settings [#839](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/839)
+* Raise `CartAbandonedNotification` from the abandoned cart pipeline [#805](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/805)
+* Guard against a null content node in `StockPropertyValueConverter` [#848](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/848)
+* Fix a crash in the variant picker when a variant has no price [#829](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/829)
+* Fix a `NULL dateTimeUtc` error in the transaction activity migration [#831](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/831)
+* Preserve the original stack trace on errors surfaced by `PollyExecutionStrategyBase` [#815](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/815)
+* Fix `DateTime` settings failing to parse space-separated values
+* Reset (rather than cancel) the transaction when a customer abandons checkout [#789](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/789)
+* Fix order transaction, export authorization, and top-buyers analytics bugs
+* Use the CMS scope in `StoreTelemetryRepository` to avoid querying CMS tables against the Commerce database
+
+#### [17.1.6](https://github.com/umbraco/Umbraco.Commerce.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.1.6) (8th Jul 2026)
+* Fix a false-positive "transaction amount changed" exception in `BeginPaymentFormAsync`
+* Fix a `NullReferenceException` when using dynamic shipping with no product measurements or no store location
+* Fix a `NullReferenceException` when a dynamic shipping rate range provider alias cannot be resolved
+
 #### [17.1.5](https://github.com/umbraco/Umbraco.Commerce.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.1.5) (28th May 2026)
 * Fix payment form generation throwing "Order has changed and needs recalculating" exception when a customer is auto-assigned on payment start [#832](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/832)
 * Preserve an existing customer reference on the order when a member logs in (only auto-assign when no reference is set)

--- a/18/umbraco-commerce/release-notes/README.md
+++ b/18/umbraco-commerce/release-notes/README.md
@@ -27,8 +27,8 @@ This section contains the release notes for Umbraco Commerce 18, including all c
 * Guard against a null content node in `StockPropertyValueConverter` (#848).
 * Fixed a crash in the variant picker when a variant has no price (#829).
 * Fixed a `NULL dateTimeUtc` error in the transaction activity migration (#831).
-* Preserve the original stack trace when `PollyExecutionStrategyBase` rethrows (#815).
-* Fixed `DateTime` settings deserialization failing on space-separated values.
+* Preserve the original stack trace on errors surfaced by `PollyExecutionStrategyBase` (#815).
+* Fixed `DateTime` settings failing to parse space-separated values.
 * Reset (rather than cancel) the transaction when a customer abandons checkout (#789).
 * Fixed order transaction, export authorization, and top-buyers analytics bugs.
 * Use the CMS scope in `StoreTelemetryRepository` to avoid querying CMS tables against the Commerce database.
@@ -37,7 +37,7 @@ This section contains the release notes for Umbraco Commerce 18, including all c
 
 * Fixed a false-positive "transaction amount changed" exception in `BeginPaymentFormAsync`.
 * Fixed a `NullReferenceException` when using dynamic shipping with no product measurements or no store location.
-* Fixed a `NullReferenceException` when a dynamic shipping rate range provider alias is unresolvable.
+* Fixed a `NullReferenceException` when a dynamic shipping rate range provider alias cannot be resolved.
 
 #### 18.0.0 (23rd Jun 2026)
 

--- a/18/umbraco-commerce/release-notes/README.md
+++ b/18/umbraco-commerce/release-notes/README.md
@@ -18,6 +18,31 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 This section contains the release notes for Umbraco Commerce 18, including all changes for this version.
 
+#### 18.0.2 (15th Jul 2026)
+
+* Fixed cart conversion "Reached Checkout" and "Purchased" totals drifting for past periods (#835).
+* Fixed the product picker in the discount rule editor losing store context.
+* Tolerate legacy member group names in discount rule settings (#839).
+* Raise `CartAbandonedNotification` from the abandoned cart pipeline (#805).
+* Guard against a null content node in `StockPropertyValueConverter` (#848).
+* Fixed a crash in the variant picker when a variant has no price (#829).
+* Fixed a `NULL dateTimeUtc` error in the transaction activity migration (#831).
+* Preserve the original stack trace when `PollyExecutionStrategyBase` rethrows (#815).
+* Fixed `DateTime` settings deserialization failing on space-separated values.
+* Reset (rather than cancel) the transaction when a customer abandons checkout (#789).
+* Fixed order transaction, export authorization, and top-buyers analytics bugs.
+* Use the CMS scope in `StoreTelemetryRepository` to avoid querying CMS tables against the Commerce database.
+
+#### 18.0.1 (08th Jul 2026)
+
+* Fixed a false-positive "transaction amount changed" exception in `BeginPaymentFormAsync`.
+* Fixed a `NullReferenceException` when using dynamic shipping with no product measurements or no store location.
+* Fixed a `NullReferenceException` when a dynamic shipping rate range provider alias is unresolvable.
+
+#### 18.0.0 (23rd Jun 2026)
+
+* Final release for Umbraco v18. See 18.0.0-rc1 below for the breaking changes introduced in this major.
+
 #### 18.0.0-rc1 (05th Jun 2026)
 
 * Initial release candidate for Umbraco v18. 


### PR DESCRIPTION
## What

Brings the Umbraco Commerce release notes up to date with the latest shipped releases on both supported major lines.

**v18** (`18/umbraco-commerce/release-notes/README.md`) — page previously stopped at `18.0.0-rc1`:
- **18.0.0** (23rd Jun 2026) — final v18 release
- **18.0.1** (08th Jul 2026)
- **18.0.2** (15th Jul 2026)

**v17** (`17/umbraco-commerce/release-notes/README.md`) — page previously stopped at `17.1.5`:
- **17.1.6** (8th Jul 2026)
- **17.1.7** (15th Jul 2026)

## Why

The public release notes lagged the actual releases: Core shipped through 18.0.2 and 17.1.7, but the docs stopped at 18.0.0-rc1 and 17.1.5 respectively.

## Notes

- Entries are ordered newest-first to match each page's existing convention; v17 entries use the issue-tracker link format already used on that page.
- Content is derived from the Core release commit log for each version boundary.
- Wording avoids terms outside the Vale dictionary; the remaining `runner / vale` failures are pre-existing errors in unrelated files (`13/umbraco-cms/*`, `.github/README.md`) and are not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)