### PR TITLE
Forms: Fix built-in setting type alias for XSLT file pickers

### DIFF
--- a/17/umbraco-forms/developer/extending/setting-types.md
+++ b/17/umbraco-forms/developer/extending/setting-types.md
@@ -102,7 +102,7 @@ Some are defined with the Umbraco CMS and some ship with the Forms package.
 | Umb.PropertyEditorUi.DocumentPicker            | CMS    | Uses a content picker                                     |                                               |
 | Umb.PropertyEditorUi.Dropdown                  | CMS    | Used for selection from a list of options                 |                                               |
 | Umb.PropertyEditorUi.Integer                   | CMS    | Uses numerical text box for entry                         |                                               |
-| Umb.PropertyEditorUi.MediaEntityPicker         | CMS    | Uses a media item picker for entry                        | The "Send email with XSLT template" workflow  |
+| Umb.PropertyEditorUi.MediaPicker               | CMS    | Uses a media item picker for entry                        | The "Send XSLT transformed email", "Post as XML", and "Save as an XML file" workflows |
 | Umb.PropertyEditorUi.MultipleTextString        | CMS    | Uses multiple text boxes for entry                        |                                               |
 | Umb.PropertyEditorUi.RadioButtonList           | CMS    | Uses multiple radio buttons for entry                     |                                               |
 | Umb.PropertyEditorUi.Slider                    | CMS    | Uses a slider for range input                             | The "reCAPTCHAv3" field type                  |

--- a/18/umbraco-forms/developer/extending/setting-types.md
+++ b/18/umbraco-forms/developer/extending/setting-types.md
@@ -102,7 +102,7 @@ Some are defined with the Umbraco CMS and some ship with the Forms package.
 | Umb.PropertyEditorUi.DocumentPicker            | CMS    | Uses a content picker                                     |                                               |
 | Umb.PropertyEditorUi.Dropdown                  | CMS    | Used for selection from a list of options                 |                                               |
 | Umb.PropertyEditorUi.Integer                   | CMS    | Uses numerical text box for entry                         |                                               |
-| Umb.PropertyEditorUi.MediaEntityPicker         | CMS    | Uses a media item picker for entry                        | The "Send email with XSLT template" workflow  |
+| Umb.PropertyEditorUi.MediaPicker               | CMS    | Uses a media item picker for entry                        | The "Send XSLT transformed email", "Post as XML", and "Save as an XML file" workflows |
 | Umb.PropertyEditorUi.MultipleTextString        | CMS    | Uses multiple text boxes for entry                        |                                               |
 | Umb.PropertyEditorUi.RadioButtonList           | CMS    | Uses multiple radio buttons for entry                     |                                               |
 | Umb.PropertyEditorUi.Slider                    | CMS    | Uses a slider for range input                             | The "reCAPTCHAv3" field type                  |


### PR DESCRIPTION
## 📋 Description

The built-in setting types table (v17 and v18 `setting-types.md`) listed `Umb.PropertyEditorUi.MediaEntityPicker` as the alias used by the XSLT file setting on workflow types, but the workflows (`Send XSLT transformed email`, `Post as XML`, `Save as an XML file`) actually use `Umb.PropertyEditorUi.MediaPicker`. `MediaEntityPicker` is also folder-only in current Umbraco CMS, so it can't select a file at all with that alias.

Corrected the alias to `MediaPicker` and updated the "Used in" column to list all three workflows that use it. The v13 docs use a different (pre-rewrite) setting type format and don't reference this alias, so no change was needed there.

## 📎 Related Issues (if applicable)

Related to https://github.com/umbraco/Umbraco.Forms.Issues/issues/1767

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [ ] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Forms documentation, v17 and v18.

## Deadline (if relevant)

When approved!