### PR TITLE
Forms: Add release notes for 13.9.10 and 18.1.1

### DIFF
--- a/13/umbraco-forms/release-notes.md
+++ b/13/umbraco-forms/release-notes.md
@@ -16,6 +16,14 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 13 including all changes for this version.
 
+### [13.9.10](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F13.9.10) (August 27th 2026)
+* Records: Read record field values in batches, instead of one database query for each field value [#1774](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1774)
+* Records: Populate the Examine records index in groups of records, instead of holding every record for a form in memory at once [#1774](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1774)
+
+{% hint style="info" %}
+On installations with many form entries, the records index rebuild could fail to complete. This release reduces the number of database queries and the amount of memory that rebuild needs.
+{% endhint %}
+
 ### 13.9.9 (August 18th 2026)
 * Prevent backoffice users without access to sensitive data from reading the values and uploaded files of fields marked as sensitive [GHSA-p6vj-8vxc-mf5c](https://github.com/umbraco/Umbraco.Forms.Issues/security/advisories/GHSA-p6vj-8vxc-mf5c)
 * Withhold the details of the member who submitted an entry from backoffice users without access to sensitive data [GHSA-p6vj-8vxc-mf5c](https://github.com/umbraco/Umbraco.Forms.Issues/security/advisories/GHSA-p6vj-8vxc-mf5c)

--- a/18/umbraco-forms/release-notes.md
+++ b/18/umbraco-forms/release-notes.md
@@ -20,6 +20,14 @@ If you are upgrading to a new major version, you can find information about the 
 
 This section contains the release notes for Umbraco Forms 18 including all changes for this version.
 
+### [18.1.1](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F18.1.1) (August 27th 2026)
+
+* Upgrading: Fix a boot failure when upgrading directly from Forms 17.5.0 [#1782](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1782)
+
+{% hint style="warning" %}
+If you run Forms 17.5.0, upgrade to 18.1.1 or later. Versions 18.0.0 to 18.1.0 do not recognize the migration state that Forms 17.5.0 ends on, and the upgrade fails at boot. For details, see the [Version Specific Upgrade Notes](upgrading/version-specific.md) article.
+{% endhint %}
+
 ### [18.1.0](https://github.com/umbraco/Umbraco.Forms.Issues/issues?q=is%3Aissue+label%3Arelease%2F18.1.0) (August 20th 2026)
 
 The changes below are the ones made since `18.1.0-rc`. For everything else in this release, see the `18.1.0-rc` notes.

--- a/18/umbraco-forms/upgrading/migration-ids.md
+++ b/18/umbraco-forms/upgrading/migration-ids.md
@@ -38,6 +38,7 @@ A unique **migration ID** is generated for each Umbraco Forms upgrade that requi
 | b8e2f4a1-3c5d-4e6f-9a7b-1d2e3f4a5b6c | 17.3.0                | Adds an index on UniqueId to the UFRecords table for analytics performance.        |
 | d4f5e6a7-8b9c-4d0e-1f2a-3b4c5d6e7f8a | 17.3.0                | Replaces the index on UFRecords with a covering index that includes UmbracoPageId. |
 | 33c9d3f4-7d41-46f7-a44d-5ed32f26448d | 17.4.0                | Rebuild the Examine records index so that existing records gain sortable fields.   |
+| 188009a1-e582-4971-aff7-87f7e4381bd0 | 18.0.6                | Rebuilds the Examine records index so values of sensitive fields are excluded.     |
 | 16f1cd91-d614-4e0b-844f-0a2434441d34 | 17.5.0                | Adds the UmbracoPageKey column to the Records table.                               |
 | b7d4e1a9-3c62-4f08-9a15-2e6d8f04c3b1 | 17.5.0                | Populates UmbracoPageKey from the existing UmbracoPageId values.                   |
 | 3a03c625-3ddc-4eda-9bf3-cc88f112e9a9 | 17.5.0                | Rebuilds the Examine records index so records gain the page key field.             |
@@ -46,8 +47,7 @@ A unique **migration ID** is generated for each Umbraco Forms upgrade that requi
 | 9a013edc-579b-46b5-a85d-d9288e2e074e | 17.5.0                | Migrates the Save as Umbraco node workflow root node setting to dynamic root.      |
 | 2b63c684-8d61-43ec-842f-e5af2205c28d | 17.5.0                | Adds indexes on the Records table for member entry counts and analytics.           |
 | 7c1f5a86-2e4b-4d93-8f07-6b25a9c41de8 | 17.5.0                | Adds hour-level breakdowns to the analytics daily summary table for local time zones.|
-| 0625d467-f048-4b5b-aa38-3d42fbfa8cd3 | 17.5.0                | Rebuild the records index.                                                          |
-| 188009a1-e582-4971-aff7-87f7e4381bd0 | 18.0.6                | Rebuilds the Examine records index so values of sensitive fields are excluded.     |
+| 0625d467-f048-4b5b-aa38-3d42fbfa8cd3 | 17.5.0                | Rebuild the records index. Recognized on the version 18 chain from 18.1.1.         |
 | 91ef4e6d-3fbd-40a2-b42c-77dc5b2791c4 | 18.1.0                | Adds the UmbracoPageKey column to the Records table.                               |
 | a4cc5acc-ee57-40e6-a0aa-73763e7ac444 | 18.1.0                | Populates UmbracoPageKey from the existing UmbracoPageId values.                   |
 | 51948cde-a4fc-4889-b855-7a08ce5cbd6e | 18.1.0                | Rebuilds the Examine records index so records gain the page key field.             |

--- a/18/umbraco-forms/upgrading/version-specific.md
+++ b/18/umbraco-forms/upgrading/version-specific.md
@@ -16,6 +16,16 @@ If you are upgrading to a minor or patch version, you can find the details about
 
 Version 18 of Umbraco Forms has a minimum dependency on Umbraco CMS core of `18.0.0`. It runs on .NET 10.
 
+### Upgrading directly from Forms 17.5.0
+
+This fix was introduced in version 18.1.1. It affects you if you upgrade directly from Forms 17.5.0 to an earlier version 18 release.
+
+{% hint style="warning" %}
+Versions 18.0.0 to 18.1.0 do not recognize the migration state that Forms 17.5.0 ends on. The upgrade fails at boot with `The migration plan "UmbracoForms" does not support migrating from state "0625d467-f048-4b5b-aa38-3d42fbfa8cd3"`.
+{% endhint %}
+
+Upgrade to version 18.1.1 or later instead. See [issue #1782](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1782) for details.
+
 ### Upgrading directly from Forms 13.9.9
 
 This fix was introduced in version 18.1.0. It affects you if you upgrade directly from Forms 13.9.9 to an earlier version 18 release.


### PR DESCRIPTION
## 📋 Description

Adds the release notes for Umbraco Forms **13.9.10** and **18.1.1**, and the upgrade documentation that goes with them.

* **13.9.10** — the Examine records index rebuild could fail to complete on installations with many form entries. Record field values are now read in batches instead of one database query for each value, and the index is populated in groups of records instead of holding every record for a form in memory at once.
* **18.1.1** — a site fully upgraded to Forms 17.5.0 failed to boot on version 18, because versions 18.0.0 to 18.1.0 do not recognize the migration state that the 17.5.0 chain ends on. A new "Upgrading directly from Forms 17.5.0" section in the version 18 upgrade notes documents the symptom and the fix, mirroring the existing section for 13.9.9.
* **Migration IDs (version 18)** — records that `0625d467-f048-4b5b-aa38-3d42fbfa8cd3` is recognized on the version 18 chain from 18.1.1, and moves the `188009a1-e582-4971-aff7-87f7e4381bd0` row into the order the migration plan runs it.

## 📎 Related Issues (if applicable)

* [umbraco/Umbraco.Forms.Issues#1774](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1774) — `UmbracoFormsRecordsIndex` fails to build
* [umbraco/Umbraco.Forms.Issues#1782](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1782) — Upgrading from 17.5.0 to 18.x fails on migration state `0625d467-...`

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful. Not applicable, text only.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Forms 13.9.10 and Umbraco Forms 18.1.1

## Deadline (if relevant)

To publish alongside the 13.9.10 and 18.1.1 releases on 27th August 2026.