### PR TITLE
Add Umbraco Commerce 18.1.3 release notes

### DIFF
--- a/18/umbraco-commerce/release-notes/README.md
+++ b/18/umbraco-commerce/release-notes/README.md
@@ -21,7 +21,7 @@ This section contains the release notes for Umbraco Commerce 18, including all c
 #### 18.1.3 (21st Aug 2026)
 
 * Fixed a startup crash on large stores during the customer data migration ([#883](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/883)).
-* Fixed cart cleanup failing with a foreign key constraint error on large stores ([#874](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/874)).
+* Fixed cart cleanup failing with a foreign key constraint error on large stores ([#882](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/882)).
 * Fixed payment provider callback URLs trusting a spoofable `X-Original-Host` header.
 
 #### 18.1.2 (17th Aug 2026)

--- a/18/umbraco-commerce/release-notes/README.md
+++ b/18/umbraco-commerce/release-notes/README.md
@@ -18,6 +18,12 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 This section contains the release notes for Umbraco Commerce 18, including all changes for this version.
 
+#### 18.1.3 (21st Aug 2026)
+
+* Fixed a startup crash on large stores during the customer data migration ([#883](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/883)).
+* Fixed cart cleanup failing with a foreign key constraint error on large stores ([#874](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/874)).
+* Fixed payment provider callback URLs trusting a spoofable `X-Original-Host` header.
+
 #### 18.1.2 (17th Aug 2026)
 
 * Fixed a backoffice crash when viewing an order linked to a customer by member key or another non-ID reference ([#878](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/878)).


### PR DESCRIPTION
## Summary
- Adds the 18.1.3 entry to the Umbraco Commerce 18 release notes, covering the three fixes shipped in this hotfix release: a startup crash on large stores during the customer data migration (#883), a cart cleanup foreign key constraint error on large stores (#882), and a payment provider callback URL security fix.

## Test plan
- [x] Matches the established formatting/tense/style of neighboring entries in this file

🤖 Generated with Claude Code