### PR TITLE
Release notes for Workflow 17.4.0 and 18.1.0

### DIFF
--- a/.github/styles/UmbracoDocs/Acronyms.yml
+++ b/.github/styles/UmbracoDocs/Acronyms.yml
@@ -63,6 +63,7 @@ exceptions:
   - IaaS     # Infrastructure as a Service
   - IDE      # Integrated Development Environment
   - IIS      # Internet Information Services
+  - IMAP     # Internet Message Access Protocol
   - INFO     # Information
   - ISO      # International Organization for Standardization
   - JPG      # Joint Photographic Experts Group

--- a/.github/styles/config/dictionaries/umbraco.dic
+++ b/.github/styles/config/dictionaries/umbraco.dic
@@ -716,6 +716,7 @@ tiptapExtension
 TKey
 TModel
 todays
+tooltip
 topbar
 topmenu
 totalRecords
@@ -760,6 +761,7 @@ uncategorized
 uncheck
 Uncomment
 underperforming
+unencrypted
 unfinalized
 Unintuitive
 unioned

--- a/17/umbraco-workflow/SUMMARY.md
+++ b/17/umbraco-workflow/SUMMARY.md
@@ -19,6 +19,7 @@
 
 * [Content Approval Settings](getting-started/content-approval-settings.md)
 * [Content Review Settings](getting-started/content-review-settings.md)
+* [Workflow Detail Dialog](getting-started/workflow-detail-dialog.md)
 * [Dashboards and Buttons](getting-started/dashboards-and-buttons.md)
 * [Submitting Content for Approval](getting-started/submitting-changes.md)
 * [Workspace View](getting-started/workflow-workspace-view.md)

--- a/17/umbraco-workflow/SUMMARY.md
+++ b/17/umbraco-workflow/SUMMARY.md
@@ -25,6 +25,7 @@
 * [Notifications](getting-started/notifications.md)
 * [Configuration](getting-started/configuration.md)
 * [Approval thresholds](getting-started/approval-thresholds.md)
+* [External Approval](getting-started/external-approval.md)
 * [History Cleanup](getting-started/history-cleanup.md)
 
 ## Workflow Section

--- a/17/umbraco-workflow/getting-started/dashboards-and-buttons.md
+++ b/17/umbraco-workflow/getting-started/dashboards-and-buttons.md
@@ -23,10 +23,6 @@ When no workflow is active, the button state is determined by the current user's
 
 Umbraco Workflow overrides Umbraco's User/Group publishing permissions. If the user has permission to update the node, they will be able to initiate a workflow process on that node. Umbraco Workflow shifts Umbraco from a centrally administered publishing model (controlled by a site administrator) to a distributed model. In this model, editors publish content based on their responsibilities assigned during the workflows.
 
-In cases, where the content is already in a workflow, a notification is displayed at the top of the editor. Depending on the Workflow **Settings**, you can enable/disable editing access on a content node in a workflow.
-
-![Disabled content edits](../.gitbook/assets/blocked_content.png)
-
 For nodes where the workflow has been disabled, the default Umbraco options are displayed.
 
 ![Default Button](../.gitbook/assets/Default_Buttons.png)

--- a/17/umbraco-workflow/getting-started/external-approval.md
+++ b/17/umbraco-workflow/getting-started/external-approval.md
@@ -9,7 +9,7 @@ description: >-
 External Approval is available in Workflow 17.4 and above. This feature requires a license. Learn more about [Workflow's licensing model](https://umbraco.com/products/umbraco-workflow).
 {% endhint %}
 
-External Approval allows editors to participate in workflow processes without accessing the Umbaco Backoffice. This allows content stakeholders to approve content changes without needing to know how to use Umbraco.
+External Approval allows editors to participate in workflow processes without accessing the Umbraco Backoffice. This allows content stakeholders to approve content changes without needing to know how to use Umbraco.
 
 There are two ways for an approval group member to action a pending task from the notification email, instead of logging in to the Backoffice:
 

--- a/17/umbraco-workflow/getting-started/external-approval.md
+++ b/17/umbraco-workflow/getting-started/external-approval.md
@@ -20,7 +20,7 @@ Both are optional, licensed features and are enabled independently, per approval
 
 ## External approval
 
-When External approval is enabled for a group, the notification email sent to a pending task's approvers includes a link to a standalone approval page. Opening the link:
+When External approval is enabled for a group, the notification email includes a link to a standalone approval page. Opening the link:
 
 * Signs the recipient in as the user the link was generated for, without a Backoffice login.
 * Shows a preview of the content change, alongside the task detail (workflow stage, comments, and any attachment).
@@ -41,7 +41,7 @@ The task is actioned automatically once the reply is processed, and the recipien
 
 Quoted history in the reply (previous message text, signatures added by common mail clients) is stripped automatically before the keyword is read.
 
-Email reply approval is only available for the single, active-task notification, not for the reminder digest email. A digest can bundle several unrelated tasks together and a plain reply cannot say which one it applies to.
+Email reply approval is only available for the single, active-task notification, not for the reminder digest email. A digest can bundle unrelated tasks together and a plain reply cannot say which one it applies to.
 
 ## Enabling the feature
 

--- a/17/umbraco-workflow/getting-started/external-approval.md
+++ b/17/umbraco-workflow/getting-started/external-approval.md
@@ -1,0 +1,137 @@
+---
+description: >-
+  Allow editors to participate in workflow processes without accessing the CMS.
+---
+
+# External Approval
+
+{% hint style="info" %}
+External Approval is available in Workflow 17.4 and above. This feature requires a license. Learn more about [Workflow's licensing model](https://umbraco.com/products/umbraco-workflow).
+{% endhint %}
+
+External Approval allows editors to participate in workflow processes without accessing the Umbaco Backoffice. This allows content stakeholders to approve content changes without needing to know how to use Umbraco.
+
+There are two ways for an approval group member to action a pending task from the notification email, instead of logging in to the Backoffice:
+
+* **External approval** - a secure, time-limited link in the email opens a standalone approval page.
+* **Email reply approval** - replying to the notification email with `APPROVE` or `REJECT` actions the task directly.
+
+Both are optional, licensed features and are enabled independently, per approval group.
+
+## External approval
+
+When External approval is enabled for a group, the notification email sent to a pending task's approvers includes a link to a standalone approval page. Opening the link:
+
+* Signs the recipient in as the user the link was generated for, without a Backoffice login.
+* Shows a preview of the content change, alongside the task detail (workflow stage, comments, and any attachment).
+* Lets the recipient switch between configured preview environments and device sizes.
+* Presents **Approve** and **Reject** actions that call the same API used by the Backoffice.
+
+The link is only included for a recipient when all of the following are true:
+
+* The group has **External approval** enabled.
+* The group does not have a **Group Email** set. The link identifies the individual it was generated for, so it cannot be issued for a shared mailbox.
+* There is an active (incomplete) task for the recipient to action.
+
+## Email reply approval
+
+When Email reply approval is enabled for a group, the notification email for a pending task includes a `Reply-To` address. A recipient can use the buttons embedded in the notification email to generate a reply message, or reply directly to the notification.
+
+The task is actioned automatically once the reply is processed, and the recipient then receives a plain-text confirmation. If the reply cannot be actioned, the recipient receives an explanation instead - for example, an expired token or an unrecognized keyword.
+
+Quoted history in the reply (previous message text, signatures added by common mail clients) is stripped automatically before the keyword is read.
+
+Email reply approval is only available for the single, active-task notification, not for the reminder digest email. A digest can bundle several unrelated tasks together and a plain reply cannot say which one it applies to.
+
+## Enabling the feature
+
+Both channels are enabled per approval group, from the group's **Settings** tab in the **Workflow** section:
+
+* **Allow external approval** - enables the magic-link channel for members of the group.
+* **Allow approval by email reply** - enables the email-reply channel for members of the group.
+
+Neither option is available for a group with a **Group Email** address set, since both channels issue a credential to a single, known individual.
+
+{% hint style="warning" %}
+The link and the reply address both act as a bearer credential for the duration of their validity. Anyone holding the link, or able to reply from the recipient's mailbox, can approve or reject the task as that user. Treat them with the same care as a password, and keep the token expiry (see below) as short as practical for your approval process.
+{% endhint %}
+
+## Configuration requirements
+
+### General
+
+| Setting                       | Default        | Description                                                                                                                                                                    |
+| ------------------------------ | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SiteUrl`                       | -              | Required for external approval. The approval link is built from this URL. Refer to [Configuration](configuration.md#settingscustomization) for details.                                             |
+| `EditUrl`                       | -              | Required for both channels. If not set, no workflow notification email is generated at all, so no approval link or reply address is delivered.                                                     |
+| `SendNotifications`             | -              | Must be `true`. If workflow notification emails are disabled, no approval links or reply addresses are ever sent.                                                                                    |
+| `ExternalApprovalTokenExpiry`   | `2.00:00:00` (48 hours) | A `TimeSpan` controlling how long an external approval link or a reply-approval token remains valid after it is generated, for both channels.                                              |
+
+`SiteUrl`, `EditUrl`, and `SendNotifications` are configured from the Workflow settings dashboard, or via `SettingsCustomization` in `appsettings.json` - see [Configuration](configuration.md). `ExternalApprovalTokenExpiry` is set directly under `Umbraco:Workflow` in `appsettings.json`:
+
+```json
+{
+  "Umbraco": {
+    "Workflow": {
+      "ExternalApprovalTokenExpiry": "2.00:00:00"
+    }
+  }
+}
+```
+
+The CMS must also be able to send email (SMTP server, pickup directory, or a custom email notification handler configured under `Umbraco:CMS:Global:Smtp`. Neither channel can deliver a link or a reply address otherwise.
+
+{% hint style="info" %}
+Approval tokens are protected using the ASP.NET Data Protection key ring. In a load-balanced environment confirm the key ring is persisted and shared between servers. Otherwise, a link generated on one server is rejected as invalid by another and every outstanding link breaks on the next deployment.
+{% endhint %}
+
+### Email reply approval
+
+Email reply approval additionally requires an IMAP mailbox to be polled for replies. This is configured under `Umbraco:Workflow:EmailReplyApproval` in `appsettings.json`. There is no Backoffice settings UI for this configuration, consistent with how other outbound email credentials are handled in Workflow.
+
+```json
+{
+  "Umbraco": {
+    "Workflow": {
+      "EmailReplyApproval": {
+        "Enabled": false,
+        "Host": null,
+        "Port": 993,
+        "UseSsl": true,
+        "Username": null,
+        "Password": null,
+        "Mailbox": "INBOX",
+        "ReplyAddress": null,
+        "PollingPeriod": "0.00:05:00"
+      }
+    }
+  }
+}
+```
+
+| Setting          | Default            | Description                                                                                                                                                                                            |
+| ----------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Enabled`          | `false`             | Enables polling the configured mailbox for approval replies. Must be `true` for this channel to have any effect, even if it is enabled for one or more approval groups.                              |
+| `Host`             | -                   | IMAP host of the mailbox that receives approval replies.                                                                                                                                               |
+| `Port`             | `993`               | IMAP port. Defaults to the standard implicit-TLS port.                                                                                                                                                 |
+| `UseSsl`           | `true`              | Connect using implicit TLS. When `false`, the connection uses STARTTLS instead. There is no unencrypted fallback.                                                                                     |
+| `Username`         | -                   | IMAP authentication username.                                                                                                                                                                          |
+| `Password`         | -                   | IMAP authentication password.                                                                                                                                                                          |
+| `Mailbox`          | `INBOX`             | Mailbox folder to poll for replies.                                                                                                                                                                    |
+| `ReplyAddress`     | -                   | The base address replies are sent to. The approval token is carried by plus-addressing the local part of this address, for example `workflow-reply@yourdomain.com` becomes `workflow-reply+<token>@yourdomain.com`. |
+| `PollingPeriod`    | `0.00:05:00` (5 minutes) | A `TimeSpan` controlling how often the mailbox is polled for new replies. Must be shorter than `ExternalApprovalTokenExpiry`, or a reply can arrive after its token has already expired.        |
+
+{% hint style="warning" %}
+`Username` and `Password` are credentials. Provide them via user secrets, environment variables, or a key vault provider rather than committing them to `appsettings.json`.
+{% endhint %}
+
+Mail sent to `ReplyAddress` (including plus-addressed variants) must be delivered into the polled `Mailbox`. If the reply address is an alias of, or is routed to, a different mailbox than the one being polled, replies are never seen.
+
+## Health checks
+
+Workflow adds two health checks to help diagnose configuration issues for these features:
+
+* **External Approval Configuration** - checks licensing, notification and site URL configuration, and the token expiry. It also flags any group with external approval enabled that also has a group email set.
+* **Action-by-Email Configuration** - checks licensing, the IMAP connection settings, the reply address, and the polling period against the token expiry. It also flags any group with email reply approval enabled that also has a group email set.
+
+Both checks are found in the **Settings > Health Check** dashboard, under the **Workflow** group.

--- a/17/umbraco-workflow/getting-started/workflow-detail-dialog.md
+++ b/17/umbraco-workflow/getting-started/workflow-detail-dialog.md
@@ -1,0 +1,33 @@
+# Workflow Detail Dialog
+
+The Workflow detail dialog provides the interface for managing active workflow processes.
+
+When the current node is pending workflow approval, the **Workflow Detail** dialog displays detailed information such as:
+
+* Option to [approve, reject, or cancel pending workflow tasks](workflow-workspace-view.md#approve-reject-or-cancel-pending-workflow-tasks).
+* View change description and track differences across pending and completed workflows.
+* View the group responsible for approving the pending workflow.
+* View pending language variant(s) workflow.
+* View the workflow activity (eg. pending approval/task approvals/rejects) for the current workflow process.
+
+![Active Workflow sub-section](../.gitbook/assets/Active-Workflow-detailed-info-v14.png)
+
+You can access Active Workflows from two places - the **Content** section and the **Workflow** section (depending on your user permission). Workflow Administrators (those users with access to the Workflow section) can access workflows assigned to a different group. In the **Workflow History**, these are noted as being performed by the admin.
+
+### Approve, Reject, or Cancel pending workflow tasks
+
+#### Approve Workflow Tasks
+
+To approve a Workflow task, click on the **Approve** button in the Action section.
+
+#### Reject Workflow Tasks
+
+To reject a Workflow task, click on the **Reject** button in the Action section. Depending on the approval stage, the reviewer can decide where to send the rejected task.
+
+For first-stage approvals, the rejected task is sent back to the original editor/author. For second-stage approvals and above, the reviewer can send the rejected task either to the original editor or any other previous workflow group.
+
+![Reject Workflow Tasks](../.gitbook/assets/assign-rejected-task.png)
+
+#### Cancel pending Workflow Tasks
+
+To cancel a pending Workflow task, click on the **Cancel** button in the Action section.

--- a/17/umbraco-workflow/getting-started/workflow-workspace-view.md
+++ b/17/umbraco-workflow/getting-started/workflow-workspace-view.md
@@ -1,44 +1,9 @@
 # Workspace View
 
-Umbraco Workflow adds a [Workspace View](https://docs.umbraco.com/umbraco-cms/customizing/extending-overview/extension-types/workspaces/workspace-views) to all content nodes in the **Content** section where a workflow is enabled. The Workflow workspace view includes three sub-sections:
+Umbraco Workflow adds a [Workspace View](https://docs.umbraco.com/umbraco-cms/customizing/extending-overview/extension-types/workspaces/workspace-views) to all content nodes in the **Content** section where a workflow is enabled. The Workflow workspace view includes two sub-sections:
 
-* [Active Workflow](workflow-workspace-view.md#active-workflow)
 * [Configuration](workflow-workspace-view.md#configuration)
 * [History](workflow-workspace-view.md#history)
-
-## Active Workflow
-
-The Active workflow sub-section provides an interface for managing workflows for the current content node.
-
-When the current node is pending workflow approval, the **Active workflow** sub-section displays detailed information such as:
-
-* Option to [approve, reject, or cancel pending workflow tasks](workflow-workspace-view.md#approve-reject-or-cancel-pending-workflow-tasks).
-* View change description and track differences across pending and completed workflows.
-* View the group responsible for approving the pending workflow.
-* View pending language variant(s) workflow.
-* View the workflow activity (eg. pending approval/task approvals/rejects) for the current workflow process.
-
-![Active Workflow sub-section](../.gitbook/assets/Active-Workflow-detailed-info-v14.png)
-
-You can access Active Workflows from two places - the **Content** section and the **Workflow** section (depending on your user permission). Workflow Administrators (those users with access to the Workflow section) can access workflows assigned to a different group. In the **Workflow History**, these are noted as being performed by the admin.
-
-### Approve, Reject, or Cancel pending workflow tasks
-
-#### Approve Workflow Tasks
-
-To approve a Workflow task, click on the **Approve** button in the Action section.
-
-#### Reject Workflow Tasks
-
-To reject a Workflow task, click on the **Reject** button in the Action section. Depending on the approval stage, the reviewer can decide where to send the rejected task.
-
-For first-stage approvals, the rejected task is sent back to the original editor/author. For second-stage approvals and above, the reviewer can send the rejected task either to the original editor or any other previous workflow group.
-
-![Reject Workflow Tasks](../.gitbook/assets/assign-rejected-task.png)
-
-#### Cancel pending Workflow Tasks
-
-To cancel a pending Workflow task, click on the **Cancel** button in the Action section.
 
 ## Configuration
 
@@ -97,6 +62,6 @@ The History sub-section provides a chronological audit trail of workflow activit
 
 You can also **Filter** the records based on the information listed above. Additionally, you can adjust the total number of records displayed on a page.
 
-The **Detail** button at the end of the record displays an overlay with content similar to the Active workflow sub-section.
+The **Detail** button at the end of the record displays an overlay with content similar to the Workflow Detail dialog.
 
 ![Details overlay](../.gitbook/assets/Workflow-Content-app-Details-overlay-v14.png)

--- a/17/umbraco-workflow/getting-started/workflow-workspace-view.md
+++ b/17/umbraco-workflow/getting-started/workflow-workspace-view.md
@@ -39,7 +39,7 @@ Review the current Permissions for Approval Groups in the **Approval Groups** se
 
 ![Approval Groups Roles](../.gitbook/assets/approval-groups-roles-v14.png)
 
-Document type approval flows may contain conditional stages, such as including **Translators** in the workflow only when the **Description** property has changed. For more information on settings conditions in Document type approval flows, see the [Document type approval flows](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/workflow-section/workflow-settings.md#document-type-approval-flows) section in the [Workflow Settings](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/workflow-section/workflow-settings.md) article.
+Document type approval flows may contain conditional stages, such as including **Translators** in the workflow only when the **Description** property has changed. For more information on settings conditions in Document type approval flows, see the [Document type approval flows](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/getting-started/content-approval-settings.md#document-type-approval-flows) section in the [Content approval settings](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/getting-started/content-approval-settings.md) article.
 
 Configuration cannot be modified when a content node is in a workflow process.
 

--- a/17/umbraco-workflow/release-notes.md
+++ b/17/umbraco-workflow/release-notes.md
@@ -16,11 +16,17 @@ Check the [Version Specific Upgrade Notes](upgrading/version-specific.md) articl
 
 This section contains the release notes for Umbraco Workflow 17, including all changes for this version.
 
-### 17.4.0 (August 20 2026)
+### [17.4.0](https://github.com/umbraco/Umbraco.Workflow.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.4.0)  (August 20 2026)
 
 #### Adds approval by magic link and email reply
 
-Reviewers can now approve or reject a workflow task directly from the notification email. Task can be approved either by opening a secure, time-limited link without logging in to the backoffice, or by replying to the email with an approve or reject instruction. New health checks validate the action-by-email and external approval configuration.
+Reviewers can now approve or reject a workflow task directly from the notification email. 
+
+Tasks can be approved in two ways:
+* By opening a secure, time-limited link without logging in to the backoffice
+* By replying to the email with an approve or reject instruction
+
+New health checks validate the action-by-email and external approval configuration.
 
 This feature requires a license. Check the [External Approval](getting-started/external-approval.md) article for more information.
 

--- a/17/umbraco-workflow/release-notes.md
+++ b/17/umbraco-workflow/release-notes.md
@@ -16,6 +16,36 @@ Check the [Version Specific Upgrade Notes](upgrading/version-specific.md) articl
 
 This section contains the release notes for Umbraco Workflow 17, including all changes for this version.
 
+### 17.4.0 (August 20 2026)
+
+#### Adds approval by magic link and email reply
+
+Reviewers can now approve or reject a workflow task directly from the notification email. Task can be approved either by opening a secure, time-limited link without logging in to the backoffice, or by replying to the email with an approve or reject instruction. New health checks validate the action-by-email and external approval configuration.
+
+This feature requires a license. Check the [External Approval](getting-started/external-approval.md) article for more information.
+
+#### Adds Date mode for content reviews
+
+Content review due dates can be set to a specific date instead of only a recurring period. When editing an existing configuration, the due date can be regenerated from the current date or from the content's last published date.
+
+#### Workflow actions moved to extensions
+
+Approve, reject, cancel, and resubmit actions, along with the preview, diff, and attachment buttons, are now implemented as extensions. This lays the groundwork for third-party actions to be registered alongside the built-in ones.
+
+#### Bug fixes and other changes
+
+* Fixes a SQL syntax error when loading approval groups under cultures whose negative sign is not the ASCII hyphen, such as `sv-SE` [#165](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/165)
+* Fixes errors when opening Settings > Workflow > Content approvals > Configuration on an unlicensed install, including a settings tree node incorrectly labeled `workflow_workflow` [#164](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/164)
+* Fixes advanced search so toggle properties can be searched and read-only label properties correctly show a search input [#163](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/163)
+* Fixes a bug where licensed settings values were reset to their defaults when saved from an unlicensed install
+* Fixes tooltip positioning in the Advanced Search dashboard
+* Fixes the reject dialog showing a "reject to group" option when rejecting at the first stage of a workflow
+* Fixes the workflow modal breaking when SignalR triggers a rebuild of its host element
+* Adds health checks for email notification configuration, action-by-email configuration, email template integrity, and external approval configuration
+* Localizes email templates at render time instead of maintaining a separate template per culture
+* Normalizes stored content review culture values for invariant content
+* Fixes orphaned data rows left behind when deleting an alternate version
+
 ### 17.3.6 (July 24 2026)
 
 * Fixes a bug where teardown of a required context was not correctly guarded in a specific code path, leaving Workflow unresponsive.

--- a/17/umbraco-workflow/workflow-section/approval-groups.md
+++ b/17/umbraco-workflow/workflow-section/approval-groups.md
@@ -26,9 +26,15 @@ You can search for a specific group using the Search bar. Select a group from th
 
 The **Settings** tab consists of the following fields:
 
+* **Allow external approval:** Set to true to allow members of this group to action workflow tasks without logging in to the CMS. A secure link is included in the notification email. Requires a license. See [External Approval](../getting-started/external-approval.md) for more information.
+* **Allow approval by email reply:** Set to true to allow members of this group to approve or reject tasks. They do this by replying directly to the notification email. Requires a license. See [External Approval](../getting-started/external-approval.md) for more information.
 * **Group Email:** Workflow notifications are sent to a generic inbox (a group's email address) rather than the individual group members.
 * **Group Language:** Select a language variant for the email.
 * **Workflow Activity:** Provides a chart displaying an overview of the workflow activity such as approved, cancelled, rejected, or pending approvals for the current group.
+
+{% hint style="info" %}
+**Allow external approval** and **Allow approval by email reply** are not available for a group with a **Group Email** address set. Both features issue a link or reply address tied to a single, known individual, so they cannot be used with a shared mailbox.
+{% endhint %}
 
 ![Approval group Settings](../.gitbook/assets/Approval-group-settings-v14.png)
 

--- a/17/umbraco-workflow/workflow-section/approval-groups.md
+++ b/17/umbraco-workflow/workflow-section/approval-groups.md
@@ -81,7 +81,7 @@ The **Roles** tab provides an overview of the current workflow roles for the Gro
 * **Node-based approvals**: This workflow applies only to the specified node.
 * **Document-type approvals**: This workflow applies to all the nodes of a given Document Type.
 
-You can set these **Roles** in the Workflow **Settings** section. For more information, see the [Workflow Settings](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/workflow-section/workflow-settings.md) article.
+You can set these **Roles** in the Workflow **Settings** section. For more information, see the [Content approval settings](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/getting-started/content-approval-settings.md) article.
 
 ![Approval group Roles](../.gitbook/assets/approval-groups-role-v14.png)
 
@@ -99,6 +99,6 @@ The History tab provides an overview of the workflow activity for the current gr
 
 You can also **Filter** the records based on the Document Type, Requested by, Created date, Completed date, Page Language, Workflow Type, and Workflow Status. Additionally, you can adjust the total number of records displayed on a page.
 
-The **Detail** button at the end of the record displays an overlay with content similar to the [Active workflow](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/getting-started/workflow-content-app.md#active-workflow) sub-section.
+The **Detail** button at the end of the record displays an overlay with content similar to the [workflow detail dialog](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/getting-started/workflow-detail-dialog).
 
 ![Details overlay](../.gitbook/assets/Workflow-Content-app-Details-overlay-v14.png)

--- a/17/umbraco-workflow/workflow-section/approval-groups.md
+++ b/17/umbraco-workflow/workflow-section/approval-groups.md
@@ -99,6 +99,6 @@ The History tab provides an overview of the workflow activity for the current gr
 
 You can also **Filter** the records based on the Document Type, Requested by, Created date, Completed date, Page Language, Workflow Type, and Workflow Status. Additionally, you can adjust the total number of records displayed on a page.
 
-The **Detail** button at the end of the record displays an overlay with content similar to the [workflow detail dialog](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/getting-started/workflow-detail-dialog).
+The **Detail** button at the end of the record displays an overlay with content similar to the [workflow detail dialog](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/getting-started/workflow-detail-dialog.md).
 
 ![Details overlay](../.gitbook/assets/Workflow-Content-app-Details-overlay-v14.png)

--- a/18/umbraco-workflow/SUMMARY.md
+++ b/18/umbraco-workflow/SUMMARY.md
@@ -19,6 +19,7 @@
 
 * [Content Approval Settings](getting-started/content-approval-settings.md)
 * [Content Review Settings](getting-started/content-review-settings.md)
+* [Workflow Detail Dialog](getting-started/workflow-detail-dialog.md)
 * [Dashboards and Buttons](getting-started/dashboards-and-buttons.md)
 * [Submitting Content for Approval](getting-started/submitting-changes.md)
 * [Workspace View](getting-started/workflow-workspace-view.md)

--- a/18/umbraco-workflow/SUMMARY.md
+++ b/18/umbraco-workflow/SUMMARY.md
@@ -25,6 +25,7 @@
 * [Notifications](getting-started/notifications.md)
 * [Configuration](getting-started/configuration.md)
 * [Approval thresholds](getting-started/approval-thresholds.md)
+* [External Approval](getting-started/external-approval.md)
 * [History Cleanup](getting-started/history-cleanup.md)
 
 ## Workflow Section

--- a/18/umbraco-workflow/getting-started/dashboards-and-buttons.md
+++ b/18/umbraco-workflow/getting-started/dashboards-and-buttons.md
@@ -23,10 +23,6 @@ When no workflow is active, the button state is determined by the current user's
 
 Umbraco Workflow overrides Umbraco's User/Group publishing permissions. If the user has permission to update the node, they will be able to initiate a workflow process on that node. Umbraco Workflow shifts Umbraco from a centrally administered publishing model (controlled by a site administrator) to a distributed model. In this model, editors publish content based on their responsibilities assigned during the workflows.
 
-In cases, where the content is already in a workflow, a notification is displayed at the top of the editor. Depending on the Workflow **Settings**, you can enable/disable editing access on a content node in a workflow.
-
-![Disabled content edits](../.gitbook/assets/blocked_content.png)
-
 For nodes where the workflow has been disabled, the default Umbraco options are displayed.
 
 ![Default Button](../.gitbook/assets/Default_Buttons.png)

--- a/18/umbraco-workflow/getting-started/external-approval.md
+++ b/18/umbraco-workflow/getting-started/external-approval.md
@@ -9,7 +9,7 @@ description: >-
 External Approval is available in Workflow 18.1 and above. This feature requires a license. Learn more about [Workflow's licensing model](https://umbraco.com/products/umbraco-workflow).
 {% endhint %}
 
-External Approval allows editors to participate in workflow processes without accessing the Umbaco Backoffice. This allows content stakeholders to approve content changes without needing to know how to use Umbraco.
+External Approval allows editors to participate in workflow processes without accessing the Umbraco Backoffice. This allows content stakeholders to approve content changes without needing to know how to use Umbraco.
 
 There are two ways for an approval group member to action a pending task from the notification email, instead of logging in to the Backoffice:
 

--- a/18/umbraco-workflow/getting-started/external-approval.md
+++ b/18/umbraco-workflow/getting-started/external-approval.md
@@ -20,7 +20,7 @@ Both are optional, licensed features and are enabled independently, per approval
 
 ## External approval
 
-When External approval is enabled for a group, the notification email sent to a pending task's approvers includes a link to a standalone approval page. Opening the link:
+When External approval is enabled for a group, the notification email includes a link to a standalone approval page. Opening the link:
 
 * Signs the recipient in as the user the link was generated for, without a Backoffice login.
 * Shows a preview of the content change, alongside the task detail (workflow stage, comments, and any attachment).
@@ -41,7 +41,7 @@ The task is actioned automatically once the reply is processed, and the recipien
 
 Quoted history in the reply (previous message text, signatures added by common mail clients) is stripped automatically before the keyword is read.
 
-Email reply approval is only available for the single, active-task notification, not for the reminder digest email. A digest can bundle several unrelated tasks together and a plain reply cannot say which one it applies to.
+Email reply approval is only available for the single, active-task notification, not for the reminder digest email. A digest can bundle unrelated tasks together and a plain reply cannot say which one it applies to.
 
 ## Enabling the feature
 

--- a/18/umbraco-workflow/getting-started/external-approval.md
+++ b/18/umbraco-workflow/getting-started/external-approval.md
@@ -1,0 +1,137 @@
+---
+description: >-
+  Allow editors to participate in workflow processes without accessing the CMS.
+---
+
+# External Approval
+
+{% hint style="info" %}
+External Approval is available in Workflow 18.1 and above. This feature requires a license. Learn more about [Workflow's licensing model](https://umbraco.com/products/umbraco-workflow).
+{% endhint %}
+
+External Approval allows editors to participate in workflow processes without accessing the Umbaco Backoffice. This allows content stakeholders to approve content changes without needing to know how to use Umbraco.
+
+There are two ways for an approval group member to action a pending task from the notification email, instead of logging in to the Backoffice:
+
+* **External approval** - a secure, time-limited link in the email opens a standalone approval page.
+* **Email reply approval** - replying to the notification email with `APPROVE` or `REJECT` actions the task directly.
+
+Both are optional, licensed features and are enabled independently, per approval group.
+
+## External approval
+
+When External approval is enabled for a group, the notification email sent to a pending task's approvers includes a link to a standalone approval page. Opening the link:
+
+* Signs the recipient in as the user the link was generated for, without a Backoffice login.
+* Shows a preview of the content change, alongside the task detail (workflow stage, comments, and any attachment).
+* Lets the recipient switch between configured preview environments and device sizes.
+* Presents **Approve** and **Reject** actions that call the same API used by the Backoffice.
+
+The link is only included for a recipient when all of the following are true:
+
+* The group has **External approval** enabled.
+* The group does not have a **Group Email** set. The link identifies the individual it was generated for, so it cannot be issued for a shared mailbox.
+* There is an active (incomplete) task for the recipient to action.
+
+## Email reply approval
+
+When Email reply approval is enabled for a group, the notification email for a pending task includes a `Reply-To` address. A recipient can use the buttons embedded in the notification email to generate a reply message, or reply directly to the notification.
+
+The task is actioned automatically once the reply is processed, and the recipient then receives a plain-text confirmation. If the reply cannot be actioned, the recipient receives an explanation instead - for example, an expired token or an unrecognized keyword.
+
+Quoted history in the reply (previous message text, signatures added by common mail clients) is stripped automatically before the keyword is read.
+
+Email reply approval is only available for the single, active-task notification, not for the reminder digest email. A digest can bundle several unrelated tasks together and a plain reply cannot say which one it applies to.
+
+## Enabling the feature
+
+Both channels are enabled per approval group, from the group's **Settings** tab in the **Workflow** section:
+
+* **Allow external approval** - enables the magic-link channel for members of the group.
+* **Allow approval by email reply** - enables the email-reply channel for members of the group.
+
+Neither option is available for a group with a **Group Email** address set, since both channels issue a credential to a single, known individual.
+
+{% hint style="warning" %}
+The link and the reply address both act as a bearer credential for the duration of their validity. Anyone holding the link, or able to reply from the recipient's mailbox, can approve or reject the task as that user. Treat them with the same care as a password, and keep the token expiry (see below) as short as practical for your approval process.
+{% endhint %}
+
+## Configuration requirements
+
+### General
+
+| Setting                       | Default        | Description                                                                                                                                                                    |
+| ------------------------------ | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SiteUrl`                       | -              | Required for external approval. The approval link is built from this URL. Refer to [Configuration](configuration.md#settingscustomization) for details.                                             |
+| `EditUrl`                       | -              | Required for both channels. If not set, no workflow notification email is generated at all, so no approval link or reply address is delivered.                                                     |
+| `SendNotifications`             | -              | Must be `true`. If workflow notification emails are disabled, no approval links or reply addresses are ever sent.                                                                                    |
+| `ExternalApprovalTokenExpiry`   | `2.00:00:00` (48 hours) | A `TimeSpan` controlling how long an external approval link or a reply-approval token remains valid after it is generated, for both channels.                                              |
+
+`SiteUrl`, `EditUrl`, and `SendNotifications` are configured from the Workflow settings dashboard, or via `SettingsCustomization` in `appsettings.json` - see [Configuration](configuration.md). `ExternalApprovalTokenExpiry` is set directly under `Umbraco:Workflow` in `appsettings.json`:
+
+```json
+{
+  "Umbraco": {
+    "Workflow": {
+      "ExternalApprovalTokenExpiry": "2.00:00:00"
+    }
+  }
+}
+```
+
+The CMS must also be able to send email (SMTP server, pickup directory, or a custom email notification handler configured under `Umbraco:CMS:Global:Smtp`. Neither channel can deliver a link or a reply address otherwise.
+
+{% hint style="info" %}
+Approval tokens are protected using the ASP.NET Data Protection key ring. In a load-balanced environment confirm the key ring is persisted and shared between servers. Otherwise, a link generated on one server is rejected as invalid by another and every outstanding link breaks on the next deployment.
+{% endhint %}
+
+### Email reply approval
+
+Email reply approval additionally requires an IMAP mailbox to be polled for replies. This is configured under `Umbraco:Workflow:EmailReplyApproval` in `appsettings.json`. There is no Backoffice settings UI for this configuration, consistent with how other outbound email credentials are handled in Workflow.
+
+```json
+{
+  "Umbraco": {
+    "Workflow": {
+      "EmailReplyApproval": {
+        "Enabled": false,
+        "Host": null,
+        "Port": 993,
+        "UseSsl": true,
+        "Username": null,
+        "Password": null,
+        "Mailbox": "INBOX",
+        "ReplyAddress": null,
+        "PollingPeriod": "0.00:05:00"
+      }
+    }
+  }
+}
+```
+
+| Setting          | Default            | Description                                                                                                                                                                                            |
+| ----------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Enabled`          | `false`             | Enables polling the configured mailbox for approval replies. Must be `true` for this channel to have any effect, even if it is enabled for one or more approval groups.                              |
+| `Host`             | -                   | IMAP host of the mailbox that receives approval replies.                                                                                                                                               |
+| `Port`             | `993`               | IMAP port. Defaults to the standard implicit-TLS port.                                                                                                                                                 |
+| `UseSsl`           | `true`              | Connect using implicit TLS. When `false`, the connection uses STARTTLS instead. There is no unencrypted fallback.                                                                                     |
+| `Username`         | -                   | IMAP authentication username.                                                                                                                                                                          |
+| `Password`         | -                   | IMAP authentication password.                                                                                                                                                                          |
+| `Mailbox`          | `INBOX`             | Mailbox folder to poll for replies.                                                                                                                                                                    |
+| `ReplyAddress`     | -                   | The base address replies are sent to. The approval token is carried by plus-addressing the local part of this address, for example `workflow-reply@yourdomain.com` becomes `workflow-reply+<token>@yourdomain.com`. |
+| `PollingPeriod`    | `0.00:05:00` (5 minutes) | A `TimeSpan` controlling how often the mailbox is polled for new replies. Must be shorter than `ExternalApprovalTokenExpiry`, or a reply can arrive after its token has already expired.        |
+
+{% hint style="warning" %}
+`Username` and `Password` are credentials. Provide them via user secrets, environment variables, or a key vault provider rather than committing them to `appsettings.json`.
+{% endhint %}
+
+Mail sent to `ReplyAddress` (including plus-addressed variants) must be delivered into the polled `Mailbox`. If the reply address is an alias of, or is routed to, a different mailbox than the one being polled, replies are never seen.
+
+## Health checks
+
+Workflow adds two health checks to help diagnose configuration issues for these features:
+
+* **External Approval Configuration** - checks licensing, notification and site URL configuration, and the token expiry. It also flags any group with external approval enabled that also has a group email set.
+* **Action-by-Email Configuration** - checks licensing, the IMAP connection settings, the reply address, and the polling period against the token expiry. It also flags any group with email reply approval enabled that also has a group email set.
+
+Both checks are found in the **Settings > Health Check** dashboard, under the **Workflow** group.

--- a/18/umbraco-workflow/getting-started/workflow-detail-dialog.md
+++ b/18/umbraco-workflow/getting-started/workflow-detail-dialog.md
@@ -1,0 +1,33 @@
+# Workflow Detail Dialog
+
+The Workflow detail dialog provides the interface for managing active workflow processes.
+
+When the current node is pending workflow approval, the **Workflow Detail** dialog displays detailed information such as:
+
+* Option to [approve, reject, or cancel pending workflow tasks](workflow-workspace-view.md#approve-reject-or-cancel-pending-workflow-tasks).
+* View change description and track differences across pending and completed workflows.
+* View the group responsible for approving the pending workflow.
+* View pending language variant(s) workflow.
+* View the workflow activity (eg. pending approval/task approvals/rejects) for the current workflow process.
+
+![Active Workflow sub-section](../.gitbook/assets/Active-Workflow-detailed-info-v14.png)
+
+You can access Active Workflows from two places - the **Content** section and the **Workflow** section (depending on your user permission). Workflow Administrators (those users with access to the Workflow section) can access workflows assigned to a different group. In the **Workflow History**, these are noted as being performed by the admin.
+
+### Approve, Reject, or Cancel pending workflow tasks
+
+#### Approve Workflow Tasks
+
+To approve a Workflow task, click on the **Approve** button in the Action section.
+
+#### Reject Workflow Tasks
+
+To reject a Workflow task, click on the **Reject** button in the Action section. Depending on the approval stage, the reviewer can decide where to send the rejected task.
+
+For first-stage approvals, the rejected task is sent back to the original editor/author. For second-stage approvals and above, the reviewer can send the rejected task either to the original editor or any other previous workflow group.
+
+![Reject Workflow Tasks](../.gitbook/assets/assign-rejected-task.png)
+
+#### Cancel pending Workflow Tasks
+
+To cancel a pending Workflow task, click on the **Cancel** button in the Action section.

--- a/18/umbraco-workflow/getting-started/workflow-workspace-view.md
+++ b/18/umbraco-workflow/getting-started/workflow-workspace-view.md
@@ -1,44 +1,9 @@
 # Workspace View
 
-Umbraco Workflow adds a [Workspace View](https://docs.umbraco.com/umbraco-cms/customizing/extending-overview/extension-types/workspaces/workspace-views) to all content nodes in the **Content** section where a workflow is enabled. The Workflow workspace view includes three sub-sections:
+Umbraco Workflow adds a [Workspace View](https://docs.umbraco.com/umbraco-cms/customizing/extending-overview/extension-types/workspaces/workspace-views) to all content nodes in the **Content** section where a workflow is enabled. The Workflow workspace view includes two sub-sections:
 
-* [Active Workflow](workflow-workspace-view.md#active-workflow)
 * [Configuration](workflow-workspace-view.md#configuration)
 * [History](workflow-workspace-view.md#history)
-
-## Active Workflow
-
-The Active workflow sub-section provides an interface for managing workflows for the current content node.
-
-When the current node is pending workflow approval, the **Active workflow** sub-section displays detailed information such as:
-
-* Option to [approve, reject, or cancel pending workflow tasks](workflow-workspace-view.md#approve-reject-or-cancel-pending-workflow-tasks).
-* View change description and track differences across pending and completed workflows.
-* View the group responsible for approving the pending workflow.
-* View pending language variant(s) workflow.
-* View the workflow activity (eg. pending approval/task approvals/rejects) for the current workflow process.
-
-![Active Workflow sub-section](../.gitbook/assets/Active-Workflow-detailed-info-v14.png)
-
-You can access Active Workflows from two places - the **Content** section and the **Workflow** section (depending on your user permission). Workflow Administrators (those users with access to the Workflow section) can access workflows assigned to a different group. In the **Workflow History**, these are noted as being performed by the admin.
-
-### Approve, Reject, or Cancel pending workflow tasks
-
-#### Approve Workflow Tasks
-
-To approve a Workflow task, click on the **Approve** button in the Action section.
-
-#### Reject Workflow Tasks
-
-To reject a Workflow task, click on the **Reject** button in the Action section. Depending on the approval stage, the reviewer can decide where to send the rejected task.
-
-For first-stage approvals, the rejected task is sent back to the original editor/author. For second-stage approvals and above, the reviewer can send the rejected task either to the original editor or any other previous workflow group.
-
-![Reject Workflow Tasks](../.gitbook/assets/assign-rejected-task.png)
-
-#### Cancel pending Workflow Tasks
-
-To cancel a pending Workflow task, click on the **Cancel** button in the Action section.
 
 ## Configuration
 
@@ -54,7 +19,7 @@ For example, German variants can be approved by the German speakers group, while
 
 You can add different groups for different stages of content approval flow. Content Approval flow groups can be reordered via drag and drop. You can also apply the approval flow either for publish and unpublish workflows or only publish workflow.
 
-![Content approval flow](<../.gitbook/assets/content-approval-flow-v14 (1).png>)
+![Content approval flow](../.gitbook/assets/content-approval-flow-v14.png)
 
 #### Approval Flow Types
 
@@ -68,13 +33,13 @@ A given content node may have all three approval flow types applied but only one
 | **Document type approval flow** | Set in the **Settings** section. Applies to all content nodes of the selected Document Type unless overridden by a Content approval flow set directly on the node. Requires a license.       | Secondary |
 | **Inherited approval flow**     | Used when a content node has no Content approval flow set, nor a flow applied to its Document Type. Umbraco Workflow will traverse the content tree upwards to find a Content approval flow. | Lowest    |
 
-![Approval Flow Types](<../.gitbook/assets/content-approval-flow-v14 (1).png>)
+![Approval Flow Types](../.gitbook/assets/content-approval-flow-v14.png)
 
 Review the current Permissions for Approval Groups in the **Approval Groups** section for **Node-based approvals** and **Document type approvals** only. For more information see the [Roles](../workflow-section/approval-groups.md#roles) section in the [Approval Groups](../workflow-section/approval-groups.md) article.
 
 ![Approval Groups Roles](../.gitbook/assets/approval-groups-roles-v14.png)
 
-Document type approval flows may contain conditional stages, such as including **Translators** in the workflow only when the **Description** property has changed. For more information on settings conditions in Document type approval flows, see the [Document type approval flows](content-approval-settings.md#document-type-approval-flows) section in the [Workflow Settings](content-approval-settings.md) article.
+Document type approval flows may contain conditional stages, such as including **Translators** in the workflow only when the **Description** property has changed. For more information on settings conditions in Document type approval flows, see the [Document type approval flows](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/workflow-section/workflow-settings.md#document-type-approval-flows) section in the [Workflow Settings](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/workflow-section/workflow-settings.md) article.
 
 Configuration cannot be modified when a content node is in a workflow process.
 
@@ -97,6 +62,6 @@ The History sub-section provides a chronological audit trail of workflow activit
 
 You can also **Filter** the records based on the information listed above. Additionally, you can adjust the total number of records displayed on a page.
 
-The **Detail** button at the end of the record displays an overlay with content similar to the Active workflow sub-section.
+The **Detail** button at the end of the record displays an overlay with content similar to the Workflow Detail dialog.
 
 ![Details overlay](../.gitbook/assets/Workflow-Content-app-Details-overlay-v14.png)

--- a/18/umbraco-workflow/getting-started/workflow-workspace-view.md
+++ b/18/umbraco-workflow/getting-started/workflow-workspace-view.md
@@ -39,7 +39,7 @@ Review the current Permissions for Approval Groups in the **Approval Groups** se
 
 ![Approval Groups Roles](../.gitbook/assets/approval-groups-roles-v14.png)
 
-Document type approval flows may contain conditional stages, such as including **Translators** in the workflow only when the **Description** property has changed. For more information on settings conditions in Document type approval flows, see the [Document type approval flows](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/workflow-section/workflow-settings.md#document-type-approval-flows) section in the [Workflow Settings](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/workflow-section/workflow-settings.md) article.
+Document type approval flows may contain conditional stages, such as including **Translators** in the workflow only when the **Description** property has changed. For more information on settings conditions in Document type approval flows, see the [Document type approval flows](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/getting-started/content-approval-settings.md#document-type-approval-flows) section in the [Content approval settings](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/getting-started/content-approval-settings.md) article.
 
 Configuration cannot be modified when a content node is in a workflow process.
 

--- a/18/umbraco-workflow/release-notes.md
+++ b/18/umbraco-workflow/release-notes.md
@@ -16,6 +16,42 @@ Check the [Version Specific Upgrade Notes](upgrading/version-specific.md) articl
 
 This section contains the release notes for Umbraco Workflow 18, including all changes for this version.
 
+### [18.1.0](https://github.com/umbraco/Umbraco.Workflow.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.1.0)  (August 20 2026)
+
+#### Adds approval by magic link and email reply
+
+Reviewers can now approve or reject a workflow task directly from the notification email. 
+
+Tasks can be approved in two ways:
+* By opening a secure, time-limited link without logging in to the backoffice
+* By replying to the email with an approve or reject instruction
+
+New health checks validate the action-by-email and external approval configuration.
+
+This feature requires a license. Check the [External Approval](getting-started/external-approval.md) article for more information.
+
+#### Adds Date mode for content reviews
+
+Content review due dates can be set to a specific date instead of only a recurring period. When editing an existing configuration, the due date can be regenerated from the current date or from the content's last published date.
+
+#### Workflow actions moved to extensions
+
+Approve, reject, cancel, and resubmit actions, along with the preview, diff, and attachment buttons, are now implemented as extensions. This lays the groundwork for third-party actions to be registered alongside the built-in ones.
+
+#### Bug fixes and other changes
+
+* Fixes a SQL syntax error when loading approval groups under cultures whose negative sign is not the ASCII hyphen, such as `sv-SE` [#165](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/165)
+* Fixes errors when opening Settings > Workflow > Content approvals > Configuration on an unlicensed install, including a settings tree node incorrectly labeled `workflow_workflow` [#164](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/164)
+* Fixes advanced search so toggle properties can be searched and read-only label properties correctly show a search input [#163](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/163)
+* Fixes a bug where licensed settings values were reset to their defaults when saved from an unlicensed install
+* Fixes tooltip positioning in the Advanced Search dashboard
+* Fixes the reject dialog showing a "reject to group" option when rejecting at the first stage of a workflow
+* Fixes the workflow modal breaking when SignalR triggers a rebuild of its host element
+* Adds health checks for email notification configuration, action-by-email configuration, email template integrity, and external approval configuration
+* Localizes email templates at render time instead of maintaining a separate template per culture
+* Normalizes stored content review culture values for invariant content
+* Fixes orphaned data rows left behind when deleting an alternate version
+
 ### 18.0.3 (July 24 2026)
 
 * Fixes a bug where teardown of a required context was not correctly guarded in a specific code path, leaving Workflow unresponsive.

--- a/18/umbraco-workflow/workflow-section/approval-groups.md
+++ b/18/umbraco-workflow/workflow-section/approval-groups.md
@@ -26,9 +26,15 @@ You can search for a specific group using the Search bar. Select a group from th
 
 The **Settings** tab consists of the following fields:
 
+* **Allow external approval:** Set to true to allow members of this group to action workflow tasks without logging in to the CMS. A secure link is included in the notification email. Requires a license. See [External Approval](../getting-started/external-approval.md) for more information.
+* **Allow approval by email reply:** Set to true to allow members of this group to approve or reject tasks. They do this by replying directly to the notification email. Requires a license. See [External Approval](../getting-started/external-approval.md) for more information.
 * **Group Email:** Workflow notifications are sent to a generic inbox (a group's email address) rather than the individual group members.
 * **Group Language:** Select a language variant for the email.
 * **Workflow Activity:** Provides a chart displaying an overview of the workflow activity such as approved, cancelled, rejected, or pending approvals for the current group.
+
+{% hint style="info" %}
+**Allow external approval** and **Allow approval by email reply** are not available for a group with a **Group Email** address set. Both features issue a link or reply address tied to a single, known individual, so they cannot be used with a shared mailbox.
+{% endhint %}
 
 ![Approval group Settings](../.gitbook/assets/Approval-group-settings-v14.png)
 

--- a/18/umbraco-workflow/workflow-section/approval-groups.md
+++ b/18/umbraco-workflow/workflow-section/approval-groups.md
@@ -81,7 +81,7 @@ The **Roles** tab provides an overview of the current workflow roles for the Gro
 * **Node-based approvals**: This workflow applies only to the specified node.
 * **Document-type approvals**: This workflow applies to all the nodes of a given Document Type.
 
-You can set these **Roles** in the Workflow **Settings** section. For more information, see the [Content Approval settings](../getting-started/content-approval-settings.md) article.
+You can set these **Roles** in the Workflow **Settings** section. For more information, see the [Content approval settings](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/getting-started/content-approval-settings.md) article.
 
 ![Approval group Roles](../.gitbook/assets/approval-groups-role-v14.png)
 
@@ -99,6 +99,6 @@ The History tab provides an overview of the workflow activity for the current gr
 
 You can also **Filter** the records based on the Document Type, Requested by, Created date, Completed date, Page Language, Workflow Type, and Workflow Status. Additionally, you can adjust the total number of records displayed on a page.
 
-The **Detail** button at the end of the record displays an overlay with content similar to the [Active workflow](../getting-started/workflow-workspace-view.md#active-workflow) sub-section.
+The **Detail** button at the end of the record displays an overlay with content similar to the [workflow detail dialog](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/getting-started/workflow-detail-dialog).
 
 ![Details overlay](../.gitbook/assets/Workflow-Content-app-Details-overlay-v14.png)

--- a/18/umbraco-workflow/workflow-section/approval-groups.md
+++ b/18/umbraco-workflow/workflow-section/approval-groups.md
@@ -99,6 +99,6 @@ The History tab provides an overview of the workflow activity for the current gr
 
 You can also **Filter** the records based on the Document Type, Requested by, Created date, Completed date, Page Language, Workflow Type, and Workflow Status. Additionally, you can adjust the total number of records displayed on a page.
 
-The **Detail** button at the end of the record displays an overlay with content similar to the [workflow detail dialog](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/getting-started/workflow-detail-dialog).
+The **Detail** button at the end of the record displays an overlay with content similar to the [workflow detail dialog](https://github.com/umbraco/UmbracoDocs/blob/main/17/umbraco-workflow/getting-started/workflow-detail-dialog.md).
 
 ![Details overlay](../.gitbook/assets/Workflow-Content-app-Details-overlay-v14.png)


### PR DESCRIPTION
- Updates release-notes.md with 17.4/18.1 (same for both)
- Includes docs for the new (returning) External Approval feature
  - adds new page
  - includes page in summary.md
  - updates approval-groups.md with references to new settings
  - links approval-groups.md back to external-approval.md
- Removes reference to active-workflow banner in 17/18 - this no longer exists