### PR TITLE
Add Umbraco Commerce 18.0.5 release notes

### DIFF
--- a/18/umbraco-commerce/release-notes/README.md
+++ b/18/umbraco-commerce/release-notes/README.md
@@ -18,6 +18,11 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 This section contains the release notes for Umbraco Commerce 18, including all changes for this version.
 
+#### 18.0.5 (11th Aug 2026)
+
+* Fixed email rendering crash when there's no active HTTP request (#872).
+* Fixed cart cleanup timing out on stores with a large number of old carts (#874).
+
 #### 18.0.4 (29th Jul 2026)
 
 * Added logging to record why an order is moved to the error status, and when a payment is reset or redirected through a payment provider's cancel or error URL (#866).


### PR DESCRIPTION
## Summary
- Adds the 18.0.5 entry to the Umbraco Commerce release notes.
- Covers two fixes: email rendering crash with no active HTTP request (#872) and cart cleanup timing out on stores with a large number of old carts (#874).

## Test plan
- [x] Matches the established format/tone of neighboring entries in this file

🤖 Generated with Claude Code