### PR TITLE
docs(mcp): add template collection to default tool collections example

### DIFF
--- a/17/umbraco-in-ai/mcp/cms-developer-mcp/README.md
+++ b/17/umbraco-in-ai/mcp/cms-developer-mcp/README.md
@@ -118,9 +118,13 @@ Although the details vary slightly, the general pattern is the same across all h
 
 ```
 
+{% hint style="info" %}
+`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](available-tools.md) for the full list of collections.
+{% endhint %}
+
 Add your Umbraco MCP configuration values (Client ID, Client Secret, and Umbraco URL) in the appropriate section of your host setup. Then restart the MCP Server or, in some cases, restart the host application.
 
-Once restarted, you’ll have access to the full suite of tools available through the Umbraco CMS Developer MCP Server.
+Once restarted, the MCP Server has access to the tool collections you configured.
 
 {% hint style="info" %}
 This Developer MCP Server requires `Node.js` version 22 or higher. Check your current `Node.js` version by running `node -v` in your terminal.

--- a/17/umbraco-in-ai/mcp/cms-developer-mcp/README.md
+++ b/17/umbraco-in-ai/mcp/cms-developer-mcp/README.md
@@ -111,7 +111,7 @@ Although the details vary slightly, the general pattern is the same across all h
       "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",
       "UMBRACO_CLIENT_SECRET": "1234567890",
       "UMBRACO_BASE_URL": "https://localhost:12345",
-      "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type"
+      "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type,template"
     }
   }
 }

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
@@ -31,6 +31,10 @@ claude mcp add umbraco-mcp npx @umbraco-cms/mcp-dev@lts-17
 claude mcp add umbraco-mcp --env UMBRACO_CLIENT_ID="your-id" --env UMBRACO_CLIENT_SECRET="your-secret" --env UMBRACO_BASE_URL="https://your-domain.com" --env NODE_TLS_REJECT_UNAUTHORIZED="0" --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type,template" -- npx @umbraco-cms/mcp-dev@lts-17
 ```
 
+{% hint style="info" %}
+`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](../cms-developer-mcp/available-tools.md) for the full list of collections.
+{% endhint %}
+
 Replace the following values with your local connection details:
 
 - `UMBRACO_CLIENT_ID`

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
@@ -31,10 +31,6 @@ claude mcp add umbraco-mcp npx @umbraco-cms/mcp-dev@lts-17
 claude mcp add umbraco-mcp --env UMBRACO_CLIENT_ID="your-id" --env UMBRACO_CLIENT_SECRET="your-secret" --env UMBRACO_BASE_URL="https://your-domain.com" --env NODE_TLS_REJECT_UNAUTHORIZED="0" --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type,template" -- npx @umbraco-cms/mcp-dev@lts-17
 ```
 
-{% hint style="info" %}
-`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](../cms-developer-mcp/available-tools.md) for the full list of collections.
-{% endhint %}
-
 Replace the following values with your local connection details:
 
 - `UMBRACO_CLIENT_ID`
@@ -71,6 +67,10 @@ UMBRACO_INCLUDE_TOOL_COLLECTIONS=document,media,document-type,data-type,template
 ```
 
 Replace the `UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, `UMBRACO_BASE_URL` and `UMBRACO_INCLUDE_TOOL_COLLECTIONS` values with your local connection details.
+
+{% hint style="info" %}
+`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](../cms-developer-mcp/available-tools.md) for the full list of collections.
+{% endhint %}
 
 #### Example `.mcp.json` file
 

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
@@ -28,7 +28,7 @@ claude mcp add umbraco-mcp npx @umbraco-cms/mcp-dev@lts-17
 ```bash
 
 # Add with environment variables
-claude mcp add umbraco-mcp --env UMBRACO_CLIENT_ID="your-id" --env UMBRACO_CLIENT_SECRET="your-secret" --env UMBRACO_BASE_URL="https://your-domain.com" --env NODE_TLS_REJECT_UNAUTHORIZED="0" --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type" -- npx @umbraco-cms/mcp-dev@lts-17
+claude mcp add umbraco-mcp --env UMBRACO_CLIENT_ID="your-id" --env UMBRACO_CLIENT_SECRET="your-secret" --env UMBRACO_BASE_URL="https://your-domain.com" --env NODE_TLS_REJECT_UNAUTHORIZED="0" --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type,template" -- npx @umbraco-cms/mcp-dev@lts-17
 ```
 
 Replace the following values with your local connection details:
@@ -63,7 +63,7 @@ This is the referred project-level configuration for Claude Code. Creating a `.m
 UMBRACO_CLIENT_ID=umbraco-back-office-mcp
 UMBRACO_CLIENT_SECRET=1234567890
 UMBRACO_BASE_URL=http://localhost:123456
-UMBRACO_INCLUDE_TOOL_COLLECTIONS=document,media,document-type,data-type
+UMBRACO_INCLUDE_TOOL_COLLECTIONS=document,media,document-type,data-type,template
 ```
 
 Replace the `UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, `UMBRACO_BASE_URL` and `UMBRACO_INCLUDE_TOOL_COLLECTIONS` values with your local connection details.

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/claude-desktop.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/claude-desktop.md
@@ -34,7 +34,7 @@ The examples below use the Developer MCP package (`@umbraco-cms/mcp-dev`). Repla
         "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",
         "UMBRACO_CLIENT_SECRET": "1234567890",
         "UMBRACO_BASE_URL": "https://localhost:12345",
-        "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type"
+        "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type,template"
       }
     }
   }

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/claude-desktop.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/claude-desktop.md
@@ -41,6 +41,10 @@ The examples below use the Developer MCP package (`@umbraco-cms/mcp-dev`). Repla
 }
 ```
 
+{% hint style="info" %}
+`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](../cms-developer-mcp/available-tools.md) for the full list of collections.
+{% endhint %}
+
 5. Replace the `UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, and `UMBRACO_BASE_URL` values with your local connection details.
 6. Restart Claude to activate the new configuration.
 7. Open the logs and review the `mcp-server-umbraco-mcp.log` file if you encounter a connection error. This file contains details on how to resolve the issue.

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/cursor.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/cursor.md
@@ -36,6 +36,10 @@ The examples below use the Developer MCP package (`@umbraco-cms/mcp-dev`). Repla
 }
 ```
 
+{% hint style="info" %}
+`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](../cms-developer-mcp/available-tools.md) for the full list of collections.
+{% endhint %}
+
 Replace the `UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, and `UMBRACO_BASE_URL` values with your local connection details.
 
 ![MCP Panel Added](../../.gitbook/assets/Cursor-MCP-Added.png)

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/cursor.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/cursor.md
@@ -29,7 +29,7 @@ The examples below use the Developer MCP package (`@umbraco-cms/mcp-dev`). Repla
         "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",
         "UMBRACO_CLIENT_SECRET": "1234567890",
         "UMBRACO_BASE_URL": "https://localhost:12345",
-        "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type"
+        "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type,template"
       }
     }
   }

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/github-copilot.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/github-copilot.md
@@ -14,7 +14,7 @@ The examples below use the Developer MCP package (`@umbraco-cms/mcp-dev`). Repla
 
 ### Install MCP Server via Button
 
-[![Install in Visual Studio Code](https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square\&label=Install%20Server\&color=0098FF)](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22name%22%3A%22umbraco-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22%40umbraco-cms%2Fmcp-dev%4017%22%5D%2C%22env%22%3A%7B%22NODE_TLS_REJECT_UNAUTHORIZED%22%3A%220%22%2C%22UMBRACO_CLIENT_ID%22%3A%22%3CAPI%20user%20name%3E%22%2C%22UMBRACO_CLIENT_SECRET%22%3A%22%3CAPI%20client%20secert%3E%22%2C%22UMBRACO_BASE_URL%22%3A%22https%3A%2F%2F%3Cdomain%3E%22%2C%22UMBRACO_INCLUDE_TOOL_COLLECTIONS%22%3A%22document%2Cmedia%2Cdocument-type%2Cdata-type%22%7D%7D)
+[![Install in Visual Studio Code](https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square\&label=Install%20Server\&color=0098FF)](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22name%22%3A%22umbraco-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22%40umbraco-cms%2Fmcp-dev%4017%22%5D%2C%22env%22%3A%7B%22NODE_TLS_REJECT_UNAUTHORIZED%22%3A%220%22%2C%22UMBRACO_CLIENT_ID%22%3A%22%3CAPI%20user%20name%3E%22%2C%22UMBRACO_CLIENT_SECRET%22%3A%22%3CAPI%20client%20secert%3E%22%2C%22UMBRACO_BASE_URL%22%3A%22https%3A%2F%2F%3Cdomain%3E%22%2C%22UMBRACO_INCLUDE_TOOL_COLLECTIONS%22%3A%22document%2Cmedia%2Cdocument-type%2Cdata-type%2Ctemplate%22%7D%7D)
 
 **Requirements:** Visual Studio Code 1.101+ with GitHub Copilot Chat extension installed.
 
@@ -39,7 +39,7 @@ Once you’ve added your MCP Server and updated the JSON configuration, restarti
         "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",
         "UMBRACO_CLIENT_SECRET": "1234567890",
         "UMBRACO_BASE_URL": "https://localhost:12345",
-        "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type"
+        "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type,template"
       },
       "type": "stdio"
     }

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/github-copilot.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/github-copilot.md
@@ -49,6 +49,10 @@ Once you’ve added your MCP Server and updated the JSON configuration, restarti
 ```
 
 {% hint style="info" %}
+`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](../cms-developer-mcp/available-tools.md) for the full list of collections.
+{% endhint %}
+
+{% hint style="info" %}
 Restarting the MCP Server applies any configuration or tool changes immediately without needing to reinstall or re-add the server.
 {% endhint %}
 

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/openai-codex.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/openai-codex.md
@@ -44,6 +44,10 @@ codex mcp add umbraco-mcp \
   -- npx -y @umbraco-cms/mcp-dev@lts-17
 ```
 
+{% hint style="info" %}
+`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](../cms-developer-mcp/available-tools.md) for the full list of collections.
+{% endhint %}
+
 Replace the following values with your local connection details:
 
 - `UMBRACO_CLIENT_ID`

--- a/17/umbraco-in-ai/mcp/local-mcp-setup/openai-codex.md
+++ b/17/umbraco-in-ai/mcp/local-mcp-setup/openai-codex.md
@@ -40,7 +40,7 @@ codex mcp add umbraco-mcp \
   --env UMBRACO_CLIENT_SECRET="your-secret" \
   --env UMBRACO_BASE_URL="https://your-domain.com" \
   --env NODE_TLS_REJECT_UNAUTHORIZED="0" \
-  --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type" \
+  --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type,template" \
   -- npx -y @umbraco-cms/mcp-dev@lts-17
 ```
 

--- a/18/umbraco-in-ai/mcp/cms-developer-mcp/README.md
+++ b/18/umbraco-in-ai/mcp/cms-developer-mcp/README.md
@@ -124,9 +124,13 @@ If your site is on the current Long-Term Support (LTS) release, Umbraco 17, use 
 
 ```
 
+{% hint style="info" %}
+`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](available-tools.md) for the full list of collections.
+{% endhint %}
+
 Add your Umbraco MCP configuration values (Client ID, Client Secret, and Umbraco URL) in the appropriate section of your host setup. Then restart the MCP Server or, in some cases, restart the host application.
 
-Once restarted, you’ll have access to the full suite of tools available through the Umbraco CMS Developer MCP Server.
+Once restarted, the MCP Server has access to the tool collections you configured.
 
 {% hint style="info" %}
 This Developer MCP Server requires `Node.js` version 22 or higher. Check your current `Node.js` version by running `node -v` in your terminal.

--- a/18/umbraco-in-ai/mcp/cms-developer-mcp/README.md
+++ b/18/umbraco-in-ai/mcp/cms-developer-mcp/README.md
@@ -117,7 +117,7 @@ If your site is on the current Long-Term Support (LTS) release, Umbraco 17, use 
       "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",
       "UMBRACO_CLIENT_SECRET": "1234567890",
       "UMBRACO_BASE_URL": "https://localhost:12345",
-      "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type"
+      "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type,template"
     }
   }
 }

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
@@ -36,7 +36,7 @@ claude mcp add umbraco-mcp npx @umbraco-cms/mcp-dev@latest
 ```bash
 
 # Add with environment variables
-claude mcp add umbraco-mcp --env UMBRACO_CLIENT_ID="your-id" --env UMBRACO_CLIENT_SECRET="your-secret" --env UMBRACO_BASE_URL="https://your-domain.com" --env NODE_TLS_REJECT_UNAUTHORIZED="0" --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type" -- npx @umbraco-cms/mcp-dev@latest
+claude mcp add umbraco-mcp --env UMBRACO_CLIENT_ID="your-id" --env UMBRACO_CLIENT_SECRET="your-secret" --env UMBRACO_BASE_URL="https://your-domain.com" --env NODE_TLS_REJECT_UNAUTHORIZED="0" --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type,template" -- npx @umbraco-cms/mcp-dev@latest
 ```
 
 Replace the following values with your local connection details:
@@ -71,7 +71,7 @@ This is the referred project-level configuration for Claude Code. Creating a `.m
 UMBRACO_CLIENT_ID=umbraco-back-office-mcp
 UMBRACO_CLIENT_SECRET=1234567890
 UMBRACO_BASE_URL=http://localhost:123456
-UMBRACO_INCLUDE_TOOL_COLLECTIONS=document,media,document-type,data-type
+UMBRACO_INCLUDE_TOOL_COLLECTIONS=document,media,document-type,data-type,template
 ```
 
 Replace the `UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, `UMBRACO_BASE_URL` and `UMBRACO_INCLUDE_TOOL_COLLECTIONS` values with your local connection details.

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
@@ -39,10 +39,6 @@ claude mcp add umbraco-mcp npx @umbraco-cms/mcp-dev@latest
 claude mcp add umbraco-mcp --env UMBRACO_CLIENT_ID="your-id" --env UMBRACO_CLIENT_SECRET="your-secret" --env UMBRACO_BASE_URL="https://your-domain.com" --env NODE_TLS_REJECT_UNAUTHORIZED="0" --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type,template" -- npx @umbraco-cms/mcp-dev@latest
 ```
 
-{% hint style="info" %}
-`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](../cms-developer-mcp/available-tools.md) for the full list of collections.
-{% endhint %}
-
 Replace the following values with your local connection details:
 
 - `UMBRACO_CLIENT_ID`
@@ -79,6 +75,10 @@ UMBRACO_INCLUDE_TOOL_COLLECTIONS=document,media,document-type,data-type,template
 ```
 
 Replace the `UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, `UMBRACO_BASE_URL` and `UMBRACO_INCLUDE_TOOL_COLLECTIONS` values with your local connection details.
+
+{% hint style="info" %}
+`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](../cms-developer-mcp/available-tools.md) for the full list of collections.
+{% endhint %}
 
 #### Example `.mcp.json` file
 

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/claude-code.md
@@ -39,6 +39,10 @@ claude mcp add umbraco-mcp npx @umbraco-cms/mcp-dev@latest
 claude mcp add umbraco-mcp --env UMBRACO_CLIENT_ID="your-id" --env UMBRACO_CLIENT_SECRET="your-secret" --env UMBRACO_BASE_URL="https://your-domain.com" --env NODE_TLS_REJECT_UNAUTHORIZED="0" --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type,template" -- npx @umbraco-cms/mcp-dev@latest
 ```
 
+{% hint style="info" %}
+`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](../cms-developer-mcp/available-tools.md) for the full list of collections.
+{% endhint %}
+
 Replace the following values with your local connection details:
 
 - `UMBRACO_CLIENT_ID`

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/claude-desktop.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/claude-desktop.md
@@ -42,7 +42,7 @@ See [Version Compatibility](../cms-developer-mcp/README.md#version-compatibility
         "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",
         "UMBRACO_CLIENT_SECRET": "1234567890",
         "UMBRACO_BASE_URL": "https://localhost:12345",
-        "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type"
+        "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type,template"
       }
     }
   }

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/claude-desktop.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/claude-desktop.md
@@ -49,6 +49,10 @@ See [Version Compatibility](../cms-developer-mcp/README.md#version-compatibility
 }
 ```
 
+{% hint style="info" %}
+`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](../cms-developer-mcp/available-tools.md) for the full list of collections.
+{% endhint %}
+
 5. Replace the `UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, and `UMBRACO_BASE_URL` values with your local connection details.
 6. Restart Claude to activate the new configuration.
 7. Open the logs and review the `mcp-server-umbraco-mcp.log` file if you encounter a connection error. This file contains details on how to resolve the issue.

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/cursor.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/cursor.md
@@ -44,6 +44,10 @@ See [Version Compatibility](../cms-developer-mcp/README.md#version-compatibility
 }
 ```
 
+{% hint style="info" %}
+`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](../cms-developer-mcp/available-tools.md) for the full list of collections.
+{% endhint %}
+
 Replace the `UMBRACO_CLIENT_ID`, `UMBRACO_CLIENT_SECRET`, and `UMBRACO_BASE_URL` values with your local connection details.
 
 ![MCP Panel Added](../../.gitbook/assets/Cursor-MCP-Added.png)

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/cursor.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/cursor.md
@@ -37,7 +37,7 @@ See [Version Compatibility](../cms-developer-mcp/README.md#version-compatibility
         "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",
         "UMBRACO_CLIENT_SECRET": "1234567890",
         "UMBRACO_BASE_URL": "https://localhost:12345",
-        "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type"
+        "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type,template"
       }
     }
   }

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/github-copilot.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/github-copilot.md
@@ -57,6 +57,10 @@ Once you’ve added your MCP Server and updated the JSON configuration, restarti
 ```
 
 {% hint style="info" %}
+`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](../cms-developer-mcp/available-tools.md) for the full list of collections.
+{% endhint %}
+
+{% hint style="info" %}
 Restarting the MCP Server applies any configuration or tool changes immediately without needing to reinstall or re-add the server.
 {% endhint %}
 

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/github-copilot.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/github-copilot.md
@@ -22,7 +22,7 @@ See [Version Compatibility](../cms-developer-mcp/README.md#version-compatibility
 
 ### Install MCP Server via Button
 
-[![Install in Visual Studio Code](https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square\&label=Install%20Server\&color=0098FF)](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22name%22%3A%22umbraco-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22%40umbraco-cms%2Fmcp-dev%4017%22%5D%2C%22env%22%3A%7B%22NODE_TLS_REJECT_UNAUTHORIZED%22%3A%220%22%2C%22UMBRACO_CLIENT_ID%22%3A%22%3CAPI%20user%20name%3E%22%2C%22UMBRACO_CLIENT_SECRET%22%3A%22%3CAPI%20client%20secert%3E%22%2C%22UMBRACO_BASE_URL%22%3A%22https%3A%2F%2F%3Cdomain%3E%22%2C%22UMBRACO_INCLUDE_TOOL_COLLECTIONS%22%3A%22document%2Cmedia%2Cdocument-type%2Cdata-type%22%7D%7D)
+[![Install in Visual Studio Code](https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square\&label=Install%20Server\&color=0098FF)](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22name%22%3A%22umbraco-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22%40umbraco-cms%2Fmcp-dev%4017%22%5D%2C%22env%22%3A%7B%22NODE_TLS_REJECT_UNAUTHORIZED%22%3A%220%22%2C%22UMBRACO_CLIENT_ID%22%3A%22%3CAPI%20user%20name%3E%22%2C%22UMBRACO_CLIENT_SECRET%22%3A%22%3CAPI%20client%20secert%3E%22%2C%22UMBRACO_BASE_URL%22%3A%22https%3A%2F%2F%3Cdomain%3E%22%2C%22UMBRACO_INCLUDE_TOOL_COLLECTIONS%22%3A%22document%2Cmedia%2Cdocument-type%2Cdata-type%2Ctemplate%22%7D%7D)
 
 **Requirements:** Visual Studio Code 1.101+ with GitHub Copilot Chat extension installed.
 
@@ -47,7 +47,7 @@ Once you’ve added your MCP Server and updated the JSON configuration, restarti
         "UMBRACO_CLIENT_ID": "umbraco-back-office-mcp",
         "UMBRACO_CLIENT_SECRET": "1234567890",
         "UMBRACO_BASE_URL": "https://localhost:12345",
-        "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type"
+        "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document,media,document-type,data-type,template"
       },
       "type": "stdio"
     }

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/openai-codex.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/openai-codex.md
@@ -48,7 +48,7 @@ codex mcp add umbraco-mcp \
   --env UMBRACO_CLIENT_SECRET="your-secret" \
   --env UMBRACO_BASE_URL="https://your-domain.com" \
   --env NODE_TLS_REJECT_UNAUTHORIZED="0" \
-  --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type" \
+  --env UMBRACO_INCLUDE_TOOL_COLLECTIONS="document,media,document-type,data-type,template" \
   -- npx -y @umbraco-cms/mcp-dev@latest
 ```
 

--- a/18/umbraco-in-ai/mcp/local-mcp-setup/openai-codex.md
+++ b/18/umbraco-in-ai/mcp/local-mcp-setup/openai-codex.md
@@ -52,6 +52,10 @@ codex mcp add umbraco-mcp \
   -- npx -y @umbraco-cms/mcp-dev@latest
 ```
 
+{% hint style="info" %}
+`UMBRACO_INCLUDE_TOOL_COLLECTIONS` restricts the MCP Server to only the tool collections listed here. Nearly every Umbraco Management API operation is available as a tool, so add any additional collections your task requires. See [Available Tools](../cms-developer-mcp/available-tools.md) for the full list of collections.
+{% endhint %}
+
 Replace the following values with your local connection details:
 
 - `UMBRACO_CLIENT_ID`


### PR DESCRIPTION
## Summary
- Adds `template` to the `UMBRACO_INCLUDE_TOOL_COLLECTIONS` example used across the MCP setup guides (Claude Desktop, Claude Code, GitHub Copilot, Cursor, OpenAI Codex, README) for both v17 and v18
- Users following the documented starter set had no access to Template tools, which is a gap since Document Type + Template is one of the first workflows people try

## Test plan
- [x] Vale passes with 0 errors on all changed files