### PR TITLE
Add Umbraco Commerce 18.1.2 release notes

### DIFF
--- a/18/umbraco-commerce/release-notes/README.md
+++ b/18/umbraco-commerce/release-notes/README.md
@@ -18,6 +18,13 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 This section contains the release notes for Umbraco Commerce 18, including all changes for this version.
 
+#### 18.1.2 (17th Aug 2026)
+
+* Fixed a backoffice crash when viewing an order linked to a customer by member key or another non-ID reference (#878).
+* Fixed data corruption from a discount migration that could invalidate member-group discount rules (#877).
+* Fixed missing database indexes causing slow order and order line deletes on large stores (#879).
+* Fixed missing price fields in the dynamic shipping rate range editor (#880).
+
 #### 18.1.0 (12th Aug 2026)
 
 * Added customer management, including customer records, addresses, communication history, and statistics that stay in sync with orders automatically.


### PR DESCRIPTION
## Summary
- Adds the 18.1.2 entry to the Umbraco Commerce 18 release notes, covering the four fixes shipped in this hotfix release.

## Test plan
- [x] Matches the established formatting/tense/style of neighboring entries in this file

🤖 Generated with Claude Code