### PR TITLE
Automate: document approval branching, container handles, and connection updates

### DIFF
--- a/17/umbraco-automate/add-ons/deploy/transferring-automations.md
+++ b/17/umbraco-automate/add-ons/deploy/transferring-automations.md
@@ -13,7 +13,7 @@ Install the Deploy add-on on both the source and target environments. You can th
 | Entity | Transfers? | Notes |
 | ------ | ---------- | ----- |
 | **Workspace Group** | Yes | Folders that hold workspaces. |
-| **Workspace** | Yes | Includes the service account and user group references, but not individual member assignments. A referenced user group that doesn't exist on the target is dropped, with a warning in the workspace editor telling you how many need to be added again. |
+| **Workspace** | Yes | Includes the service account and user group references, but not individual member assignments. An unresolved user group is dropped with a warning. See [Manage Workspaces](../../backoffice/workspaces.md). |
 | **Automation** | Yes | The published version of the automation, with all triggers, actions, and bindings. |
 | **Connection** | Yes (definition only) | The connection record is created on the target environment. Encrypted credential values are skipped by default — re-authenticate or fill them in on the target. |
 | **Run history** | No | Run records are environment-specific and never transfer. |

--- a/17/umbraco-automate/add-ons/deploy/transferring-automations.md
+++ b/17/umbraco-automate/add-ons/deploy/transferring-automations.md
@@ -13,7 +13,7 @@ Install the Deploy add-on on both the source and target environments. You can th
 | Entity | Transfers? | Notes |
 | ------ | ---------- | ----- |
 | **Workspace Group** | Yes | Folders that hold workspaces. |
-| **Workspace** | Yes | Includes service account reference but not member assignments. |
+| **Workspace** | Yes | Includes the service account and user group references, but not individual member assignments. A referenced user group that doesn't exist on the target is dropped, with a warning in the workspace editor telling you how many need to be added again. |
 | **Automation** | Yes | The published version of the automation, with all triggers, actions, and bindings. |
 | **Connection** | Yes (definition only) | The connection record is created on the target environment. Encrypted credential values are skipped by default — re-authenticate or fill them in on the target. |
 | **Run history** | No | Run records are environment-specific and never transfer. |

--- a/17/umbraco-automate/add-ons/slack/connection.md
+++ b/17/umbraco-automate/add-ons/slack/connection.md
@@ -20,6 +20,8 @@ Before an automation can post to Slack, you must create a **Slack** connection a
 8. After the popup closes, click **Test connection** to confirm the access token works.
 9. Click **Save**.
 
+If Slack hasn't been set up on this server yet (no client ID or secret configured in `appsettings.json`), the **Authenticate** button is disabled. A warning explains what an administrator needs to add.
+
 ## Allow the Connection in a Workspace
 
 1. Open the workspace that will own the automation that uses Slack.

--- a/17/umbraco-automate/backoffice/approvals.md
+++ b/17/umbraco-automate/backoffice/approvals.md
@@ -13,8 +13,25 @@ The **Request Approval** action pauses an automation and waits for a user to app
 1. The automation reaches a **Request Approval** step.
 2. The run is suspended and an approval entry is created with the configured prompt.
 3. A user with access to the workspace opens the approval and chooses **Approve** or **Reject**.
-4. On **Approve**, the run resumes from the next step. The approver's user key and any comment are recorded on the step output.
-5. On **Reject**, the approval step fails. The run's configured error behavior on that step then decides whether to retry, suspend, terminate, or compensate.
+4. The step finishes and the run follows whichever branch matches the decision.
+
+A rejection is not an error. The **Request Approval** node has two outgoing handles on the canvas — **Approved** and **Rejected**. Send each outcome down a different path, the same way you would with an **If** node. See [Control Flow](../concepts/control-flow.md).
+
+If a run finishes on the Rejected path, its status is **Rejected**, a separate status from **Failed**. Nothing went wrong — a person said no.
+
+## Using the Decision in Later Steps
+
+The step's output is available to any step that runs after it:
+
+| Field                 | Description                                                     |
+| --------------------- | ----------------------------------------------------------------- |
+| `approved`            | `true` or `false`. Use this to branch, for example `${ steps.approval.approved }`. |
+| `outcome`             | The decision as text: `Approved` or `Rejected`.                 |
+| `comment`             | The optional note the approver left.                            |
+| `approvedByUserKey`   | The user key of whoever made the decision.                      |
+| `decisionUtc`         | The date and time the decision was made.                        |
+
+See [Bindings](../concepts/bindings.md) for the full binding syntax.
 
 ## Request Approval Settings
 
@@ -35,4 +52,5 @@ The **Approvals** dashboard in the Automate section lists every approval awaitin
 
 * [Build an Automation](building-an-automation.md)
 * [Manage Workspaces](workspaces.md)
+* [Control Flow](../concepts/control-flow.md)
 * [Bindings](../concepts/bindings.md)

--- a/17/umbraco-automate/backoffice/runs.md
+++ b/17/umbraco-automate/backoffice/runs.md
@@ -10,7 +10,7 @@ Every execution of an automation produces a **run** record. Use the **Runs** vie
 
 1. Open the automation in the tree.
 2. Switch to the **Runs** tab.
-3. Scroll or page through the list of runs, most recent first.
+3. Scroll or page through the list of runs, most recent first. The list refreshes automatically as new runs start and finish.
 
 <figure><img src="../.gitbook/assets/runs-list.png" alt="The runs list showing recent executions of an automation."><figcaption><p>The runs list view.</p></figcaption></figure>
 
@@ -24,7 +24,7 @@ Click a run to open the run detail view. The canvas replays the automation with 
 | Blue   | Running                                                  |
 | Green  | Completed                                                |
 | Red    | Failed                                                   |
-| Yellow | Waiting for input (for example, an approval) or sleeping |
+| Yellow | Waiting for input (for example, an approval), sleeping, or Rejected (a human declined an approval — not a failure) |
 
 Click a step to open its data panel.
 

--- a/17/umbraco-automate/backoffice/workspaces.md
+++ b/17/umbraco-automate/backoffice/workspaces.md
@@ -46,6 +46,12 @@ Events the new account isn't authorized for are silently skipped at dispatch. Ac
 Review the **Runs** tab after any service-account change.
 {% endhint %}
 
+{% hint style="info" %}
+
+If a workspace was transferred from another environment (for example via Deploy), it may reference a user group that doesn't exist here. That group is dropped from **User Groups**. A warning tells you how many groups need to be added again.
+
+{% endhint %}
+
 ## Workspace Groups
 
 Workspaces can be organized into **workspace groups** — folders in the tree. To create a workspace group, right-click the root of the tree and select **Create workspace group**. Workspace groups are organizational only; they do not affect access.

--- a/17/umbraco-automate/concepts/connections.md
+++ b/17/umbraco-automate/concepts/connections.md
@@ -14,7 +14,7 @@ Without connections, every action that talks to an external service would need i
 
 * **Reuse** — multiple automations can share the same connection.
 * **Environment safety** — credentials are configured per environment and never travel with an exported automation.
-* **Security** — credentials are encrypted at rest and masked in run logs.
+* **Security** — credentials are encrypted at rest, masked in run logs, and hidden behind a masked input in the connection editor.
 
 ## Connection Types
 
@@ -35,7 +35,7 @@ Most connection types implement a validation step. Click **Test connection** in 
 
 ## Configuration References
 
-Connection settings support configuration references. Values starting with `$` are resolved from configuration (`appsettings.json`, environment variables, Azure Key Vault, and so on) at runtime.
+Connection settings support configuration references. A value starting with `$`, or a `$Key:Path` reference embedded inside a larger string (for example `Bearer $Umbraco:Automate:Secrets:Token`), is resolved from configuration at runtime. Configuration sources include `appsettings.json`, environment variables, and Azure Key Vault.
 
 References resolve from two dedicated configuration sections:
 

--- a/17/umbraco-automate/concepts/control-flow.md
+++ b/17/umbraco-automate/concepts/control-flow.md
@@ -24,6 +24,21 @@ The **If** node evaluates a binding expression and routes the run down one of tw
 
 <figure><img src="../.gitbook/assets/if-control-flow.png" alt="An automation branching on an If node with then and else branches."><figcaption><p>An If node with two outgoing branches.</p></figcaption></figure>
 
+## Body and Done: While, For Each, and Parallel
+
+**While**, **For Each**, and **Parallel** are container nodes — instead of a single next step, each owns a body of steps and renders two handles:
+
+* **Body** — the step(s) that run inside the loop, or as a branch of the Parallel.
+* **Done** — the step that runs once, after every iteration or branch has finished.
+
+Connect whatever comes next after the loop to the **Done** handle, not the Body handle. Otherwise, it runs on every iteration instead of once at the end.
+
+For **Parallel** only, the Body handle accepts more than one connection — each one becomes its own concurrent branch. Every other handle, on every node, accepts at most one.
+
+{% hint style="info" %}
+Automations built before these handles existed keep working as they did. With no Done connection, Automate works out what runs next from the shape of the steps drawn after the loop.
+{% endhint %}
+
 ## For Each
 
 The **For Each** node iterates over a collection. The current item and index are exposed inside the inner branch so you can reference them from steps:
@@ -34,6 +49,11 @@ ${ loop.item.url }
 ${ loop.index }
 ```
 
+## Other Steps That Branch
+
+Not every branch comes from a control flow node. Some actions declare their own outcome handles. **Request Approval** branches on **Approved** and **Rejected** instead of running a single next step — see [Use Approvals](../backoffice/approvals.md).
+
 ## See Also
 
 * [Bindings](bindings.md)
+* [Use Approvals](../backoffice/approvals.md)

--- a/17/umbraco-automate/concepts/runs.md
+++ b/17/umbraco-automate/concepts/runs.md
@@ -14,11 +14,13 @@ Each run records enough data to trace what happened from trigger to final outcom
 
 | Field              | Description                                                                    |
 | ------------------ | ------------------------------------------------------------------------------ |
-| **Status**         | Pending, Running, Completed, Failed, Suspended, or Cancelled.                  |
+| **Status**         | Pending, Running, Completed, Failed, Suspended, Cancelled, or Rejected.        |
 | **Initiator**      | Who or what started the run — a user, an event handler, a webhook, a schedule. |
 | **Trigger output** | The data emitted by the trigger.                                               |
 | **Steps**          | For each step: status, input, output, error, duration, retry count.            |
 | **Version**        | Which published version of the automation was used.                            |
+
+A run's status is **Rejected**, not **Failed**, when it ends because a human declined a [Request Approval](../backoffice/approvals.md) step and nothing else went wrong. It is a terminal status, but not an error — the automation ran exactly as designed.
 
 ## Run Detail View
 

--- a/17/umbraco-automate/concepts/triggers.md
+++ b/17/umbraco-automate/concepts/triggers.md
@@ -17,7 +17,7 @@ Use built-in triggers to start automations from backoffice events, schedules, an
 | Trigger               | Fires when                                                                                                                                    |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Manual Trigger**    | A user runs the automation by hand from the backoffice.                                                                                       |
-| **Scheduled Trigger** | A Command Run On Notice (CRON) expression matches the current time.                                                                                                   |
+| **Scheduled Trigger** | A Command Run On Notice (CRON) expression matches the current time. Can also be run by hand with **Run now**, the same as a Manual Trigger.  |
 | **Webhook**           | An HTTP request is received at the automation's webhook URL. Authentication is configured per automation (Hash-based Message Authentication Code (HMAC) signature or a shared secret). |
 
 ### Content
@@ -62,7 +62,12 @@ Add-on packages contribute additional triggers. See [Add-ons](../add-ons/) for t
 
 ## Trigger Output
 
-Every trigger produces output data that subsequent steps can bind to. For example, the **Content** **Published** trigger outputs the content name, key, content type alias, and culture.
+Every trigger produces output data that subsequent steps can bind to. For example, the **Content** **Published** trigger outputs the content name, key, content type alias, and culture. The **Scheduled Trigger** outputs the time it fired and the CRON expression that fired it:
+
+```
+${ trigger.firedAtUtc }
+${ trigger.cronExpression }
+```
 
 Use the binding picker in the step settings dialog to insert trigger output values into action settings:
 

--- a/17/umbraco-automate/extending/custom-connection-type.md
+++ b/17/umbraco-automate/extending/custom-connection-type.md
@@ -13,7 +13,7 @@ A custom connection type lets actions in your project share reusable credentials
 
 ## Settings Model
 
-Mark sensitive fields with `IsSensitive = true` so the value is encrypted at rest and masked in run logs.
+Mark sensitive fields with `IsSensitive = true`. The value is then encrypted at rest, masked in run logs, and shown behind a masked password input in the connection editor.
 
 {% code title="MyServiceConnectionSettings.cs" %}
 ```csharp

--- a/17/umbraco-automate/getting-started/configuration.md
+++ b/17/umbraco-automate/getting-started/configuration.md
@@ -97,6 +97,12 @@ A settings field can reference a configuration value at run time with a `$Key:Pa
 $Umbraco:Automate:Secrets:SlackToken
 ```
 
+A reference can also be embedded inside a larger string, for example in an HTTP header value:
+
+```
+Bearer $Umbraco:Automate:Secrets:ApiToken
+```
+
 This lets administrators keep credentials and per-environment values in configuration — `appsettings.json`, environment variables, Azure Key Vault, and so on — rather than in the automation database.
 
 ### Allowed Key Prefixes

--- a/18/umbraco-automate/add-ons/deploy/transferring-automations.md
+++ b/18/umbraco-automate/add-ons/deploy/transferring-automations.md
@@ -13,7 +13,7 @@ Install the Deploy add-on on both the source and target environments. You can th
 | Entity | Transfers? | Notes |
 | ------ | ---------- | ----- |
 | **Workspace Group** | Yes | Folders that hold workspaces. |
-| **Workspace** | Yes | Includes the service account and user group references, but not individual member assignments. A referenced user group that doesn't exist on the target is dropped, with a warning in the workspace editor telling you how many need to be added again. |
+| **Workspace** | Yes | Includes the service account and user group references, but not individual member assignments. An unresolved user group is dropped with a warning. See [Manage Workspaces](../../backoffice/workspaces.md). |
 | **Automation** | Yes | The published version of the automation, with all triggers, actions, and bindings. |
 | **Connection** | Yes (definition only) | The connection record is created on the target environment. Encrypted credential values are skipped by default — re-authenticate or fill them in on the target. |
 | **Run history** | No | Run records are environment-specific and never transfer. |

--- a/18/umbraco-automate/add-ons/deploy/transferring-automations.md
+++ b/18/umbraco-automate/add-ons/deploy/transferring-automations.md
@@ -13,7 +13,7 @@ Install the Deploy add-on on both the source and target environments. You can th
 | Entity | Transfers? | Notes |
 | ------ | ---------- | ----- |
 | **Workspace Group** | Yes | Folders that hold workspaces. |
-| **Workspace** | Yes | Includes service account reference but not member assignments. |
+| **Workspace** | Yes | Includes the service account and user group references, but not individual member assignments. A referenced user group that doesn't exist on the target is dropped, with a warning in the workspace editor telling you how many need to be added again. |
 | **Automation** | Yes | The published version of the automation, with all triggers, actions, and bindings. |
 | **Connection** | Yes (definition only) | The connection record is created on the target environment. Encrypted credential values are skipped by default — re-authenticate or fill them in on the target. |
 | **Run history** | No | Run records are environment-specific and never transfer. |

--- a/18/umbraco-automate/add-ons/slack/connection.md
+++ b/18/umbraco-automate/add-ons/slack/connection.md
@@ -20,6 +20,8 @@ Before an automation can post to Slack, you must create a **Slack** connection a
 8. After the popup closes, click **Test connection** to confirm the access token works.
 9. Click **Save**.
 
+If Slack hasn't been set up on this server yet (no client ID or secret configured in `appsettings.json`), the **Authenticate** button is disabled. A warning explains what an administrator needs to add.
+
 ## Allow the Connection in a Workspace
 
 1. Open the workspace that will own the automation that uses Slack.

--- a/18/umbraco-automate/backoffice/approvals.md
+++ b/18/umbraco-automate/backoffice/approvals.md
@@ -15,8 +15,25 @@ The **Request Approval** action pauses an automation and waits for a user to app
 1. The automation reaches a **Request Approval** step.
 2. The run is suspended and an approval entry is created with the configured prompt.
 3. A user with access to the workspace opens the approval and chooses **Approve** or **Reject**.
-4. On **Approve**, the run resumes from the next step. The approver's user key and any comment are recorded on the step output.
-5. On **Reject**, the approval step fails. The run's configured error behavior on that step then decides whether to retry, suspend, terminate, or compensate.
+4. The step finishes and the run follows whichever branch matches the decision.
+
+A rejection is not an error. The **Request Approval** node has two outgoing handles on the canvas — **Approved** and **Rejected**. Send each outcome down a different path, the same way you would with an **If** node. See [Control Flow](../concepts/control-flow.md).
+
+If a run finishes on the Rejected path, its status is **Rejected**, a separate status from **Failed**. Nothing went wrong — a person said no.
+
+## Using the Decision in Later Steps
+
+The step's output is available to any step that runs after it:
+
+| Field                 | Description                                                     |
+| --------------------- | ----------------------------------------------------------------- |
+| `approved`            | `true` or `false`. Use this to branch, for example `${ steps.approval.approved }`. |
+| `outcome`             | The decision as text: `Approved` or `Rejected`.                 |
+| `comment`             | The optional note the approver left.                            |
+| `approvedByUserKey`   | The user key of whoever made the decision.                      |
+| `decisionUtc`         | The date and time the decision was made.                        |
+
+See [Bindings](../concepts/bindings.md) for the full binding syntax.
 
 ## Request Approval Settings
 
@@ -39,4 +56,5 @@ The **Approvals** dashboard in the Automate section lists every approval awaitin
 
 * [Build an Automation](building-an-automation.md)
 * [Manage Workspaces](workspaces.md)
+* [Control Flow](../concepts/control-flow.md)
 * [Bindings](../concepts/bindings.md)

--- a/18/umbraco-automate/backoffice/connections.md
+++ b/18/umbraco-automate/backoffice/connections.md
@@ -41,6 +41,8 @@ The **Authenticate** button calls the connection type's validator. For OAuth con
 
 A failed test shows the error message so you can correct the settings before saving. Connection types that do not implement a validator return a warning instead of a success.
 
+If an OAuth provider hasn't been set up yet (no client ID or secret in `appsettings.json`), the **Authenticate** button is disabled. A warning explains what an administrator needs to add, with a link to the provider's setup instructions where available.
+
 ## Use a Connection in an Action
 
 When you configure an action that requires a connection, the connection picker only shows connections of the matching type that the current workspace has allowed.

--- a/18/umbraco-automate/backoffice/runs.md
+++ b/18/umbraco-automate/backoffice/runs.md
@@ -10,7 +10,7 @@ Every execution of an automation produces a **run** record. Use the **Runs** vie
 
 1. Open the automation in the tree.
 2. Switch to the **Runs** tab.
-3. Scroll or page through the list of runs, most recent first.
+3. Scroll or page through the list of runs, most recent first. The list refreshes automatically as new runs start and finish.
 
 <figure><img src="../.gitbook/assets/runs-list.png" alt="The runs list showing recent executions of an automation."><figcaption><p>The runs list view.</p></figcaption></figure>
 
@@ -24,7 +24,7 @@ Click a run to open the run detail view. The canvas replays the automation with 
 | Blue   | Running                                                  |
 | Green  | Completed                                                |
 | Red    | Failed                                                   |
-| Yellow | Waiting for input (for example, an approval) or sleeping |
+| Yellow | Waiting for input (for example, an approval), sleeping, or Rejected (a human declined an approval — not a failure) |
 
 Click a step to open its data panel.
 

--- a/18/umbraco-automate/backoffice/workspaces.md
+++ b/18/umbraco-automate/backoffice/workspaces.md
@@ -47,6 +47,12 @@ Events the new account isn't authorized for are silently skipped at dispatch. Ac
 Review the **Runs** tab after any service-account change.
 {% endhint %}
 
+{% hint style="info" %}
+
+If a workspace was transferred from another environment (for example via Deploy), it may reference a user group that doesn't exist here. That group is dropped from **User Groups**. A warning tells you how many groups need to be added again.
+
+{% endhint %}
+
 ## Workspace Groups
 
 Workspaces can be organized into **workspace groups** — folders in the tree. To create a workspace group, right-click the root of the tree and select **Create workspace group**. Workspace groups are organizational only; they do not affect access.

--- a/18/umbraco-automate/concepts/connections.md
+++ b/18/umbraco-automate/concepts/connections.md
@@ -14,7 +14,7 @@ Without connections, every action that talks to an external service would need i
 
 * **Reuse** — multiple automations can share the same connection.
 * **Environment safety** — credentials are configured per environment and never travel with an exported automation.
-* **Security** — credentials are encrypted at rest and masked in run logs.
+* **Security** — credentials are encrypted at rest, masked in run logs, and hidden behind a masked input in the connection editor.
 
 ## Connection Types
 
@@ -35,7 +35,7 @@ Most connection types implement a validation step. Click **Test connection** in 
 
 ## Configuration References
 
-Connection settings support configuration references. Values starting with `$` are resolved from configuration (`appsettings.json`, environment variables, Azure Key Vault, and so on) at runtime.
+Connection settings support configuration references. A value starting with `$`, or a `$Key:Path` reference embedded inside a larger string (for example `Bearer $Umbraco:Automate:Secrets:Token`), is resolved from configuration at runtime. Configuration sources include `appsettings.json`, environment variables, and Azure Key Vault.
 
 References resolve from two dedicated configuration sections:
 

--- a/18/umbraco-automate/concepts/control-flow.md
+++ b/18/umbraco-automate/concepts/control-flow.md
@@ -24,6 +24,21 @@ The **If** node evaluates a binding expression and routes the run down one of tw
 
 <figure><img src="../.gitbook/assets/if-control-flow.png" alt="An automation branching on an If node with then and else branches."><figcaption><p>An If node with two outgoing branches.</p></figcaption></figure>
 
+## Body and Done: While, For Each, and Parallel
+
+**While**, **For Each**, and **Parallel** are container nodes — instead of a single next step, each owns a body of steps and renders two handles:
+
+* **Body** — the step(s) that run inside the loop, or as a branch of the Parallel.
+* **Done** — the step that runs once, after every iteration or branch has finished.
+
+Connect whatever comes next after the loop to the **Done** handle, not the Body handle. Otherwise, it runs on every iteration instead of once at the end.
+
+For **Parallel** only, the Body handle accepts more than one connection — each one becomes its own concurrent branch. Every other handle, on every node, accepts at most one.
+
+{% hint style="info" %}
+Automations built before these handles existed keep working as they did. With no Done connection, Automate works out what runs next from the shape of the steps drawn after the loop.
+{% endhint %}
+
 ## For Each
 
 The **For Each** node iterates over a collection. The current item and index are exposed inside the inner branch so you can reference them from steps:
@@ -34,6 +49,11 @@ ${ loop.item.url }
 ${ loop.index }
 ```
 
+## Other Steps That Branch
+
+Not every branch comes from a control flow node. Some actions declare their own outcome handles. **Request Approval** branches on **Approved** and **Rejected** instead of running a single next step — see [Use Approvals](../backoffice/approvals.md).
+
 ## See Also
 
 * [Bindings](bindings.md)
+* [Use Approvals](../backoffice/approvals.md)

--- a/18/umbraco-automate/concepts/runs.md
+++ b/18/umbraco-automate/concepts/runs.md
@@ -14,11 +14,13 @@ Each run records enough data to trace what happened from trigger to final outcom
 
 | Field              | Description                                                                    |
 | ------------------ | ------------------------------------------------------------------------------ |
-| **Status**         | Pending, Running, Completed, Failed, Suspended, or Cancelled.                  |
+| **Status**         | Pending, Running, Completed, Failed, Suspended, Cancelled, or Rejected.        |
 | **Initiator**      | Who or what started the run — a user, an event handler, a webhook, a schedule. |
 | **Trigger output** | The data emitted by the trigger.                                               |
 | **Steps**          | For each step: status, input, output, error, duration, retry count.            |
 | **Version**        | Which published version of the automation was used.                            |
+
+A run's status is **Rejected**, not **Failed**, when it ends because a human declined a [Request Approval](../backoffice/approvals.md) step and nothing else went wrong. It is a terminal status, but not an error — the automation ran exactly as designed.
 
 ## Run Detail View
 

--- a/18/umbraco-automate/concepts/triggers.md
+++ b/18/umbraco-automate/concepts/triggers.md
@@ -17,7 +17,7 @@ Use built-in triggers to start automations from backoffice events, schedules, an
 | Trigger               | Fires when                                                                                                                                    |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Manual Trigger**    | A user runs the automation by hand from the backoffice.                                                                                       |
-| **Scheduled Trigger** | A Command Run On Notice (CRON) expression matches the current time.                                                                                                   |
+| **Scheduled Trigger** | A Command Run On Notice (CRON) expression matches the current time. Can also be run by hand with **Run now**, the same as a Manual Trigger.  |
 | **Webhook**           | An HTTP request is received at the automation's webhook URL. Authentication is configured per automation (Hash-based Message Authentication Code (HMAC) signature or a shared secret). |
 
 ### Content
@@ -62,7 +62,12 @@ Add-on packages contribute additional triggers. See [Add-ons](../add-ons/) for t
 
 ## Trigger Output
 
-Every trigger produces output data that subsequent steps can bind to. For example, the **Content** **Published** trigger outputs the content name, key, content type alias, and culture.
+Every trigger produces output data that subsequent steps can bind to. For example, the **Content** **Published** trigger outputs the content name, key, content type alias, and culture. The **Scheduled Trigger** outputs the time it fired and the CRON expression that fired it:
+
+```
+${ trigger.firedAtUtc }
+${ trigger.cronExpression }
+```
 
 Use the binding picker in the step settings dialog to insert trigger output values into action settings:
 

--- a/18/umbraco-automate/extending/custom-connection-type.md
+++ b/18/umbraco-automate/extending/custom-connection-type.md
@@ -13,7 +13,7 @@ A custom connection type lets actions in your project share reusable credentials
 
 ## Settings Model
 
-Mark sensitive fields with `IsSensitive = true` so the value is encrypted at rest and masked in run logs.
+Mark sensitive fields with `IsSensitive = true`. The value is then encrypted at rest, masked in run logs, and shown behind a masked password input in the connection editor.
 
 {% code title="MyServiceConnectionSettings.cs" %}
 ```csharp

--- a/18/umbraco-automate/getting-started/configuration.md
+++ b/18/umbraco-automate/getting-started/configuration.md
@@ -97,6 +97,12 @@ A settings field can reference a configuration value at run time with a `$Key:Pa
 $Umbraco:Automate:Secrets:SlackToken
 ```
 
+A reference can also be embedded inside a larger string, for example in an HTTP header value:
+
+```
+Bearer $Umbraco:Automate:Secrets:ApiToken
+```
+
 This lets administrators keep credentials and per-environment values in configuration — `appsettings.json`, environment variables, Azure Key Vault, and so on — rather than in the automation database.
 
 ### Allowed Key Prefixes


### PR DESCRIPTION
## 📋 Description

Updates the Umbraco Automate documentation (versions 17 and 18) to cover recent product changes:

- **Approvals**: Request Approval now branches on **Approved**/**Rejected** outcome handles instead of failing on rejection. Documents the step's output fields (`approved`, `outcome`, `comment`, `approvedByUserKey`, `decisionUtc`) and the new **Rejected** run status.
- **Control flow**: While, For Each, and Parallel container nodes now render **Body**/**Done** handles. Documents Parallel's multi-branch Body handle and the legacy fallback for automations built before these handles existed.
- **Workspaces**: Documents the warning shown when a Deploy-imported workspace references a user group that doesn't resolve on the target environment.
- **Connections**: Documents the OAuth **Authenticate** button's disabled state when a provider isn't configured, the masked connection editor input for sensitive fields, and `$Key:Path` configuration references embedded inside a larger string.

All content was verified against the current source (`v17/release/2026.08.4`) for factual accuracy. Vale linting passes clean and all internal links resolve.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Automate versions 17.3.0 and 18.3.0

## Deadline (if relevant)

Thursday 20th August