### PR TITLE
Add Umbraco Commerce 17.1.11 release notes

### DIFF
--- a/17/umbraco-commerce/release-notes/README.md
+++ b/17/umbraco-commerce/release-notes/README.md
@@ -18,6 +18,9 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 This section contains the release notes for Umbraco Commerce 17 including all changes for this version.
 
+#### [17.1.11](https://github.com/umbraco/Umbraco.Commerce.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.1.11) (7th Aug 2026)
+* Fix the Commerce section failing to load on CMS 17.6.0 [#868](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/868)
+
 #### [17.1.9](https://github.com/umbraco/Umbraco.Commerce.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.1.9) (29th Jul 2026)
 * Add logging to record why an order is moved to the error status, and when a payment is reset or redirected through a payment provider's cancel or error URL [#866](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/866)
 


### PR DESCRIPTION
## Summary
- Adds the 17.1.11 entry to the Umbraco Commerce v17 release notes
- Covers the fix for the Commerce backoffice section failing to load on CMS 17.6.0 ([Umbraco.Commerce.Issues#868](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/868))

## Test plan
- [x] Matches the existing entry format/style for the v17 release notes page

🤖 Generated with Claude Code