### PR TITLE
Keep the default variant separate in the Engage dedup script

### DIFF
--- a/17/umbraco-engage/scripts/DeduplicatePageVariants.sql
+++ b/17/umbraco-engage/scripts/DeduplicatePageVariants.sql
@@ -9,6 +9,11 @@
 -- NOTE: Run this during a maintenance window or low-traffic period.
 -- The UPDATE on umbracoEngageAnalyticsPageview can take a while on
 -- installations with a large number of pageviews.
+--
+-- NOTE: An empty segment is the default (original) variant, and is deliberately
+-- distinct from NULL, which marks rows written before the served segment was
+-- recorded. The comparisons below must not collapse the two together: this
+-- script repoints pageviews and deletes rows, and cannot be undone.
 -- =============================================================================
 
 -- Step 1: Reassign pageviews from duplicate variants to the canonical variant
@@ -29,7 +34,8 @@ INNER JOIN (
 ) canonical
     ON dupVariant.[nodeId] = canonical.[nodeId]
     AND dupVariant.[culture] = canonical.[culture]
-    AND ISNULL(dupVariant.[segment], '') = ISNULL(canonical.[segment], '')
+    AND (dupVariant.[segment] = canonical.[segment]
+         OR (dupVariant.[segment] IS NULL AND canonical.[segment] IS NULL))
     AND ISNULL(dupVariant.[contentTypeId], -1) = ISNULL(canonical.[contentTypeId], -1)
 WHERE dupVariant.[id] <> canonical.[id];
 
@@ -44,7 +50,8 @@ AND EXISTS (
     SELECT 1 FROM [umbracoEngageAnalyticsUmbracoPageVariant] canonical
     WHERE canonical.[nodeId] = v.[nodeId]
     AND canonical.[culture] = v.[culture]
-    AND ISNULL(canonical.[segment], '') = ISNULL(v.[segment], '')
+    AND (canonical.[segment] = v.[segment]
+         OR (canonical.[segment] IS NULL AND v.[segment] IS NULL))
     AND ISNULL(canonical.[contentTypeId], -1) = ISNULL(v.[contentTypeId], -1)
     AND canonical.[id] < v.[id]
 );

--- a/17/umbraco-engage/scripts/DeduplicatePageVariants.sql
+++ b/17/umbraco-engage/scripts/DeduplicatePageVariants.sql
@@ -14,6 +14,10 @@
 -- distinct from NULL, which marks rows written before the served segment was
 -- recorded. The comparisons below must not collapse the two together: this
 -- script repoints pageviews and deletes rows, and cannot be undone.
+--
+-- NOTE: Traffic collected on 17.0, 17.1, or 16.0 to 16.2 also carries an empty
+-- segment, written before variant tracking existed. Those rows cannot be told
+-- apart from genuine original-variant rows, so this script groups them together.
 -- =============================================================================
 
 -- Step 1: Reassign pageviews from duplicate variants to the canonical variant

--- a/17/umbraco-engage/upgrading/schema-alignment-guide.md
+++ b/17/umbraco-engage/upgrading/schema-alignment-guide.md
@@ -138,6 +138,10 @@ Run the `DeduplicatePageVariants.sql` script against your database. This consoli
 {% hint style="info" %}
 This step is optional. The update on the pageviews table can take a while on large installations, so plan accordingly.
 {% endhint %}
+
+{% hint style="info" %}
+Engage began recording which variant was served in 17.4. Installations that collected traffic on 17.0, 17.1, or 16.0 to 16.2 also hold rows with an empty segment from before that change. Those rows look identical to genuine original-variant rows, so the script groups them together. Original-variant figures on those installations therefore include some traffic that predates variant tracking. Nothing can separate the two retrospectively. Figures for traffic collected on 17.4 and later are unaffected.
+{% endhint %}
 {% endstep %}
 {% endstepper %}
 

--- a/18/umbraco-engage/scripts/DeduplicatePageVariants.sql
+++ b/18/umbraco-engage/scripts/DeduplicatePageVariants.sql
@@ -9,6 +9,11 @@
 -- NOTE: Run this during a maintenance window or low-traffic period.
 -- The UPDATE on umbracoEngageAnalyticsPageview can take a while on
 -- installations with a large number of pageviews.
+--
+-- NOTE: An empty segment is the default (original) variant, and is deliberately
+-- distinct from NULL, which marks rows written before the served segment was
+-- recorded. The comparisons below must not collapse the two together: this
+-- script repoints pageviews and deletes rows, and cannot be undone.
 -- =============================================================================
 
 -- Step 1: Reassign pageviews from duplicate variants to the canonical variant
@@ -29,7 +34,8 @@ INNER JOIN (
 ) canonical
     ON dupVariant.[nodeId] = canonical.[nodeId]
     AND dupVariant.[culture] = canonical.[culture]
-    AND ISNULL(dupVariant.[segment], '') = ISNULL(canonical.[segment], '')
+    AND (dupVariant.[segment] = canonical.[segment]
+         OR (dupVariant.[segment] IS NULL AND canonical.[segment] IS NULL))
     AND ISNULL(dupVariant.[contentTypeId], -1) = ISNULL(canonical.[contentTypeId], -1)
 WHERE dupVariant.[id] <> canonical.[id];
 
@@ -44,7 +50,8 @@ AND EXISTS (
     SELECT 1 FROM [umbracoEngageAnalyticsUmbracoPageVariant] canonical
     WHERE canonical.[nodeId] = v.[nodeId]
     AND canonical.[culture] = v.[culture]
-    AND ISNULL(canonical.[segment], '') = ISNULL(v.[segment], '')
+    AND (canonical.[segment] = v.[segment]
+         OR (canonical.[segment] IS NULL AND v.[segment] IS NULL))
     AND ISNULL(canonical.[contentTypeId], -1) = ISNULL(v.[contentTypeId], -1)
     AND canonical.[id] < v.[id]
 );

--- a/18/umbraco-engage/scripts/DeduplicatePageVariants.sql
+++ b/18/umbraco-engage/scripts/DeduplicatePageVariants.sql
@@ -14,6 +14,10 @@
 -- distinct from NULL, which marks rows written before the served segment was
 -- recorded. The comparisons below must not collapse the two together: this
 -- script repoints pageviews and deletes rows, and cannot be undone.
+--
+-- NOTE: Traffic collected on 17.0, 17.1, or 16.0 to 16.2 also carries an empty
+-- segment, written before variant tracking existed. Those rows cannot be told
+-- apart from genuine original-variant rows, so this script groups them together.
 -- =============================================================================
 
 -- Step 1: Reassign pageviews from duplicate variants to the canonical variant

--- a/18/umbraco-engage/upgrading/schema-alignment-guide.md
+++ b/18/umbraco-engage/upgrading/schema-alignment-guide.md
@@ -138,6 +138,10 @@ Run the `DeduplicatePageVariants.sql` script against your database. This consoli
 {% hint style="info" %}
 This step is optional. The update on the pageviews table can take a while on large installations, so plan accordingly.
 {% endhint %}
+
+{% hint style="info" %}
+Engage began recording which variant was served in 17.4. Installations that collected traffic on 17.0, 17.1, or 16.0 to 16.2 also hold rows with an empty segment from before that change. Those rows look identical to genuine original-variant rows, so the script groups them together. Original-variant figures on those installations therefore include some traffic that predates variant tracking. Nothing can separate the two retrospectively. Figures for traffic collected on 17.4 and later are unaffected.
+{% endhint %}
 {% endstep %}
 {% endstepper %}
 


### PR DESCRIPTION
## 📋 Description

The `DeduplicatePageVariants.sql` script consolidates duplicate page variant rows, and the schema alignment guide instructs customers to run it. In its published form the script also destroys the record of which A/B test variant a pageview belonged to. This change corrects the two segment comparisons responsible. The deduplication itself is unchanged.

### What was wrong

Umbraco Engage now records which variant was served on each pageview. An empty `segment` means the original variant. `NULL` means the row predates that tracking. The two values are deliberately different.

Both comparisons in the script collapsed them together:

```sql
ISNULL(dupVariant.[segment], '') = ISNULL(canonical.[segment], '')
```

The `canonical` subquery groups `NULL` and `''` as separate rows, because `segment` sits in the `GROUP BY`. The join then treats them as equal. Every variant row therefore matched both canonical rows.

The result is not a merge. It is a swap. Pre-fix pageviews move onto the row that reports as the original, and original pageviews move onto the row that reports as pre-fix. Step 2 then deletes the row left without pageviews. Bucket totals stay plausible afterwards, so the damage is not visible in reporting.

A/B test variant rows are unaffected, because their segment is a real alias that matches nothing else. Only the original is lost. The script repoints pageviews rather than copying them, so the change cannot be reversed.

### What changed

Both segment comparisons now use a null-safe form that keeps `NULL` and `''` apart:

```sql
(dupVariant.[segment] = canonical.[segment]
 OR (dupVariant.[segment] IS NULL AND canonical.[segment] IS NULL))
```

The same correction applies to the `EXISTS` clause in Step 2, which guards the `DELETE`.

The `contentTypeId` comparison keeps its `ISNULL(..., -1)` form. That column is never `-1`, so no valid value collapses.

A note in the header records why the two values must stay separate. The trap is invisible from the SQL alone.

### One caveat this fix cannot remove

Engage began recording the served segment in 17.4. Earlier releases also wrote an empty segment, but it carried no meaning then. Traffic collected on 17.0, 17.1, or 16.0 to 16.2 therefore sits in rows that look identical to genuine original-variant rows.

Nothing distinguishes the two, so the script groups them together. Original-variant figures on installations with that history include some traffic predating variant tracking. This was already true before this change, and no script can separate them retrospectively.

The schema alignment guide now states this in the deduplication step, and the script header repeats it for anyone reading the SQL on its own. Figures for traffic collected on 17.4 and later are unaffected.

### Testing

The script was run against SQL Server 2025 on a scratch database. The two tables were rebuilt from their real column definitions. The scenario seeds one node with:

* one pre-fix row, `segment` `NULL`, holding 7 pageviews
* two original rows, `segment` `''`, holding 3 pageviews between them
* two A/B variant rows, holding 3 pageviews between them

Bucket sizes differ on purpose, so a swap cannot be mistaken for a correct result. Each pageview carries a tag recording where it started, so it stays traceable through the reassignment.

| Script | `NULL` bucket | `''` bucket | variant bucket |
|---|---|---|---|
| seeded | 7 pre-fix | 3 original | 3 ab-variant |
| before this change | 7 **original** | 3 **pre-fix** | 3 ab-variant |
| after this change | 7 pre-fix | 3 original | 3 ab-variant |

After the change, duplicates collapse correctly, three variant rows remain, no pageview is orphaned, and no bucket holds pageviews from more than one origin.

The published file itself was executed, not a copy of it.

## 📎 Related Issues (if applicable)

Tracked in the Umbraco Engage internal tracker. There is no public issue.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [ ] All links work and point to the correct resources. — no links added or changed
* [ ] Screenshots or diagrams are included if useful. — not applicable
* [x] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed. — not applicable

## Product & Version (if relevant)

Umbraco Engage. Documentation versions 17 and 18, where this script is published. All four changed files remain identical across the two versions.

The script is referenced from `upgrading/schema-alignment-guide.md`, which instructs readers to run it and embeds the file. That guide gains the caveat described above.

## Deadline (if relevant)

Before the next Engage release that records the served segment on a pageview.

Until that release, the `segment` column is always `NULL` in shipped builds, so the script cannot do any harm. Once it ships, anyone following the schema alignment guide destroys their own original-variant data.
