### PR TITLE
Slack docs: fix missing Scopes config in installation guide

### DIFF
--- a/17/umbraco-automate/add-ons/slack/installation.md
+++ b/17/umbraco-automate/add-ons/slack/installation.md
@@ -59,7 +59,7 @@ Add the Slack client credentials to `appsettings.json`:
 {% endcode %}
 
 {% hint style="warning" %}
-The `Scopes` array must match the bot token scopes you added to the Slack App in step 3. Missing a scope here means it won't be requested during authentication, even if it's enabled on the Slack App. The action will then fail with a scope-related error.
+The `Scopes` array must match the bot token scopes you added to the Slack App in [step 3 above](#create-a-slack-app). Missing a scope here means it won't be requested during authentication, even if it's enabled on the Slack App. The action will then fail with a scope-related error.
 {% endhint %}
 
 {% hint style="warning" %}

--- a/17/umbraco-automate/add-ons/slack/installation.md
+++ b/17/umbraco-automate/add-ons/slack/installation.md
@@ -28,6 +28,11 @@ The Slack add-on depends on `Umbraco.Automate.OpenIddict`, the reusable OAuth in
 1. Go to <https://api.slack.com/apps> and click **Create New App**.
 2. Pick **From scratch** and choose a workspace to develop the app in.
 3. Under **OAuth & Permissions**, add the `chat:write` bot token scope. Add more scopes if you plan to use them.
+
+{% hint style="info" %}
+See Slack's [full list of scopes](https://api.slack.com/scopes) if your automation needs a feature beyond sending messages.
+{% endhint %}
+
 4. Under **OAuth & Permissions**, add the following **Redirect URL**: `https://<your-site>/umbraco/automate/oauth/callback/slack`.
 5. Note the **Client ID** and **Client Secret** under **Basic Information**.
 
@@ -43,7 +48,8 @@ Add the Slack client credentials to `appsettings.json`:
       "Providers": {
         "Slack": {
           "ClientId": "your-client-id",
-          "ClientSecret": "your-client-secret"
+          "ClientSecret": "your-client-secret",
+          "Scopes": ["chat:write"]
         }
       }
     }
@@ -53,8 +59,21 @@ Add the Slack client credentials to `appsettings.json`:
 {% endcode %}
 
 {% hint style="warning" %}
+The `Scopes` array must match the bot token scopes you added to the Slack App in step 3. Missing a scope here means it won't be requested during authentication, even if it's enabled on the Slack App. The action will then fail with a scope-related error.
+{% endhint %}
+
+{% hint style="warning" %}
 Keep the client secret out of source control. Use environment variables, user secrets, or a key vault to inject it at deployment time.
 {% endhint %}
+
+## Updating Scopes
+
+If a new action requires an additional scope after you've already set up the connection:
+
+1. Add the scope to the Slack App's **Bot Token Scopes**.
+2. Add the same scope to the `Scopes` array in `appsettings.json`.
+3. Restart the site.
+4. [Re-authenticate the existing Slack connection](connection.md#re-authenticate).
 
 ## Verify
 

--- a/18/umbraco-automate/add-ons/slack/installation.md
+++ b/18/umbraco-automate/add-ons/slack/installation.md
@@ -59,7 +59,7 @@ Add the Slack client credentials to `appsettings.json`:
 {% endcode %}
 
 {% hint style="warning" %}
-The `Scopes` array must match the bot token scopes you added to the Slack App in step 3. Missing a scope here means it won't be requested during authentication, even if it's enabled on the Slack App. The action will then fail with a scope-related error.
+The `Scopes` array must match the bot token scopes you added to the Slack App in [step 3 above](#create-a-slack-app). Missing a scope here means it won't be requested during authentication, even if it's enabled on the Slack App. The action will then fail with a scope-related error.
 {% endhint %}
 
 {% hint style="warning" %}

--- a/18/umbraco-automate/add-ons/slack/installation.md
+++ b/18/umbraco-automate/add-ons/slack/installation.md
@@ -28,6 +28,11 @@ The Slack add-on depends on `Umbraco.Automate.OpenIddict`, the reusable OAuth in
 1. Go to <https://api.slack.com/apps> and click **Create New App**.
 2. Pick **From scratch** and choose a workspace to develop the app in.
 3. Under **OAuth & Permissions**, add the `chat:write` bot token scope. Add more scopes if you plan to use them.
+
+{% hint style="info" %}
+See Slack's [full list of scopes](https://api.slack.com/scopes) if your automation needs a feature beyond sending messages.
+{% endhint %}
+
 4. Under **OAuth & Permissions**, add the following **Redirect URL**: `https://<your-site>/umbraco/automate/oauth/callback/slack`.
 5. Note the **Client ID** and **Client Secret** under **Basic Information**.
 
@@ -43,7 +48,8 @@ Add the Slack client credentials to `appsettings.json`:
       "Providers": {
         "Slack": {
           "ClientId": "your-client-id",
-          "ClientSecret": "your-client-secret"
+          "ClientSecret": "your-client-secret",
+          "Scopes": ["chat:write"]
         }
       }
     }
@@ -53,8 +59,21 @@ Add the Slack client credentials to `appsettings.json`:
 {% endcode %}
 
 {% hint style="warning" %}
+The `Scopes` array must match the bot token scopes you added to the Slack App in step 3. Missing a scope here means it won't be requested during authentication, even if it's enabled on the Slack App. The action will then fail with a scope-related error.
+{% endhint %}
+
+{% hint style="warning" %}
 Keep the client secret out of source control. Use environment variables, user secrets, or a key vault to inject it at deployment time.
 {% endhint %}
+
+## Updating Scopes
+
+If a new action requires an additional scope after you've already set up the connection:
+
+1. Add the scope to the Slack App's **Bot Token Scopes**.
+2. Add the same scope to the `Scopes` array in `appsettings.json`.
+3. Restart the site.
+4. [Re-authenticate the existing Slack connection](connection.md#re-authenticate).
 
 ## Verify
 


### PR DESCRIPTION
## 📋 Description

Fixes missing `Scopes` configuration in the Slack add-on installation docs, which caused authentication to fail silently with "Invalid permissions requested / No scopes requested" issue.

Changes in this PR:

- Added `"Scopes": ["chat:write"]` to the `appsettings.json` example under **Configure the Credentials**.
- Added a warning hint clarifying that the `Scopes` array must match the Bot Token Scopes added to the Slack App, and that a mismatch causes a scope-related failure at runtime rather than at authentication.
- Added a new **Updating Scopes** section covering the steps needed when a new action requires an additional scope: update the Slack App, update `appsettings.json`, restart, re-authenticate.
- Linked `chat:write` to Slack's own scope reference, and added a pointer to Slack's full scope list for use cases beyond the current Send Slack Message action.
- Kept the existing single-sentence scope guidance in step 3 (rather than a per-feature table) since there's currently only one Slack action in the package; revisit as a table if/when more actions are added.


## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Automate v17 and v18

## Deadline (if relevant)

Anytime

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
