### PR TITLE
Add Umbraco Cloud August 2026 release notes

### DIFF
--- a/umbraco-cloud/SUMMARY.md
+++ b/umbraco-cloud/SUMMARY.md
@@ -169,6 +169,7 @@
 ## Release Notes
 
 * [Overview 2026](release-notes/overview-2026/README.md)
+  * [August 2026](release-notes/overview-2026/2026-08-releasenotes.md)
   * [July 2026](release-notes/overview-2026/2026-07-releasenotes.md)
   * [June 2026](release-notes/overview-2026/2026-06-releasenotes.md)
   * [May 2026](release-notes/overview-2026/2026-05-releasenotes.md)

--- a/umbraco-cloud/release-notes/overview-2026/2026-08-releasenotes.md
+++ b/umbraco-cloud/release-notes/overview-2026/2026-08-releasenotes.md
@@ -1,0 +1,19 @@
+# August 2026
+
+## Key Takeaways
+
+* **Release Umbraco.Cloud.Cms 13.1.1, 17.2.2, & 18.0.2** - Hides the internal `azurewebsites.net` URL in additional cases. Adds the routes used by Umbraco ID and external login providers to the `ReservedUrls` setting.
+
+## Release Umbraco.Cloud.Cms 13.1.1, 17.2.2, & 18.0.2
+
+New versions of the `Umbraco.Cloud.Cms` package are available: 13.1.1, 17.2.2, and 18.0.2.
+
+All three versions contain two changes.
+
+### Internal URL hidden in additional cases
+
+The internal `azurewebsites.net` URL is now hidden in cases where it could still reach visitors. This follows up on the fix released in 13.1.0, 17.2.1, and 18.0.1.
+
+### Login provider routes added to ReservedUrls
+
+The routes used by Umbraco ID and by external login providers are added to the [`ReservedUrls`](../../../18/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md#reserved-urls) setting. Umbraco leaves these routes alone, so the content request pipeline no longer handles the sign-in callbacks.

--- a/umbraco-cloud/release-notes/overview-2026/README.md
+++ b/umbraco-cloud/release-notes/overview-2026/README.md
@@ -6,6 +6,10 @@ description: Get an overview of the release notes for each month in 2026.
 
 Each item is prefixed with the date (DD/MM) it was added to the release notes. Use the dates to match a change in behaviour on your project with a release.
 
+## [August 2026](2026-08-releasenotes.md)
+
+* [13/08] - **Release Umbraco.Cloud.Cms 13.1.1, 17.2.2, & 18.0.2** - Hides the internal azurewebsites.net URL in additional cases. Adds the routes used by Umbraco ID and external login providers to the ReservedUrls setting.
+
 ## [July 2026](2026-07-releasenotes.md)
 
 * [08/07] - **Readiness gating** - During restarts, outages, and upgrades, Umbraco Cloud now keeps showing the error page until your site reports that it is ready, so traffic no longer overwhelms a site that is still warming up.


### PR DESCRIPTION
## 📋 Description

Adds release notes for August 2026 on Umbraco Cloud, covering the release of `Umbraco.Cloud.Cms` 13.1.1, 17.2.2, and 18.0.2.

The release contains two changes:

* The internal `azurewebsites.net` URL is hidden in additional cases. This follows up on the fix released in 13.1.0, 17.2.1, and 18.0.1 in July.
* The routes used by Umbraco ID and by external login providers are added to the `ReservedUrls` setting.

Changes in this PR:

* New article: `umbraco-cloud/release-notes/overview-2026/2026-08-releasenotes.md`
* Added an August 2026 section with a `[13/08]` bullet to `umbraco-cloud/release-notes/overview-2026/README.md`
* Added the article to `umbraco-cloud/SUMMARY.md`

This PR was drafted with AI assistance (Claude Code) and reviewed by me before submitting.

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Cloud — `Umbraco.Cloud.Cms` 13.1.1, 17.2.2, and 18.0.2.

## Deadline (if relevant)

Publish with the 13/08/2026 release.