### PR TITLE
Add Deploy 13.4.5 release notes

### DIFF
--- a/13/umbraco-deploy/release-notes.md
+++ b/13/umbraco-deploy/release-notes.md
@@ -16,10 +16,14 @@ If you are upgrading to a new major version you can find the details about the b
 
 This section contains the release notes for Umbraco Deploy 13 including all changes for this version.
 
+### [13.4.5](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.4.5) (July 22nd 2026)
+
+* Fix restore of media folders with many files failing mid-stream by awaiting multipart response writes [#335](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/335).
+
 ### [13.4.4](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.4.4) (July 20th 2026)
 
-* Transfer invariant properties when deploying the default culture [#249](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/249)
-* Fix restore of trashed content leaving a stale recycle bin path and level [#267](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/267)
+* Transfer invariant properties when deploying the default culture [#249](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/249).
+* Fix restore of trashed content leaving a stale recycle bin path and level [#267](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/267).
 
 ### [13.4.3](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F13.4.3) (October 9th 2025)
 


### PR DESCRIPTION
## 📋 Description

Adds release notes for Umbraco Deploy 13.4.5 (July 22nd 2026):

- Fix restore of media folders with many files failing mid-stream by awaiting multipart response writes ([#335](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/335)).

## 📎 Related Issues (if applicable)

Fixes referenced from the Umbraco.Deploy.Issues tracker: [#335](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/335).

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Deploy 13.4.5.

## Deadline (if relevant)

This version is already available, so as soon as possible!