### PR TITLE
Add Umbraco.Forms.Deploy 17.0.1 and 18.0.1 release notes

### DIFF
--- a/17/umbraco-forms/release-notes.md
+++ b/17/umbraco-forms/release-notes.md
@@ -310,6 +310,17 @@ This change also ensures that field types remain registered. This prevents issue
 
 * Update dependencies to 17.0.0-rc1
 
+## Umbraco.Forms.Deploy
+
+### 17.0.1 (July 24th 2026)
+
+* Fix Umbraco Forms artifact property mappings lost on transfer/restore, including *Show summary page* and related form settings [#331](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/331).
+* Fix deploy of `Form.MessageOnSubmitBlocks` and its block element type dependencies (Umbraco Forms 17.3.0 or later).
+
+### 17.0.0 (November 27th 2025)
+
+* Compatibility with Umbraco Forms 17 and Deploy 17.
+
 ## Legacy release notes
 
 You can find the release notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/12/umbraco-forms/release-notes.md) and [Umbraco Forms Package page](https://our.umbraco.com/packages/developer-tools/umbraco-forms/).

--- a/17/umbraco-forms/release-notes.md
+++ b/17/umbraco-forms/release-notes.md
@@ -314,12 +314,12 @@ This change also ensures that field types remain registered. This prevents issue
 
 ### 17.0.1 (July 24th 2026)
 
-* Fix Umbraco Forms artifact property mappings lost on transfer/restore, including *Show summary page* and related form settings [#331](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/331).
-* Fix deploy of `Form.MessageOnSubmitBlocks` and its block element type dependencies (Umbraco Forms 17.3.0 or later).
+* Fix Umbraco Forms artifact property mappings lost on transfer/restore, including *Show summary page* and related form settings [#331](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/331)
+* Fix deploy of `Form.MessageOnSubmitBlocks` and its block element type dependencies (Umbraco Forms 17.3.0 or later)
 
 ### 17.0.0 (November 27th 2025)
 
-* Compatibility with Umbraco Forms 17 and Deploy 17.
+* Compatibility with Umbraco Forms 17 and Deploy 17
 
 ## Legacy release notes
 

--- a/18/umbraco-forms/release-notes.md
+++ b/18/umbraco-forms/release-notes.md
@@ -55,6 +55,17 @@ This section contains the release notes for Umbraco Forms 18 including all chang
 
 * Update dependencies to 18.0.0-rc1
 
+## Umbraco.Forms.Deploy
+
+### 18.0.1 (July 24th 2026)
+
+* Fix Umbraco Forms artifact property mappings lost on transfer/restore, including *Show summary page* and related form settings [#331](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/331).
+* Fix deploy of `Form.MessageOnSubmitBlocks` and its block element type dependencies (Umbraco Forms 17.3.0 or later).
+
+### 18.0.0 (June 25th 2026)
+
+* Compatibility with Umbraco Forms 18 and Deploy 18.
+
 ## Legacy release notes
 
 You can find the release notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/12/umbraco-forms/release-notes.md) and [Umbraco Forms Package page](https://our.umbraco.com/packages/developer-tools/umbraco-forms/).

--- a/18/umbraco-forms/release-notes.md
+++ b/18/umbraco-forms/release-notes.md
@@ -59,12 +59,12 @@ This section contains the release notes for Umbraco Forms 18 including all chang
 
 ### 18.0.1 (July 24th 2026)
 
-* Fix Umbraco Forms artifact property mappings lost on transfer/restore, including *Show summary page* and related form settings [#331](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/331).
-* Fix deploy of `Form.MessageOnSubmitBlocks` and its block element type dependencies (Umbraco Forms 17.3.0 or later).
+* Fix Umbraco Forms artifact property mappings lost on transfer/restore, including *Show summary page* and related form settings [#331](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/331)
+* Fix deploy of `Form.MessageOnSubmitBlocks` and its block element type dependencies (Umbraco Forms 17.3.0 or later)
 
 ### 18.0.0 (June 25th 2026)
 
-* Compatibility with Umbraco Forms 18 and Deploy 18.
+* Compatibility with Umbraco Forms 18 and Deploy 18
 
 ## Legacy release notes
 


### PR DESCRIPTION
## 📋 Description

Adds release notes for Umbraco.Forms.Deploy 17.0.1 and 18.0.1 (both published July 24th 2026), plus backfills the previously undocumented 17.0.0 and 18.0.0 compatibility releases so the new `## Umbraco.Forms.Deploy` sections in the Forms 17 and 18 release notes are complete.

**17.0.1** and **18.0.1** ship the same two fixes:

- Fix Umbraco Forms artifact property mappings lost on transfer/restore, including *Show summary page* and related form settings ([#331](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/331)).
- Fix deploy of `Form.MessageOnSubmitBlocks` and its block element type dependencies (Umbraco Forms 17.3.0 or later).

**17.0.0** and **18.0.0** are recorded as compatibility releases against Umbraco Forms and Deploy 17 / 18.

## 📎 Related Issues (if applicable)

Fixes referenced from the Umbraco.Deploy.Issues tracker: [#331](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/331).

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco.Forms.Deploy 17.0.0, 17.0.1, 18.0.0, and 18.0.1.

## Deadline (if relevant)

These versions are already available, so as soon as possible!