### PR TITLE
docs: add upgrade note about forms api path change

### DIFF
--- a/17/umbraco-forms/upgrading/version-specific.md
+++ b/17/umbraco-forms/upgrading/version-specific.md
@@ -36,6 +36,25 @@ To resolve this, choose one of the following options:
 
 For the updated snippets and the tag helper, see the [Rendering Forms Scripts](../developer/rendering-scripts.md) article. For the configuration option, see the [Configuration](../developer/configuration/README.md#trackrenderedformsstoragemethod) article.
 
+### Forms API URL paths
+
+This change was introduced in version 14. It affects you if you upgrade directly from version 13 to version 17.
+
+The Forms API endpoints moved under a `delivery` path segment. Both the endpoint for requesting a form definition and the endpoint for submitting a form entry changed:
+
+| Endpoint | Version 13 | Version 14 onwards |
+| --- | --- | --- |
+| Request a form definition | `GET /umbraco/forms/api/v1/definitions/{id}` | `GET /umbraco/forms/delivery/api/v1/definitions/{id}` |
+| Submit a form entry | `POST /umbraco/forms/api/v1/entries/{id}` | `POST /umbraco/forms/delivery/api/v1/entries/{id}` |
+
+{% hint style="warning" %}
+Requests to the version 13 paths return a 404 status code. Client-side scripts that submit forms fail without a validation error, as the request never reaches the Forms API.
+{% endhint %}
+
+Update any code that calls these endpoints, including client-side scripts, server-to-server integrations, and generated API clients.
+
+For the current endpoint definitions, see the [Headless/AJAX Forms](../developer/ajaxforms.md) article.
+
 ## Legacy version specific upgrade notes
 
 You can find the version specific upgrade notes for versions out of support in the [Legacy documentation on GitHub](https://github.com/umbraco/UmbracoDocs/blob/umbraco-eol-versions/11/umbraco-forms/installation/version-specific.md).


### PR DESCRIPTION
## 📋 Description

  Adds an upgrade note to the Umbraco Forms 17 version-specific upgrade documentation covering the Forms API URL path change.

  The Forms API endpoints moved under a `delivery` path segment in version 14, but this was never captured as an upgrade note. It surfaces when upgrading directly from version 13 to version 17, where
  the old paths return a 404 and client-side form submissions fail silently.

  | Endpoint | Version 13 | Version 14 onwards |
  | --- | --- | --- |
  | Request a form definition | `GET /umbraco/forms/api/v1/definitions/{id}` | `GET /umbraco/forms/delivery/api/v1/definitions/{id}` |
  | Submit a form entry | `POST /umbraco/forms/api/v1/entries/{id}` | `POST /umbraco/forms/delivery/api/v1/entries/{id}` |

  The new section follows the structure of the existing "Storage method for tracking rendered forms" note on the same page: the version the change was introduced in, the before/after behaviour, a
  warning hint describing the symptom, and then the remediation with a link to the API reference.

  ### Changes

  * Added a `Forms API URL paths` section to `17/umbraco-forms/upgrading/version-specific.md`.

  Both endpoints are covered rather than only the POST, since anyone hitting the submission 404 will hit the definition one first.

  ## 📎 Related Issues (if applicable)

  N/A

  ## ✅ Contributor Checklist

  I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

  * [x] Code blocks are correctly formatted.
  * [x] Sentences are short and clear (preferably under 25 words).
  * [x] Passive voice and first-person language (“we”, “I”) are avoided.
  * [x] Relevant pages are linked.
  * [x] All links work and point to the correct resources.
  * [x] Screenshots or diagrams are included if useful.
  * [x] Any code examples or instructions have been tested. <!-- URL paths verified against the v13 and v17 Headless/AJAX Forms articles -->
  * [x] Typos, broken links, and broken images are fixed.

  ## Product & Version (if relevant)

  Umbraco Forms 17

  ## Deadline (if relevant)

  N/A