### PR TITLE
Added redirect for Modal page

### DIFF
--- a/17/umbraco-cms/.gitbook.yaml
+++ b/17/umbraco-cms/.gitbook.yaml
@@ -723,3 +723,4 @@ redirects:
     run-in-production/infrastructure-and-ops/server-setup/load-balancing/signalr-in-load-balanced-environments: run-in-production/infrastructure-and-ops/server-setup/load-balancing/signalr-in-backoffice-load-balanced-environment.md
     extend-your-project/backoffice-extensions/utilities/modals/confirm-dialog: extend-your-project/backoffice-extensions/extending-overview/extension-types/modals/confirm-dialog.md
     extend-your-project/backoffice-extensions/utilities/sorting: extend-your-project/backoffice-extensions/sorting.md
+    extend-your-project/backoffice-extensions/utilities/modals: extend-your-project/backoffice-extensions/extending-overview/extension-types/modals/README.md

--- a/18/umbraco-cms/.gitbook.yaml
+++ b/18/umbraco-cms/.gitbook.yaml
@@ -208,3 +208,4 @@ redirects:
     get-started/editors-manual/downloadable-content/youtube-create-a-simple-umbraco-website: get-started/backoffice-essentials/downloadable-content/youtube-create-a-simple-umbraco-website.md
     extend-your-project/backoffice-extensions/utilities/modals/confirm-dialog: extend-your-project/backoffice-extensions/extending-overview/extension-types/modals/confirm-dialog.md
     extend-your-project/backoffice-extensions/utilities/sorting: extend-your-project/backoffice-extensions/sorting.md
+    extend-your-project/backoffice-extensions/utilities/modals: extend-your-project/backoffice-extensions/extending-overview/extension-types/modals/README.md


### PR DESCRIPTION
## 📋 Description

GitBook feedback contained https://docs.umbraco.com/umbraco-cms/extend-your-project/backoffice-extensions/utilities/modals which leads to Page Not found error. Modals is located at https://docs.umbraco.com/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-types/modals.

Added redirect for it.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS v17 and 18

## Deadline (if relevant)

Anytime
## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
