### PR TITLE
Correct and improve documentation for serving media from a different folder

### DIFF
--- a/13/umbraco-cms/extending/filesystemproviders/README.md
+++ b/13/umbraco-cms/extending/filesystemproviders/README.md
@@ -103,7 +103,7 @@ To achieve this, you must first create your own file system by implementing the 
 {% hint style="info" %}
 Implementing `IFileProviderFactory` allows Umbraco to compose your media file system into the webroot file provider during startup. It is mounted at the URL configured in `UmbracoMediaPath`.
 
-Image processing resolves media through that provider. A media file system without `IFileProviderFactory` serves images at their original size only.
+Without it, Umbraco cannot serve or process media from your file system through that path. Image processing resolves media only through the webroot file provider.
 {% endhint %}
 
 You then replace the media filesystem by composition using `IUmbracoBuilder.SetMediaFileSystem(...)` (as is demonstrated in the paragraphs above), but instead of returning a `PhysicalFileSystem`, you return your own file system implementation.

--- a/13/umbraco-cms/extending/filesystemproviders/README.md
+++ b/13/umbraco-cms/extending/filesystemproviders/README.md
@@ -51,20 +51,32 @@ When creating a `PhysicalFileSystem` it takes some dependencies like `IIOHelper`
 
 The `rootPath` is where your media will be stored on the disk. Since netcore by default stores files in the `wwwroot`, we must put our desired folder somewhere within `wwwroot` to ensure that we use `hostingEnvironment.MapPathWebRoot(~/CustomMediaFolder)`. The `~` will be mapped to your `wwwroot` folder, so the final `rootPath` will be `your/project/path/wwwroot/CustomMediaFolder`. The `~` is therefore important.
 
-The `rootUrl` is the base URL that your media files will be served from. In this case, your image URL could look something like `mysite.com/CustomMediaFolder/MyAwesomePicture.png`. Again the `~` is important.
-
-In the code sample above, the `rootUrl` must map to the the same physical location as `rootPath`, which again must be placed under `wwwroot`. If you want to store the media files outside of `wwwroot` there is an extra step involved; you need to instruct netcore to include static files from a different physical location.
-
 The `rootUrl` is the base URL that your media files will be served from. In this case, your image URL could look something like `mysite.com/CustomMediaFolder/MyAwesomePicture.png`. Again the `~` is important. With the code sample above, the `rootUrl` must map to the same physical location as `rootPath`, otherwise, you will get 404's for your images.
 
-If you want to store the media files outside of `wwwroot` there is an extra step involved; you need to instruct netcore to include static files from a different physical location.
+### Storing media outside the webroot
 
-In the `Program.cs` file, register a new static file location like so:
+A custom media file system is not the right tool for storing media on a physical or network path outside `wwwroot`. Use the `UmbracoMediaPhysicalRootPath` setting instead:
+
+```json
+{
+  "Umbraco": {
+    "CMS": {
+      "Global": {
+        "UmbracoMediaPath": "~/media",
+        "UmbracoMediaPhysicalRootPath": "C:\\storage\\umbracoMedia"
+      }
+    }
+  }
+}
+```
+
+Umbraco builds a `PhysicalFileSystem` from these settings, exactly as in the sample above. It also composes the folder into the webroot file provider for you. This keeps both static file serving and image processing working. See [FileSystemProviders Configuration](../../reference/configuration/filesystemproviders.md) for details.
+
+{% hint style="warning" %}
+**Do not register the media folder as an additional static file provider.** A pattern sometimes used for this scenario is to add a `PhysicalFileProvider` for the media folder in `Program.cs`:
 
 ```csharp
-...
-WebApplication app = builder.Build();
-
+// Do not do this - it silently disables image resizing.
 app.UseStaticFiles(new StaticFileOptions
     {
         FileProvider = new PhysicalFileProvider(Path.Combine("C:", "storage", "umbracoMedia")),
@@ -72,40 +84,27 @@ app.UseStaticFiles(new StaticFileOptions
     });
 ```
 
-The PhysicalFileProvider takes a single parameter, the **`RootPath`**. This is the rooted filesystem path using directory separator chars and not ending with a directory separator, eg: `c:\storage\umbracoMedia` or `\\server\path`. The safest way to achieve this is using `Path.Combine`.
+There are two problems with this:
 
-You also have to specify the **`RequestPath`**. This is the relative URL where the media will be served using URL separator chars and not ending with a separator, eg: `/CustomPath` or `/Media`.
+* Umbraco registers the ImageSharp middleware inside `app.UseUmbraco()`. A static file middleware registered before that call handles the request first and ignores the querystring, so `?width=500` returns the full-size original.
+* ImageSharp resolves images only through the webroot file provider. Files served from a separate `PhysicalFileProvider` are invisible to it, so resizing still does not work even if the registration is moved after `app.UseUmbraco()`.
 
-Now you can use your newly registered static file location as if it was `wwwroot`. Notice how you no longer need to use `hostingEnvironment.MapPathWebRoot(folderLocation)`, since you're no longer trying to map the location to somewhere within `wwwroot`, but instead use your newly registered static file location.
+Every image is then served at its original size, including backoffice thumbnails. To check whether a site is affected, request an image with and without a resizing querystring. `?width=50` must return a smaller response than the same URL without the querystring.
+{% endhint %}
 
-```csharp
-public void Compose(IUmbracoBuilder builder)
-{
-    builder.SetMediaFileSystem((factory) =>
-    {
-        IHostingEnvironment hostingEnvironment = factory.GetRequiredService<IHostingEnvironment>();
-        var rootPath = Path.Combine("C:", "storage", "umbracoMedia");
-        var rootUrl = hostingEnvironment.ToAbsolute("/CustomPath");
-
-        return new PhysicalFileSystem(
-            factory.GetRequiredService<IIOHelper>(),
-            hostingEnvironment,
-            factory.GetRequiredService<ILogger<PhysicalFileSystem>>(),
-            rootPath,
-            rootUrl);
-    });
-}
-```
-
-This is almost the same as when registering a location within the `wwwroot` folder. The only difference is that `rootPath` is now set to the path we gave the `PhysicalFileProvider` and the `rootUrl` is the same as we set as the `RequestPath` in the `StaticFileOption`.
-
-Our media is now stored in `C:\storage\umbracoMedia`, and is served from the base URL `/CustomPath`, so an image URL will look something like `mysite.com/CustomPath/MyAwesomePicture.png`.
+Reserve a custom media file system for storage that is genuinely of a different kind, such as Azure Blob Storage or Amazon S3.
 
 ### Creating a custom file system
 
 You can replace `PhysicalFileSystem` with a custom file system implementation - eg. if you want your media files stored on Amazon S3 or elsewhere outside your site.
 
 To achieve this, you must first create your own file system by implementing the interfaces `IFileSystem` and `IFileProviderFactory` (the interfaces that are implemented by `PhysicalFileSystem`).
+
+{% hint style="info" %}
+Implementing `IFileProviderFactory` allows Umbraco to compose your media file system into the webroot file provider during startup. It is mounted at the URL configured in `UmbracoMediaPath`.
+
+Image processing resolves media through that provider. A media file system without `IFileProviderFactory` serves images at their original size only.
+{% endhint %}
 
 You then replace the media filesystem by composition using `IUmbracoBuilder.SetMediaFileSystem(...)` (as is demonstrated in the paragraphs above), but instead of returning a `PhysicalFileSystem`, you return your own file system implementation.
 

--- a/13/umbraco-cms/fundamentals/setup/server-setup/load-balancing/file-system-replication.md
+++ b/13/umbraco-cms/fundamentals/setup/server-setup/load-balancing/file-system-replication.md
@@ -6,6 +6,8 @@ No file replication is configured, deployment handles updating files on the diff
 
 If the file system on your servers isn't performing any file replication then no _Umbraco_ configuration file changes are necessary. However Media will need to be configured to use a shared location such as Blob storage or S3.
 
+Media can also live on a shared network location, using a Universal Naming Convention (UNC) path. Set the `UmbracoMediaPhysicalRootPath` global setting rather than registering the share as a static file provider. Umbraco then builds and registers the media file system itself, which keeps image processing working. See [FileSystemProviders Configuration](../../../../reference/configuration/filesystemproviders.md#physical-path).
+
 Depending on the configuration and performance of the environment's local storage you might need to consider [Examine Directory Factory Options](file-system-replication.md#examine-directory-factory-options) and the [Umbraco temporary storage location](https://our.umbraco.com/documentation/Reference/Configuration-for-Umbraco-7-and-8/webconfig/#umbracocorelocaltempstorage).
 
 ## Synchronised File System

--- a/13/umbraco-cms/reference/configuration/filesystemproviders.md
+++ b/13/umbraco-cms/reference/configuration/filesystemproviders.md
@@ -52,13 +52,31 @@ To configure the PhysicalFileSystem for a virtual folder, create a new filesyste
 
 ### Physical path
 
-There are a few more steps involved if you want to store the media files in a separate folder outside the webroot.
+To store the media files in a folder outside the webroot, configure a physical root path in `appsettings.json`. You do not need a custom file system for this.
 
-First you must register the folder as a static file provider in your `Program.cs` file like so:
+```json
+{
+  "Umbraco": {
+    "CMS": {
+      "Global": {
+        "UmbracoMediaPath": "~/media",
+        "UmbracoMediaPhysicalRootPath": "C:\\storage\\umbracoMedia"
+      }
+    }
+  }
+}
+```
+
+* `UmbracoMediaPhysicalRootPath` is the full filesystem path where the media files are stored. Both absolute server paths (`C:\storage\umbracoMedia` or `\\servername\path`) and paths relative to the webroot (`../../Shared/Media`) are supported.
+* `UmbracoMediaPath` is the relative URL that media is served from. It defaults to `~/media`, and only needs changing if you also want media served from a different URL.
+
+From these settings Umbraco builds the same `PhysicalFileSystem` you would otherwise write by hand. It also composes that folder into the webroot file provider, so both static file serving and image processing continue to work.
+
+{% hint style="warning" %}
+**Do not register the media folder as an additional static file provider.** A pattern sometimes used for this scenario is to add a `PhysicalFileProvider` for the media folder in `Program.cs`:
 
 ```csharp
-...
-WebApplication app = builder.Build();
+// Do not do this - it silently disables image resizing.
 app.UseStaticFiles(new StaticFileOptions
     {
         FileProvider = new PhysicalFileProvider(Path.Combine("C:", "storage", "umbracoMedia")),
@@ -66,47 +84,17 @@ app.UseStaticFiles(new StaticFileOptions
     });
 ```
 
-Now you can register the folder as the media filesystem
+There are two problems with this:
 
-```csharp
-using System.IO;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Cms.Core.Hosting;
-using Umbraco.Cms.Core.IO;
-using Umbraco.Cms.Infrastructure.DependencyInjection;
+* Umbraco registers the ImageSharp middleware inside `app.UseUmbraco()`. A static file middleware registered before that call handles the request first and ignores the querystring, so `?width=500` returns the full-size original.
+* ImageSharp resolves images only through the webroot file provider. Files served from a separate `PhysicalFileProvider` are invisible to it, so resizing still does not work even if the registration is moved after `app.UseUmbraco()`.
 
-namespace FilesystemProviders;
+Every image is then served at its original size, including backoffice thumbnails. The problem only surfaces once media is stored outside the webroot.
 
-public class FilesystemComposer : IComposer
-{
-    public void Compose(IUmbracoBuilder builder)
-    {
-        builder.SetMediaFileSystem((factory) =>
-        {
-            IHostingEnvironment hostingEnvironment = factory.GetRequiredService<IHostingEnvironment>();
-            var rootPath = Path.Combine("C:", "storage", "umbracoMedia");
-            var rootUrl = hostingEnvironment.ToAbsolute("/CustomPath");
+To check whether a site is affected, request an image with and without a resizing querystring. `?width=50` must return a smaller response than the same URL without the querystring.
+{% endhint %}
 
-            return new PhysicalFileSystem(
-                factory.GetRequiredService<IIOHelper>(),
-                hostingEnvironment,
-                factory.GetRequiredService<ILogger<PhysicalFileSystem>>(),
-                rootPath,
-                rootUrl);
-        });
-    }
-}
-```
-
-This is much the same as when you register it within the wwwroot with a virtual folder. The only difference is that now you provide an absolute root path and root URL to the physical filesystem.
-
-* `rootPath` is the full filesystem path where you want media files to be stored. It has to be rooted, must use directory separators (`\`) and must not end with a separator. For example, `Z:` or `C:\path\to\folder` or `\\servername\path`.
-* `rootUrl` is the URL where the files will be accessible from. It must use URL separators (`/`) and must not end with a separator. It can either be a folder, like `/UmbracoMedia`, in which case it will considered as subfolder of the main domain (`example.com/UmbracoMedia`) or can be a fully qualified URL, with also domain name and protocol (for ex `http://media.example.com/media`).
-
-For more information see [Extending FileSystemProviders](../../extending/filesystemproviders/).
+For a different kind of storage, such as Azure Blob Storage or Amazon S3, replace the media file system instead. For more information see [Extending FileSystemProviders](../../extending/filesystemproviders/).
 
 ## Custom providers
 

--- a/17/umbraco-cms/develop-with-umbraco/configuration/filesystemproviders.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/filesystemproviders.md
@@ -52,13 +52,31 @@ To configure the PhysicalFileSystem for a virtual folder, create a new filesyste
 
 ### Physical path
 
-There are a few more steps involved if you want to store the media files in a separate folder outside the webroot.
+To store the media files in a folder outside the webroot, configure a physical root path in `appsettings.json`. You do not need a custom file system for this.
 
-First you must register the folder as a static file provider in your `Program.cs` file like so:
+```json
+{
+  "Umbraco": {
+    "CMS": {
+      "Global": {
+        "UmbracoMediaPath": "~/media",
+        "UmbracoMediaPhysicalRootPath": "C:\\storage\\umbracoMedia"
+      }
+    }
+  }
+}
+```
+
+* `UmbracoMediaPhysicalRootPath` is the full filesystem path where the media files are stored. Both absolute server paths (`C:\storage\umbracoMedia` or `\\servername\path`) and paths relative to the webroot (`../../Shared/Media`) are supported.
+* `UmbracoMediaPath` is the relative URL that media is served from. It defaults to `~/media`, and only needs changing if you also want media served from a different URL.
+
+From these settings Umbraco builds the same `PhysicalFileSystem` you would otherwise write by hand. It also composes that folder into the webroot file provider, so both static file serving and image processing continue to work.
+
+{% hint style="warning" %}
+**Do not register the media folder as an additional static file provider.** A pattern sometimes used for this scenario is to add a `PhysicalFileProvider` for the media folder in `Program.cs`:
 
 ```csharp
-...
-WebApplication app = builder.Build();
+// Do not do this - it silently disables image resizing.
 app.UseStaticFiles(new StaticFileOptions
     {
         FileProvider = new PhysicalFileProvider(Path.Combine("C:", "storage", "umbracoMedia")),
@@ -66,43 +84,17 @@ app.UseStaticFiles(new StaticFileOptions
     });
 ```
 
-Now you can register the folder as the media filesystem
+There are two problems with this:
 
-```csharp
-using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Core.IO;
-using Umbraco.Cms.Infrastructure.DependencyInjection;
-using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
+* Umbraco registers the ImageSharp middleware inside `app.UseUmbraco()`. A static file middleware registered before that call handles the request first and ignores the querystring, so `?width=500` returns the full-size original.
+* ImageSharp resolves images only through the webroot file provider. Files served from a separate `PhysicalFileProvider` are invisible to it, so resizing still does not work even if the registration is moved after `app.UseUmbraco()`.
 
-namespace FilesystemProviders;
+Every image is then served at its original size, including backoffice thumbnails. The problem only surfaces once media is stored outside the webroot.
 
-public class FilesystemComposer : IComposer
-{
- public void Compose(IUmbracoBuilder builder)
- {
-  builder.SetMediaFileSystem((factory) =>
-  {
-   IHostingEnvironment hostingEnvironment = factory.GetRequiredService<IHostingEnvironment>();
-   var rootPath = Path.Combine("C:", "storage", "umbracoMedia");
-   var rootUrl = hostingEnvironment.ToAbsolute("/CustomPath");
+To check whether a site is affected, request an image with and without a resizing querystring. `?width=50` must return a smaller response than the same URL without the querystring.
+{% endhint %}
 
-   return new PhysicalFileSystem(
-    factory.GetRequiredService<IIOHelper>(),
-    hostingEnvironment,
-    factory.GetRequiredService<ILogger<PhysicalFileSystem>>(),
-    rootPath,
-    rootUrl);
-  });
- }
-}
-```
-
-This is much the same as when you register it within the wwwroot with a virtual folder. The only difference is that now you provide an absolute root path and root URL to the physical filesystem.
-
-* `rootPath` is the full filesystem path where you want media files to be stored. It has to be rooted, must use directory separators (`\`) and must not end with a separator. For example, `Z:` or `C:\path\to\folder` or `\\servername\path`.
-* `rootUrl` is the URL where the files will be accessible from. It must use URL separators (`/`) and must not end with a separator. It can either be a folder, like `/UmbracoMedia`, in which case it will considered as subfolder of the main domain (`example.com/UmbracoMedia`) or can be a fully qualified URL, with also domain name and protocol (for ex `http://media.example.com/media`).
-
-For more information see [Extending FileSystemProviders](../../extend-your-project/server-side-extensions/filesystemproviders/).
+For a different kind of storage, such as Azure Blob Storage or Amazon S3, replace the media file system instead. For more information see [Extending FileSystemProviders](../../extend-your-project/server-side-extensions/filesystemproviders/).
 
 ## Custom providers
 

--- a/17/umbraco-cms/extend-your-project/server-side-extensions/filesystemproviders/README.md
+++ b/17/umbraco-cms/extend-your-project/server-side-extensions/filesystemproviders/README.md
@@ -103,7 +103,7 @@ To achieve this, you must first create your own file system by implementing the 
 {% hint style="info" %}
 Implementing `IFileProviderFactory` allows Umbraco to compose your media file system into the webroot file provider during startup. It is mounted at the URL configured in `UmbracoMediaPath`.
 
-Image processing resolves media through that provider. A media file system without `IFileProviderFactory` serves images at their original size only.
+Without it, Umbraco cannot serve or process media from your file system through that path. Image processing resolves media only through the webroot file provider.
 {% endhint %}
 
 You then replace the media filesystem by composition using `IUmbracoBuilder.SetMediaFileSystem(...)` (as is demonstrated in the paragraphs above), but instead of returning a `PhysicalFileSystem`, you return your own file system implementation.

--- a/17/umbraco-cms/extend-your-project/server-side-extensions/filesystemproviders/README.md
+++ b/17/umbraco-cms/extend-your-project/server-side-extensions/filesystemproviders/README.md
@@ -51,20 +51,32 @@ When creating a `PhysicalFileSystem` it takes some dependencies like `IIOHelper`
 
 The `rootPath` is where your media will be stored on the disk. Since netcore by default stores files in the `wwwroot`, we must put our desired folder somewhere within `wwwroot` to ensure that we use `hostingEnvironment.MapPathWebRoot(~/CustomMediaFolder)`. The `~` will be mapped to your `wwwroot` folder, so the final `rootPath` will be `your/project/path/wwwroot/CustomMediaFolder`. The `~` is therefore important.
 
-The `rootUrl` is the base URL that your media files will be served from. In this case, your image URL could look something like `mysite.com/CustomMediaFolder/MyAwesomePicture.png`. Again the `~` is important.
-
-In the code sample above, the `rootUrl` must map to the same physical location as `rootPath`, which again must be placed under `wwwroot`. If you want to store the media files outside of `wwwroot` there is an extra step involved; you need to instruct netcore to include static files from a different physical location.
-
 The `rootUrl` is the base URL that your media files will be served from. In this case, your image URL could look something like `mysite.com/CustomMediaFolder/MyAwesomePicture.png`. Again the `~` is important. With the code sample above, the `rootUrl` must map to the same physical location as `rootPath`, otherwise, you will get 404's for your images.
 
-If you want to store the media files outside of `wwwroot` there is an extra step involved; you need to instruct netcore to include static files from a different physical location.
+### Storing media outside the webroot
 
-In the `Program.cs` file, register a new static file location like so:
+A custom media file system is not the right tool for storing media on a physical or network path outside `wwwroot`. Use the `UmbracoMediaPhysicalRootPath` setting instead:
+
+```json
+{
+  "Umbraco": {
+    "CMS": {
+      "Global": {
+        "UmbracoMediaPath": "~/media",
+        "UmbracoMediaPhysicalRootPath": "C:\\storage\\umbracoMedia"
+      }
+    }
+  }
+}
+```
+
+Umbraco builds a `PhysicalFileSystem` from these settings, exactly as in the sample above. It also composes the folder into the webroot file provider for you. This keeps both static file serving and image processing working. See [FileSystemProviders Configuration](../../../develop-with-umbraco/configuration/filesystemproviders.md) for details.
+
+{% hint style="warning" %}
+**Do not register the media folder as an additional static file provider.** A pattern sometimes used for this scenario is to add a `PhysicalFileProvider` for the media folder in `Program.cs`:
 
 ```csharp
-...
-WebApplication app = builder.Build();
-
+// Do not do this - it silently disables image resizing.
 app.UseStaticFiles(new StaticFileOptions
     {
         FileProvider = new PhysicalFileProvider(Path.Combine("C:", "storage", "umbracoMedia")),
@@ -72,40 +84,27 @@ app.UseStaticFiles(new StaticFileOptions
     });
 ```
 
-The PhysicalFileProvider takes a single parameter, the **`RootPath`**. This is the rooted filesystem path using directory separator chars and not ending with a directory separator, eg: `c:\storage\umbracoMedia` or `\\server\path`. The safest way to achieve this is using `Path.Combine`.
+There are two problems with this:
 
-You also have to specify the **`RequestPath`**. This is the relative URL where the media will be served using URL separator chars and not ending with a separator, eg: `/CustomPath` or `/Media`.
+* Umbraco registers the ImageSharp middleware inside `app.UseUmbraco()`. A static file middleware registered before that call handles the request first and ignores the querystring, so `?width=500` returns the full-size original.
+* ImageSharp resolves images only through the webroot file provider. Files served from a separate `PhysicalFileProvider` are invisible to it, so resizing still does not work even if the registration is moved after `app.UseUmbraco()`.
 
-Now you can use your newly registered static file location as if it was `wwwroot`. Notice how you no longer need to use `hostingEnvironment.MapPathWebRoot(folderLocation)`, since you're no longer trying to map the location to somewhere within `wwwroot`, but instead use your newly registered static file location.
+Every image is then served at its original size, including backoffice thumbnails. To check whether a site is affected, request an image with and without a resizing querystring. `?width=50` must return a smaller response than the same URL without the querystring.
+{% endhint %}
 
-```csharp
-public void Compose(IUmbracoBuilder builder)
-{
-    builder.SetMediaFileSystem((factory) =>
-    {
-        IHostingEnvironment hostingEnvironment = factory.GetRequiredService<IHostingEnvironment>();
-        var rootPath = Path.Combine("C:", "storage", "umbracoMedia");
-        var rootUrl = hostingEnvironment.ToAbsolute("/CustomPath");
-
-        return new PhysicalFileSystem(
-            factory.GetRequiredService<IIOHelper>(),
-            hostingEnvironment,
-            factory.GetRequiredService<ILogger<PhysicalFileSystem>>(),
-            rootPath,
-            rootUrl);
-    });
-}
-```
-
-This is almost the same as when registering a location within the `wwwroot` folder. The only difference is that `rootPath` is now set to the path we gave the `PhysicalFileProvider` and the `rootUrl` is the same as we set as the `RequestPath` in the `StaticFileOption`.
-
-Our media is now stored in `C:\storage\umbracoMedia`, and is served from the base URL `/CustomPath`, so an image URL will look something like `mysite.com/CustomPath/MyAwesomePicture.png`.
+Reserve a custom media file system for storage that is genuinely of a different kind, such as Azure Blob Storage or Amazon S3.
 
 ### Creating a custom file system
 
 You can replace `PhysicalFileSystem` with a custom file system implementation - eg. if you want your media files stored on Amazon S3 or elsewhere outside your site.
 
 To achieve this, you must first create your own file system by implementing the interfaces `IFileSystem` and `IFileProviderFactory` (the interfaces that are implemented by `PhysicalFileSystem`).
+
+{% hint style="info" %}
+Implementing `IFileProviderFactory` allows Umbraco to compose your media file system into the webroot file provider during startup. It is mounted at the URL configured in `UmbracoMediaPath`.
+
+Image processing resolves media through that provider. A media file system without `IFileProviderFactory` serves images at their original size only.
+{% endhint %}
 
 You then replace the media filesystem by composition using `IUmbracoBuilder.SetMediaFileSystem(...)` (as is demonstrated in the paragraphs above), but instead of returning a `PhysicalFileSystem`, you return your own file system implementation.
 

--- a/17/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/load-balancing/file-system-replication.md
+++ b/17/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/load-balancing/file-system-replication.md
@@ -6,6 +6,8 @@ No file replication is configured, deployment handles updating files on the diff
 
 If the file system on your servers isn't performing any file replication then no _Umbraco_ configuration file changes are necessary. However Media will need to be configured to use a shared location such as Blob storage or S3.
 
+Media can also live on a shared network location, using a Universal Naming Convention (UNC) path. Set the `UmbracoMediaPhysicalRootPath` global setting rather than registering the share as a static file provider. Umbraco then builds and registers the media file system itself, which keeps image processing working. See [FileSystemProviders Configuration](../../../../develop-with-umbraco/configuration/filesystemproviders.md#physical-path).
+
 Depending on the configuration and performance of the environment's local storage you might need to consider [Examine Directory Factory Options](file-system-replication.md#examine-directory-factory-options) and the [Umbraco temporary storage location](https://our.umbraco.com/documentation/Reference/Configuration-for-Umbraco-7-and-8/webconfig/#umbracocorelocaltempstorage).
 
 ## Synchronised File System

--- a/18/umbraco-cms/develop-with-umbraco/configuration/filesystemproviders.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/filesystemproviders.md
@@ -52,13 +52,31 @@ To configure the PhysicalFileSystem for a virtual folder, create a new filesyste
 
 ### Physical path
 
-There are a few more steps involved if you want to store the media files in a separate folder outside the webroot.
+To store the media files in a folder outside the webroot, configure a physical root path in `appsettings.json`. You do not need a custom file system for this.
 
-First you must register the folder as a static file provider in your `Program.cs` file like so:
+```json
+{
+  "Umbraco": {
+    "CMS": {
+      "Global": {
+        "UmbracoMediaPath": "~/media",
+        "UmbracoMediaPhysicalRootPath": "C:\\storage\\umbracoMedia"
+      }
+    }
+  }
+}
+```
+
+* `UmbracoMediaPhysicalRootPath` is the full filesystem path where the media files are stored. Both absolute server paths (`C:\storage\umbracoMedia` or `\\servername\path`) and paths relative to the webroot (`../../Shared/Media`) are supported.
+* `UmbracoMediaPath` is the relative URL that media is served from. It defaults to `~/media`, and only needs changing if you also want media served from a different URL.
+
+From these settings Umbraco builds the same `PhysicalFileSystem` you would otherwise write by hand. It also composes that folder into the webroot file provider, so both static file serving and image processing continue to work.
+
+{% hint style="warning" %}
+**Do not register the media folder as an additional static file provider.** A pattern sometimes used for this scenario is to add a `PhysicalFileProvider` for the media folder in `Program.cs`:
 
 ```csharp
-...
-WebApplication app = builder.Build();
+// Do not do this - it silently disables image resizing.
 app.UseStaticFiles(new StaticFileOptions
     {
         FileProvider = new PhysicalFileProvider(Path.Combine("C:", "storage", "umbracoMedia")),
@@ -66,43 +84,17 @@ app.UseStaticFiles(new StaticFileOptions
     });
 ```
 
-Now you can register the folder as the media filesystem
+There are two problems with this:
 
-```csharp
-using Umbraco.Cms.Core.Composing;
-using Umbraco.Cms.Core.IO;
-using Umbraco.Cms.Infrastructure.DependencyInjection;
-using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
+* Umbraco registers the ImageSharp middleware inside `app.UseUmbraco()`. A static file middleware registered before that call handles the request first and ignores the querystring, so `?width=500` returns the full-size original.
+* ImageSharp resolves images only through the webroot file provider. Files served from a separate `PhysicalFileProvider` are invisible to it, so resizing still does not work even if the registration is moved after `app.UseUmbraco()`.
 
-namespace FilesystemProviders;
+Every image is then served at its original size, including backoffice thumbnails. The problem only surfaces once media is stored outside the webroot.
 
-public class FilesystemComposer : IComposer
-{
- public void Compose(IUmbracoBuilder builder)
- {
-  builder.SetMediaFileSystem((factory) =>
-  {
-   IHostingEnvironment hostingEnvironment = factory.GetRequiredService<IHostingEnvironment>();
-   var rootPath = Path.Combine("C:", "storage", "umbracoMedia");
-   var rootUrl = hostingEnvironment.ToAbsolute("/CustomPath");
+To check whether a site is affected, request an image with and without a resizing querystring. `?width=50` must return a smaller response than the same URL without the querystring.
+{% endhint %}
 
-   return new PhysicalFileSystem(
-    factory.GetRequiredService<IIOHelper>(),
-    hostingEnvironment,
-    factory.GetRequiredService<ILogger<PhysicalFileSystem>>(),
-    rootPath,
-    rootUrl);
-  });
- }
-}
-```
-
-This is much the same as when you register it within the wwwroot with a virtual folder. The only difference is that now you provide an absolute root path and root URL to the physical filesystem.
-
-* `rootPath` is the full filesystem path where you want media files to be stored. It has to be rooted, must use directory separators (`\`) and must not end with a separator. For example, `Z:` or `C:\path\to\folder` or `\\servername\path`.
-* `rootUrl` is the URL where the files will be accessible from. It must use URL separators (`/`) and must not end with a separator. It can either be a folder, like `/UmbracoMedia`, in which case it will considered as subfolder of the main domain (`example.com/UmbracoMedia`) or can be a fully qualified URL, with also domain name and protocol (for ex `http://media.example.com/media`).
-
-For more information see [Extending FileSystemProviders](../../extend-your-project/server-side-extensions/filesystemproviders/).
+For a different kind of storage, such as Azure Blob Storage or Amazon S3, replace the media file system instead. For more information see [Extending FileSystemProviders](../../extend-your-project/server-side-extensions/filesystemproviders/).
 
 ## Custom providers
 

--- a/18/umbraco-cms/extend-your-project/server-side-extensions/filesystemproviders/README.md
+++ b/18/umbraco-cms/extend-your-project/server-side-extensions/filesystemproviders/README.md
@@ -103,7 +103,7 @@ To achieve this, you must first create your own file system by implementing the 
 {% hint style="info" %}
 Implementing `IFileProviderFactory` allows Umbraco to compose your media file system into the webroot file provider during startup. It is mounted at the URL configured in `UmbracoMediaPath`.
 
-Image processing resolves media through that provider. A media file system without `IFileProviderFactory` serves images at their original size only.
+Without it, Umbraco cannot serve or process media from your file system through that path. Image processing resolves media only through the webroot file provider.
 {% endhint %}
 
 You then replace the media filesystem by composition using `IUmbracoBuilder.SetMediaFileSystem(...)` (as is demonstrated in the paragraphs above), but instead of returning a `PhysicalFileSystem`, you return your own file system implementation.

--- a/18/umbraco-cms/extend-your-project/server-side-extensions/filesystemproviders/README.md
+++ b/18/umbraco-cms/extend-your-project/server-side-extensions/filesystemproviders/README.md
@@ -51,20 +51,32 @@ When creating a `PhysicalFileSystem` it takes some dependencies like `IIOHelper`
 
 The `rootPath` is where your media will be stored on the disk. Since netcore by default stores files in the `wwwroot`, we must put our desired folder somewhere within `wwwroot` to ensure that we use `hostingEnvironment.MapPathWebRoot(~/CustomMediaFolder)`. The `~` will be mapped to your `wwwroot` folder, so the final `rootPath` will be `your/project/path/wwwroot/CustomMediaFolder`. The `~` is therefore important.
 
-The `rootUrl` is the base URL that your media files will be served from. In this case, your image URL could look something like `mysite.com/CustomMediaFolder/MyAwesomePicture.png`. Again the `~` is important.
-
-In the code sample above, the `rootUrl` must map to the same physical location as `rootPath`, which again must be placed under `wwwroot`. If you want to store the media files outside of `wwwroot` there is an extra step involved; you need to instruct netcore to include static files from a different physical location.
-
 The `rootUrl` is the base URL that your media files will be served from. In this case, your image URL could look something like `mysite.com/CustomMediaFolder/MyAwesomePicture.png`. Again the `~` is important. With the code sample above, the `rootUrl` must map to the same physical location as `rootPath`, otherwise, you will get 404's for your images.
 
-If you want to store the media files outside of `wwwroot` there is an extra step involved; you need to instruct netcore to include static files from a different physical location.
+### Storing media outside the webroot
 
-In the `Program.cs` file, register a new static file location like so:
+A custom media file system is not the right tool for storing media on a physical or network path outside `wwwroot`. Use the `UmbracoMediaPhysicalRootPath` setting instead:
+
+```json
+{
+  "Umbraco": {
+    "CMS": {
+      "Global": {
+        "UmbracoMediaPath": "~/media",
+        "UmbracoMediaPhysicalRootPath": "C:\\storage\\umbracoMedia"
+      }
+    }
+  }
+}
+```
+
+Umbraco builds a `PhysicalFileSystem` from these settings, exactly as in the sample above. It also composes the folder into the webroot file provider for you. This keeps both static file serving and image processing working. See [FileSystemProviders Configuration](../../../develop-with-umbraco/configuration/filesystemproviders.md) for details.
+
+{% hint style="warning" %}
+**Do not register the media folder as an additional static file provider.** A pattern sometimes used for this scenario is to add a `PhysicalFileProvider` for the media folder in `Program.cs`:
 
 ```csharp
-...
-WebApplication app = builder.Build();
-
+// Do not do this - it silently disables image resizing.
 app.UseStaticFiles(new StaticFileOptions
     {
         FileProvider = new PhysicalFileProvider(Path.Combine("C:", "storage", "umbracoMedia")),
@@ -72,40 +84,27 @@ app.UseStaticFiles(new StaticFileOptions
     });
 ```
 
-The PhysicalFileProvider takes a single parameter, the **`RootPath`**. This is the rooted filesystem path using directory separator chars and not ending with a directory separator, eg: `c:\storage\umbracoMedia` or `\\server\path`. The safest way to achieve this is using `Path.Combine`.
+There are two problems with this:
 
-You also have to specify the **`RequestPath`**. This is the relative URL where the media will be served using URL separator chars and not ending with a separator, eg: `/CustomPath` or `/Media`.
+* Umbraco registers the ImageSharp middleware inside `app.UseUmbraco()`. A static file middleware registered before that call handles the request first and ignores the querystring, so `?width=500` returns the full-size original.
+* ImageSharp resolves images only through the webroot file provider. Files served from a separate `PhysicalFileProvider` are invisible to it, so resizing still does not work even if the registration is moved after `app.UseUmbraco()`.
 
-Now you can use your newly registered static file location as if it was `wwwroot`. Notice how you no longer need to use `hostingEnvironment.MapPathWebRoot(folderLocation)`, since you're no longer trying to map the location to somewhere within `wwwroot`, but instead use your newly registered static file location.
+Every image is then served at its original size, including backoffice thumbnails. To check whether a site is affected, request an image with and without a resizing querystring. `?width=50` must return a smaller response than the same URL without the querystring.
+{% endhint %}
 
-```csharp
-public void Compose(IUmbracoBuilder builder)
-{
-    builder.SetMediaFileSystem((factory) =>
-    {
-        IHostingEnvironment hostingEnvironment = factory.GetRequiredService<IHostingEnvironment>();
-        var rootPath = Path.Combine("C:", "storage", "umbracoMedia");
-        var rootUrl = hostingEnvironment.ToAbsolute("/CustomPath");
-
-        return new PhysicalFileSystem(
-            factory.GetRequiredService<IIOHelper>(),
-            hostingEnvironment,
-            factory.GetRequiredService<ILogger<PhysicalFileSystem>>(),
-            rootPath,
-            rootUrl);
-    });
-}
-```
-
-This is almost the same as when registering a location within the `wwwroot` folder. The only difference is that `rootPath` is now set to the path we gave the `PhysicalFileProvider` and the `rootUrl` is the same as we set as the `RequestPath` in the `StaticFileOption`.
-
-Our media is now stored in `C:\storage\umbracoMedia`, and is served from the base URL `/CustomPath`, so an image URL will look something like `mysite.com/CustomPath/MyAwesomePicture.png`.
+Reserve a custom media file system for storage that is genuinely of a different kind, such as Azure Blob Storage or Amazon S3.
 
 ### Creating a custom file system
 
 You can replace `PhysicalFileSystem` with a custom file system implementation - eg. if you want your media files stored on Amazon S3 or elsewhere outside your site.
 
 To achieve this, you must first create your own file system by implementing the interfaces `IFileSystem` and `IFileProviderFactory` (the interfaces that are implemented by `PhysicalFileSystem`).
+
+{% hint style="info" %}
+Implementing `IFileProviderFactory` allows Umbraco to compose your media file system into the webroot file provider during startup. It is mounted at the URL configured in `UmbracoMediaPath`.
+
+Image processing resolves media through that provider. A media file system without `IFileProviderFactory` serves images at their original size only.
+{% endhint %}
 
 You then replace the media filesystem by composition using `IUmbracoBuilder.SetMediaFileSystem(...)` (as is demonstrated in the paragraphs above), but instead of returning a `PhysicalFileSystem`, you return your own file system implementation.
 

--- a/18/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/load-balancing/file-system-replication.md
+++ b/18/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/load-balancing/file-system-replication.md
@@ -6,6 +6,8 @@ No file replication is configured, deployment handles updating files on the diff
 
 If the file system on your servers isn't performing any file replication then no _Umbraco_ configuration file changes are necessary. However Media will need to be configured to use a shared location such as Blob storage or S3.
 
+Media can also live on a shared network location, using a Universal Naming Convention (UNC) path. Set the `UmbracoMediaPhysicalRootPath` global setting rather than registering the share as a static file provider. Umbraco then builds and registers the media file system itself, which keeps image processing working. See [FileSystemProviders Configuration](../../../../develop-with-umbraco/configuration/filesystemproviders.md#physical-path).
+
 Depending on the configuration and performance of the environment's local storage you might need to consider [Examine Directory Factory Options](file-system-replication.md#examine-directory-factory-options) and the [Umbraco temporary storage location](https://our.umbraco.com/documentation/Reference/Configuration-for-Umbraco-7-and-8/webconfig/#umbracocorelocaltempstorage).
 
 ## Synchronised File System


### PR DESCRIPTION
## 📋 Description

Corrects and improves the documentation for serving media from a folder outside the webroot.

The previous guidance told readers to register the media folder as an extra static file provider in `Program.cs`, then point a custom `PhysicalFileSystem` at it. That recipe silently disables image resizing, and the sample showed the registration immediately after `WebApplication app = builder.Build()` — that is, before `app.UseUmbraco()`.

Two independent problems make it fail:

1. Umbraco registers the ImageSharp middleware in the Umbraco PrePipeline, inside `app.UseUmbraco()`. A static file middleware registered before that call answers first and discards the resizing querystring, so `?width=500` returns the full-size original. Umbraco's own source comments this exact failure mode.
2. `AddUmbracoImageSharp()` does `.ClearProviders().AddProvider<WebRootImageProvider>()`, so ImageSharp resolves images only through `IWebHostEnvironment.WebRootFileProvider`. A file served from a separate `PhysicalFileProvider` is invisible to it.

Because of (2), simply moving the registration after `app.UseUmbraco()` does **not** fix resizing. The image is still returned at full size. So the recipe has been replaced rather than reordered.

For a physical or network path, no custom file system is needed at all. `UmbracoMediaPhysicalRootPath` builds the same `PhysicalFileSystem`, and `UseUmbracoMediaFileProvider()` composes it into `WebRootFileProvider`, which keeps ImageSharp working.

### What changed

Three pages, each in the `13`, `17` and `18` folders:

* **FileSystemProviders Configuration** — the "Physical path" section now leads with `UmbracoMediaPath` / `UmbracoMediaPhysicalRootPath`. A warning box shows the old pattern, explains both failure modes, and gives a one-line check readers can run. This page previously had no pointer to these settings at all.
* **Custom File Systems (IFileSystem)** — new "Storing media outside the webroot" section carrying the same guidance, so the trap is caught on whichever page a reader lands on. Custom file systems are reserved for genuinely different storage (Azure Blob Storage, Amazon S3). A note under "Creating a custom file system" explains that implementing `IFileProviderFactory` is what allows Umbraco to compose the file system into the webroot provider — without it, images serve at original size only.
* **Standalone File System** (load balancing) — names `UmbracoMediaPhysicalRootPath` for a shared network location, next to the existing "Blob storage or S3" sentence.

While rewriting that region, two paragraphs that were duplicated verbatim in the existing text were removed, along with a "the the" typo in the `13` copy.

## 🔍 Verification

**Source.** Each claim was checked against the source of each documented version, not just one. The ImageSharp PrePipeline registration, the `ClearProviders().AddProvider<WebRootImageProvider>()` call, the rooted-path handling of `UmbracoMediaPhysicalRootPath`, and the composition into `WebRootFileProvider` are all identical in `release/13.6.1`, 17 and `release/18.1.1`.

**Runtime.** The recommended approach was run end-to-end on Umbraco 17. My local project was configured with `UmbracoMediaPhysicalRootPath` and a real media library was moved out of `wwwroot`. Media served correctly, and resizing kept working: a 133,271 byte image returned 39,245 bytes at `width=400&height=300`. Filenames containing accented characters were included, since media now resolves through `MediaPrependBasePathFileProvider` rather than plain webroot static files.

**The discouraged pattern.** Rather than rely on reading the source, the old recipe was also run. A folder outside the webroot was registered as a separate `PhysicalFileProvider` on `/CustomPath`, with a correctly configured `/media` path alongside it as a control.

* Registered **before** `app.UseUmbraco()`: `/CustomPath/image.jpg?width=50` returned 133,271 bytes, byte-identical to the same URL without a querystring. The control `/media/image.jpg?width=50` returned 1,744 bytes in the same run, confirming ImageSharp itself was working.
* Registered **after** `app.UseUmbraco()`: `/CustomPath/image.jpg?width=50` still returned 133,271 bytes, as did `width=300&height=300`. The control still resized.

This confirms both failure modes, and confirms that correcting the middleware order alone is not a fix.

## 📎 Related Issues (if applicable)

Fixes #8286

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 13, 17, 18

## Deadline (if relevant)

Any time.
