### PR TITLE
Add Umbraco Commerce 18.0.3 and 17.1.8 release notes

### DIFF
--- a/17/umbraco-commerce/release-notes/README.md
+++ b/17/umbraco-commerce/release-notes/README.md
@@ -18,6 +18,13 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 This section contains the release notes for Umbraco Commerce 17 including all changes for this version.
 
+#### [17.1.8](https://github.com/umbraco/Umbraco.Commerce.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.1.8) (27th Jul 2026)
+* Fix a second order save being triggered while frozen prices were recalculating, which could cause a concurrency error
+* Improve logging when an order calculation fails, so the underlying cause and order details are recorded
+* Fix the cart becoming unusable when an order line's product can no longer be found [#863](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/863)
+* Fix creating a product picker data type failing with a "property editor not found" error
+* Fix product attribute and preset changes requiring the Settings section instead of the Commerce section
+
 #### [17.1.7](https://github.com/umbraco/Umbraco.Commerce.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.1.7) (15th Jul 2026)
 * Fix cart conversion "Reached Checkout" and "Purchased" totals drifting for past periods [#835](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/835)
 * Fix the product picker in the discount rule editor losing store context

--- a/17/umbraco-commerce/release-notes/README.md
+++ b/17/umbraco-commerce/release-notes/README.md
@@ -22,7 +22,7 @@ This section contains the release notes for Umbraco Commerce 17 including all ch
 * Fix a second order save being triggered while frozen prices were recalculating, which could cause a concurrency error
 * Improve logging when an order calculation fails, so the underlying cause and order details are recorded
 * Fix the cart becoming unusable when an order line's product can no longer be found [#863](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/863)
-* Fix creating a product picker data type failing with a "property editor not found" error
+* Fix creating a product picker Data Type failing with a "property editor not found" error
 * Fix product attribute and preset changes requiring the Settings section instead of the Commerce section
 
 #### [17.1.7](https://github.com/umbraco/Umbraco.Commerce.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.1.7) (15th Jul 2026)

--- a/18/umbraco-commerce/release-notes/README.md
+++ b/18/umbraco-commerce/release-notes/README.md
@@ -18,6 +18,14 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 This section contains the release notes for Umbraco Commerce 18, including all changes for this version.
 
+#### 18.0.3 (27th Jul 2026)
+
+* Fixed a second order save being triggered while frozen prices were recalculating, which could cause a concurrency error.
+* Improved logging when an order calculation fails, so the underlying cause and order details are recorded.
+* Fixed the cart becoming unusable when an order line's product can no longer be found (#863).
+* Fixed creating a product picker data type failing with a "property editor not found" error.
+* Fixed product attribute and preset changes requiring the Settings section instead of the Commerce section.
+
 #### 18.0.2 (15th Jul 2026)
 
 * Fixed cart conversion "Reached Checkout" and "Purchased" totals drifting for past periods (#835).

--- a/18/umbraco-commerce/release-notes/README.md
+++ b/18/umbraco-commerce/release-notes/README.md
@@ -23,7 +23,7 @@ This section contains the release notes for Umbraco Commerce 18, including all c
 * Fixed a second order save being triggered while frozen prices were recalculating, which could cause a concurrency error.
 * Improved logging when an order calculation fails, so the underlying cause and order details are recorded.
 * Fixed the cart becoming unusable when an order line's product can no longer be found (#863).
-* Fixed creating a product picker data type failing with a "property editor not found" error.
+* Fixed creating a product picker Data Type failing with a "property editor not found" error.
 * Fixed product attribute and preset changes requiring the Settings section instead of the Commerce section.
 
 #### 18.0.2 (15th Jul 2026)


### PR DESCRIPTION
## Summary
Adds release notes for Umbraco Commerce 18.0.3 and 17.1.8 (cart/order-calculation hotfix round).

## Test plan
- [ ] Docs team review for style/links

🤖 Generated with [Claude Code](https://claude.com/claude-code)