### PR TITLE
Forms: Guard the UTC timestamp correction script against re-runs

### DIFF
--- a/17/umbraco-forms/.gitbook/assets/correct-utc-timestamps.sql
+++ b/17/umbraco-forms/.gitbook/assets/correct-utc-timestamps.sql
@@ -1,25 +1,116 @@
--- Correct post-v17 data that was stored with DateTime.Now instead of DateTime.UtcNow.
--- @TimeZone: your server Windows timezone name (e.g. Romance Standard Time)
--- @UpgradeDate: approximate date you first upgraded to v17.0.0
---               (rows BEFORE this date were already correctly migrated to UTC)
+/*
+    Umbraco Forms: correct system dates that were stored as local server time instead of UTC.
 
+    This applies to sites that ran Umbraco Forms 17.0.0 to 17.2.x. In those versions the v17.0.0
+    migration converted existing dates to UTC, but new rows were still written with local server
+    time. Umbraco Forms 17.3.0 corrected the write path, so rows created from that deployment
+    onwards are already UTC and must not be shifted again.
+
+    SQL Server only. The AT TIME ZONE syntax is not supported by SQLite.
+
+    Before you run this script:
+
+    1. Take a database backup. Nothing in the schema records whether a row has already been
+       shifted, so a repeated or partial run cannot be undone from the data alone.
+    2. Set the three variables below.
+    3. Read the notes at the end of this file.
+
+    When the script completes it writes a marker to umbracoKeyValue. If that marker is already
+    present, the script reports it and exits without changing any rows.
+*/
+
+SET XACT_ABORT ON
+
+-- Your server's Windows time zone name, for example 'Romance Standard Time'.
 DECLARE @TimeZone NVARCHAR(100) = 'Romance Standard Time'
+
+-- The date you first upgraded to 17.0.0. Rows created before this date were already converted
+-- to UTC by the MigrateSystemDatesToUtc migration.
 DECLARE @UpgradeDate DATETIME = '2026-03-01'
 
+-- The date you deployed 17.3.0 or later. Rows created on or after this date are already UTC.
+DECLARE @FixDate DATETIME = '2026-04-23'
+
+DECLARE @MarkerKey NVARCHAR(256) = 'Umbraco.Forms.UtcTimestampCorrection'
+
+IF EXISTS (SELECT 1 FROM umbracoKeyValue WHERE [key] = @MarkerKey)
+BEGIN
+    PRINT 'This correction has already been applied to this database. No rows were changed.'
+    RETURN
+END
+
+IF @FixDate <= @UpgradeDate
+BEGIN
+    PRINT 'Set @FixDate to a date later than @UpgradeDate. No rows were changed.'
+    RETURN
+END
+
+-- Reports how many entries fall inside the affected window. Run this SELECT on its own first if
+-- you want to confirm the window before writing anything.
+SELECT
+    COUNT(*) AS AffectedRecords,
+    MIN(Created) AS EarliestAffected,
+    MAX(Created) AS LatestAffected
+FROM UFRecords
+WHERE Created > @UpgradeDate AND Created < @FixDate
+
+BEGIN TRANSACTION
+
 -- Record tables
-UPDATE UFRecords SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFRecords SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFRecordAudit SET UpdatedOn = UpdatedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE UpdatedOn > @UpgradeDate
-UPDATE UFRecordWorkflowAudit SET ExecutedOn = ExecutedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE ExecutedOn > @UpgradeDate
+UPDATE UFRecords SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFRecords SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFRecordAudit SET UpdatedOn = UpdatedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE UpdatedOn > @UpgradeDate AND UpdatedOn < @FixDate
+UPDATE UFRecordWorkflowAudit SET ExecutedOn = ExecutedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE ExecutedOn > @UpgradeDate AND ExecutedOn < @FixDate
 
 -- Entity metadata tables
-UPDATE UFPrevalueSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFPrevalueSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFWorkflows SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFWorkflows SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFDataSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFDataSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFFolders SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFFolders SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFForms SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFForms SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
+UPDATE UFPrevalueSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFPrevalueSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFWorkflows SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFWorkflows SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFDataSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFDataSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFFolders SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFFolders SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFForms SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFForms SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+
+-- The Analytics charts are served from a pre-aggregated summary table, not from UFRecords
+-- directly, and those rows were built from the incorrect timestamps. Deleting the affected days
+-- makes the background task recalculate them from the corrected entries. Both tables hold only
+-- values derived from UFRecords and UFRecordWorkflowAudit, so no data is lost.
+-- The range extends one day past each boundary because a shifted entry can move across a day.
+IF OBJECT_ID('UFAnalyticsDailySummary', 'U') IS NOT NULL
+BEGIN
+    DELETE FROM UFAnalyticsDailySummary
+    WHERE [Date] >= DATEADD(DAY, -1, CAST(@UpgradeDate AS DATE))
+      AND [Date] < DATEADD(DAY, 1, CAST(@FixDate AS DATE))
+
+    DELETE FROM UFAnalyticsProcessedDates
+    WHERE [Date] >= DATEADD(DAY, -1, CAST(@UpgradeDate AS DATE))
+      AND [Date] < DATEADD(DAY, 1, CAST(@FixDate AS DATE))
+END
+
+INSERT INTO umbracoKeyValue ([key], [value], [updated])
+VALUES (@MarkerKey, CONVERT(NVARCHAR(30), SYSUTCDATETIME(), 126), SYSUTCDATETIME())
+
+COMMIT TRANSACTION
+
+PRINT 'Correction applied. Restart the site so the analytics summary is rebuilt.'
+
+/*
+    Notes
+
+    The UFRecordDataDateTime table is excluded on purpose. Those values are dates entered by the
+    person filling in the form, not system dates. Shifting them would change the answer.
+
+    The window boundaries are compared against the stored value, so entries within a few hours of
+    either boundary can be judged incorrectly. Use the exact deployment times if you have them.
+
+    The original MigrateSystemDatesToUtc migration converted the UFPrevalueSource Created and
+    Updated columns twice. This was fixed in 17.3.0, but a site that ran 17.0 to 17.2 may hold
+    double-converted values in those two columns that need correcting separately.
+
+    After restarting, confirm the rebuild finished under
+    Settings > Health Check > Forms > Analytics Processing. The rebuild does not run if analytics
+    processing is disabled in configuration.
+*/

--- a/17/umbraco-forms/.gitbook/assets/correct-utc-timestamps.sql
+++ b/17/umbraco-forms/.gitbook/assets/correct-utc-timestamps.sql
@@ -28,7 +28,8 @@ DECLARE @TimeZone NVARCHAR(100) = 'Romance Standard Time'
 -- to UTC by the MigrateSystemDatesToUtc migration.
 DECLARE @UpgradeDate DATETIME = '2026-03-01'
 
--- The date you deployed 17.3.0 or later. Rows created on or after this date are already UTC.
+-- The date you first deployed a version of 17.3.0 or newer. Rows created on or after this date
+-- are already UTC. If you upgraded 17.2 to 17.3 and later to 17.4, use the 17.3 date.
 DECLARE @FixDate DATETIME = '2026-04-23'
 
 DECLARE @MarkerKey NVARCHAR(256) = 'Umbraco.Forms.UtcTimestampCorrection'

--- a/17/umbraco-forms/release-notes.md
+++ b/17/umbraco-forms/release-notes.md
@@ -106,7 +106,7 @@ Take a database backup before you run it. Then set the three variables at the to
 
 * `@TimeZone`: your server's Windows time zone name.
 * `@UpgradeDate`: the date you first upgraded to v17.0.0. Rows created before this date were already converted to UTC.
-* `@FixDate`: the date you deployed v17.3.0 or later. Rows created on or after this date are already UTC and must not be shifted again.
+* `@FixDate`: the date you first deployed a version of v17.3.0 or newer. Rows created on or after this date are already UTC and must not be shifted again. If you upgraded from v17.2 to v17.3 and later to v17.4, use the v17.3 date.
 
 The script writes a marker to `umbracoKeyValue` when it completes. On a second run it reports the marker and exits without changing any rows.
 

--- a/17/umbraco-forms/release-notes.md
+++ b/17/umbraco-forms/release-notes.md
@@ -100,15 +100,25 @@ This release fixes the issue by:
 * Removing the legacy server-side timezone offset conversion in the entries list — the browser now handles UTC-to-local conversion consistently
 
 {% hint style="warning" %}
-Data written between v17.0.0 and this release may contain local server timestamps instead of UTC. A SQL script is provided below to correct historical data.
+Data written between v17.0.0 and this release may contain local server timestamps instead of UTC. A SQL script is provided below to correct historical data. It runs on SQL Server only.
 
-Before running it, set `@TimeZone` to your server's Windows timezone name. Set `@UpgradeDate` to the approximate date you first upgraded to v17.0.0. The script excludes the `UFRecordDataDateTime` table, as those values represent user-entered dates that should not be shifted.
+Take a database backup before you run it. Then set the three variables at the top of the script:
+
+* `@TimeZone`: your server's Windows time zone name.
+* `@UpgradeDate`: the date you first upgraded to v17.0.0. Rows created before this date were already converted to UTC.
+* `@FixDate`: the date you deployed v17.3.0 or later. Rows created on or after this date are already UTC and must not be shifted again.
+
+The script writes a marker to `umbracoKeyValue` when it completes. On a second run it reports the marker and exits without changing any rows.
+
+The script also clears the affected days from the analytics summary tables. The background task rebuilds those days from the corrected entries on the next application start. Confirm the rebuild under **Settings** > **Health Check** > **Forms** > **Analytics Processing**.
+
+The script excludes the `UFRecordDataDateTime` table, as those values represent user-entered dates that should not be shifted.
 
 The original `MigrateSystemDatesToUtc` migration contained a duplicate conversion for `UFPrevalueSource`. Created and Updated columns were converted twice. This has been fixed, but sites on v17.0–v17.2 may have double-converted PrevalueSource dates that require manual correction.
 {% endhint %}
 
 {% file src=".gitbook/assets/correct-utc-timestamps.sql" %}
-Corrects historical data written with local server time instead of UTC between v17.0.0 and v17.3.0. Set the timezone and cutoff date before running.
+Corrects historical data written with local server time instead of UTC between v17.0.0 and v17.3.0. Set the time zone and both cutoff dates before running.
 {% endfile %}
 
 #### Other

--- a/17/umbraco-forms/scripts/correct-utc-timestamps.sql
+++ b/17/umbraco-forms/scripts/correct-utc-timestamps.sql
@@ -1,25 +1,116 @@
--- Correct post-v17 data that was stored with DateTime.Now instead of DateTime.UtcNow.
--- @TimeZone: your server Windows timezone name (e.g. Romance Standard Time)
--- @UpgradeDate: approximate date you first upgraded to v17.0.0
---               (rows BEFORE this date were already correctly migrated to UTC)
+/*
+    Umbraco Forms: correct system dates that were stored as local server time instead of UTC.
 
+    This applies to sites that ran Umbraco Forms 17.0.0 to 17.2.x. In those versions the v17.0.0
+    migration converted existing dates to UTC, but new rows were still written with local server
+    time. Umbraco Forms 17.3.0 corrected the write path, so rows created from that deployment
+    onwards are already UTC and must not be shifted again.
+
+    SQL Server only. The AT TIME ZONE syntax is not supported by SQLite.
+
+    Before you run this script:
+
+    1. Take a database backup. Nothing in the schema records whether a row has already been
+       shifted, so a repeated or partial run cannot be undone from the data alone.
+    2. Set the three variables below.
+    3. Read the notes at the end of this file.
+
+    When the script completes it writes a marker to umbracoKeyValue. If that marker is already
+    present, the script reports it and exits without changing any rows.
+*/
+
+SET XACT_ABORT ON
+
+-- Your server's Windows time zone name, for example 'Romance Standard Time'.
 DECLARE @TimeZone NVARCHAR(100) = 'Romance Standard Time'
+
+-- The date you first upgraded to 17.0.0. Rows created before this date were already converted
+-- to UTC by the MigrateSystemDatesToUtc migration.
 DECLARE @UpgradeDate DATETIME = '2026-03-01'
 
+-- The date you deployed 17.3.0 or later. Rows created on or after this date are already UTC.
+DECLARE @FixDate DATETIME = '2026-04-23'
+
+DECLARE @MarkerKey NVARCHAR(256) = 'Umbraco.Forms.UtcTimestampCorrection'
+
+IF EXISTS (SELECT 1 FROM umbracoKeyValue WHERE [key] = @MarkerKey)
+BEGIN
+    PRINT 'This correction has already been applied to this database. No rows were changed.'
+    RETURN
+END
+
+IF @FixDate <= @UpgradeDate
+BEGIN
+    PRINT 'Set @FixDate to a date later than @UpgradeDate. No rows were changed.'
+    RETURN
+END
+
+-- Reports how many entries fall inside the affected window. Run this SELECT on its own first if
+-- you want to confirm the window before writing anything.
+SELECT
+    COUNT(*) AS AffectedRecords,
+    MIN(Created) AS EarliestAffected,
+    MAX(Created) AS LatestAffected
+FROM UFRecords
+WHERE Created > @UpgradeDate AND Created < @FixDate
+
+BEGIN TRANSACTION
+
 -- Record tables
-UPDATE UFRecords SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFRecords SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFRecordAudit SET UpdatedOn = UpdatedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE UpdatedOn > @UpgradeDate
-UPDATE UFRecordWorkflowAudit SET ExecutedOn = ExecutedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE ExecutedOn > @UpgradeDate
+UPDATE UFRecords SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFRecords SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFRecordAudit SET UpdatedOn = UpdatedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE UpdatedOn > @UpgradeDate AND UpdatedOn < @FixDate
+UPDATE UFRecordWorkflowAudit SET ExecutedOn = ExecutedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE ExecutedOn > @UpgradeDate AND ExecutedOn < @FixDate
 
 -- Entity metadata tables
-UPDATE UFPrevalueSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFPrevalueSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFWorkflows SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFWorkflows SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFDataSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFDataSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFFolders SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFFolders SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFForms SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFForms SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
+UPDATE UFPrevalueSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFPrevalueSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFWorkflows SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFWorkflows SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFDataSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFDataSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFFolders SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFFolders SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFForms SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFForms SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+
+-- The Analytics charts are served from a pre-aggregated summary table, not from UFRecords
+-- directly, and those rows were built from the incorrect timestamps. Deleting the affected days
+-- makes the background task recalculate them from the corrected entries. Both tables hold only
+-- values derived from UFRecords and UFRecordWorkflowAudit, so no data is lost.
+-- The range extends one day past each boundary because a shifted entry can move across a day.
+IF OBJECT_ID('UFAnalyticsDailySummary', 'U') IS NOT NULL
+BEGIN
+    DELETE FROM UFAnalyticsDailySummary
+    WHERE [Date] >= DATEADD(DAY, -1, CAST(@UpgradeDate AS DATE))
+      AND [Date] < DATEADD(DAY, 1, CAST(@FixDate AS DATE))
+
+    DELETE FROM UFAnalyticsProcessedDates
+    WHERE [Date] >= DATEADD(DAY, -1, CAST(@UpgradeDate AS DATE))
+      AND [Date] < DATEADD(DAY, 1, CAST(@FixDate AS DATE))
+END
+
+INSERT INTO umbracoKeyValue ([key], [value], [updated])
+VALUES (@MarkerKey, CONVERT(NVARCHAR(30), SYSUTCDATETIME(), 126), SYSUTCDATETIME())
+
+COMMIT TRANSACTION
+
+PRINT 'Correction applied. Restart the site so the analytics summary is rebuilt.'
+
+/*
+    Notes
+
+    The UFRecordDataDateTime table is excluded on purpose. Those values are dates entered by the
+    person filling in the form, not system dates. Shifting them would change the answer.
+
+    The window boundaries are compared against the stored value, so entries within a few hours of
+    either boundary can be judged incorrectly. Use the exact deployment times if you have them.
+
+    The original MigrateSystemDatesToUtc migration converted the UFPrevalueSource Created and
+    Updated columns twice. This was fixed in 17.3.0, but a site that ran 17.0 to 17.2 may hold
+    double-converted values in those two columns that need correcting separately.
+
+    After restarting, confirm the rebuild finished under
+    Settings > Health Check > Forms > Analytics Processing. The rebuild does not run if analytics
+    processing is disabled in configuration.
+*/

--- a/17/umbraco-forms/scripts/correct-utc-timestamps.sql
+++ b/17/umbraco-forms/scripts/correct-utc-timestamps.sql
@@ -28,7 +28,8 @@ DECLARE @TimeZone NVARCHAR(100) = 'Romance Standard Time'
 -- to UTC by the MigrateSystemDatesToUtc migration.
 DECLARE @UpgradeDate DATETIME = '2026-03-01'
 
--- The date you deployed 17.3.0 or later. Rows created on or after this date are already UTC.
+-- The date you first deployed a version of 17.3.0 or newer. Rows created on or after this date
+-- are already UTC. If you upgraded 17.2 to 17.3 and later to 17.4, use the 17.3 date.
 DECLARE @FixDate DATETIME = '2026-04-23'
 
 DECLARE @MarkerKey NVARCHAR(256) = 'Umbraco.Forms.UtcTimestampCorrection'

--- a/18/umbraco-forms/.gitbook/assets/correct-utc-timestamps.sql
+++ b/18/umbraco-forms/.gitbook/assets/correct-utc-timestamps.sql
@@ -1,25 +1,116 @@
--- Correct post-v17 data that was stored with DateTime.Now instead of DateTime.UtcNow.
--- @TimeZone: your server Windows timezone name (e.g. Romance Standard Time)
--- @UpgradeDate: approximate date you first upgraded to v17.0.0
---               (rows BEFORE this date were already correctly migrated to UTC)
+/*
+    Umbraco Forms: correct system dates that were stored as local server time instead of UTC.
 
+    This applies to sites that ran Umbraco Forms 17.0.0 to 17.2.x. In those versions the v17.0.0
+    migration converted existing dates to UTC, but new rows were still written with local server
+    time. Umbraco Forms 17.3.0 corrected the write path, so rows created from that deployment
+    onwards are already UTC and must not be shifted again.
+
+    SQL Server only. The AT TIME ZONE syntax is not supported by SQLite.
+
+    Before you run this script:
+
+    1. Take a database backup. Nothing in the schema records whether a row has already been
+       shifted, so a repeated or partial run cannot be undone from the data alone.
+    2. Set the three variables below.
+    3. Read the notes at the end of this file.
+
+    When the script completes it writes a marker to umbracoKeyValue. If that marker is already
+    present, the script reports it and exits without changing any rows.
+*/
+
+SET XACT_ABORT ON
+
+-- Your server's Windows time zone name, for example 'Romance Standard Time'.
 DECLARE @TimeZone NVARCHAR(100) = 'Romance Standard Time'
+
+-- The date you first upgraded to 17.0.0. Rows created before this date were already converted
+-- to UTC by the MigrateSystemDatesToUtc migration.
 DECLARE @UpgradeDate DATETIME = '2026-03-01'
 
+-- The date you deployed 17.3.0 or later. Rows created on or after this date are already UTC.
+DECLARE @FixDate DATETIME = '2026-04-23'
+
+DECLARE @MarkerKey NVARCHAR(256) = 'Umbraco.Forms.UtcTimestampCorrection'
+
+IF EXISTS (SELECT 1 FROM umbracoKeyValue WHERE [key] = @MarkerKey)
+BEGIN
+    PRINT 'This correction has already been applied to this database. No rows were changed.'
+    RETURN
+END
+
+IF @FixDate <= @UpgradeDate
+BEGIN
+    PRINT 'Set @FixDate to a date later than @UpgradeDate. No rows were changed.'
+    RETURN
+END
+
+-- Reports how many entries fall inside the affected window. Run this SELECT on its own first if
+-- you want to confirm the window before writing anything.
+SELECT
+    COUNT(*) AS AffectedRecords,
+    MIN(Created) AS EarliestAffected,
+    MAX(Created) AS LatestAffected
+FROM UFRecords
+WHERE Created > @UpgradeDate AND Created < @FixDate
+
+BEGIN TRANSACTION
+
 -- Record tables
-UPDATE UFRecords SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFRecords SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFRecordAudit SET UpdatedOn = UpdatedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE UpdatedOn > @UpgradeDate
-UPDATE UFRecordWorkflowAudit SET ExecutedOn = ExecutedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE ExecutedOn > @UpgradeDate
+UPDATE UFRecords SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFRecords SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFRecordAudit SET UpdatedOn = UpdatedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE UpdatedOn > @UpgradeDate AND UpdatedOn < @FixDate
+UPDATE UFRecordWorkflowAudit SET ExecutedOn = ExecutedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE ExecutedOn > @UpgradeDate AND ExecutedOn < @FixDate
 
 -- Entity metadata tables
-UPDATE UFPrevalueSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFPrevalueSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFWorkflows SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFWorkflows SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFDataSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFDataSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFFolders SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFFolders SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFForms SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFForms SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
+UPDATE UFPrevalueSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFPrevalueSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFWorkflows SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFWorkflows SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFDataSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFDataSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFFolders SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFFolders SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFForms SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFForms SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+
+-- The Analytics charts are served from a pre-aggregated summary table, not from UFRecords
+-- directly, and those rows were built from the incorrect timestamps. Deleting the affected days
+-- makes the background task recalculate them from the corrected entries. Both tables hold only
+-- values derived from UFRecords and UFRecordWorkflowAudit, so no data is lost.
+-- The range extends one day past each boundary because a shifted entry can move across a day.
+IF OBJECT_ID('UFAnalyticsDailySummary', 'U') IS NOT NULL
+BEGIN
+    DELETE FROM UFAnalyticsDailySummary
+    WHERE [Date] >= DATEADD(DAY, -1, CAST(@UpgradeDate AS DATE))
+      AND [Date] < DATEADD(DAY, 1, CAST(@FixDate AS DATE))
+
+    DELETE FROM UFAnalyticsProcessedDates
+    WHERE [Date] >= DATEADD(DAY, -1, CAST(@UpgradeDate AS DATE))
+      AND [Date] < DATEADD(DAY, 1, CAST(@FixDate AS DATE))
+END
+
+INSERT INTO umbracoKeyValue ([key], [value], [updated])
+VALUES (@MarkerKey, CONVERT(NVARCHAR(30), SYSUTCDATETIME(), 126), SYSUTCDATETIME())
+
+COMMIT TRANSACTION
+
+PRINT 'Correction applied. Restart the site so the analytics summary is rebuilt.'
+
+/*
+    Notes
+
+    The UFRecordDataDateTime table is excluded on purpose. Those values are dates entered by the
+    person filling in the form, not system dates. Shifting them would change the answer.
+
+    The window boundaries are compared against the stored value, so entries within a few hours of
+    either boundary can be judged incorrectly. Use the exact deployment times if you have them.
+
+    The original MigrateSystemDatesToUtc migration converted the UFPrevalueSource Created and
+    Updated columns twice. This was fixed in 17.3.0, but a site that ran 17.0 to 17.2 may hold
+    double-converted values in those two columns that need correcting separately.
+
+    After restarting, confirm the rebuild finished under
+    Settings > Health Check > Forms > Analytics Processing. The rebuild does not run if analytics
+    processing is disabled in configuration.
+*/

--- a/18/umbraco-forms/.gitbook/assets/correct-utc-timestamps.sql
+++ b/18/umbraco-forms/.gitbook/assets/correct-utc-timestamps.sql
@@ -28,7 +28,8 @@ DECLARE @TimeZone NVARCHAR(100) = 'Romance Standard Time'
 -- to UTC by the MigrateSystemDatesToUtc migration.
 DECLARE @UpgradeDate DATETIME = '2026-03-01'
 
--- The date you deployed 17.3.0 or later. Rows created on or after this date are already UTC.
+-- The date you first deployed a version of 17.3.0 or newer. Rows created on or after this date
+-- are already UTC. If you upgraded 17.2 to 17.3 and later to 17.4, use the 17.3 date.
 DECLARE @FixDate DATETIME = '2026-04-23'
 
 DECLARE @MarkerKey NVARCHAR(256) = 'Umbraco.Forms.UtcTimestampCorrection'

--- a/18/umbraco-forms/scripts/correct-utc-timestamps.sql
+++ b/18/umbraco-forms/scripts/correct-utc-timestamps.sql
@@ -1,25 +1,116 @@
--- Correct post-v17 data that was stored with DateTime.Now instead of DateTime.UtcNow.
--- @TimeZone: your server Windows timezone name (e.g. Romance Standard Time)
--- @UpgradeDate: approximate date you first upgraded to v17.0.0
---               (rows BEFORE this date were already correctly migrated to UTC)
+/*
+    Umbraco Forms: correct system dates that were stored as local server time instead of UTC.
 
+    This applies to sites that ran Umbraco Forms 17.0.0 to 17.2.x. In those versions the v17.0.0
+    migration converted existing dates to UTC, but new rows were still written with local server
+    time. Umbraco Forms 17.3.0 corrected the write path, so rows created from that deployment
+    onwards are already UTC and must not be shifted again.
+
+    SQL Server only. The AT TIME ZONE syntax is not supported by SQLite.
+
+    Before you run this script:
+
+    1. Take a database backup. Nothing in the schema records whether a row has already been
+       shifted, so a repeated or partial run cannot be undone from the data alone.
+    2. Set the three variables below.
+    3. Read the notes at the end of this file.
+
+    When the script completes it writes a marker to umbracoKeyValue. If that marker is already
+    present, the script reports it and exits without changing any rows.
+*/
+
+SET XACT_ABORT ON
+
+-- Your server's Windows time zone name, for example 'Romance Standard Time'.
 DECLARE @TimeZone NVARCHAR(100) = 'Romance Standard Time'
+
+-- The date you first upgraded to 17.0.0. Rows created before this date were already converted
+-- to UTC by the MigrateSystemDatesToUtc migration.
 DECLARE @UpgradeDate DATETIME = '2026-03-01'
 
+-- The date you deployed 17.3.0 or later. Rows created on or after this date are already UTC.
+DECLARE @FixDate DATETIME = '2026-04-23'
+
+DECLARE @MarkerKey NVARCHAR(256) = 'Umbraco.Forms.UtcTimestampCorrection'
+
+IF EXISTS (SELECT 1 FROM umbracoKeyValue WHERE [key] = @MarkerKey)
+BEGIN
+    PRINT 'This correction has already been applied to this database. No rows were changed.'
+    RETURN
+END
+
+IF @FixDate <= @UpgradeDate
+BEGIN
+    PRINT 'Set @FixDate to a date later than @UpgradeDate. No rows were changed.'
+    RETURN
+END
+
+-- Reports how many entries fall inside the affected window. Run this SELECT on its own first if
+-- you want to confirm the window before writing anything.
+SELECT
+    COUNT(*) AS AffectedRecords,
+    MIN(Created) AS EarliestAffected,
+    MAX(Created) AS LatestAffected
+FROM UFRecords
+WHERE Created > @UpgradeDate AND Created < @FixDate
+
+BEGIN TRANSACTION
+
 -- Record tables
-UPDATE UFRecords SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFRecords SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFRecordAudit SET UpdatedOn = UpdatedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE UpdatedOn > @UpgradeDate
-UPDATE UFRecordWorkflowAudit SET ExecutedOn = ExecutedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE ExecutedOn > @UpgradeDate
+UPDATE UFRecords SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFRecords SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFRecordAudit SET UpdatedOn = UpdatedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE UpdatedOn > @UpgradeDate AND UpdatedOn < @FixDate
+UPDATE UFRecordWorkflowAudit SET ExecutedOn = ExecutedOn AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE ExecutedOn > @UpgradeDate AND ExecutedOn < @FixDate
 
 -- Entity metadata tables
-UPDATE UFPrevalueSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFPrevalueSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFWorkflows SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFWorkflows SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFDataSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFDataSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFFolders SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFFolders SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
-UPDATE UFForms SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate
-UPDATE UFForms SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate
+UPDATE UFPrevalueSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFPrevalueSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFWorkflows SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFWorkflows SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFDataSource SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFDataSource SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFFolders SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFFolders SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+UPDATE UFForms SET Created = Created AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Created > @UpgradeDate AND Created < @FixDate
+UPDATE UFForms SET Updated = Updated AT TIME ZONE @TimeZone AT TIME ZONE 'UTC' WHERE Updated > @UpgradeDate AND Updated < @FixDate
+
+-- The Analytics charts are served from a pre-aggregated summary table, not from UFRecords
+-- directly, and those rows were built from the incorrect timestamps. Deleting the affected days
+-- makes the background task recalculate them from the corrected entries. Both tables hold only
+-- values derived from UFRecords and UFRecordWorkflowAudit, so no data is lost.
+-- The range extends one day past each boundary because a shifted entry can move across a day.
+IF OBJECT_ID('UFAnalyticsDailySummary', 'U') IS NOT NULL
+BEGIN
+    DELETE FROM UFAnalyticsDailySummary
+    WHERE [Date] >= DATEADD(DAY, -1, CAST(@UpgradeDate AS DATE))
+      AND [Date] < DATEADD(DAY, 1, CAST(@FixDate AS DATE))
+
+    DELETE FROM UFAnalyticsProcessedDates
+    WHERE [Date] >= DATEADD(DAY, -1, CAST(@UpgradeDate AS DATE))
+      AND [Date] < DATEADD(DAY, 1, CAST(@FixDate AS DATE))
+END
+
+INSERT INTO umbracoKeyValue ([key], [value], [updated])
+VALUES (@MarkerKey, CONVERT(NVARCHAR(30), SYSUTCDATETIME(), 126), SYSUTCDATETIME())
+
+COMMIT TRANSACTION
+
+PRINT 'Correction applied. Restart the site so the analytics summary is rebuilt.'
+
+/*
+    Notes
+
+    The UFRecordDataDateTime table is excluded on purpose. Those values are dates entered by the
+    person filling in the form, not system dates. Shifting them would change the answer.
+
+    The window boundaries are compared against the stored value, so entries within a few hours of
+    either boundary can be judged incorrectly. Use the exact deployment times if you have them.
+
+    The original MigrateSystemDatesToUtc migration converted the UFPrevalueSource Created and
+    Updated columns twice. This was fixed in 17.3.0, but a site that ran 17.0 to 17.2 may hold
+    double-converted values in those two columns that need correcting separately.
+
+    After restarting, confirm the rebuild finished under
+    Settings > Health Check > Forms > Analytics Processing. The rebuild does not run if analytics
+    processing is disabled in configuration.
+*/

--- a/18/umbraco-forms/scripts/correct-utc-timestamps.sql
+++ b/18/umbraco-forms/scripts/correct-utc-timestamps.sql
@@ -28,7 +28,8 @@ DECLARE @TimeZone NVARCHAR(100) = 'Romance Standard Time'
 -- to UTC by the MigrateSystemDatesToUtc migration.
 DECLARE @UpgradeDate DATETIME = '2026-03-01'
 
--- The date you deployed 17.3.0 or later. Rows created on or after this date are already UTC.
+-- The date you first deployed a version of 17.3.0 or newer. Rows created on or after this date
+-- are already UTC. If you upgraded 17.2 to 17.3 and later to 17.4, use the 17.3 date.
 DECLARE @FixDate DATETIME = '2026-04-23'
 
 DECLARE @MarkerKey NVARCHAR(256) = 'Umbraco.Forms.UtcTimestampCorrection'

--- a/18/umbraco-forms/upgrading/version-specific.md
+++ b/18/umbraco-forms/upgrading/version-specific.md
@@ -16,6 +16,34 @@ If you are upgrading to a minor or patch version, you can find the details about
 
 Version 18 of Umbraco Forms has a minimum dependency on Umbraco CMS core of `18.0.0`. It runs on .NET 10.
 
+### UTC date handling
+
+This fix was introduced in version 17.3.0. It affects you if you upgrade to version 18 from version 17.0, 17.1, or 17.2.
+
+Version 17.0.0 included a migration (`MigrateSystemDatesToUtc`) that converted existing system dates to UTC. The application code still wrote new records using `DateTime.Now`, which is local server time. This left inconsistent timestamps on form entries, workflow audit trails, and entity metadata. Version 17.3.0 corrected the code that writes those dates.
+
+{% hint style="warning" %}
+Data written between v17.0.0 and the fix may contain local server timestamps instead of UTC. Upgrading to version 18 does not correct that data. A SQL script is provided below to correct it. The script runs on SQL Server only.
+
+Take a database backup before you run it. Then set the three variables at the top of the script:
+
+* `@TimeZone`: your server's Windows time zone name.
+* `@UpgradeDate`: the date you first upgraded to v17.0.0. Rows created before this date were already converted to UTC.
+* `@FixDate`: the date you first deployed a version that includes the fix. That is v17.3.0 or newer, or any version 18 release. Rows created on or after this date are already UTC and must not be shifted again.
+
+The script writes a marker to `umbracoKeyValue` when it completes. On a second run it reports the marker and exits without changing any rows.
+
+The script also clears the affected days from the analytics summary tables. The background task rebuilds those days from the corrected entries on the next application start. Confirm the rebuild under **Settings** > **Health Check** > **Forms** > **Analytics Processing**.
+
+The script excludes the `UFRecordDataDateTime` table, as those values represent user-entered dates that should not be shifted.
+
+The original `MigrateSystemDatesToUtc` migration contained a duplicate conversion for `UFPrevalueSource`. The Created and Updated columns were converted twice. This has been fixed, but sites that ran v17.0 to v17.2 may have double-converted PrevalueSource dates that require manual correction.
+{% endhint %}
+
+{% file src="../.gitbook/assets/correct-utc-timestamps.sql" %}
+Corrects historical data written with local server time instead of UTC. Set the time zone and both cutoff dates before running.
+{% endfile %}
+
 ### Storage method for tracking rendered forms
 
 This change was introduced in version 14. It affects you if you upgrade directly from version 13 to version 18.


### PR DESCRIPTION
The `correct-utc-timestamps.sql` script published with the Umbraco Forms 17.3.0 release notes has no upper bound on any of its statements. Every one reads `WHERE Created > @UpgradeDate`.

Forms has written correct UTC timestamps since 17.3.0, so a site running the script today shifts those already-correct rows a second time. This came up on https://github.com/umbraco/Umbraco.Forms.Issues/issues/1759, where the site needs the historical fix but is now on 17.4.6.

## Changes

Script:

- New `@FixDate` variable, applied as an upper bound to all 14 statements.
- A marker row in `umbracoKeyValue`. A second run reports the marker and exits without changing rows.
- Wrapped in a single transaction with `SET XACT_ABORT ON`.
- A preview `SELECT` reporting the affected entry count and date span.
- Deletes the affected days from `UFAnalyticsDailySummary` and `UFAnalyticsProcessedDates`, so the background task rebuilds the Analytics charts from the corrected entries. Both tables hold only derived values.
- Guard on `@FixDate` being later than `@UpgradeDate`, and a note on the boundary comparison being approximate.

Release notes:

- The v17.3.0 hint lists all three variables, the backup step, the marker behaviour, and how to confirm the analytics rebuild.

Applied to all four copies of the script (17 and 18, each under `scripts/` and `.gitbook/assets/`).

## Verification

- The script parses against SQL Server with `SET PARSEONLY ON` (exit 0, no errors).
- Vale reports no new issues. The one remaining warning on the `{% file %}` caption line predates this branch.