### PR TITLE
Umbraco Forms: Add security advisory release notes for 13.9.8, 17.4.7 and 18.0.5

### DIFF
--- a/.github/styles/UmbracoDocs/Acronyms.yml
+++ b/.github/styles/UmbracoDocs/Acronyms.yml
@@ -49,6 +49,7 @@ exceptions:
   - FTP      # File Transfer Protocol
   - GDPR     # General Data Protection Regulation
   - GET      # HTTP GET method
+  - GHSA     # GitHub Security Advisory
   - GIF      # Graphics Interchange Format
   - GUI      # Graphical user interface
   - GUID     # Globally Unique Identifier

--- a/13/umbraco-forms/release-notes.md
+++ b/13/umbraco-forms/release-notes.md
@@ -16,6 +16,9 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 13 including all changes for this version.
 
+### [13.9.8](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F13.9.8) (July 22nd 2026)
+* Enforce server-side validation of the form step to prevent bypassing page validation and CAPTCHA on submission [GHSA-fv48-47xr-hwfj](https://github.com/umbraco/Umbraco.Forms.Issues/security/advisories/GHSA-fv48-47xr-hwfj)
+
 ### [13.9.7](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F13.9.7) (July 13th 2026)
 * Import: Fix error importing forms exported from Umbraco Forms 10 with string prevalues [#1405](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1405)
 * Conditions: Apply page button conditions to the visible submit button [#1705](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1705)

--- a/17/umbraco-forms/release-notes.md
+++ b/17/umbraco-forms/release-notes.md
@@ -18,6 +18,9 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 17 including all changes for this version.
 
+### [17.4.7](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F17.4.7) (July 22nd 2026)
+* Enforce server-side validation of the form step to prevent bypassing page validation and CAPTCHA on submission [GHSA-fv48-47xr-hwfj](https://github.com/umbraco/Umbraco.Forms.Issues/security/advisories/GHSA-fv48-47xr-hwfj)
+
 ### [17.4.6](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F17.4.6) (July 13th 2026)
 * Conditions: Apply page button conditions to the visible submit button [#1705](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1705)
 * Conditions: Fall back to the option value when a choice caption is empty [#1727](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1727)

--- a/18/umbraco-forms/release-notes.md
+++ b/18/umbraco-forms/release-notes.md
@@ -20,6 +20,9 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 18 including all changes for this version.
 
+### [18.0.5](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F18.0.5) (July 22nd 2026)
+* Enforce server-side validation of the form step to prevent bypassing page validation and CAPTCHA on submission [GHSA-fv48-47xr-hwfj](https://github.com/umbraco/Umbraco.Forms.Issues/security/advisories/GHSA-fv48-47xr-hwfj)
+
 ### [18.0.4](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F18.0.4) (July 13th 2026)
 * Conditions: Apply page button conditions to the visible submit button [#1705](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1705)
 * Conditions: Fall back to the option value when a choice caption is empty [#1727](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1727)


### PR DESCRIPTION
## 📋 Description

Adds release-notes entries for the Umbraco Forms security patch releases **13.9.8**, **17.4.7** and **18.0.5**, each documenting the form-step validation advisory **GHSA-fv48-47xr-hwfj** (High severity). Entries follow the existing security-release pattern (a release-notes bullet linking to the GitHub Security Advisory).

Also adds `GHSA` (GitHub Security Advisory) to the Vale acronyms exceptions list, since the acronym recurs in every security release note.

## 📎 Related Issues (if applicable)

Documents [GHSA-fv48-47xr-hwfj](https://github.com/umbraco/Umbraco.Forms.Issues/security/advisories/GHSA-fv48-47xr-hwfj).

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

> **Note:** the GHSA link intentionally 404s until the advisory is published. This PR is a **draft** and should be merged only once GHSA-fv48-47xr-hwfj is public. Vale was run on the three changed files and is clean on the added lines.

## Product & Version (if relevant)

Umbraco Forms — 13, 17 and 18.

## Deadline (if relevant)

Publish alongside the public disclosure of GHSA-fv48-47xr-hwfj.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
