### PR TITLE
Clarify Checkout view overrides require a rebuild on Umbraco 17+

### DIFF
--- a/commerce-add-ons/packages/checkout/customize-checkout.md
+++ b/commerce-add-ons/packages/checkout/customize-checkout.md
@@ -17,7 +17,19 @@ To do this follow these steps:
 1. Copy the equivalent [files and partials](https://github.com/umbraco/Umbraco.Commerce.Checkout/tree/main/src/Umbraco.Commerce.Checkout/Views/UmbracoCommerceCheckout).
 2. Add them to `Views/UmbracoCommerceCheckout` in your project directory. It might be necessary to create the folder first.
 3. Make a small text change to one of the Views to verify that the files are in use.
-4. Verify that the changes are carried out and displayed correctly.
+4. Rebuild and restart your site, then verify that the changes are carried out and displayed correctly.
+
+The Checkout package ships its Views precompiled. When you add a matching View to your project's `Views/UmbracoCommerceCheckout` folder, your copy takes precedence over the packaged one, letting you override a single step without having to redefine them all.
+
+{% hint style="info" %}
+**Umbraco 17 and later (including Umbraco 18): view changes require a rebuild**
+
+From Umbraco CMS 17 onwards, Razor runtime compilation is no longer enabled by default. It has been removed from the CMS core and moved to the optional [`Umbraco.Cms.DevelopmentMode.Backoffice`](https://docs.umbraco.com/umbraco-cms/reference/configuration/runtimesettings) package.
+
+Overriding Views still works, but your overrides are compiled into the site at **build time**. After adding or editing a View, you must **rebuild and restart** the site for the changes to appear - editing a `.cshtml` file and only refreshing the browser will have no effect.
+
+To restore the previous behavior, where View changes are picked up without a rebuild during local development, add the `Umbraco.Cms.DevelopmentMode.Backoffice` package to your project. For background, see the [Umbraco CMS version-specific upgrade notes](https://docs.umbraco.com/umbraco-cms/get-started/upgrading-and-migrating/version-specific).
+{% endhint %}
 
 You are now ready to start customizing the Checkout page to fit the design of your website.
 

--- a/commerce-add-ons/packages/checkout/customize-checkout.md
+++ b/commerce-add-ons/packages/checkout/customize-checkout.md
@@ -8,49 +8,38 @@ It is assumed that you already have an Umbraco website configured Umbraco Commer
 
 Umbraco Commerce Checkout is a free and open-source add-on package for Umbraco Commerce. It is possible to amend the default behavior to customize the checkout to your needs.
 
-## How overriding works
+## Overriding the checkout Views
 
-The Checkout package ships its Views **precompiled** into the package assembly. To change a View, you provide your own copy at the same path under `Views/UmbracoCommerceCheckout`. For your copy to be used, **your site must also compile a View at that path at build time** - your compiled View then takes precedence over the package's precompiled one.
+Checkout's Views are precompiled into the package. To customize one, add your own copy at the same path under `Views/UmbracoCommerceCheckout`, and make sure your site compiles Views at build time so your copy is used instead of the packaged one.
 
 {% hint style="warning" %}
-**Umbraco 17 and later: dropping in a View is not enough on its own**
-
-New Umbraco projects are created in `BackofficeDevelopment` development mode, which sets the following in the project's `.csproj`:
+New Umbraco projects (17+) are set up for backoffice development, which disables build-time View compilation:
 
 ```xml
 <RazorCompileOnBuild>false</RazorCompileOnBuild>
 <RazorCompileOnPublish>false</RazorCompileOnPublish>
 ```
 
-With these settings your site does **not** compile the Views you add under `Views/UmbracoCommerceCheckout`, so the package's precompiled Views keep being used and your changes never appear - even after a rebuild.
+While this is set, Views you add under `Views/UmbracoCommerceCheckout` are ignored and your changes will not appear. To enable overrides:
 
-Razor **runtime compilation** does not work around this. It compiles on-disk Views only at paths where no precompiled View exists (this is what lets you live-edit your own templates and partials). It does **not** displace a package's precompiled View, so installing `Umbraco.Cms.DevelopmentMode.Backoffice` does not make Checkout overrides take effect either.
+1. Switch Models Builder to a source-code mode (`SourceCodeAuto` or `SourceCodeManual`) and generate your models. Build-time compilation is not compatible with the default `InMemoryAuto` mode - see [Models Builder settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/modelsbuildersettings).
+2. Remove the `RazorCompileOnBuild` and `RazorCompileOnPublish` lines above (or set them to `true`).
 
-To use file-based overrides, your site must compile Views at **build time**:
-
-1. Switch Models Builder to a source-code mode (`SourceCodeAuto` or `SourceCodeManual`) and generate your models - see [Models Builder settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/modelsbuildersettings). Build-time Razor compilation is incompatible with the default `InMemoryAuto` mode, because in-memory models do not exist at build time.
-2. Remove `<RazorCompileOnBuild>false</RazorCompileOnBuild>` and `<RazorCompileOnPublish>false</RazorCompileOnPublish>` from your `.csproj` (or set them to `true`).
-3. Rebuild the site.
-
-This is the same configuration Umbraco requires for [Production runtime mode](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/server-setup/runtime-modes), so it also moves you toward a production-ready setup.
+This matches the configuration Umbraco requires for [Production runtime mode](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/server-setup/runtime-modes).
 {% endhint %}
 
-## Setup
-
-Once your site is configured to compile Views at build time (see the note above), follow these steps:
+Once your site compiles Views at build time, override a checkout step as follows:
 
 1. Copy the equivalent [files and partials](https://github.com/umbraco/Umbraco.Commerce.Checkout/tree/main/src/Umbraco.Commerce.Checkout/Views/UmbracoCommerceCheckout).
 2. Add them to `Views/UmbracoCommerceCheckout` in your project directory. It might be necessary to create the folder first.
-3. Make a small text change to one of the Views.
+3. Make your changes.
 4. Rebuild and restart your site, then verify that the change is displayed correctly.
-
-You are now ready to start customizing the Checkout page to fit the design of your website.
 
 ## Alternative: use a Template
 
-If you would rather not change your build-time compilation settings, you can assign a **Template** to the checkout page in the backoffice and place your markup there. A Template lives at its own View path with no precompiled View competing with it, so it renders (and live-edits) normally, and Checkout renders it instead of its built-in View.
+Instead of overriding the Views, you can assign a **Template** to the checkout page in the backoffice and place your markup there. Checkout will use the Template instead of its built-in View.
 
-Note that a Template receives the checkout page's `IPublishedContent` as its model - not the view model the packaged Views use - so with this approach you build that step's markup yourself against the Umbraco Commerce APIs.
+With this approach the Template receives the checkout page's `IPublishedContent` as its model - not the view model the packaged Views use - so you build that step's markup yourself against the Umbraco Commerce APIs.
 
 ## Useful links
 

--- a/commerce-add-ons/packages/checkout/customize-checkout.md
+++ b/commerce-add-ons/packages/checkout/customize-checkout.md
@@ -39,7 +39,9 @@ Once your site compiles Views at build time, override a checkout step as follows
 
 Instead of overriding the Views, you can assign a **Template** to the checkout page in the backoffice and place your markup there. Checkout will use the Template instead of its built-in View.
 
-With this approach the Template receives the checkout page's `IPublishedContent` as its model - not the view model the packaged Views use - so you build that step's markup yourself against the Umbraco Commerce APIs.
+With this approach, the Template receives the checkout page's IPublishedContent as its model—not the packaged Views' view model.
+
+You then build that step's markup yourself against the Umbraco Commerce APIs.
 
 ## Useful links
 

--- a/commerce-add-ons/packages/checkout/customize-checkout.md
+++ b/commerce-add-ons/packages/checkout/customize-checkout.md
@@ -8,30 +8,47 @@ It is assumed that you already have an Umbraco website configured Umbraco Commer
 
 Umbraco Commerce Checkout is a free and open-source add-on package for Umbraco Commerce. It is possible to amend the default behavior to customize the checkout to your needs.
 
+## How overriding works
+
+The Checkout package ships its Views **precompiled** into the package assembly. To change a View, you provide your own copy at the same path (`Views/UmbracoCommerceCheckout/...`). When your site **compiles that View at build time**, your copy takes precedence over the packaged one, letting you override a single step without redefining them all.
+
+{% hint style="warning" %}
+**Umbraco 17 and later: your site must compile Views at build time**
+
+New Umbraco projects use the `InMemoryAuto` Models Builder mode, which sets the following in the project's `.csproj`:
+
+```xml
+<RazorCompileOnBuild>false</RazorCompileOnBuild>
+<RazorCompileOnPublish>false</RazorCompileOnPublish>
+```
+
+With these settings, Views you add under `Views/UmbracoCommerceCheckout` are **not compiled**, so the packaged (precompiled) Views keep being used and your changes never appear - even after a rebuild.
+
+Razor **runtime compilation** does *not* help here: it does not override a package's precompiled Views, so installing `Umbraco.Cms.DevelopmentMode.Backoffice` will not make file-based overrides take effect either.
+
+To use file-based overrides, your site must compile Views at build time:
+
+1. Switch Models Builder to a source-code mode (for example `SourceCodeAuto` or `SourceCodeManual`) - see [Models Builder settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/modelsbuildersettings).
+2. Remove `<RazorCompileOnBuild>false</RazorCompileOnBuild>` and `<RazorCompileOnPublish>false</RazorCompileOnPublish>` from your `.csproj` (or set them to `true`).
+3. Rebuild the site.
+
+For background on why runtime compilation was removed from the core in Umbraco 17, see the [Umbraco CMS version-specific upgrade notes](https://docs.umbraco.com/umbraco-cms/get-started/upgrading-and-migrating/version-specific).
+{% endhint %}
+
 ## Setup
 
-To allow customization you must first 'override' the existing files for the step required to be modified.
-
-To do this follow these steps:
+Once your site is configured to compile Views at build time (see the note above), follow these steps:
 
 1. Copy the equivalent [files and partials](https://github.com/umbraco/Umbraco.Commerce.Checkout/tree/main/src/Umbraco.Commerce.Checkout/Views/UmbracoCommerceCheckout).
 2. Add them to `Views/UmbracoCommerceCheckout` in your project directory. It might be necessary to create the folder first.
-3. Make a small text change to one of the Views to verify that the files are in use.
-4. Rebuild and restart your site, then verify that the changes are carried out and displayed correctly.
-
-The Checkout package ships its Views precompiled. When you add a matching View to your project's `Views/UmbracoCommerceCheckout` folder, your copy takes precedence over the packaged one, letting you override a single step without having to redefine them all.
-
-{% hint style="info" %}
-**Umbraco 17 and later (including Umbraco 18): view changes require a rebuild**
-
-From Umbraco CMS 17 onwards, Razor runtime compilation is no longer enabled by default. It has been removed from the CMS core and moved to the optional [`Umbraco.Cms.DevelopmentMode.Backoffice`](https://docs.umbraco.com/umbraco-cms/reference/configuration/runtimesettings) package.
-
-Overriding Views still works, but your overrides are compiled into the site at **build time**. After adding or editing a View, you must **rebuild and restart** the site for the changes to appear - editing a `.cshtml` file and only refreshing the browser will have no effect.
-
-To restore the previous behavior, where View changes are picked up without a rebuild during local development, add the `Umbraco.Cms.DevelopmentMode.Backoffice` package to your project. For background, see the [Umbraco CMS version-specific upgrade notes](https://docs.umbraco.com/umbraco-cms/get-started/upgrading-and-migrating/version-specific).
-{% endhint %}
+3. Make a small text change to one of the Views.
+4. Rebuild and restart your site, then verify that the change is displayed correctly.
 
 You are now ready to start customizing the Checkout page to fit the design of your website.
+
+## Alternative: use a Template
+
+If you would rather not change your build-time compilation settings, you can assign a **Template** to the checkout page in the backoffice and place your markup there. When a checkout page has a Template assigned, Checkout renders that Template instead of its built-in View. Templates are edited through the backoffice and do not depend on overriding the packaged Views.
 
 ## Useful links
 

--- a/commerce-add-ons/packages/checkout/customize-checkout.md
+++ b/commerce-add-ons/packages/checkout/customize-checkout.md
@@ -10,29 +10,29 @@ Umbraco Commerce Checkout is a free and open-source add-on package for Umbraco C
 
 ## How overriding works
 
-The Checkout package ships its Views **precompiled** into the package assembly. To change a View, you provide your own copy at the same path (`Views/UmbracoCommerceCheckout/...`). When your site **compiles that View at build time**, your copy takes precedence over the packaged one, letting you override a single step without redefining them all.
+The Checkout package ships its Views **precompiled** into the package assembly. To change a View, you provide your own copy at the same path under `Views/UmbracoCommerceCheckout`. For your copy to be used, **your site must also compile a View at that path at build time** - your compiled View then takes precedence over the package's precompiled one.
 
 {% hint style="warning" %}
-**Umbraco 17 and later: your site must compile Views at build time**
+**Umbraco 17 and later: dropping in a View is not enough on its own**
 
-New Umbraco projects use the `InMemoryAuto` Models Builder mode, which sets the following in the project's `.csproj`:
+New Umbraco projects are created in `BackofficeDevelopment` development mode, which sets the following in the project's `.csproj`:
 
 ```xml
 <RazorCompileOnBuild>false</RazorCompileOnBuild>
 <RazorCompileOnPublish>false</RazorCompileOnPublish>
 ```
 
-With these settings, Views you add under `Views/UmbracoCommerceCheckout` are **not compiled**, so the packaged (precompiled) Views keep being used and your changes never appear - even after a rebuild.
+With these settings your site does **not** compile the Views you add under `Views/UmbracoCommerceCheckout`, so the package's precompiled Views keep being used and your changes never appear - even after a rebuild.
 
-Razor **runtime compilation** does *not* help here: it does not override a package's precompiled Views, so installing `Umbraco.Cms.DevelopmentMode.Backoffice` will not make file-based overrides take effect either.
+Razor **runtime compilation** does not work around this. It compiles on-disk Views only at paths where no precompiled View exists (this is what lets you live-edit your own templates and partials). It does **not** displace a package's precompiled View, so installing `Umbraco.Cms.DevelopmentMode.Backoffice` does not make Checkout overrides take effect either.
 
-To use file-based overrides, your site must compile Views at build time:
+To use file-based overrides, your site must compile Views at **build time**:
 
-1. Switch Models Builder to a source-code mode (for example `SourceCodeAuto` or `SourceCodeManual`) - see [Models Builder settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/modelsbuildersettings).
+1. Switch Models Builder to a source-code mode (`SourceCodeAuto` or `SourceCodeManual`) and generate your models - see [Models Builder settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/modelsbuildersettings). Build-time Razor compilation is incompatible with the default `InMemoryAuto` mode, because in-memory models do not exist at build time.
 2. Remove `<RazorCompileOnBuild>false</RazorCompileOnBuild>` and `<RazorCompileOnPublish>false</RazorCompileOnPublish>` from your `.csproj` (or set them to `true`).
 3. Rebuild the site.
 
-For background on why runtime compilation was removed from the core in Umbraco 17, see the [Umbraco CMS version-specific upgrade notes](https://docs.umbraco.com/umbraco-cms/get-started/upgrading-and-migrating/version-specific).
+This is the same configuration Umbraco requires for [Production runtime mode](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/server-setup/runtime-modes), so it also moves you toward a production-ready setup.
 {% endhint %}
 
 ## Setup
@@ -48,7 +48,9 @@ You are now ready to start customizing the Checkout page to fit the design of yo
 
 ## Alternative: use a Template
 
-If you would rather not change your build-time compilation settings, you can assign a **Template** to the checkout page in the backoffice and place your markup there. When a checkout page has a Template assigned, Checkout renders that Template instead of its built-in View. Templates are edited through the backoffice and do not depend on overriding the packaged Views.
+If you would rather not change your build-time compilation settings, you can assign a **Template** to the checkout page in the backoffice and place your markup there. A Template lives at its own View path with no precompiled View competing with it, so it renders (and live-edits) normally, and Checkout renders it instead of its built-in View.
+
+Note that a Template receives the checkout page's `IPublishedContent` as its model - not the view model the packaged Views use - so with this approach you build that step's markup yourself against the Umbraco Commerce APIs.
 
 ## Useful links
 

--- a/commerce-add-ons/packages/checkout/customize-checkout.md
+++ b/commerce-add-ons/packages/checkout/customize-checkout.md
@@ -10,7 +10,7 @@ Umbraco Commerce Checkout is a free and open-source add-on package for Umbraco C
 
 ## Overriding the checkout Views
 
-Checkout's Views are precompiled into the package. To customize one, add your own copy at the same path under `Views/UmbracoCommerceCheckout`, and make sure your site compiles Views at build time so your copy is used instead of the packaged one.
+To customize one, add your copy to the same path under Views/UmbracoCommerceCheckout. Ensure your site compiles Views at build time so your copy is used instead of the packaged one.
 
 {% hint style="warning" %}
 New Umbraco projects (17+) are set up for backoffice development, which disables build-time View compilation:


### PR DESCRIPTION
## What & why

The [Customize Checkout](https://docs.umbraco.com/umbraco-commerce-packages/checkout/customize-checkout) guide tells users to drop overriding Views into `Views/UmbracoCommerceCheckout`, make a change, and verify it appears. On a default **Umbraco 17/18** project this silently does nothing — reported in [Umbraco.Commerce.Issues#865](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/865).

### Root cause (verified end-to-end)

The Checkout package ships its Views **precompiled** (`AddRazorSupportForMvc`). An override only wins if the **host app also compiles a View at that path at build time** — the app's compiled View then out-ranks the package's precompiled one (application-part ordering).

Default projects are created in `BackofficeDevelopment` development mode, whose `.csproj` sets `RazorCompileOnBuild=false` / `RazorCompileOnPublish=false`. So the app never compiles the dropped-in View, and the package's precompiled View keeps being used — even after a rebuild.

Razor **runtime compilation does not work around this.** It compiles on-disk Views only at paths with *no* precompiled View (that's what live-edits your own templates); it does **not** displace a package's precompiled View. So `Umbraco.Cms.DevelopmentMode.Backoffice` doesn't help.

Verified in a real **Umbraco 17.5.3 + Commerce 17.1.6 + Checkout 17.0.0** site (the reporter's exact versions):

| Scenario | Result |
|---|---|
| Default (`RazorCompileOnBuild=false`, `DevelopmentMode.Backoffice` active) | Override **ignored** — `assembly = Umbraco.Commerce.Checkout` |
| `RazorCompileOnBuild=true` | Override **wins** — renders the custom markup |
| Fresh path with no precompiled competitor | Runtime-compiled from disk, live-edits without rebuild |
| `RazorCompileOnBuild=true` + a View referencing an `InMemoryAuto` model | Build **fails** (`CS0234`) — why the source-code Models Builder step is required |

### Change

Rewrites the page to explain: overriding needs **build-time** compilation; the default `BackofficeDevelopment` mode disables it (`RazorCompileOnBuild=false`); runtime compilation can't displace a package's precompiled View; the fix is a source-code Models Builder mode + build-time compilation (which also aligns with Production readiness); and the **Template** alternative (distinct path, renders normally, but receives `IPublishedContent` rather than the checkout view model).

Single unversioned page under `commerce-add-ons/`, so one edit covers both v17 and v18 readers.

> Kept as **draft** pending final review. Supersedes the two earlier commits on this branch, whose guidance was incorrect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)