### PR TITLE
Updated the SentenceLenght rule to be more accepting

### DIFF
--- a/.github/styles/UmbracoDocs/SentenceLength.yml
+++ b/.github/styles/UmbracoDocs/SentenceLength.yml
@@ -8,4 +8,4 @@ link: https://docs.umbraco.com/contributing/documentation/style-guide#avoid-long
 scope: sentence
 level: warning
 max: 25
-token: \b(\w+)\b
+token: \b\w+(?:[.-]\w+)*\b


### PR DESCRIPTION
## 📋 Description

Updated the rule that checks PR for long sentences.
It now treats words separated by `.` and `-` as one word.
Examples: 17.2.2 is one word, Umbraco.License is one word and case-sensitive is one word.

## 📎 Related Issues (if applicable)

#8301 

