### PR TITLE
Clarify organization-level GitHub workflow permissions

### DIFF
--- a/umbraco-cloud/build-and-customize-your-solution/handle-deployments-and-environments/umbraco-cicd/samplecicdpipeline/github-actions.md
+++ b/umbraco-cloud/build-and-customize-your-solution/handle-deployments-and-environments/umbraco-cicd/samplecicdpipeline/github-actions.md
@@ -131,6 +131,10 @@ This is how you can grant these permissions:
 
 <figure><img src="../../../../.gitbook/assets/github-workflow-permissions.png" alt=""><figcaption><p>GitHub Workflow permissions</p></figcaption></figure>
 
+{% hint style="info" %}
+If the **Read and write permissions** option is disabled, workflow permissions may be managed at the organization level. You can review or update this setting under **Organization Settings** → **Actions** → **General** → **Workflow permissions**.
+{% endhint %}
+
 ## Set up the GitHub Actions pipeline
 
 While working with the project on your local machine, follow these steps to prepare the pipeline, using the [samples from the repository](https://github.com/umbraco/Umbraco.Cloud.CICDFlow.Samples).


### PR DESCRIPTION
## 📋 Description

While implementing the GitHub Actions workflow for Umbraco Cloud, I found that the **Read and write permissions** option was disabled at the repository level because workflow permissions were managed at the organization level.

This PR adds a note explaining this possibility and indicates where the setting can be reviewed or updated in the organization settings.

## Product & Version 
Umbraco Cloud

