### PR TITLE
Automate: Document advanced extension points

### DIFF
--- a/.github/styles/UmbracoDocs/Acronyms.yml
+++ b/.github/styles/UmbracoDocs/Acronyms.yml
@@ -26,6 +26,7 @@ exceptions:
   - CDN      # Content Delivery Network
   - CI       # Continuous Integration
   - CLI      # Command Line Interface
+  - CLR      # Common Language Runtime
   - CNAME    # 
   - CMD      # Command (Windows shell)
   - CMS      # Content Management System

--- a/.github/styles/config/dictionaries/umbraco.dic
+++ b/.github/styles/config/dictionaries/umbraco.dic
@@ -47,11 +47,13 @@ assignDomain
 async
 Auditability
 authorizer
+authorizers
 authProvider
 Axios
 autocomplete
 autocompletion
 autogenerate
+Automate's
 Automations
 automations
 Autoplay

--- a/17/umbraco-automate/SUMMARY.md
+++ b/17/umbraco-automate/SUMMARY.md
@@ -73,6 +73,9 @@
 * [Create a Custom Trigger](extending/custom-trigger.md)
 * [Create a Custom Action](extending/custom-action.md)
 * [Create a Custom Connection Type](extending/custom-connection-type.md)
+* [Schedule and Webhook Triggers](extending/schedule-and-webhook-triggers.md)
+* [Control What Runs](extending/controlling-execution.md)
+* [Additional Action Behavior](extending/action-behavior.md)
 
 ## Tutorials
 

--- a/17/umbraco-automate/extending/README.md
+++ b/17/umbraco-automate/extending/README.md
@@ -12,15 +12,20 @@ Umbraco Automate can be extended in C#. Add new triggers, actions, and connectio
 
 Choose the extension point that matches the behavior you want to add.
 
-| Extension Point                                              | Use Case                                                                                 |
-| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| [Create a Custom Trigger](custom-trigger.md)                 | React to a domain event or external signal that is not covered by the built-in triggers. |
-| [Create a Custom Action](custom-action.md)                   | Add a new unit of work that automations can use as a step.                               |
-| [Create a Custom Connection Type](custom-connection-type.md) | Add a new credential type for an external service.                                       |
+| Extension Point                                                       | Use Case                                                                                  |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [Create a Custom Trigger](custom-trigger.md)                          | React to a domain event or external signal that is not covered by the built-in triggers.  |
+| [Create a Custom Action](custom-action.md)                            | Add a new unit of work that automations can use as a step.                                |
+| [Create a Custom Connection Type](custom-connection-type.md)          | Add a new credential type for an external service.                                        |
+| [Schedule and Webhook Triggers](schedule-and-webhook-triggers.md)     | Fire a trigger on a cron schedule, from an inbound webhook, or from a non-Umbraco event.  |
+| [Control What Runs](controlling-execution.md)                         | Gate trigger dispatch, stop automation-triggered cycles, or wrap every action's execution. |
+| [Additional Action Behavior](action-behavior.md)                      | Give an action a dynamic output schema, an audit trail entry, or export-time redaction.   |
 
 ## How Discovery Works
 
 Triggers, actions, and connection types are auto-discovered at startup using Umbraco's type loader. Apply the relevant attribute (`[Trigger]`, `[Action]`, or `[ConnectionType]`) and inherit from the right base class. No manual registration is needed.
+
+Some extension points need explicit registration instead of attribute discovery — webhook authenticators, trigger dispatch authorizers, and action middleware. See the relevant article above for the registration call each one needs.
 
 ## See Also
 

--- a/17/umbraco-automate/extending/action-behavior.md
+++ b/17/umbraco-automate/extending/action-behavior.md
@@ -152,6 +152,8 @@ Replace the default only when a setting is conditionally sensitive in a way `IsS
 
 {% code title="MyProjectComposer.cs" %}
 ```csharp
+using Umbraco.Automate.Core.Automations.Transfer;
+
 builder.Services.AddSingleton<ISensitiveSettingsStripper, MyStripper>();
 ```
 {% endcode %}

--- a/17/umbraco-automate/extending/action-behavior.md
+++ b/17/umbraco-automate/extending/action-behavior.md
@@ -1,0 +1,169 @@
+---
+description: >-
+  Give an action a settings-driven output schema, write it to the audit
+  trail automatically, and control what gets stripped from it on export.
+---
+
+# Additional Action Behavior
+
+[Create a Custom Action](custom-action.md) covers the settings, output, and `ExecuteAsync` an action needs to run as a step. The extension points on this page add behavior most actions get for free, or opt into with a single interface.
+
+## A Settings-Driven Output Schema
+
+`ActionBase<TSettings, TOutput>` declares a fixed output shape from `TOutput`. Some actions cannot know their output shape until the step is configured. For example, an action that calls a user-defined API returns whatever that API responds with. Inherit from `DynamicOutputActionBase<TSettings>` instead, and compute the output schema from the resolved settings:
+
+{% code title="CallApiSettings.cs" %}
+```csharp
+using Umbraco.Automate.Core.Settings;
+
+namespace MyProject.Automate;
+
+public sealed class CallApiSettings
+{
+    [Field(Label = "URL", SupportsBindings = true)]
+    public string Url { get; set; } = string.Empty;
+
+    [Field(Label = "Response Schema", Description = "A JSON Schema describing the response body.")]
+    public string? ResponseSchemaJson { get; set; }
+}
+```
+{% endcode %}
+
+{% code title="CallApiAction.cs" %}
+```csharp
+using Json.Schema;
+using Umbraco.Automate.Core.Actions;
+
+namespace MyProject.Automate;
+
+[Action("myProject.callApi", "Call API",
+    Description = "Calls a user-configured endpoint and returns its response shape.",
+    Group = "My Project",
+    Icon = "icon-code")]
+public sealed class CallApiAction : DynamicOutputActionBase<CallApiSettings>
+{
+    public CallApiAction(ActionInfrastructure infrastructure)
+        : base(infrastructure)
+    {
+    }
+
+    protected override Task<JsonSchema?> GetOutputSchemaAsync(
+        CallApiSettings? settings,
+        CancellationToken cancellationToken = default)
+    {
+        // Required setting not yet configured — no schema to offer downstream steps.
+        if (string.IsNullOrEmpty(settings?.ResponseSchemaJson))
+        {
+            return Task.FromResult<JsonSchema?>(null);
+        }
+
+        return Task.FromResult<JsonSchema?>(JsonSchema.FromText(settings.ResponseSchemaJson));
+    }
+
+    public override async Task<ActionResult> ExecuteAsync(
+        ActionContext context,
+        CancellationToken cancellationToken)
+    {
+        var settings = context.GetSettings<CallApiSettings>();
+
+        // ...call settings.Url and shape the response to match the schema above...
+
+        return Success(new object());
+    }
+}
+```
+{% endcode %}
+
+Downstream steps bind to whatever fields the resolved schema describes, the same way they bind to a fixed `TOutput`'s properties. Return `null` from `GetOutputSchemaAsync` while a required setting is unset — Automate treats a null schema as "not configured yet" rather than an error.
+
+## An Audit Trail, From One Marker Interface
+
+Actions that modify CMS content or media can implement `ICmsAction`, a marker interface with no members:
+
+```csharp
+public interface ICmsAction;
+```
+
+Add it to an action that changes content. Automate's built-in audit trail middleware then writes a structured entry to Umbraco's audit log automatically, once the action completes successfully:
+
+{% code title="ArchivePageSettings.cs" %}
+```csharp
+using Umbraco.Automate.Core.Settings;
+
+namespace MyProject.Automate;
+
+public sealed class ArchivePageSettings
+{
+    [Field(Label = "Content Key", SupportsBindings = true)]
+    public string ContentKey { get; set; } = string.Empty;
+}
+```
+{% endcode %}
+
+{% code title="ArchivePageOutput.cs" %}
+```csharp
+namespace MyProject.Automate;
+
+public sealed class ArchivePageOutput
+{
+}
+```
+{% endcode %}
+
+{% code title="ArchivePageAction.cs" %}
+```csharp
+using Umbraco.Automate.Core.Actions;
+
+namespace MyProject.Automate;
+
+[Action("myProject.archivePage", "Archive Page",
+    Group = "My Project",
+    Icon = "icon-box",
+    RequiredSections = [Umbraco.Cms.Core.Constants.Applications.Content])]
+public sealed class ArchivePageAction
+    : ActionBase<ArchivePageSettings, ArchivePageOutput>, ICmsAction
+{
+    public ArchivePageAction(ActionInfrastructure infrastructure)
+        : base(infrastructure)
+    {
+    }
+
+    public override async Task<ActionResult> ExecuteAsync(
+        ActionContext context,
+        CancellationToken cancellationToken)
+    {
+        // ...move the content node...
+
+        return Success(new ArchivePageOutput());
+    }
+}
+```
+{% endcode %}
+
+Leave `ICmsAction` off actions that only read data — a **Get Content** action, for example — since a read produces nothing worth auditing. Automate writes the entry against the automation's service account, tagged with the action's alias and step. The step never fails if the audit write itself fails.
+
+## Secrets Stripped on Export
+
+Settings marked `IsSensitive = true` on a `[Field]` attribute are already masked in the backoffice and encrypted at rest. `ISensitiveSettingsStripper` is the service that acts on that flag when an automation leaves the system — through the in-app export flow or the [Deploy integration](../add-ons/deploy/README.md). Those values never land in a portable file.
+
+The default implementation strips every setting flagged `IsSensitive` from a trigger's, step's, or connection's settings, based on each one's settings schema. Most projects never need to touch this — mark the setting `IsSensitive` on its `[Field]` attribute and the default stripper handles it.
+
+Replace the default only when a setting is conditionally sensitive in a way `IsSensitive` cannot express on its own. For example, a field whose sensitivity depends on another setting's value:
+
+{% code title="MyProjectComposer.cs" %}
+```csharp
+builder.Services.AddSingleton<ISensitiveSettingsStripper, MyStripper>();
+```
+{% endcode %}
+
+{% hint style="warning" %}
+Registering a replacement overwrites Automate's own stripper rather than wrapping it. Automate's default implementation is internal and cannot be called from a replacement. A custom `ISensitiveSettingsStripper` needs to strip every `IsSensitive` field itself, not only the extra case it was written for.
+{% endhint %}
+
+## Registration
+
+`DynamicOutputActionBase` and `ICmsAction` need no registration beyond the `[Action]` attribute already required for any custom action. `ISensitiveSettingsStripper` needs the explicit `AddSingleton` registration shown above, and only when the default behavior is not enough.
+
+## Verify
+
+Restart your Umbraco site. Configure a dynamic-output action's settings and confirm downstream steps can bind to the fields its schema describes. Run a `ICmsAction` step and check Umbraco's audit log for the entry. Export the automation and confirm sensitive fields are absent from the exported file.

--- a/17/umbraco-automate/extending/controlling-execution.md
+++ b/17/umbraco-automate/extending/controlling-execution.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Gate trigger dispatch against your own permission model, stop automations
+  Gate trigger dispatch against your own permission model; stop automations
   from re-triggering each other, and wrap every action with custom
   cross-cutting logic.
 ---
@@ -157,7 +157,7 @@ Registration order sets the nesting order: middleware appended earlier wraps mid
 
 ## Registration
 
-`ITriggerDispatchAuthorizer` and `IActionMiddleware` implementations both need explicit registration on their collection builders — `AutomateTriggerDispatchAuthorizers()` and `AutomateActionMiddleware()`. `IAutomationOriginatedEventBehavior` needs no registration: implement it on a trigger settings class and Automate calls it directly during dispatch.
+`ITriggerDispatchAuthorizer` and `IActionMiddleware` implementations both need explicit registration on their collection builders — `AutomateTriggerDispatchAuthorizers()` and `AutomateActionMiddleware()`. `IAutomationOriginatedEventBehavior` needs no registration: implement it on a trigger settings class, and Automate calls it directly during dispatch.
 
 ## Verify
 

--- a/17/umbraco-automate/extending/controlling-execution.md
+++ b/17/umbraco-automate/extending/controlling-execution.md
@@ -32,12 +32,12 @@ public sealed class StoreScopedTriggerDispatchAuthorizer : ITriggerDispatchAutho
         // Return Success when this authorizer has nothing to say about the
         // given trigger or output — the dispatcher treats Success as "not
         // blocking", not "explicitly approved".
-        if (context.Output is not MyStoreScopedTriggerOutput output)
+        if (context.TypedOutput is not MyStoreScopedTriggerOutput output)
         {
             return Task.FromResult(AutomationAuthorizationResult.Success);
         }
 
-        var allowed = /* look up whether context.WorkspaceId may act on output.StoreId */ true;
+        var allowed = /* look up whether context.Automation.WorkspaceId may act on output.StoreId */ true;
 
         return Task.FromResult(allowed
             ? AutomationAuthorizationResult.Success
@@ -153,7 +153,7 @@ builder.AutomateActionMiddleware()
 ```
 {% endcode %}
 
-Registration order sets the nesting order: middleware appended earlier wraps middleware appended later. Placing custom middleware after the built-in error-handling middleware changes what it sees. Unhandled exceptions from the action already surface as a failed `ActionResult` by the time the middleware runs, rather than as a thrown exception.
+Registration order sets the nesting order: middleware appended earlier wraps middleware appended later, with the action itself innermost. Because `Append` always adds to the end of the list, custom middleware ends up inside the built-in error-handling middleware, not wrapping it. An unhandled exception from the action reaches custom middleware as a raw exception through its own call to `next`. Automate's error-handling middleware only converts it to a failed `ActionResult` afterward, once the exception has propagated back out past your middleware. Wrap your own call to `next` in a try/catch if your middleware needs to guarantee it always sees an `ActionResult`.
 
 ## Registration
 

--- a/17/umbraco-automate/extending/controlling-execution.md
+++ b/17/umbraco-automate/extending/controlling-execution.md
@@ -1,0 +1,164 @@
+---
+description: >-
+  Gate trigger dispatch against your own permission model, stop automations
+  from re-triggering each other, and wrap every action with custom
+  cross-cutting logic.
+---
+
+# Control What Runs
+
+The building blocks in [Create a Custom Trigger](custom-trigger.md) and [Create a Custom Action](custom-action.md) decide what a trigger or action does. The extension points on this page decide whether it gets to run at all, and what happens around it when it does.
+
+## Gate Dispatch With Your Own Permission Model
+
+A trigger's own `CanHandle` method filters events by business logic — for example, only entities whose name matches a prefix. `ITriggerDispatchAuthorizer` is a separate, later check: it runs per automation at dispatch time, after `CanHandle` has already matched.
+
+Automate ships a built-in authorizer that checks the workspace service account's CMS start-node access. Register your own to gate against a permission model that CMS start nodes cannot express, such as a per-tenant or per-store allowlist.
+
+{% code title="StoreScopedTriggerDispatchAuthorizer.cs" %}
+```csharp
+using Umbraco.Automate.Core.Dispatch;
+using Umbraco.Automate.Core.Dispatch.Authorization;
+using Umbraco.Automate.Core.Security;
+
+namespace MyProject.Automate;
+
+public sealed class StoreScopedTriggerDispatchAuthorizer : ITriggerDispatchAuthorizer
+{
+    public Task<AutomationAuthorizationResult> AuthorizeAsync(
+        TriggerDispatchAuthorizationContext context,
+        CancellationToken cancellationToken)
+    {
+        // Return Success when this authorizer has nothing to say about the
+        // given trigger or output — the dispatcher treats Success as "not
+        // blocking", not "explicitly approved".
+        if (context.Output is not MyStoreScopedTriggerOutput output)
+        {
+            return Task.FromResult(AutomationAuthorizationResult.Success);
+        }
+
+        var allowed = /* look up whether context.WorkspaceId may act on output.StoreId */ true;
+
+        return Task.FromResult(allowed
+            ? AutomationAuthorizationResult.Success
+            : AutomationAuthorizationResult.Fail("Workspace is not scoped to this store."));
+    }
+}
+```
+{% endcode %}
+
+Register it on the authorizer collection:
+
+{% code title="MyProjectComposer.cs" %}
+```csharp
+builder.AutomateTriggerDispatchAuthorizers()
+    .Add<StoreScopedTriggerDispatchAuthorizer>();
+```
+{% endcode %}
+
+Authorizers run in registration order. The first result with `Authorized = false` skips the run for that automation, and no further authorizer is consulted for it.
+
+## Stop Automations From Re-Triggering Each Other
+
+An action that publishes content can itself raise the notification a **Content Published** trigger listens for. Left unchecked, that lets one automation's actions start another automation, which can start another, and so on.
+
+Trigger settings that implement `IAutomationOriginatedEventBehavior` control this per trigger. Automate consults it whenever an incoming event was itself caused by an automation run:
+
+```csharp
+public interface IAutomationOriginatedEventBehavior
+{
+    AutomationOriginatedEventBehavior OnAutomationOriginated { get; }
+}
+```
+
+`AutomationOriginatedEventBehavior` has three values:
+
+| Value | Effect |
+| --- | --- |
+| `Run` | The trigger fires normally, even for automation-originated events. |
+| `SkipOnCycle` | The trigger skips only when firing would re-enter the same automation. This is the default. |
+| `SkipAlways` | The trigger never fires for automation-originated events. |
+
+Implement the interface explicitly on the settings Plain Old CLR Object (POCO) so a string-backed dropdown property can still satisfy it:
+
+{% code title="MyCustomTriggerSettings.cs" %}
+```csharp
+using Umbraco.Automate.Core.Settings;
+using Umbraco.Automate.Core.Triggers;
+
+namespace MyProject.Automate;
+
+public sealed class MyCustomTriggerSettings : IAutomationOriginatedEventBehavior
+{
+    [Field(Label = "On automation-originated event")]
+    public string OnAutomationOriginatedEvent { get; set; }
+        = nameof(AutomationOriginatedEventBehavior.SkipOnCycle);
+
+    AutomationOriginatedEventBehavior IAutomationOriginatedEventBehavior.OnAutomationOriginated
+        => Enum.TryParse<AutomationOriginatedEventBehavior>(
+            OnAutomationOriginatedEvent, ignoreCase: true, out var value)
+            ? value
+            : AutomationOriginatedEventBehavior.SkipOnCycle;
+}
+```
+{% endcode %}
+
+## Wrap Every Action With Custom Logic
+
+`IActionMiddleware` wraps action execution the way ASP.NET Core middleware wraps a request. Each registered middleware can inspect or modify the context before calling the action, react to the result afterwards, or short-circuit entirely.
+
+Automate's own audit trail, error handling, and settings validation are all built as middleware. Add your own for logging, metrics, or a cross-cutting policy that every action should honor.
+
+{% code title="StepTimingMiddleware.cs" %}
+```csharp
+using Umbraco.Automate.Core.Actions.Middleware;
+
+namespace MyProject.Automate;
+
+public sealed class StepTimingMiddleware : IActionMiddleware
+{
+    private readonly ILogger<StepTimingMiddleware> _logger;
+
+    public StepTimingMiddleware(ILogger<StepTimingMiddleware> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<ActionResult> ApplyAsync(
+        ActionContext context,
+        ActionMiddlewareDelegate next,
+        CancellationToken cancellationToken)
+    {
+        var start = DateTimeOffset.UtcNow;
+
+        var result = await next(context, cancellationToken);
+
+        _logger.LogInformation(
+            "{ActionAlias} took {Elapsed}",
+            context.ActionAlias,
+            DateTimeOffset.UtcNow - start);
+
+        return result;
+    }
+}
+```
+{% endcode %}
+
+Middleware is not auto-discovered. Append it to the collection in registration order, alongside the built-in middleware:
+
+{% code title="MyProjectComposer.cs" %}
+```csharp
+builder.AutomateActionMiddleware()
+    .Append<StepTimingMiddleware>();
+```
+{% endcode %}
+
+Registration order sets the nesting order: middleware appended earlier wraps middleware appended later. Placing custom middleware after the built-in error-handling middleware changes what it sees. Unhandled exceptions from the action already surface as a failed `ActionResult` by the time the middleware runs, rather than as a thrown exception.
+
+## Registration
+
+`ITriggerDispatchAuthorizer` and `IActionMiddleware` implementations both need explicit registration on their collection builders — `AutomateTriggerDispatchAuthorizers()` and `AutomateActionMiddleware()`. `IAutomationOriginatedEventBehavior` needs no registration: implement it on a trigger settings class and Automate calls it directly during dispatch.
+
+## Verify
+
+Restart your Umbraco site. Trigger the event your authorizer or middleware targets, then check the automation's run history. A blocked dispatch produces no run. A re-triggered cycle produces no second run once `SkipOnCycle` or `SkipAlways` is set.

--- a/17/umbraco-automate/extending/schedule-and-webhook-triggers.md
+++ b/17/umbraco-automate/extending/schedule-and-webhook-triggers.md
@@ -1,0 +1,205 @@
+---
+description: >-
+  Build triggers that fire on a schedule, respond to webhooks, or react to
+  any .NET event using ScheduledTriggerBase, WebhookTriggerBase, and
+  IEventTrigger.
+---
+
+# Schedule and Webhook Triggers
+
+[Create a Custom Trigger](custom-trigger.md) covers the most common case: a trigger that reacts to an Umbraco notification. Automate also ships base classes for two other common cases, and an interface for events that come from neither Umbraco nor a schedule.
+
+## Trigger on a Schedule
+
+Inherit from `ScheduledTriggerBase<TSettings, TOutput>` to build a trigger that fires on a cron expression instead of an event. Override `GetCronExpression` to read the expression from the trigger's own settings.
+
+{% code title="DailyDigestTriggerSettings.cs" %}
+```csharp
+using Umbraco.Automate.Core.Settings;
+
+namespace MyProject.Automate;
+
+public sealed class DailyDigestTriggerSettings
+{
+    [Field(Label = "Cron Expression", Description = "When the digest should run.")]
+    public string CronExpression { get; set; } = "0 6 * * *";
+
+    [Field(Label = "Time Zone", Description = "An IANA or Windows time zone ID.")]
+    public string TimeZoneId { get; set; } = "UTC";
+}
+```
+{% endcode %}
+
+{% code title="DailyDigestTriggerOutput.cs" %}
+```csharp
+namespace MyProject.Automate;
+
+public sealed class DailyDigestTriggerOutput
+{
+    public DateTimeOffset FiredAtUtc { get; init; }
+}
+```
+{% endcode %}
+
+{% code title="DailyDigestTrigger.cs" %}
+```csharp
+using Umbraco.Automate.Core.Triggers;
+
+namespace MyProject.Automate;
+
+[Trigger("myProject.dailyDigest", "Daily Digest",
+    Description = "Fires on a cron schedule.",
+    Group = "My Project",
+    Icon = "icon-time")]
+public sealed class DailyDigestTrigger
+    : ScheduledTriggerBase<DailyDigestTriggerSettings, DailyDigestTriggerOutput>
+{
+    public DailyDigestTrigger(TriggerInfrastructure infrastructure)
+        : base(infrastructure)
+    {
+    }
+
+    public override string GetCronExpression(object? settings)
+        => (settings as DailyDigestTriggerSettings)?.CronExpression ?? "0 6 * * *";
+}
+```
+{% endcode %}
+
+`GetTimeZone` defaults to UTC. Override it to evaluate the cron expression against the settings' configured time zone instead:
+
+```csharp
+public override TimeZoneInfo GetTimeZone(object? settings)
+    => TimeZoneInfo.FindSystemTimeZoneById(
+        (settings as DailyDigestTriggerSettings)?.TimeZoneId ?? "UTC");
+```
+
+## Trigger from a Webhook
+
+Inherit from `WebhookTriggerBase<TSettings, TOutput>` to build a trigger that starts an automation from an inbound HTTP request, instead of a CMS event.
+
+{% code title="OrderPaidTriggerSettings.cs" %}
+```csharp
+namespace MyProject.Automate;
+
+public sealed class OrderPaidTriggerSettings
+{
+}
+```
+{% endcode %}
+
+{% code title="OrderPaidTriggerOutput.cs" %}
+```csharp
+namespace MyProject.Automate;
+
+public sealed class OrderPaidTriggerOutput
+{
+    public string OrderReference { get; init; } = string.Empty;
+
+    public decimal AmountPaid { get; init; }
+}
+```
+{% endcode %}
+
+{% code title="OrderPaidTrigger.cs" %}
+```csharp
+using Umbraco.Automate.Core.Triggers;
+
+namespace MyProject.Automate;
+
+[Trigger("myProject.orderPaid", "Order Paid",
+    Description = "Fires when the payment provider posts a paid webhook.",
+    Group = "My Project",
+    Icon = "icon-coins")]
+public sealed class OrderPaidTrigger
+    : WebhookTriggerBase<OrderPaidTriggerSettings, OrderPaidTriggerOutput>
+{
+    public OrderPaidTrigger(TriggerInfrastructure infrastructure)
+        : base(infrastructure)
+    {
+    }
+}
+```
+{% endcode %}
+
+A webhook trigger receives its payload through Automate's webhook endpoint. Map the posted body to trigger output the same way a notification-based trigger maps a notification — see [Create a Custom Trigger](custom-trigger.md) for the `MapEvent` and `CanHandle` pattern.
+
+### Verifying the Request Came From Your Vendor
+
+An inbound webhook URL is public. Verify the request before trusting its payload by implementing `IWebhookAuthenticator`, or by inheriting the convenience base class `WebhookAuthenticatorBase<TSettings>`. It reads discovery metadata from a `[WebhookAuthenticator]` attribute and derives the settings schema from `TSettings` automatically.
+
+{% code title="StripeWebhookAuthenticator.cs" %}
+```csharp
+using Umbraco.Automate.Core.Settings;
+using Umbraco.Automate.Core.Triggers.Webhooks;
+
+namespace MyProject.Automate;
+
+public sealed class StripeWebhookAuthenticatorSettings
+{
+    [Field(Label = "Signing Secret", IsSensitive = true)]
+    public string? SigningSecret { get; set; }
+}
+
+[WebhookAuthenticator("stripe", "Stripe Signature")]
+public sealed class StripeWebhookAuthenticator
+    : WebhookAuthenticatorBase<StripeWebhookAuthenticatorSettings>
+{
+    protected override bool Validate(
+        WebhookAuthenticationContext context,
+        StripeWebhookAuthenticatorSettings settings)
+    {
+        // Read the "Stripe-Signature" header from context.Request,
+        // recompute it from context.Body and settings.SigningSecret,
+        // and compare using a constant-time comparison.
+        return true;
+    }
+}
+```
+{% endcode %}
+
+Set `RequiresBody` to `false` when a scheme validates against headers alone. Automate skips reading the request body before calling `Validate`. Callers get a fast 401 response for unauthorized requests on large payloads instead of waiting on a body read that gets discarded anyway.
+
+Unlike triggers and actions, webhook authenticators are not auto-discovered from the `[WebhookAuthenticator]` attribute alone. Register each one explicitly:
+
+{% code title="MyProjectComposer.cs" %}
+```csharp
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+
+namespace MyProject.Automate;
+
+public sealed class MyProjectComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.AutomateWebhookAuthenticators()
+            .Add<StripeWebhookAuthenticator>();
+    }
+}
+```
+{% endcode %}
+
+The attribute supplies the alias, display name, and description shown in the authentication strategy picker on the webhook trigger's settings. The collection registration is what makes the authenticator selectable.
+
+## Trigger from Any .NET Event
+
+Umbraco notifications are the most common event source, but not the only one. `IEventTrigger<TEvent>` declares that a trigger responds to events of type `TEvent`. `NotificationTriggerBase<TSettings, TOutput, TNotification>`, the base class used in [Create a Custom Trigger](custom-trigger.md), implements this interface for Umbraco notifications specifically:
+
+```csharp
+public interface IEventTrigger<in TEvent>
+{
+    IEnumerable<TriggerEvent> MapEvent(TEvent @event);
+}
+```
+
+For an Umbraco notification, `NotificationTriggerBase` already wires up the dispatcher. A trigger that inherits from it and overrides `MapEvent` is discovered and connected automatically, as shown in [Create a Custom Trigger](custom-trigger.md).
+
+For an event that is not an Umbraco notification, `MapEvent` still describes how to turn one event into zero or more `TriggerEvent` instances. Nothing in the framework calls it automatically — publish the event and invoke the trigger's `MapEvent` from your own listener.
+
+## Registration
+
+Scheduled and webhook triggers are discovered at startup the same way as notification triggers — by their `[Trigger]` attribute and base class. Webhook authenticators are the exception and need the explicit `AutomateWebhookAuthenticators()` registration shown above.
+
+## Verify
+
+Restart your Umbraco site. A scheduled trigger appears in the trigger picker and fires on its cron expression once an automation using it is published. A webhook trigger exposes a webhook URL on the automation, and a registered authenticator appears as an option in that trigger's authentication strategy picker.

--- a/18/umbraco-automate/SUMMARY.md
+++ b/18/umbraco-automate/SUMMARY.md
@@ -73,6 +73,9 @@
 * [Create a Custom Trigger](extending/custom-trigger.md)
 * [Create a Custom Action](extending/custom-action.md)
 * [Create a Custom Connection Type](extending/custom-connection-type.md)
+* [Schedule and Webhook Triggers](extending/schedule-and-webhook-triggers.md)
+* [Control What Runs](extending/controlling-execution.md)
+* [Additional Action Behavior](extending/action-behavior.md)
 
 ## Tutorials
 

--- a/18/umbraco-automate/extending/README.md
+++ b/18/umbraco-automate/extending/README.md
@@ -12,15 +12,20 @@ Umbraco Automate can be extended in C#. Add new triggers, actions, and connectio
 
 Choose the extension point that matches the behavior you want to add.
 
-| Extension Point                                              | Use Case                                                                                 |
-| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| [Create a Custom Trigger](custom-trigger.md)                 | React to a domain event or external signal that is not covered by the built-in triggers. |
-| [Create a Custom Action](custom-action.md)                   | Add a new unit of work that automations can use as a step.                               |
-| [Create a Custom Connection Type](custom-connection-type.md) | Add a new credential type for an external service.                                       |
+| Extension Point                                                       | Use Case                                                                                  |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [Create a Custom Trigger](custom-trigger.md)                          | React to a domain event or external signal that is not covered by the built-in triggers.  |
+| [Create a Custom Action](custom-action.md)                            | Add a new unit of work that automations can use as a step.                                |
+| [Create a Custom Connection Type](custom-connection-type.md)          | Add a new credential type for an external service.                                        |
+| [Schedule and Webhook Triggers](schedule-and-webhook-triggers.md)     | Fire a trigger on a cron schedule, from an inbound webhook, or from a non-Umbraco event.  |
+| [Control What Runs](controlling-execution.md)                         | Gate trigger dispatch, stop automation-triggered cycles, or wrap every action's execution. |
+| [Additional Action Behavior](action-behavior.md)                      | Give an action a dynamic output schema, an audit trail entry, or export-time redaction.   |
 
 ## How Discovery Works
 
 Triggers, actions, and connection types are auto-discovered at startup using Umbraco's type loader. Apply the relevant attribute (`[Trigger]`, `[Action]`, or `[ConnectionType]`) and inherit from the right base class. No manual registration is needed.
+
+Some extension points need explicit registration instead of attribute discovery — webhook authenticators, trigger dispatch authorizers, and action middleware. See the relevant article above for the registration call each one needs.
 
 ## See Also
 

--- a/18/umbraco-automate/extending/action-behavior.md
+++ b/18/umbraco-automate/extending/action-behavior.md
@@ -152,6 +152,8 @@ Replace the default only when a setting is conditionally sensitive in a way `IsS
 
 {% code title="MyProjectComposer.cs" %}
 ```csharp
+using Umbraco.Automate.Core.Automations.Transfer;
+
 builder.Services.AddSingleton<ISensitiveSettingsStripper, MyStripper>();
 ```
 {% endcode %}

--- a/18/umbraco-automate/extending/action-behavior.md
+++ b/18/umbraco-automate/extending/action-behavior.md
@@ -1,0 +1,169 @@
+---
+description: >-
+  Give an action a settings-driven output schema, write it to the audit
+  trail automatically, and control what gets stripped from it on export.
+---
+
+# Additional Action Behavior
+
+[Create a Custom Action](custom-action.md) covers the settings, output, and `ExecuteAsync` an action needs to run as a step. The extension points on this page add behavior most actions get for free, or opt into with a single interface.
+
+## A Settings-Driven Output Schema
+
+`ActionBase<TSettings, TOutput>` declares a fixed output shape from `TOutput`. Some actions cannot know their output shape until the step is configured. For example, an action that calls a user-defined API returns whatever that API responds with. Inherit from `DynamicOutputActionBase<TSettings>` instead, and compute the output schema from the resolved settings:
+
+{% code title="CallApiSettings.cs" %}
+```csharp
+using Umbraco.Automate.Core.Settings;
+
+namespace MyProject.Automate;
+
+public sealed class CallApiSettings
+{
+    [Field(Label = "URL", SupportsBindings = true)]
+    public string Url { get; set; } = string.Empty;
+
+    [Field(Label = "Response Schema", Description = "A JSON Schema describing the response body.")]
+    public string? ResponseSchemaJson { get; set; }
+}
+```
+{% endcode %}
+
+{% code title="CallApiAction.cs" %}
+```csharp
+using Json.Schema;
+using Umbraco.Automate.Core.Actions;
+
+namespace MyProject.Automate;
+
+[Action("myProject.callApi", "Call API",
+    Description = "Calls a user-configured endpoint and returns its response shape.",
+    Group = "My Project",
+    Icon = "icon-code")]
+public sealed class CallApiAction : DynamicOutputActionBase<CallApiSettings>
+{
+    public CallApiAction(ActionInfrastructure infrastructure)
+        : base(infrastructure)
+    {
+    }
+
+    protected override Task<JsonSchema?> GetOutputSchemaAsync(
+        CallApiSettings? settings,
+        CancellationToken cancellationToken = default)
+    {
+        // Required setting not yet configured — no schema to offer downstream steps.
+        if (string.IsNullOrEmpty(settings?.ResponseSchemaJson))
+        {
+            return Task.FromResult<JsonSchema?>(null);
+        }
+
+        return Task.FromResult<JsonSchema?>(JsonSchema.FromText(settings.ResponseSchemaJson));
+    }
+
+    public override async Task<ActionResult> ExecuteAsync(
+        ActionContext context,
+        CancellationToken cancellationToken)
+    {
+        var settings = context.GetSettings<CallApiSettings>();
+
+        // ...call settings.Url and shape the response to match the schema above...
+
+        return Success(new object());
+    }
+}
+```
+{% endcode %}
+
+Downstream steps bind to whatever fields the resolved schema describes, the same way they bind to a fixed `TOutput`'s properties. Return `null` from `GetOutputSchemaAsync` while a required setting is unset — Automate treats a null schema as "not configured yet" rather than an error.
+
+## An Audit Trail, From One Marker Interface
+
+Actions that modify CMS content or media can implement `ICmsAction`, a marker interface with no members:
+
+```csharp
+public interface ICmsAction;
+```
+
+Add it to an action that changes content. Automate's built-in audit trail middleware then writes a structured entry to Umbraco's audit log automatically, once the action completes successfully:
+
+{% code title="ArchivePageSettings.cs" %}
+```csharp
+using Umbraco.Automate.Core.Settings;
+
+namespace MyProject.Automate;
+
+public sealed class ArchivePageSettings
+{
+    [Field(Label = "Content Key", SupportsBindings = true)]
+    public string ContentKey { get; set; } = string.Empty;
+}
+```
+{% endcode %}
+
+{% code title="ArchivePageOutput.cs" %}
+```csharp
+namespace MyProject.Automate;
+
+public sealed class ArchivePageOutput
+{
+}
+```
+{% endcode %}
+
+{% code title="ArchivePageAction.cs" %}
+```csharp
+using Umbraco.Automate.Core.Actions;
+
+namespace MyProject.Automate;
+
+[Action("myProject.archivePage", "Archive Page",
+    Group = "My Project",
+    Icon = "icon-box",
+    RequiredSections = [Umbraco.Cms.Core.Constants.Applications.Content])]
+public sealed class ArchivePageAction
+    : ActionBase<ArchivePageSettings, ArchivePageOutput>, ICmsAction
+{
+    public ArchivePageAction(ActionInfrastructure infrastructure)
+        : base(infrastructure)
+    {
+    }
+
+    public override async Task<ActionResult> ExecuteAsync(
+        ActionContext context,
+        CancellationToken cancellationToken)
+    {
+        // ...move the content node...
+
+        return Success(new ArchivePageOutput());
+    }
+}
+```
+{% endcode %}
+
+Leave `ICmsAction` off actions that only read data — a **Get Content** action, for example — since a read produces nothing worth auditing. Automate writes the entry against the automation's service account, tagged with the action's alias and step. The step never fails if the audit write itself fails.
+
+## Secrets Stripped on Export
+
+Settings marked `IsSensitive = true` on a `[Field]` attribute are already masked in the backoffice and encrypted at rest. `ISensitiveSettingsStripper` is the service that acts on that flag when an automation leaves the system — through the in-app export flow or the [Deploy integration](../add-ons/deploy/README.md). Those values never land in a portable file.
+
+The default implementation strips every setting flagged `IsSensitive` from a trigger's, step's, or connection's settings, based on each one's settings schema. Most projects never need to touch this — mark the setting `IsSensitive` on its `[Field]` attribute and the default stripper handles it.
+
+Replace the default only when a setting is conditionally sensitive in a way `IsSensitive` cannot express on its own. For example, a field whose sensitivity depends on another setting's value:
+
+{% code title="MyProjectComposer.cs" %}
+```csharp
+builder.Services.AddSingleton<ISensitiveSettingsStripper, MyStripper>();
+```
+{% endcode %}
+
+{% hint style="warning" %}
+Registering a replacement overwrites Automate's own stripper rather than wrapping it. Automate's default implementation is internal and cannot be called from a replacement. A custom `ISensitiveSettingsStripper` needs to strip every `IsSensitive` field itself, not only the extra case it was written for.
+{% endhint %}
+
+## Registration
+
+`DynamicOutputActionBase` and `ICmsAction` need no registration beyond the `[Action]` attribute already required for any custom action. `ISensitiveSettingsStripper` needs the explicit `AddSingleton` registration shown above, and only when the default behavior is not enough.
+
+## Verify
+
+Restart your Umbraco site. Configure a dynamic-output action's settings and confirm downstream steps can bind to the fields its schema describes. Run a `ICmsAction` step and check Umbraco's audit log for the entry. Export the automation and confirm sensitive fields are absent from the exported file.

--- a/18/umbraco-automate/extending/controlling-execution.md
+++ b/18/umbraco-automate/extending/controlling-execution.md
@@ -32,12 +32,12 @@ public sealed class StoreScopedTriggerDispatchAuthorizer : ITriggerDispatchAutho
         // Return Success when this authorizer has nothing to say about the
         // given trigger or output — the dispatcher treats Success as "not
         // blocking", not "explicitly approved".
-        if (context.Output is not MyStoreScopedTriggerOutput output)
+        if (context.TypedOutput is not MyStoreScopedTriggerOutput output)
         {
             return Task.FromResult(AutomationAuthorizationResult.Success);
         }
 
-        var allowed = /* look up whether context.WorkspaceId may act on output.StoreId */ true;
+        var allowed = /* look up whether context.Automation.WorkspaceId may act on output.StoreId */ true;
 
         return Task.FromResult(allowed
             ? AutomationAuthorizationResult.Success
@@ -153,7 +153,7 @@ builder.AutomateActionMiddleware()
 ```
 {% endcode %}
 
-Registration order sets the nesting order: middleware appended earlier wraps middleware appended later. Placing custom middleware after the built-in error-handling middleware changes what it sees. Unhandled exceptions from the action already surface as a failed `ActionResult` by the time the middleware runs, rather than as a thrown exception.
+Registration order sets the nesting order: middleware appended earlier wraps middleware appended later, with the action itself innermost. Because `Append` always adds to the end of the list, custom middleware ends up inside the built-in error-handling middleware, not wrapping it. An unhandled exception from the action reaches custom middleware as a raw exception through its own call to `next`. Automate's error-handling middleware only converts it to a failed `ActionResult` afterward, once the exception has propagated back out past your middleware. Wrap your own call to `next` in a try/catch if your middleware needs to guarantee it always sees an `ActionResult`.
 
 ## Registration
 

--- a/18/umbraco-automate/extending/controlling-execution.md
+++ b/18/umbraco-automate/extending/controlling-execution.md
@@ -1,0 +1,164 @@
+---
+description: >-
+  Gate trigger dispatch against your own permission model, stop automations
+  from re-triggering each other, and wrap every action with custom
+  cross-cutting logic.
+---
+
+# Control What Runs
+
+The building blocks in [Create a Custom Trigger](custom-trigger.md) and [Create a Custom Action](custom-action.md) decide what a trigger or action does. The extension points on this page decide whether it gets to run at all, and what happens around it when it does.
+
+## Gate Dispatch With Your Own Permission Model
+
+A trigger's own `CanHandle` method filters events by business logic — for example, only entities whose name matches a prefix. `ITriggerDispatchAuthorizer` is a separate, later check: it runs per automation at dispatch time, after `CanHandle` has already matched.
+
+Automate ships a built-in authorizer that checks the workspace service account's CMS start-node access. Register your own to gate against a permission model that CMS start nodes cannot express, such as a per-tenant or per-store allowlist.
+
+{% code title="StoreScopedTriggerDispatchAuthorizer.cs" %}
+```csharp
+using Umbraco.Automate.Core.Dispatch;
+using Umbraco.Automate.Core.Dispatch.Authorization;
+using Umbraco.Automate.Core.Security;
+
+namespace MyProject.Automate;
+
+public sealed class StoreScopedTriggerDispatchAuthorizer : ITriggerDispatchAuthorizer
+{
+    public Task<AutomationAuthorizationResult> AuthorizeAsync(
+        TriggerDispatchAuthorizationContext context,
+        CancellationToken cancellationToken)
+    {
+        // Return Success when this authorizer has nothing to say about the
+        // given trigger or output — the dispatcher treats Success as "not
+        // blocking", not "explicitly approved".
+        if (context.Output is not MyStoreScopedTriggerOutput output)
+        {
+            return Task.FromResult(AutomationAuthorizationResult.Success);
+        }
+
+        var allowed = /* look up whether context.WorkspaceId may act on output.StoreId */ true;
+
+        return Task.FromResult(allowed
+            ? AutomationAuthorizationResult.Success
+            : AutomationAuthorizationResult.Fail("Workspace is not scoped to this store."));
+    }
+}
+```
+{% endcode %}
+
+Register it on the authorizer collection:
+
+{% code title="MyProjectComposer.cs" %}
+```csharp
+builder.AutomateTriggerDispatchAuthorizers()
+    .Add<StoreScopedTriggerDispatchAuthorizer>();
+```
+{% endcode %}
+
+Authorizers run in registration order. The first result with `Authorized = false` skips the run for that automation, and no further authorizer is consulted for it.
+
+## Stop Automations From Re-Triggering Each Other
+
+An action that publishes content can itself raise the notification a **Content Published** trigger listens for. Left unchecked, that lets one automation's actions start another automation, which can start another, and so on.
+
+Trigger settings that implement `IAutomationOriginatedEventBehavior` control this per trigger. Automate consults it whenever an incoming event was itself caused by an automation run:
+
+```csharp
+public interface IAutomationOriginatedEventBehavior
+{
+    AutomationOriginatedEventBehavior OnAutomationOriginated { get; }
+}
+```
+
+`AutomationOriginatedEventBehavior` has three values:
+
+| Value | Effect |
+| --- | --- |
+| `Run` | The trigger fires normally, even for automation-originated events. |
+| `SkipOnCycle` | The trigger skips only when firing would re-enter the same automation. This is the default. |
+| `SkipAlways` | The trigger never fires for automation-originated events. |
+
+Implement the interface explicitly on the settings Plain Old CLR Object (POCO) so a string-backed dropdown property can still satisfy it:
+
+{% code title="MyCustomTriggerSettings.cs" %}
+```csharp
+using Umbraco.Automate.Core.Settings;
+using Umbraco.Automate.Core.Triggers;
+
+namespace MyProject.Automate;
+
+public sealed class MyCustomTriggerSettings : IAutomationOriginatedEventBehavior
+{
+    [Field(Label = "On automation-originated event")]
+    public string OnAutomationOriginatedEvent { get; set; }
+        = nameof(AutomationOriginatedEventBehavior.SkipOnCycle);
+
+    AutomationOriginatedEventBehavior IAutomationOriginatedEventBehavior.OnAutomationOriginated
+        => Enum.TryParse<AutomationOriginatedEventBehavior>(
+            OnAutomationOriginatedEvent, ignoreCase: true, out var value)
+            ? value
+            : AutomationOriginatedEventBehavior.SkipOnCycle;
+}
+```
+{% endcode %}
+
+## Wrap Every Action With Custom Logic
+
+`IActionMiddleware` wraps action execution the way ASP.NET Core middleware wraps a request. Each registered middleware can inspect or modify the context before calling the action, react to the result afterwards, or short-circuit entirely.
+
+Automate's own audit trail, error handling, and settings validation are all built as middleware. Add your own for logging, metrics, or a cross-cutting policy that every action should honor.
+
+{% code title="StepTimingMiddleware.cs" %}
+```csharp
+using Umbraco.Automate.Core.Actions.Middleware;
+
+namespace MyProject.Automate;
+
+public sealed class StepTimingMiddleware : IActionMiddleware
+{
+    private readonly ILogger<StepTimingMiddleware> _logger;
+
+    public StepTimingMiddleware(ILogger<StepTimingMiddleware> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<ActionResult> ApplyAsync(
+        ActionContext context,
+        ActionMiddlewareDelegate next,
+        CancellationToken cancellationToken)
+    {
+        var start = DateTimeOffset.UtcNow;
+
+        var result = await next(context, cancellationToken);
+
+        _logger.LogInformation(
+            "{ActionAlias} took {Elapsed}",
+            context.ActionAlias,
+            DateTimeOffset.UtcNow - start);
+
+        return result;
+    }
+}
+```
+{% endcode %}
+
+Middleware is not auto-discovered. Append it to the collection in registration order, alongside the built-in middleware:
+
+{% code title="MyProjectComposer.cs" %}
+```csharp
+builder.AutomateActionMiddleware()
+    .Append<StepTimingMiddleware>();
+```
+{% endcode %}
+
+Registration order sets the nesting order: middleware appended earlier wraps middleware appended later. Placing custom middleware after the built-in error-handling middleware changes what it sees. Unhandled exceptions from the action already surface as a failed `ActionResult` by the time the middleware runs, rather than as a thrown exception.
+
+## Registration
+
+`ITriggerDispatchAuthorizer` and `IActionMiddleware` implementations both need explicit registration on their collection builders — `AutomateTriggerDispatchAuthorizers()` and `AutomateActionMiddleware()`. `IAutomationOriginatedEventBehavior` needs no registration: implement it on a trigger settings class and Automate calls it directly during dispatch.
+
+## Verify
+
+Restart your Umbraco site. Trigger the event your authorizer or middleware targets, then check the automation's run history. A blocked dispatch produces no run. A re-triggered cycle produces no second run once `SkipOnCycle` or `SkipAlways` is set.

--- a/18/umbraco-automate/extending/schedule-and-webhook-triggers.md
+++ b/18/umbraco-automate/extending/schedule-and-webhook-triggers.md
@@ -1,0 +1,205 @@
+---
+description: >-
+  Build triggers that fire on a schedule, respond to webhooks, or react to
+  any .NET event using ScheduledTriggerBase, WebhookTriggerBase, and
+  IEventTrigger.
+---
+
+# Schedule and Webhook Triggers
+
+[Create a Custom Trigger](custom-trigger.md) covers the most common case: a trigger that reacts to an Umbraco notification. Automate also ships base classes for two other common cases, and an interface for events that come from neither Umbraco nor a schedule.
+
+## Trigger on a Schedule
+
+Inherit from `ScheduledTriggerBase<TSettings, TOutput>` to build a trigger that fires on a cron expression instead of an event. Override `GetCronExpression` to read the expression from the trigger's own settings.
+
+{% code title="DailyDigestTriggerSettings.cs" %}
+```csharp
+using Umbraco.Automate.Core.Settings;
+
+namespace MyProject.Automate;
+
+public sealed class DailyDigestTriggerSettings
+{
+    [Field(Label = "Cron Expression", Description = "When the digest should run.")]
+    public string CronExpression { get; set; } = "0 6 * * *";
+
+    [Field(Label = "Time Zone", Description = "An IANA or Windows time zone ID.")]
+    public string TimeZoneId { get; set; } = "UTC";
+}
+```
+{% endcode %}
+
+{% code title="DailyDigestTriggerOutput.cs" %}
+```csharp
+namespace MyProject.Automate;
+
+public sealed class DailyDigestTriggerOutput
+{
+    public DateTimeOffset FiredAtUtc { get; init; }
+}
+```
+{% endcode %}
+
+{% code title="DailyDigestTrigger.cs" %}
+```csharp
+using Umbraco.Automate.Core.Triggers;
+
+namespace MyProject.Automate;
+
+[Trigger("myProject.dailyDigest", "Daily Digest",
+    Description = "Fires on a cron schedule.",
+    Group = "My Project",
+    Icon = "icon-time")]
+public sealed class DailyDigestTrigger
+    : ScheduledTriggerBase<DailyDigestTriggerSettings, DailyDigestTriggerOutput>
+{
+    public DailyDigestTrigger(TriggerInfrastructure infrastructure)
+        : base(infrastructure)
+    {
+    }
+
+    public override string GetCronExpression(object? settings)
+        => (settings as DailyDigestTriggerSettings)?.CronExpression ?? "0 6 * * *";
+}
+```
+{% endcode %}
+
+`GetTimeZone` defaults to UTC. Override it to evaluate the cron expression against the settings' configured time zone instead:
+
+```csharp
+public override TimeZoneInfo GetTimeZone(object? settings)
+    => TimeZoneInfo.FindSystemTimeZoneById(
+        (settings as DailyDigestTriggerSettings)?.TimeZoneId ?? "UTC");
+```
+
+## Trigger from a Webhook
+
+Inherit from `WebhookTriggerBase<TSettings, TOutput>` to build a trigger that starts an automation from an inbound HTTP request, instead of a CMS event.
+
+{% code title="OrderPaidTriggerSettings.cs" %}
+```csharp
+namespace MyProject.Automate;
+
+public sealed class OrderPaidTriggerSettings
+{
+}
+```
+{% endcode %}
+
+{% code title="OrderPaidTriggerOutput.cs" %}
+```csharp
+namespace MyProject.Automate;
+
+public sealed class OrderPaidTriggerOutput
+{
+    public string OrderReference { get; init; } = string.Empty;
+
+    public decimal AmountPaid { get; init; }
+}
+```
+{% endcode %}
+
+{% code title="OrderPaidTrigger.cs" %}
+```csharp
+using Umbraco.Automate.Core.Triggers;
+
+namespace MyProject.Automate;
+
+[Trigger("myProject.orderPaid", "Order Paid",
+    Description = "Fires when the payment provider posts a paid webhook.",
+    Group = "My Project",
+    Icon = "icon-coins")]
+public sealed class OrderPaidTrigger
+    : WebhookTriggerBase<OrderPaidTriggerSettings, OrderPaidTriggerOutput>
+{
+    public OrderPaidTrigger(TriggerInfrastructure infrastructure)
+        : base(infrastructure)
+    {
+    }
+}
+```
+{% endcode %}
+
+A webhook trigger receives its payload through Automate's webhook endpoint. Map the posted body to trigger output the same way a notification-based trigger maps a notification — see [Create a Custom Trigger](custom-trigger.md) for the `MapEvent` and `CanHandle` pattern.
+
+### Verifying the Request Came From Your Vendor
+
+An inbound webhook URL is public. Verify the request before trusting its payload by implementing `IWebhookAuthenticator`, or by inheriting the convenience base class `WebhookAuthenticatorBase<TSettings>`. It reads discovery metadata from a `[WebhookAuthenticator]` attribute and derives the settings schema from `TSettings` automatically.
+
+{% code title="StripeWebhookAuthenticator.cs" %}
+```csharp
+using Umbraco.Automate.Core.Settings;
+using Umbraco.Automate.Core.Triggers.Webhooks;
+
+namespace MyProject.Automate;
+
+public sealed class StripeWebhookAuthenticatorSettings
+{
+    [Field(Label = "Signing Secret", IsSensitive = true)]
+    public string? SigningSecret { get; set; }
+}
+
+[WebhookAuthenticator("stripe", "Stripe Signature")]
+public sealed class StripeWebhookAuthenticator
+    : WebhookAuthenticatorBase<StripeWebhookAuthenticatorSettings>
+{
+    protected override bool Validate(
+        WebhookAuthenticationContext context,
+        StripeWebhookAuthenticatorSettings settings)
+    {
+        // Read the "Stripe-Signature" header from context.Request,
+        // recompute it from context.Body and settings.SigningSecret,
+        // and compare using a constant-time comparison.
+        return true;
+    }
+}
+```
+{% endcode %}
+
+Set `RequiresBody` to `false` when a scheme validates against headers alone. Automate skips reading the request body before calling `Validate`. Callers get a fast 401 response for unauthorized requests on large payloads instead of waiting on a body read that gets discarded anyway.
+
+Unlike triggers and actions, webhook authenticators are not auto-discovered from the `[WebhookAuthenticator]` attribute alone. Register each one explicitly:
+
+{% code title="MyProjectComposer.cs" %}
+```csharp
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+
+namespace MyProject.Automate;
+
+public sealed class MyProjectComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.AutomateWebhookAuthenticators()
+            .Add<StripeWebhookAuthenticator>();
+    }
+}
+```
+{% endcode %}
+
+The attribute supplies the alias, display name, and description shown in the authentication strategy picker on the webhook trigger's settings. The collection registration is what makes the authenticator selectable.
+
+## Trigger from Any .NET Event
+
+Umbraco notifications are the most common event source, but not the only one. `IEventTrigger<TEvent>` declares that a trigger responds to events of type `TEvent`. `NotificationTriggerBase<TSettings, TOutput, TNotification>`, the base class used in [Create a Custom Trigger](custom-trigger.md), implements this interface for Umbraco notifications specifically:
+
+```csharp
+public interface IEventTrigger<in TEvent>
+{
+    IEnumerable<TriggerEvent> MapEvent(TEvent @event);
+}
+```
+
+For an Umbraco notification, `NotificationTriggerBase` already wires up the dispatcher. A trigger that inherits from it and overrides `MapEvent` is discovered and connected automatically, as shown in [Create a Custom Trigger](custom-trigger.md).
+
+For an event that is not an Umbraco notification, `MapEvent` still describes how to turn one event into zero or more `TriggerEvent` instances. Nothing in the framework calls it automatically — publish the event and invoke the trigger's `MapEvent` from your own listener.
+
+## Registration
+
+Scheduled and webhook triggers are discovered at startup the same way as notification triggers — by their `[Trigger]` attribute and base class. Webhook authenticators are the exception and need the explicit `AutomateWebhookAuthenticators()` registration shown above.
+
+## Verify
+
+Restart your Umbraco site. A scheduled trigger appears in the trigger picker and fires on its cron expression once an automation using it is published. A webhook trigger exposes a webhook URL on the automation, and a registered authenticator appears as an option in that trigger's authentication strategy picker.


### PR DESCRIPTION
## 📋 Description

Adds three new articles to the Automate "Extending" section covering advanced extension points:

- **Schedule and Webhook Triggers** — `ScheduledTriggerBase`, `WebhookTriggerBase`, webhook request verification, and `IEventTrigger<TEvent>`.
- **Control What Runs** — `ITriggerDispatchAuthorizer`, `IAutomationOriginatedEventBehavior`, and `IActionMiddleware`.
- **Additional Action Behavior** — dynamic output schemas, the `ICmsAction` audit trail marker, and `ISensitiveSettingsStripper`.

Wires all three into the Extending overview page and `SUMMARY.md` for both v17 and v18. Adds the dictionary and acronym entries (`authorizers`, `Automate's`, `CLR`) needed for the new content to pass Vale.

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Automate — v17 and v18.

## Deadline (if relevant)

Ideally around the webinar happening today (26th August) as I'm talking about a few of these touch points!
