### PR TITLE
Clarify Document Type options are creation presets, not extensible defaults

### DIFF
--- a/17/umbraco-cms/.gitbook.yaml
+++ b/17/umbraco-cms/.gitbook.yaml
@@ -262,7 +262,7 @@ redirects:
     fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/user-picker: model-your-content/property-editors/built-in-umbraco-property-editors/user-picker.md
     fundamentals/data: model-your-content/content-types-and-structure/data/README.md
     fundamentals/data/defining-content: model-your-content/content-types-and-structure/data/defining-content/README.md
-    fundamentals/data/defining-content/default-document-types: model-your-content/content-types-and-structure/data/defining-content/default-document-types.md
+    fundamentals/data/defining-content/default-document-types: model-your-content/content-types-and-structure/data/defining-content/document-type-options.md
     fundamentals/data/defining-content/document-type-localization: model-your-content/content-types-and-structure/data/defining-content/document-type-localization.md
     fundamentals/data/adding-tabs: model-your-content/content-types-and-structure/data/defining-content/adding-tabs.md
     fundamentals/data/creating-media: model-your-content/content-types-and-structure/data/creating-media/README.md
@@ -724,3 +724,4 @@ redirects:
     extend-your-project/backoffice-extensions/utilities/modals/confirm-dialog: extend-your-project/backoffice-extensions/extending-overview/extension-types/modals/confirm-dialog.md
     extend-your-project/backoffice-extensions/utilities/sorting: extend-your-project/backoffice-extensions/sorting.md
     extend-your-project/backoffice-extensions/utilities/modals: extend-your-project/backoffice-extensions/extending-overview/extension-types/modals/README.md
+    model-your-content/content-types-and-structure/data/defining-content/default-document-types: model-your-content/content-types-and-structure/data/defining-content/document-type-options.md

--- a/17/umbraco-cms/SUMMARY.md
+++ b/17/umbraco-cms/SUMMARY.md
@@ -68,7 +68,7 @@
 * [Content Types and Structure](model-your-content/content-types-and-structure/README.md)
   * [Data](model-your-content/content-types-and-structure/data/README.md)
     * [Defining Content](model-your-content/content-types-and-structure/data/defining-content/README.md)
-      * [Default Document Types](model-your-content/content-types-and-structure/data/defining-content/default-document-types.md)
+      * [Document Type Options](model-your-content/content-types-and-structure/data/defining-content/document-type-options.md)
       * [Document Type Localization](model-your-content/content-types-and-structure/data/defining-content/document-type-localization.md)
       * [Using Tabs](model-your-content/content-types-and-structure/data/defining-content/adding-tabs.md)
     * [Creating Media](model-your-content/content-types-and-structure/data/creating-media/README.md)

--- a/17/umbraco-cms/model-your-content/content-types-and-structure/data/defining-content/README.md
+++ b/17/umbraco-cms/model-your-content/content-types-and-structure/data/defining-content/README.md
@@ -30,7 +30,7 @@ A Document Type is created using the Document Type editor in the **Settings** se
 
 ![CreateDoctype](../../../../.gitbook/assets/CreateDoctype.png)
 
-You can also choose to create a **Document Type** without a template and create **Folders** to organize your Document Types. Other options are to create Compositions and Element types, which you can read more about in the [Default Document Types](default-document-types.md) section.
+You can also choose to create a **Document Type** without a template and create **Folders** to organize your Document Types. Other options are to create Compositions and Element types, which you can read more about in the [Document Type Options](document-type-options.md) section.
 
 ## 2. Defining the root node
 

--- a/17/umbraco-cms/model-your-content/content-types-and-structure/data/defining-content/document-type-options.md
+++ b/17/umbraco-cms/model-your-content/content-types-and-structure/data/defining-content/document-type-options.md
@@ -1,12 +1,12 @@
 ---
 description: >-
-  On this page, you will find the default Document Types in Umbraco. If you want
-  to use these document types, you can create them in the Settings section.
+  Learn about the Document Type options available when you create a new
+  Document Type in Umbraco, and when to use each one.
 ---
 
-# Default Document Types
+# Document Type Options
 
-On this page, you will find the default Document Types in Umbraco. If you want to use these Document Types, you can create them in the Settings section.
+When you create a Document Type in the Settings section, you choose between four options. This article describes each option and when to use it.
 
 ![Create Document Type](../../../../.gitbook/assets/CreateDoctype.png)
 

--- a/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/block-editor/block-grid-editor.md
+++ b/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/block-editor/block-grid-editor.md
@@ -39,7 +39,7 @@ The Data Type editor allows you to configure the following properties:
 
 ## Setup Block Types
 
-Block Types are based on [**Element Types**](../../../content-types-and-structure/data/defining-content/default-document-types.md#element-type). These can be created beforehand or while setting up your Block Types.
+Block Types are based on [**Element Types**](../../../content-types-and-structure/data/defining-content/document-type-options.md#element-type). These can be created beforehand or while setting up your Block Types.
 
 Once you have added an Element Type as a Block Type on your Block Grid Data Type you have the option to configure it.
 

--- a/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/block-editor/block-level-variance.md
+++ b/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/block-editor/block-level-variance.md
@@ -18,9 +18,9 @@ This is known as Block Level Variance:
 
 Block Level Variance is achieved when:
 
-* The [Document Type](../../../content-types-and-structure/data/defining-content/default-document-types.md#document-type) is configured for variance, and
+* The [Document Type](../../../content-types-and-structure/data/defining-content/document-type-options.md#document-type) is configured for variance, and
 * The Block Editor property is _not_ configured for variance, and
-* The Block Editor property editor is configured to use [Element Types](../../../content-types-and-structure/data/defining-content/default-document-types.md#element-type) that _do_ vary.
+* The Block Editor property editor is configured to use [Element Types](../../../content-types-and-structure/data/defining-content/document-type-options.md#element-type) that _do_ vary.
 
 ## The "unexposed" Block state
 

--- a/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/block-editor/block-list-editor.md
+++ b/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/block-editor/block-list-editor.md
@@ -6,7 +6,7 @@
 
 `Returns: IEnumerable<BlockListItem>`
 
-**Block List** is a list editing property editor, using [Element Types](../../../content-types-and-structure/data/defining-content/default-document-types.md#element-type) to define the list item schema.
+**Block List** is a list editing property editor, using [Element Types](../../../content-types-and-structure/data/defining-content/document-type-options.md#element-type) to define the list item schema.
 
 {% hint style="info" %}
 The _Block List_ replaces the obsolete _Nested Content_ editor.

--- a/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/rich-text-editor/blocks.md
+++ b/17/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/rich-text-editor/blocks.md
@@ -1,6 +1,6 @@
 # Blocks
 
-Blocks enable editors to insert structured content elements directly into the Rich Text Editor (RTE). Blocks are [Element Types](../../../content-types-and-structure/data/defining-content/default-document-types.md#element-type) and can be configured with custom properties, styling, and behavior.
+Blocks enable editors to insert structured content elements directly into the Rich Text Editor (RTE). Blocks are [Element Types](../../../content-types-and-structure/data/defining-content/document-type-options.md#element-type) and can be configured with custom properties, styling, and behavior.
 
 Blocks can be added to the Rich Text Editor when:
 
@@ -217,6 +217,6 @@ Building Custom Views for Block representations in Backoffice is the same for al
 
 ## Related Articles
 
-* [Element Types](../../../content-types-and-structure/data/defining-content/default-document-types.md#element-type)
+* [Element Types](../../../content-types-and-structure/data/defining-content/document-type-options.md#element-type)
 * [Rich Text Editor Configuration](configuration.md)
 * [Rich Text Editor Extensions](extensions.md)

--- a/18/umbraco-cms/.gitbook.yaml
+++ b/18/umbraco-cms/.gitbook.yaml
@@ -209,3 +209,4 @@ redirects:
     extend-your-project/backoffice-extensions/utilities/modals/confirm-dialog: extend-your-project/backoffice-extensions/extending-overview/extension-types/modals/confirm-dialog.md
     extend-your-project/backoffice-extensions/utilities/sorting: extend-your-project/backoffice-extensions/sorting.md
     extend-your-project/backoffice-extensions/utilities/modals: extend-your-project/backoffice-extensions/extending-overview/extension-types/modals/README.md
+    model-your-content/content-types-and-structure/data/defining-content/default-document-types: model-your-content/content-types-and-structure/data/defining-content/document-type-options.md

--- a/18/umbraco-cms/SUMMARY.md
+++ b/18/umbraco-cms/SUMMARY.md
@@ -67,7 +67,7 @@
 * [Content Types and Structure](model-your-content/content-types-and-structure/README.md)
   * [Data](model-your-content/content-types-and-structure/data/README.md)
     * [Defining Content](model-your-content/content-types-and-structure/data/defining-content/README.md)
-      * [Default Document Types](model-your-content/content-types-and-structure/data/defining-content/default-document-types.md)
+      * [Document Type Options](model-your-content/content-types-and-structure/data/defining-content/document-type-options.md)
       * [Document Type Localization](model-your-content/content-types-and-structure/data/defining-content/document-type-localization.md)
       * [Elements](model-your-content/content-types-and-structure/data/defining-content/elements.md)
       * [Using Tabs](model-your-content/content-types-and-structure/data/defining-content/adding-tabs.md)

--- a/18/umbraco-cms/model-your-content/content-types-and-structure/data/defining-content/README.md
+++ b/18/umbraco-cms/model-your-content/content-types-and-structure/data/defining-content/README.md
@@ -30,7 +30,7 @@ A Document Type is created using the Document Type editor in the **Settings** se
 
 ![Create Document Type](../../../../.gitbook/assets/create-document-type-18.png)
 
-You can also choose to create a **Document Type** without a template and create **Folders** to organize your Document Types. Other options are to create Compositions and Element types, which you can read more about in the [Default Document Types](default-document-types.md) section.
+You can also choose to create a **Document Type** without a template and create **Folders** to organize your Document Types. Other options are to create Compositions and Element types, which you can read more about in the [Document Type Options](document-type-options.md) section.
 
 ## 2. Defining the root node
 

--- a/18/umbraco-cms/model-your-content/content-types-and-structure/data/defining-content/document-type-options.md
+++ b/18/umbraco-cms/model-your-content/content-types-and-structure/data/defining-content/document-type-options.md
@@ -1,12 +1,12 @@
 ---
 description: >-
-  On this page, you will find the default Document Types in Umbraco. If you want
-  to use these document types, you can create them in the Settings section.
+  Learn about the Document Type options available when you create a new
+  Document Type in Umbraco, and when to use each one.
 ---
 
-# Default Document Types
+# Document Type Options
 
-On this page, you will find the default Document Types in Umbraco. If you want to use these Document Types, you can create them in the Settings section.
+When you create a Document Type in the Settings section, you choose between four options. This article describes each option and when to use it.
 
 ![Create Document Type](../../../../.gitbook/assets/create-document-type-options.png)
 

--- a/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/block-editor/block-grid-editor.md
+++ b/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/block-editor/block-grid-editor.md
@@ -36,7 +36,7 @@ The Data Type editor allows you to configure the following properties:
 
 ## Setup Block Types
 
-Block Types are based on [**Element Types**](../../../content-types-and-structure/data/defining-content/default-document-types.md#element-type). These can be created beforehand or while setting up your Block Types.
+Block Types are based on [**Element Types**](../../../content-types-and-structure/data/defining-content/document-type-options.md#element-type). These can be created beforehand or while setting up your Block Types.
 
 Once you have added an Element Type as a Block Type on your Block Grid Data Type you have the option to configure it.
 

--- a/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/block-editor/block-level-variance.md
+++ b/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/block-editor/block-level-variance.md
@@ -18,9 +18,9 @@ This is known as Block Level Variance:
 
 Block Level Variance is achieved when:
 
-* The [Document Type](../../../content-types-and-structure/data/defining-content/default-document-types.md#document-type) is configured for variance, and
+* The [Document Type](../../../content-types-and-structure/data/defining-content/document-type-options.md#document-type) is configured for variance, and
 * The Block Editor property is _not_ configured for variance, and
-* The Block Editor property editor is configured to use [Element Types](../../../content-types-and-structure/data/defining-content/default-document-types.md#element-type) that _do_ vary.
+* The Block Editor property editor is configured to use [Element Types](../../../content-types-and-structure/data/defining-content/document-type-options.md#element-type) that _do_ vary.
 
 ## The "unexposed" Block state
 

--- a/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/block-editor/block-list-editor.md
+++ b/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/block-editor/block-list-editor.md
@@ -6,7 +6,7 @@
 
 `Returns: IEnumerable<BlockListItem>`
 
-**Block List** is a list editing property editor, using [Element Types](../../../content-types-and-structure/data/defining-content/default-document-types.md#element-type) to define the list item schema.
+**Block List** is a list editing property editor, using [Element Types](../../../content-types-and-structure/data/defining-content/document-type-options.md#element-type) to define the list item schema.
 
 {% hint style="info" %}
 The single-mode Block List migration now runs by default when upgrading to v18. If you have custom property editors that nest Block List values, you must implement and register `ITypedSingleBlockListProcessor` before upgrading. See the [Single block migration](../../../../get-started/upgrading-and-migrating/version-specific/single-block-migration.md) article for details.

--- a/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/rich-text-editor/blocks.md
+++ b/18/umbraco-cms/model-your-content/property-editors/built-in-umbraco-property-editors/rich-text-editor/blocks.md
@@ -1,6 +1,6 @@
 # Blocks
 
-Blocks enable editors to insert structured content elements directly into the Rich Text Editor (RTE). Blocks are [Element Types](../../../content-types-and-structure/data/defining-content/default-document-types.md#element-type) and can be configured with custom properties, styling, and behavior.
+Blocks enable editors to insert structured content elements directly into the Rich Text Editor (RTE). Blocks are [Element Types](../../../content-types-and-structure/data/defining-content/document-type-options.md#element-type) and can be configured with custom properties, styling, and behavior.
 
 Blocks can be added to the Rich Text Editor when:
 
@@ -219,6 +219,6 @@ Building Custom Views for Block representations in Backoffice is the same for al
 
 ## Related Articles
 
-* [Element Types](../../../content-types-and-structure/data/defining-content/default-document-types.md#element-type)
+* [Element Types](../../../content-types-and-structure/data/defining-content/document-type-options.md#element-type)
 * [Rich Text Editor Configuration](configuration.md)
 * [Rich Text Editor Extensions](extensions.md)


### PR DESCRIPTION
## 📋 Description

The "Default Document Types" article title implied a fixed list of Document Types you could extend, but it actually documents the four options (Document Type, Document Type with Template, Element Type, Folder) that pre-configure settings when you create a new Document Type. Renamed the article to "Document Type Options" and reworded the intro to reflect that. Updated `SUMMARY.md`, inbound links, and added redirects for v17 and v18.

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco CMS 17, 18

## Deadline (if relevant)

N/A