### PR TITLE
docs(ui-builder): release notes for 17.2.5 and 18.0.3

### DIFF
--- a/17/umbraco-ui-builder/release-notes.md
+++ b/17/umbraco-ui-builder/release-notes.md
@@ -18,6 +18,10 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 Below are the release notes for Umbraco UI Builder, detailing all changes in this version.
 
+### [**17.2.5**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.5) **(July 27th 2026)**
+
+* Fixed collection names returning the singular name in place of the plural, affecting the section dashboard cards, grouped collection tabs, and Entity Picker configuration [#229](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/229)
+
 ### [**17.2.4**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.4) **(July 16th 2026)**
 
 * Fixed read-only fields displaying JSON as `[object Object]`; JSON values now render as formatted text [#222](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/222)

--- a/18/umbraco-ui-builder/release-notes.md
+++ b/18/umbraco-ui-builder/release-notes.md
@@ -18,6 +18,11 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 Below are the release notes for Umbraco UI Builder, detailing all changes in this version.
 
+### [**18.0.3**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.3) **(July 27th 2026)**
+
+* Fixed the collection workspace heading showing the internal collection alias instead of the configured collection name [#229](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/229)
+* Fixed collection names returning the singular name in place of the plural, affecting the section dashboard cards, grouped collection tabs, and Entity Picker configuration [#229](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/229)
+
 ### [**18.0.2**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.2) **(July 16th 2026)**
 
 * Fixed read-only fields displaying JSON as `[object Object]`; JSON values now render as formatted text [#222](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/222)


### PR DESCRIPTION
## 📋 Description

Adds release notes for Umbraco UI Builder **17.2.5** and **18.0.3**, both released on 27-07-2026 and live on NuGet.

Both releases fix the same underlying defect in `CollectionMapper`, which returned a collection's singular name in place of its plural. v18 additionally fixes the collection workspace heading, which showed the internal collection alias instead of the configured name — that part was a v18-only regression, so it appears only in the 18.0.3 entry.

Two files changed, additions only (+5 / +4), each a new `###` entry at the top of `## Release History`:

* `18/umbraco-ui-builder/release-notes.md`
* `17/umbraco-ui-builder/release-notes.md`

No `SUMMARY.md` or `.gitbook.yaml` changes are needed — both pages already exist and are in the navigation.

## 📎 Related Issues (if applicable)

* umbraco/Umbraco.UIBuilder.Issues#229 — labelled `release/18.0.3` and `release/17.2.5`, so the tracker filter links in both new headings resolve.
* Code PRs: umbraco/Umbraco.UIBuilder#215 (v18) and umbraco/Umbraco.UIBuilder#216 (v17).

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful. — n/a for release notes
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

Format matches the existing entries: version bolded inside the `release/{version}` tracker filter link, date in bold parentheses in US long form with ordinal suffix, a single flat bullet list, bullets opening with a past-tense verb, and bare trailing issue links with no terminal period.

## Product & Version (if relevant)

Umbraco UI Builder 17.2.5 and 18.0.3.

## Deadline (if relevant)

No hard deadline, but both versions are already published to NuGet, so the notes are currently missing for released versions.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)