### PR TITLE
Add Umbraco Commerce 17.2.3 release notes

### DIFF
--- a/17/umbraco-commerce/release-notes/README.md
+++ b/17/umbraco-commerce/release-notes/README.md
@@ -18,6 +18,11 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 This section contains the release notes for Umbraco Commerce 17 including all changes for this version.
 
+#### 17.2.3 (21st Aug 2026)
+* Fix a startup crash on large stores during the customer data migration [#883](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/883)
+* Fix cart cleanup failing with a foreign key constraint error on large stores [#874](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/874)
+* Fix payment provider callback URLs trusting a spoofable `X-Original-Host` header
+
 #### 17.2.2 (17th Aug 2026)
 * Fix a backoffice crash when viewing an order linked to a customer by member key or another non-ID reference [#878](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/878)
 * Fix data corruption from a discount migration that could invalidate member-group discount rules [#877](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/877)

--- a/17/umbraco-commerce/release-notes/README.md
+++ b/17/umbraco-commerce/release-notes/README.md
@@ -20,7 +20,7 @@ This section contains the release notes for Umbraco Commerce 17 including all ch
 
 #### 17.2.3 (21st Aug 2026)
 * Fix a startup crash on large stores during the customer data migration [#883](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/883)
-* Fix cart cleanup failing with a foreign key constraint error on large stores [#874](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/874)
+* Fix cart cleanup failing with a foreign key constraint error on large stores [#882](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/882)
 * Fix payment provider callback URLs trusting a spoofable `X-Original-Host` header
 
 #### 17.2.2 (17th Aug 2026)


### PR DESCRIPTION
## Summary
- Adds the 17.2.3 entry to the Umbraco Commerce 17 release notes, covering the three fixes shipped in this hotfix release: a startup crash on large stores during the customer data migration (#883), a cart cleanup foreign key constraint error on large stores (#882), and a payment provider callback URL security fix.

## Test plan
- [x] Matches the established formatting/tense/style of neighboring entries in this file

🤖 Generated with Claude Code