### PR TITLE
Cloud release notes: custom error pages now shown for stopped environments

### DIFF
--- a/umbraco-cloud/build-and-customize-your-solution/handle-deployments-and-environments/error-pages.md
+++ b/umbraco-cloud/build-and-customize-your-solution/handle-deployments-and-environments/error-pages.md
@@ -12,6 +12,8 @@ The Error Pages feature lets you serve a custom HTML page to visitors when your 
 
 Error pages are shown when an environment is restarting. Most deployments require a restart, during which visitors may briefly see the error page.
 
+Error pages are also shown while an environment is stopped. When you stop an environment, visitors see the error page assigned to the hostname until you start the environment again. This makes it possible to show a custom maintenance page during planned maintenance. For more information, see the [Start and stop environments](../../release-notes/overview-2026/2026-03-releasenotes.md#start-and-stop-environments) section.
+
 On supported versions, Umbraco Cloud keeps showing the error page until your site reports that it is ready. See the [Readiness Gating](readiness-gating.md) article for details.
 
 To handle error pages when the website is running, see the [Umbraco CMS tutorial: Custom Error Pages](https://docs.umbraco.com/umbraco-cms/tutorials/custom-error-page).

--- a/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/planning-major-upgrades-safely-on-live.md
+++ b/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/planning-major-upgrades-safely-on-live.md
@@ -57,7 +57,7 @@ If you want to use Staging as a temporary visitor-facing fallback, review the fu
 - Whether any of that data could be lost when traffic moves back to Live.
 
 {% hint style="info" %}
-For business-critical sites, the safer approach is often a planned maintenance window. During this window, you take Live offline and display a maintenance page to visitors. You can then safely complete and verify the major upgrade.
+For business-critical sites, the safer approach is often a planned maintenance window. During this window, you take Live offline and display a maintenance page to visitors. You can upload the maintenance page using the [Error Pages](../../../build-and-customize-your-solution/handle-deployments-and-environments/error-pages.md) feature. You can then safely complete and verify the major upgrade.
 {% endhint %}
 
 ### Building the Copy
@@ -96,7 +96,7 @@ This path grants direct control over the database migration. Your upgraded local
 
 #### Step-by-Step Local Upgrade Execution
 
-1. **Take the Live environment offline:** This prevents outside processes from writing to the database or booting mid-migration. For more information, see the [Start and stop environments](../../../release-notes/overview-2026/2026-03-releasenotes.md#start-and-stop-environments) section. It is important to start it again once you are ready to push code to the Live environment, else the git remote will be offline.
+1. **Take the Live environment offline:** This prevents outside processes from writing to the database or booting mid-migration. For more information, see the [Start and stop environments](../../../release-notes/overview-2026/2026-03-releasenotes.md#start-and-stop-environments) section. It is important to start it again once you are ready to push code to the Live environment, else the git remote will be offline. To control what visitors see while the environment is stopped, upload a custom maintenance page beforehand using the [Error Pages](../../../build-and-customize-your-solution/handle-deployments-and-environments/error-pages.md) feature. The environment displays the assigned page for as long as it is stopped.
 2. **Back up and verify the Live database:** If Cloud's migration attempt failed partway, restore from a clean backup first to ensure a known-good starting state. For more information, see the [Restore Database](../../../build-and-customize-your-solution/set-up-your-project/databases/backups.md#restore-database) article.
 3. **Allowlist your IP address:** Open the **SQL connection details** for the **Live** environment in the Cloud Portal and **allowlist your IP address**. For more information, see the [Project Settings](../../../build-and-customize-your-solution/set-up-your-project/project-settings/README.md) and [Working with a Cloud database locally](../../../build-and-customize-your-solution/set-up-your-project/databases/cloud-database/local-database.md) articles.
 4. **Configure your connection string:** Check on your machine the exact codebase and version that is currently deployed to Live, and point its connection string at the Live database. Ensure you set an appropriate [`Connection Timeout`](https://learn.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlconnection.connectiontimeout?) value in the [`ConnectionString`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?) inside your `appsettings.json` file.

--- a/umbraco-cloud/release-notes/overview-2026/2026-03-releasenotes.md
+++ b/umbraco-cloud/release-notes/overview-2026/2026-03-releasenotes.md
@@ -59,10 +59,6 @@ You can now start and stop your Cloud environments directly from the project ove
 
 <figure><img src="../../.gitbook/assets/start-stop-environments.png" alt="Environment context menu showing Restart and Stop options"><figcaption><p>The environment context menu now includes options to stop and restart environments.</p></figcaption></figure>
 
-{% hint style="info" %}
-As of August 2026, custom error pages are also shown while an environment is stopped. See the [Error Pages](../../build-and-customize-your-solution/handle-deployments-and-environments/error-pages.md) article for how to upload and assign a custom page.
-{% endhint %}
-
 ## Release Umbraco.Cloud.Cms 17.1.0
 
 A release of Umbraco.Cloud.Cms has been created. This version does not contain any user-facing changes. It contains code preparing for the upcoming Load Balancing feature.

--- a/umbraco-cloud/release-notes/overview-2026/2026-03-releasenotes.md
+++ b/umbraco-cloud/release-notes/overview-2026/2026-03-releasenotes.md
@@ -59,6 +59,10 @@ You can now start and stop your Cloud environments directly from the project ove
 
 <figure><img src="../../.gitbook/assets/start-stop-environments.png" alt="Environment context menu showing Restart and Stop options"><figcaption><p>The environment context menu now includes options to stop and restart environments.</p></figcaption></figure>
 
+{% hint style="info" %}
+As of August 2026, custom error pages are also shown while an environment is stopped. See the [Error Pages](../../build-and-customize-your-solution/handle-deployments-and-environments/error-pages.md) article for how to upload and assign a custom page.
+{% endhint %}
+
 ## Release Umbraco.Cloud.Cms 17.1.0
 
 A release of Umbraco.Cloud.Cms has been created. This version does not contain any user-facing changes. It contains code preparing for the upcoming Load Balancing feature.

--- a/umbraco-cloud/release-notes/overview-2026/2026-08-releasenotes.md
+++ b/umbraco-cloud/release-notes/overview-2026/2026-08-releasenotes.md
@@ -2,7 +2,16 @@
 
 ## Key Takeaways
 
+* **Custom error pages shown for stopped environments** - Custom error pages are now also shown while an environment is stopped, not only during restarts and deployments.
 * **Release Umbraco.Cloud.Cms 13.1.1, 17.2.2, & 18.0.2** - Hides the internal `azurewebsites.net` URL in additional cases. Adds the routes used by Umbraco ID and external login providers to the `ReservedUrls` setting.
+
+## Custom error pages shown for stopped environments
+
+Custom error pages assigned through the [Error Pages](../../build-and-customize-your-solution/handle-deployments-and-environments/error-pages.md) feature are now also shown while an environment is stopped.
+
+When the [Start and stop environments](2026-03-releasenotes.md#start-and-stop-environments) feature was released, stopped environments served the default Umbraco Cloud error page. This happened even when a custom error page was assigned to the hostname. Stopped environments now serve the assigned custom error page, matching the behavior during restarts and deployments.
+
+This also makes the two features work well together for planned maintenance. Upload a custom maintenance page, assign it to your hostnames, and stop the environment. Visitors then see your maintenance page until you start the environment again.
 
 ## Release Umbraco.Cloud.Cms 13.1.1, 17.2.2, & 18.0.2
 

--- a/umbraco-cloud/release-notes/overview-2026/2026-08-releasenotes.md
+++ b/umbraco-cloud/release-notes/overview-2026/2026-08-releasenotes.md
@@ -9,7 +9,7 @@
 
 Custom error pages assigned through the [Error Pages](../../build-and-customize-your-solution/handle-deployments-and-environments/error-pages.md) feature are now also shown while an environment is stopped.
 
-When the [Start and stop environments](2026-03-releasenotes.md#start-and-stop-environments) feature was released, stopped environments served the default Umbraco Cloud error page. This happened even when a custom error page was assigned to the hostname. Stopped environments now serve the assigned custom error page, matching the behavior during restarts and deployments.
+When the [Start and stop environments](2026-03-releasenotes.md#start-and-stop-environments) feature was released it did not use the Error Pages feature but instead used a standard platform error page that you could not change. This now ensures you can use a custom error page, matching the behavior during restarts and deployments.
 
 This also makes the two features work well together for planned maintenance. Upload a custom maintenance page, assign it to your hostnames, and stop the environment. Visitors then see your maintenance page until you start the environment again.
 

--- a/umbraco-cloud/release-notes/overview-2026/README.md
+++ b/umbraco-cloud/release-notes/overview-2026/README.md
@@ -8,6 +8,7 @@ Each item is prefixed with the date (DD/MM) it was added to the release notes. U
 
 ## [August 2026](2026-08-releasenotes.md)
 
+* [20/08] - **Custom error pages shown for stopped environments** - Custom error pages are now also shown while an environment is stopped, not only during restarts and deployments.
 * [13/08] - **Release Umbraco.Cloud.Cms 13.1.1, 17.2.2, & 18.0.2** - Hides the internal azurewebsites.net URL in additional cases. Adds the routes used by Umbraco ID and external login providers to the ReservedUrls setting.
 
 ## [July 2026](2026-07-releasenotes.md)


### PR DESCRIPTION
## 📋 Description

Custom error pages on Umbraco Cloud are now also shown while an environment is stopped. Previously, stopping an environment (feature released March 2026) served the default Umbraco Cloud error page even when a custom page was assigned. This PR documents the change released on 20/08:

* Adds the 20/08 release note to the August 2026 release notes and the 2026 overview.
* Updates the Error Pages article to mention that error pages are also shown while an environment is stopped.
* Updates "Planning Major Upgrades Safely for Live Environments": the maintenance-window hint and the "Take the Live environment offline" step now mention uploading a custom maintenance page via the Error Pages feature, which is displayed while the environment is stopped.

Written with AI assistance (Claude Code), reviewed by me.

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Cloud (release notes + Cloud documentation, not version-specific).

## Deadline (if relevant)

Feature is released today (20-08-2026), so publishing as soon as possible is preferred.