### PR TITLE
docs(ai): Add Knowledge Sets documentation

### DIFF
--- a/17/ai-in-umbraco/SUMMARY.md
+++ b/17/ai-in-umbraco/SUMMARY.md
@@ -150,6 +150,7 @@
 * [Custom Tools](extending/tools/README.md)
   * [Creating a Tool](extending/tools/creating-a-tool.md)
 * [Custom Guardrail Evaluators](extending/guardrails/README.md)
+* [Knowledge Sets](extending/knowledge-sets/README.md)
 * [Notifications](extending/notifications/README.md)
   * [Entity Lifecycle Notifications](extending/notifications/entity-notifications.md)
 

--- a/17/ai-in-umbraco/concepts/contexts.md
+++ b/17/ai-in-umbraco/concepts/contexts.md
@@ -137,3 +137,4 @@ See [Version History](versioning.md) for more information.
 - [Profiles](profiles.md) - Use contexts with AI profiles
 - [Version History](versioning.md) - Track context changes over time
 - [Managing Contexts](../backoffice/managing-contexts.md) - Backoffice guide
+- [Knowledge Sets](../extending/knowledge-sets/README.md) - Ship background knowledge from a package in code

--- a/17/ai-in-umbraco/extending/README.md
+++ b/17/ai-in-umbraco/extending/README.md
@@ -38,6 +38,10 @@ Umbraco.AI is designed to be extensible. You can add support for new AI provider
 <td>Create evaluators for domain-specific safety and compliance rules</td>
 </tr>
 <tr>
+<td><strong>Knowledge Sets</strong></td>
+<td>Ship background knowledge about your product that the AI can draw on</td>
+</tr>
+<tr>
 <td><strong>Notifications</strong></td>
 <td>Subscribe to entity lifecycle events for validation and automation</td>
 </tr>
@@ -71,6 +75,12 @@ Umbraco.AI is designed to be extensible. You can add support for new AI provider
 - You want to compose agents into sequential or parallel workflows
 - You need custom agent collaboration patterns
 
+### Create a Knowledge Set When
+
+- You ship a package and want the AI to understand your product
+- You want to provide background reference material without an end-user having to configure anything
+- You have content that the AI should draw on only when it is relevant
+
 ### Subscribe to Notifications When
 
 - You need to validate operations before they execute
@@ -103,6 +113,10 @@ graph TD
 
 {% content-ref url="../add-ons/agent/workflows.md" %}
 [Agent Workflows](../add-ons/agent/workflows.md)
+{% endcontent-ref %}
+
+{% content-ref url="knowledge-sets/README.md" %}
+[Knowledge Sets](knowledge-sets/README.md)
 {% endcontent-ref %}
 
 {% content-ref url="notifications/README.md" %}

--- a/17/ai-in-umbraco/extending/knowledge-sets/README.md
+++ b/17/ai-in-umbraco/extending/knowledge-sets/README.md
@@ -1,0 +1,121 @@
+---
+description: >-
+    Ship background knowledge about your product to the AI by dropping a decorated class into your package.
+---
+
+# Knowledge Sets
+
+A knowledge set is a code-defined, package-embeddable collection of background knowledge about a subject — for example a product such as Umbraco Engage — that is surfaced to the AI. A package author ships knowledge by dropping a single decorated class into an assembly: it is discovered at startup, needs no configuration, and its content flows to the model on demand.
+
+Knowledge sets are the content complement to [Contexts](../../concepts/contexts.md): context resource types define the _shape_ of context, while knowledge sets provide ready-made _content_.
+
+## Overview
+
+Each knowledge set:
+
+- Has a stable ID, a display name, and an optional description and icon
+- Contains one or more **items** (shown as "Topics" in the backoffice), each a chunk of markdown
+- Is auto-discovered at startup via the `[AIKnowledgeSet]` attribute — no registration code
+- Is auto-active — installed sets are available to every request with nothing to configure
+- Is surfaced **on demand** — the model retrieves an item's content only when it is relevant
+
+## How It Works
+
+Installed knowledge sets flow through the same context resolution pipeline as contexts. For each request, the AI is shown a grouped list of the available items — each item's name and description act as a breadcrumb — and the model pulls an item's full markdown content only when it decides the item is relevant. Item content is produced lazily, so listing a set never loads its content.
+
+## Creating a Knowledge Set
+
+Derive from `AIKnowledgeSetBase`, decorate the class with `[AIKnowledgeSet]`, and override `GetItemsAsync` to return the items. Use `AIKnowledgeSetItem.FromContent` for static markdown:
+
+{% code title="EngageKnowledgeSet.cs" %}
+
+```csharp
+using Umbraco.AI.Core.Contexts.KnowledgeSets;
+
+[AIKnowledgeSet("umbraco-engage", "Umbraco Engage",
+    Description = "Background knowledge about Umbraco Engage.",
+    Icon = "icon-book")]
+public sealed class EngageKnowledgeSet : AIKnowledgeSetBase
+{
+    public override Task<IReadOnlyList<AIKnowledgeSetItem>> GetItemsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<AIKnowledgeSetItem> items =
+        [
+            AIKnowledgeSetItem.FromContent(
+                key: "goals",
+                name: "Goals",
+                content: "# Goals\nEngage goals let you track conversions across a visit...",
+                description: "How goals work in Umbraco Engage."),
+        ];
+
+        return Task.FromResult(items);
+    }
+}
+```
+
+{% endcode %}
+
+That is the complete happy path. On startup the class is discovered, and its items become knowledge the AI can draw on — no further wiring required.
+
+### Loading Content Dynamically
+
+`FromContent` wraps a literal string. When an item's content needs to be built at request time — for example loaded from a service — set `GetContentAsync` directly instead. The producer is invoked lazily, only when the content is actually retrieved:
+
+{% code title="Dynamic item" %}
+
+```csharp
+new AIKnowledgeSetItem
+{
+    Key = "segments",
+    Name = "Segments",
+    Description = "The audience segments configured on this site.",
+    GetContentAsync = async token => await _segmentService.GetSegmentsMarkdownAsync(token),
+}
+```
+
+{% endcode %}
+
+## AIKnowledgeSetItem
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `Key` | `string` | Stable, URL-safe identity within the set (e.g. `"goals"`). Keep it stable across renames. |
+| `Name` | `string` | Display name, shown in the backoffice. |
+| `Description` | `string?` | The breadcrumb the AI sees when the item is advertised — write it to help the model decide whether to retrieve the item. |
+| `GetContentAsync` | `Func<CancellationToken, Task<string>>` | Lazily produces the markdown content, injected as-is when retrieved. |
+
+## Registration
+
+Knowledge sets are auto-discovered via the `[AIKnowledgeSet]` attribute and the `IDiscoverable` interface. No manual registration is needed.
+
+To add a set that isn't auto-discovered, or to exclude one, use the collection builder in a Composer:
+
+{% code title="KnowledgeSetComposer.cs" %}
+
+```csharp
+using Umbraco.AI.Extensions;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+
+public class KnowledgeSetComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.AIKnowledgeSets()
+            .Add<EngageKnowledgeSet>()
+            .Exclude<LegacyKnowledgeSet>();
+    }
+}
+```
+
+{% endcode %}
+
+## Viewing Installed Knowledge Sets
+
+Installed sets appear under **AI Configuration > Knowledge Sets** in the backoffice. This view is read-only: you can browse the installed sets and open a topic to inspect its content. Knowledge sets are defined in code, so they cannot be created or edited from the backoffice.
+
+## Related
+
+- [Contexts](../../concepts/contexts.md) - Injecting brand voice, guidelines, and content into AI operations
+- [Custom Tools](../tools/README.md) - Give AI agents actions to perform

--- a/17/ai-in-umbraco/extending/knowledge-sets/README.md
+++ b/17/ai-in-umbraco/extending/knowledge-sets/README.md
@@ -91,7 +91,7 @@ new AIKnowledgeSetItem
 
 Knowledge sets are auto-discovered via the `[AIKnowledgeSet]` attribute and the `IDiscoverable` interface. No manual registration is needed.
 
-To add a set that isn't auto-discovered, or to exclude one, use the collection builder in a Composer:
+To turn off a set shipped by another package, exclude it in a Composer:
 
 {% code title="KnowledgeSetComposer.cs" %}
 
@@ -105,13 +105,14 @@ public class KnowledgeSetComposer : IComposer
     public void Compose(IUmbracoBuilder builder)
     {
         builder.AIKnowledgeSets()
-            .Add<ManuallyRegisteredKnowledgeSet>()
             .Exclude<ThirdPartyKnowledgeSet>();
     }
 }
 ```
 
 {% endcode %}
+
+The builder also exposes `.Add<T>()`, but you rarely need it. A decorated set is already registered by discovery. `.Add<T>()` only helps for the uncommon case of a set that implements `IAIKnowledgeSet` directly, without the `[AIKnowledgeSet]` attribute.
 
 ## Viewing Installed Knowledge Sets
 

--- a/17/ai-in-umbraco/extending/knowledge-sets/README.md
+++ b/17/ai-in-umbraco/extending/knowledge-sets/README.md
@@ -5,7 +5,9 @@ description: >-
 
 # Knowledge Sets
 
-A knowledge set is a code-defined, package-embeddable collection of background knowledge about a subject — for example a product such as Umbraco Engage — that is surfaced to the AI. A package author ships knowledge by dropping a single decorated class into an assembly: it is discovered at startup, needs no configuration, and its content flows to the model on demand.
+A knowledge set is a collection of background knowledge about a subject — for example, a product such as Umbraco Engage. It is defined in code and shipped inside a package, so the AI can draw on it.
+
+A package author ships knowledge by dropping a single decorated class into an assembly. The set is discovered at startup, needs no configuration, and its content flows to the model on demand.
 
 Knowledge sets are the content complement to [Contexts](../../concepts/contexts.md): context resource types define the _shape_ of context, while knowledge sets provide ready-made _content_.
 
@@ -21,7 +23,7 @@ Each knowledge set:
 
 ## How It Works
 
-Installed knowledge sets flow through the same context resolution pipeline as contexts. For each request, the AI is shown a grouped list of the available items — each item's name and description act as a breadcrumb — and the model pulls an item's full markdown content only when it decides the item is relevant. Item content is produced lazily, so listing a set never loads its content.
+Installed knowledge sets flow through the same context resolution pipeline as contexts. For each request, the AI is shown a grouped list of the available items, where each item's name and description act as a breadcrumb. The model then pulls an item's full markdown content only when it decides the item is relevant. Item content is produced lazily, so listing a set never loads its content.
 
 ## Creating a Knowledge Set
 
@@ -60,7 +62,7 @@ That is the complete happy path. On startup the class is discovered, and its ite
 
 ### Loading Content Dynamically
 
-`FromContent` wraps a literal string. When an item's content needs to be built at request time — for example loaded from a service — set `GetContentAsync` directly instead. The producer is invoked lazily, only when the content is actually retrieved:
+`FromContent` wraps a literal string. When an item's content needs to be built at request time — for example loaded from a service — set `GetContentAsync` directly instead. The producer is invoked lazily, only when the content is retrieved:
 
 {% code title="Dynamic item" %}
 
@@ -80,7 +82,7 @@ new AIKnowledgeSetItem
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `Key` | `string` | Stable, URL-safe identity within the set (e.g. `"goals"`). Keep it stable across renames. |
+| `Key` | `string` | Stable, URL-safe identity within the set (for example `"goals"`). Keep it stable across renames. |
 | `Name` | `string` | Display name, shown in the backoffice. |
 | `Description` | `string?` | The breadcrumb the AI sees when the item is advertised — write it to help the model decide whether to retrieve the item. |
 | `GetContentAsync` | `Func<CancellationToken, Task<string>>` | Lazily produces the markdown content, injected as-is when retrieved. |

--- a/17/ai-in-umbraco/extending/knowledge-sets/README.md
+++ b/17/ai-in-umbraco/extending/knowledge-sets/README.md
@@ -105,8 +105,8 @@ public class KnowledgeSetComposer : IComposer
     public void Compose(IUmbracoBuilder builder)
     {
         builder.AIKnowledgeSets()
-            .Add<EngageKnowledgeSet>()
-            .Exclude<LegacyKnowledgeSet>();
+            .Add<ManuallyRegisteredKnowledgeSet>()
+            .Exclude<ThirdPartyKnowledgeSet>();
     }
 }
 ```

--- a/18/ai-in-umbraco/SUMMARY.md
+++ b/18/ai-in-umbraco/SUMMARY.md
@@ -150,6 +150,7 @@
 * [Custom Tools](extending/tools/README.md)
   * [Creating a Tool](extending/tools/creating-a-tool.md)
 * [Custom Guardrail Evaluators](extending/guardrails/README.md)
+* [Knowledge Sets](extending/knowledge-sets/README.md)
 * [Notifications](extending/notifications/README.md)
   * [Entity Lifecycle Notifications](extending/notifications/entity-notifications.md)
 

--- a/18/ai-in-umbraco/concepts/contexts.md
+++ b/18/ai-in-umbraco/concepts/contexts.md
@@ -137,3 +137,4 @@ See [Version History](versioning.md) for more information.
 - [Profiles](profiles.md) - Use contexts with AI profiles
 - [Version History](versioning.md) - Track context changes over time
 - [Managing Contexts](../backoffice/managing-contexts.md) - Backoffice guide
+- [Knowledge Sets](../extending/knowledge-sets/README.md) - Ship background knowledge from a package in code

--- a/18/ai-in-umbraco/extending/README.md
+++ b/18/ai-in-umbraco/extending/README.md
@@ -38,6 +38,10 @@ Umbraco.AI is designed to be extensible. You can add support for new AI provider
 <td>Create evaluators for domain-specific safety and compliance rules</td>
 </tr>
 <tr>
+<td><strong>Knowledge Sets</strong></td>
+<td>Ship background knowledge about your product that the AI can draw on</td>
+</tr>
+<tr>
 <td><strong>Notifications</strong></td>
 <td>Subscribe to entity lifecycle events for validation and automation</td>
 </tr>
@@ -71,6 +75,12 @@ Umbraco.AI is designed to be extensible. You can add support for new AI provider
 - You want to compose agents into sequential or parallel workflows
 - You need custom agent collaboration patterns
 
+### Create a Knowledge Set When
+
+- You ship a package and want the AI to understand your product
+- You want to provide background reference material without an end-user having to configure anything
+- You have content that the AI should draw on only when it is relevant
+
 ### Subscribe to Notifications When
 
 - You need to validate operations before they execute
@@ -103,6 +113,10 @@ graph TD
 
 {% content-ref url="../add-ons/agent/workflows.md" %}
 [Agent Workflows](../add-ons/agent/workflows.md)
+{% endcontent-ref %}
+
+{% content-ref url="knowledge-sets/README.md" %}
+[Knowledge Sets](knowledge-sets/README.md)
 {% endcontent-ref %}
 
 {% content-ref url="notifications/README.md" %}

--- a/18/ai-in-umbraco/extending/knowledge-sets/README.md
+++ b/18/ai-in-umbraco/extending/knowledge-sets/README.md
@@ -1,0 +1,121 @@
+---
+description: >-
+    Ship background knowledge about your product to the AI by dropping a decorated class into your package.
+---
+
+# Knowledge Sets
+
+A knowledge set is a code-defined, package-embeddable collection of background knowledge about a subject — for example a product such as Umbraco Engage — that is surfaced to the AI. A package author ships knowledge by dropping a single decorated class into an assembly: it is discovered at startup, needs no configuration, and its content flows to the model on demand.
+
+Knowledge sets are the content complement to [Contexts](../../concepts/contexts.md): context resource types define the _shape_ of context, while knowledge sets provide ready-made _content_.
+
+## Overview
+
+Each knowledge set:
+
+- Has a stable ID, a display name, and an optional description and icon
+- Contains one or more **items** (shown as "Topics" in the backoffice), each a chunk of markdown
+- Is auto-discovered at startup via the `[AIKnowledgeSet]` attribute — no registration code
+- Is auto-active — installed sets are available to every request with nothing to configure
+- Is surfaced **on demand** — the model retrieves an item's content only when it is relevant
+
+## How It Works
+
+Installed knowledge sets flow through the same context resolution pipeline as contexts. For each request, the AI is shown a grouped list of the available items — each item's name and description act as a breadcrumb — and the model pulls an item's full markdown content only when it decides the item is relevant. Item content is produced lazily, so listing a set never loads its content.
+
+## Creating a Knowledge Set
+
+Derive from `AIKnowledgeSetBase`, decorate the class with `[AIKnowledgeSet]`, and override `GetItemsAsync` to return the items. Use `AIKnowledgeSetItem.FromContent` for static markdown:
+
+{% code title="EngageKnowledgeSet.cs" %}
+
+```csharp
+using Umbraco.AI.Core.Contexts.KnowledgeSets;
+
+[AIKnowledgeSet("umbraco-engage", "Umbraco Engage",
+    Description = "Background knowledge about Umbraco Engage.",
+    Icon = "icon-book")]
+public sealed class EngageKnowledgeSet : AIKnowledgeSetBase
+{
+    public override Task<IReadOnlyList<AIKnowledgeSetItem>> GetItemsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<AIKnowledgeSetItem> items =
+        [
+            AIKnowledgeSetItem.FromContent(
+                key: "goals",
+                name: "Goals",
+                content: "# Goals\nEngage goals let you track conversions across a visit...",
+                description: "How goals work in Umbraco Engage."),
+        ];
+
+        return Task.FromResult(items);
+    }
+}
+```
+
+{% endcode %}
+
+That is the complete happy path. On startup the class is discovered, and its items become knowledge the AI can draw on — no further wiring required.
+
+### Loading Content Dynamically
+
+`FromContent` wraps a literal string. When an item's content needs to be built at request time — for example loaded from a service — set `GetContentAsync` directly instead. The producer is invoked lazily, only when the content is actually retrieved:
+
+{% code title="Dynamic item" %}
+
+```csharp
+new AIKnowledgeSetItem
+{
+    Key = "segments",
+    Name = "Segments",
+    Description = "The audience segments configured on this site.",
+    GetContentAsync = async token => await _segmentService.GetSegmentsMarkdownAsync(token),
+}
+```
+
+{% endcode %}
+
+## AIKnowledgeSetItem
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `Key` | `string` | Stable, URL-safe identity within the set (e.g. `"goals"`). Keep it stable across renames. |
+| `Name` | `string` | Display name, shown in the backoffice. |
+| `Description` | `string?` | The breadcrumb the AI sees when the item is advertised — write it to help the model decide whether to retrieve the item. |
+| `GetContentAsync` | `Func<CancellationToken, Task<string>>` | Lazily produces the markdown content, injected as-is when retrieved. |
+
+## Registration
+
+Knowledge sets are auto-discovered via the `[AIKnowledgeSet]` attribute and the `IDiscoverable` interface. No manual registration is needed.
+
+To add a set that isn't auto-discovered, or to exclude one, use the collection builder in a Composer:
+
+{% code title="KnowledgeSetComposer.cs" %}
+
+```csharp
+using Umbraco.AI.Extensions;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+
+public class KnowledgeSetComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.AIKnowledgeSets()
+            .Add<EngageKnowledgeSet>()
+            .Exclude<LegacyKnowledgeSet>();
+    }
+}
+```
+
+{% endcode %}
+
+## Viewing Installed Knowledge Sets
+
+Installed sets appear under **AI Configuration > Knowledge Sets** in the backoffice. This view is read-only: you can browse the installed sets and open a topic to inspect its content. Knowledge sets are defined in code, so they cannot be created or edited from the backoffice.
+
+## Related
+
+- [Contexts](../../concepts/contexts.md) - Injecting brand voice, guidelines, and content into AI operations
+- [Custom Tools](../tools/README.md) - Give AI agents actions to perform

--- a/18/ai-in-umbraco/extending/knowledge-sets/README.md
+++ b/18/ai-in-umbraco/extending/knowledge-sets/README.md
@@ -91,7 +91,7 @@ new AIKnowledgeSetItem
 
 Knowledge sets are auto-discovered via the `[AIKnowledgeSet]` attribute and the `IDiscoverable` interface. No manual registration is needed.
 
-To add a set that isn't auto-discovered, or to exclude one, use the collection builder in a Composer:
+To turn off a set shipped by another package, exclude it in a Composer:
 
 {% code title="KnowledgeSetComposer.cs" %}
 
@@ -105,13 +105,14 @@ public class KnowledgeSetComposer : IComposer
     public void Compose(IUmbracoBuilder builder)
     {
         builder.AIKnowledgeSets()
-            .Add<ManuallyRegisteredKnowledgeSet>()
             .Exclude<ThirdPartyKnowledgeSet>();
     }
 }
 ```
 
 {% endcode %}
+
+The builder also exposes `.Add<T>()`, but you rarely need it. A decorated set is already registered by discovery. `.Add<T>()` only helps for the uncommon case of a set that implements `IAIKnowledgeSet` directly, without the `[AIKnowledgeSet]` attribute.
 
 ## Viewing Installed Knowledge Sets
 

--- a/18/ai-in-umbraco/extending/knowledge-sets/README.md
+++ b/18/ai-in-umbraco/extending/knowledge-sets/README.md
@@ -5,7 +5,9 @@ description: >-
 
 # Knowledge Sets
 
-A knowledge set is a code-defined, package-embeddable collection of background knowledge about a subject — for example a product such as Umbraco Engage — that is surfaced to the AI. A package author ships knowledge by dropping a single decorated class into an assembly: it is discovered at startup, needs no configuration, and its content flows to the model on demand.
+A knowledge set is a collection of background knowledge about a subject — for example, a product such as Umbraco Engage. It is defined in code and shipped inside a package, so the AI can draw on it.
+
+A package author ships knowledge by dropping a single decorated class into an assembly. The set is discovered at startup, needs no configuration, and its content flows to the model on demand.
 
 Knowledge sets are the content complement to [Contexts](../../concepts/contexts.md): context resource types define the _shape_ of context, while knowledge sets provide ready-made _content_.
 
@@ -21,7 +23,7 @@ Each knowledge set:
 
 ## How It Works
 
-Installed knowledge sets flow through the same context resolution pipeline as contexts. For each request, the AI is shown a grouped list of the available items — each item's name and description act as a breadcrumb — and the model pulls an item's full markdown content only when it decides the item is relevant. Item content is produced lazily, so listing a set never loads its content.
+Installed knowledge sets flow through the same context resolution pipeline as contexts. For each request, the AI is shown a grouped list of the available items, where each item's name and description act as a breadcrumb. The model then pulls an item's full markdown content only when it decides the item is relevant. Item content is produced lazily, so listing a set never loads its content.
 
 ## Creating a Knowledge Set
 
@@ -60,7 +62,7 @@ That is the complete happy path. On startup the class is discovered, and its ite
 
 ### Loading Content Dynamically
 
-`FromContent` wraps a literal string. When an item's content needs to be built at request time — for example loaded from a service — set `GetContentAsync` directly instead. The producer is invoked lazily, only when the content is actually retrieved:
+`FromContent` wraps a literal string. When an item's content needs to be built at request time — for example loaded from a service — set `GetContentAsync` directly instead. The producer is invoked lazily, only when the content is retrieved:
 
 {% code title="Dynamic item" %}
 
@@ -80,7 +82,7 @@ new AIKnowledgeSetItem
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `Key` | `string` | Stable, URL-safe identity within the set (e.g. `"goals"`). Keep it stable across renames. |
+| `Key` | `string` | Stable, URL-safe identity within the set (for example `"goals"`). Keep it stable across renames. |
 | `Name` | `string` | Display name, shown in the backoffice. |
 | `Description` | `string?` | The breadcrumb the AI sees when the item is advertised — write it to help the model decide whether to retrieve the item. |
 | `GetContentAsync` | `Func<CancellationToken, Task<string>>` | Lazily produces the markdown content, injected as-is when retrieved. |

--- a/18/ai-in-umbraco/extending/knowledge-sets/README.md
+++ b/18/ai-in-umbraco/extending/knowledge-sets/README.md
@@ -105,8 +105,8 @@ public class KnowledgeSetComposer : IComposer
     public void Compose(IUmbracoBuilder builder)
     {
         builder.AIKnowledgeSets()
-            .Add<EngageKnowledgeSet>()
-            .Exclude<LegacyKnowledgeSet>();
+            .Add<ManuallyRegisteredKnowledgeSet>()
+            .Exclude<ThirdPartyKnowledgeSet>();
     }
 }
 ```


### PR DESCRIPTION
Documents the **Knowledge Sets** feature that recently landed in Umbraco.AI (v18 [#252], v17 [#253]).

Knowledge Sets are a code-defined, package-embeddable primitive that lets a package ship background knowledge about a subject (e.g. a product like Umbraco Engage) which the AI draws on **on demand**. They're the content complement to context resource types — auto-discovered, auto-active, no configuration.

## What's included

Kept deliberately minimal and developer-focused (happy path first):

- **New page** `extending/knowledge-sets/README.md` — what a knowledge set is, how it works, authoring one (`AIKnowledgeSetBase` + `[AIKnowledgeSet]` + `AIKnowledgeSetItem.FromContent`), loading content dynamically, registration, and viewing installed sets in the backoffice.
- **Extending overview** — new extension-point card, "when to create" guidance, and section content-ref.
- **Contexts concept** — a `Related` cross-link, since Knowledge Sets are the content complement to contexts.
- Registered in `SUMMARY.md` under **Extending**.

Applied to both **`17/`** and **`18/`** doc lines, byte-identical.

## Notes

Opened as **draft** pending the feature's release (following the precedent of the Image Generation docs PR). The dedicated management-API / backoffice / reference pages were intentionally omitted to keep the docs lean — the read-only API and backoffice view are summarised inline on the main page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)