### PR TITLE
Document IndexExternalBlockElements indexing setting (CMS 19)

### DIFF
--- a/18/umbraco-cms/develop-with-umbraco/configuration/indexingsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/indexingsettings.md
@@ -11,6 +11,7 @@ This section allows you to configure how content is indexed for Examine.
   "CMS": {
     "Indexing": {
       "ExplicitlyIndexEachNestedProperty": true,
+      "IndexExternalBlockElements": false,
       "BatchSize": 10000
     }
   }
@@ -26,6 +27,14 @@ When indexing content, each property contained within certain complex editors ar
 The complex editors are also indexed to their own separate fields, which then contains "the sum" of all properties contained within.
 
 In some cases this yields a lot of fields in the index, which can lead to errors when performing searches. Changing this setting to `false` can mend that issue. It prevents each contained property from being written to the index in its own field.
+
+## IndexExternalBlockElements
+
+Elements from the Library can be embedded as block content in Block List and Block Grid editors. By default, the content of these Elements is not added to the search index of the documents that embed them.
+
+Set this to `true` to include that content in the index entry of the referencing document. This only applies to the external index used for front-end searches. The internal (back office) index is not affected.
+
+Rebuild your indexes after changing this setting for the change to take effect.
 
 ## BatchSize
 

--- a/18/umbraco-cms/develop-with-umbraco/configuration/indexingsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/indexingsettings.md
@@ -30,7 +30,7 @@ In some cases this yields a lot of fields in the index, which can lead to errors
 
 ## IndexExternalBlockElements
 
-Elements from the Library can be embedded as block content in Block List and Block Grid editors. By default, the content of these Elements is not added to the search index of the documents that embed them.
+[Elements](../../model-your-content/content-types-and-structure/data/defining-content/elements.md) from the Library can be embedded as block content in Block List and Block Grid editors. By default, the content of these Elements is not added to the search index of the documents that embed them.
 
 Set this to `true` to include that content in the index entry of the referencing document. This only applies to the external index used for front-end searches. The internal (backoffice) index is not affected.
 

--- a/18/umbraco-cms/develop-with-umbraco/configuration/indexingsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/indexingsettings.md
@@ -32,7 +32,7 @@ In some cases this yields a lot of fields in the index, which can lead to errors
 
 Elements from the Library can be embedded as block content in Block List and Block Grid editors. By default, the content of these Elements is not added to the search index of the documents that embed them.
 
-Set this to `true` to include that content in the index entry of the referencing document. This only applies to the external index used for front-end searches. The internal (back office) index is not affected.
+Set this to `true` to include that content in the index entry of the referencing document. This only applies to the external index used for front-end searches. The internal (backoffice) index is not affected.
 
 Rebuild your indexes after changing this setting for the change to take effect.
 


### PR DESCRIPTION
## 📋 Description

Documents the new `IndexExternalBlockElements` indexing setting, added in [umbraco/Umbraco-CMS#23271](https://github.com/umbraco/Umbraco-CMS/pull/23271). When enabled, the content of Library Elements embedded as block content in Block List and Block Grid editors is included in the external (front-end) search index of the referencing document. Disabled by default; does not affect the internal (backoffice) index.

Added to the v18 docs as a temporary home, since v19 docs don't exist yet. Should be moved to the v19 docs folder once that structure is created.

## 📎 Related Issues (if applicable)

Documents umbraco/Umbraco-CMS#23271

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco CMS 19.0. Currently placed under `18/` docs since `19/` doesn't exist yet — needs moving once it does.

## Deadline (if relevant)

Publish when 19.0 beta is released.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)