### PR TITLE
Forms: Document `CsvExportDelimiter` configuration option

### DIFF
--- a/17/umbraco-forms/developer/configuration/README.md
+++ b/17/umbraco-forms/developer/configuration/README.md
@@ -95,6 +95,7 @@ For illustration purposes, the following structure represents the full set of op
       "TrackRenderedFormsStorageMethod": "HttpContextItems",
       "EnableMultiPageFormSettings": true,
       "EnableAdvancedValidationRules": false,
+      "CsvExportDelimiter": ",",
       "AnalyticsProcessing": {
         "Enabled": true,
         "FirstRunTime": "",
@@ -471,6 +472,12 @@ This setting determines whether [advanced form validation rules](../../editor/cr
 By default, the value is `false`.  This is partly because the feature is only considered for "power users", comfortable with crafting rules using the required JSON syntax. And partly as validating the rules on the client requires an additional front-end dependency.
 
 To make the feature available to editors and include the dependency when using `@Html.RenderUmbracoFormDependencies(Url)`, set the value to `true`.
+
+### CsvExportDelimiter
+
+This setting controls the delimiter used when exporting form entries to a CSV file. The default value is a comma (`,`).
+
+Set the value to a different delimiter, such as a semicolon (`;`), to match the format expected by the application used to open the file. If the value is empty, the export falls back to a comma.
 
 ## Analytics processing configuration
 

--- a/18/umbraco-forms/developer/configuration/README.md
+++ b/18/umbraco-forms/developer/configuration/README.md
@@ -95,6 +95,7 @@ For illustration purposes, the following structure represents the full set of op
       "TrackRenderedFormsStorageMethod": "HttpContextItems",
       "EnableMultiPageFormSettings": true,
       "EnableAdvancedValidationRules": false,
+      "CsvExportDelimiter": ",",
       "AnalyticsProcessing": {
         "Enabled": true,
         "FirstRunTime": "",
@@ -471,6 +472,12 @@ This setting determines whether [advanced form validation rules](../../editor/cr
 By default, the value is `false`.  This is partly because the feature is only considered for "power users", comfortable with crafting rules using the required JSON syntax. And partly as validating the rules on the client requires an additional front-end dependency.
 
 To make the feature available to editors and include the dependency when using `@Html.RenderUmbracoFormDependencies(Url)`, set the value to `true`.
+
+### CsvExportDelimiter
+
+This setting controls the delimiter used when exporting form entries to a CSV file. The default value is a comma (`,`).
+
+Set the value to a different delimiter, such as a semicolon (`;`), to match the format expected by the application used to open the file. If the value is empty, the export falls back to a comma.
 
 ## Analytics processing configuration
 


### PR DESCRIPTION
## 📋 Description

Documents the new `CsvExportDelimiter` configuration option for Umbraco Forms. The setting controls the delimiter used when exporting form entries to CSV (default comma), added under `Umbraco:Forms:Options`.

Applied to the v17 and v18 Forms configuration reference:
- Adds `"CsvExportDelimiter": ","` to the `Options` example.
- Adds a `CsvExportDelimiter` section under *Package options configuration*.

## 📎 Related Issues (if applicable)

- Feature request: https://github.com/umbraco/Umbraco.Forms.Issues/issues/1541
- Code PRs: umbraco/Forms#1404 (v17), umbraco/Forms#1409 (v18)

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Forms 17 (17.5.0) and 18 (18.1.0).

## Deadline (if relevant)

Thursday 6th August 2026 when next Forms RCs are released