### PR TITLE
Add Umbraco Commerce 17.1.9 and 18.0.4 release notes

### DIFF
--- a/17/umbraco-commerce/release-notes/README.md
+++ b/17/umbraco-commerce/release-notes/README.md
@@ -18,6 +18,9 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 This section contains the release notes for Umbraco Commerce 17 including all changes for this version.
 
+#### [17.1.9](https://github.com/umbraco/Umbraco.Commerce.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.1.9) (29th Jul 2026)
+* Add logging to record why an order is moved to the error status, and when a payment is reset or redirected through a payment provider's cancel or error URL [#866](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/866)
+
 #### [17.1.8](https://github.com/umbraco/Umbraco.Commerce.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.1.8) (27th Jul 2026)
 * Fix a second order save being triggered while frozen prices were recalculating, which could cause a concurrency error
 * Improve logging when an order calculation fails, so the underlying cause and order details are recorded

--- a/18/umbraco-commerce/release-notes/README.md
+++ b/18/umbraco-commerce/release-notes/README.md
@@ -18,6 +18,10 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 This section contains the release notes for Umbraco Commerce 18, including all changes for this version.
 
+#### 18.0.4 (29th Jul 2026)
+
+* Added logging to record why an order is moved to the error status, and when a payment is reset or redirected through a payment provider's cancel or error URL (#866).
+
 #### 18.0.3 (27th Jul 2026)
 
 * Fixed a second order save being triggered while frozen prices were recalculating, which could cause a concurrency error.


### PR DESCRIPTION
## Summary

Adds release notes for Umbraco Commerce 17.1.9 and 18.0.4, both published to NuGet on 29th July 2026.

Both releases add diagnostic logging around orders moving to the error state, to help diagnose [#866](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/866).

## Test plan

- [ ] Both entries appear at the top of their respective Release History sections
- [ ] The 18 entry matches the existing v18 style (plain heading, past tense, unlinked issue reference)
- [ ] The 17 entry matches the existing v17 style (heading linked to the filtered issue search, present tense, inline linked issue reference)
- [ ] Vale prose linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
