### PR TITLE
Update documentation on configuring custom maintenance page

### DIFF
--- a/17/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
@@ -32,6 +32,8 @@ The following snippet contains all the available options, with default values, a
       "Id": "184a8175-bc0b-43dd-8267-d99871eaec3d",
       "NoNodesViewPath": "~/umbraco/UmbracoWebsite/NoNodes.cshtml",
       "UpgradingViewPath": "~/umbraco/UmbracoWebsite/Upgrading.cshtml",
+      "MaintenanceViewPath": "~/umbraco/UmbracoWebsite/Maintenance.cshtml",
+      "NotFoundViewPath": "~/umbraco/UmbracoWebsite/NotFound.cshtml",
       "Smtp": {
         "From": "person@umbraco.dk",
         "Host": "localhost",
@@ -235,6 +237,22 @@ Key: `UpgradingViewPath` Type: `string` (default: `~/umbraco/UmbracoWebsite/Upgr
 This setting specifies the view to render when an unattended upgrade is running in the background. Frontend and surface controller requests receive an HTTP 503 response with this view during the upgrade. See [Upgrade Unattended](../../get-started/upgrading-and-migrating/upgrade-unattended.md) for details on the upgrade process.
 
 To customize this view, create your own `.cshtml` file at a location of your choosing. Set this key to that file's path. For example `~/Views/CustomUpgrading.cshtml`.
+
+### Maintenance view path
+
+Key: `MaintenanceViewPath` Type: `string` (default: `~/umbraco/UmbracoWebsite/Maintenance.cshtml`)
+
+This setting specifies the view to render when an upgrade is pending and waiting for an administrator to run it. This is a different view from the one used for unattended upgrades, which is configured with `UpgradingViewPath`. See [Create a custom maintenance page](../../run-in-production/tutorials/create-a-custom-maintenance-page.md) for a full guide.
+
+To customize this view, create your own `.cshtml` file at a location of your choosing. Set this key to that file's path. For example `~/Views/CustomMaintenance.cshtml`.
+
+### Not found view path
+
+Key: `NotFoundViewPath` Type: `string` (default: `~/umbraco/UmbracoWebsite/NotFound.cshtml`)
+
+This setting specifies the view to render when Umbraco cannot render a page. That happens when no document matches the URL, or when the matched document has no template. This is the fallback shown when no custom error page has been configured. See [Implement Custom Error Pages](../tutorials/custom-error-page.md) for how to serve a 404 page from content instead.
+
+To customize this view, create your own `.cshtml` file at a location of your choosing. Set this key to that file's path. For example `~/Views/CustomNotFound.cshtml`.
 
 ## SMTP settings
 

--- a/17/umbraco-cms/run-in-production/tutorials/create-a-custom-maintenance-page.md
+++ b/17/umbraco-cms/run-in-production/tutorials/create-a-custom-maintenance-page.md
@@ -10,14 +10,58 @@ A maintenance page will be shown when an Umbraco project is running an upgrade. 
 
 ![The default maintenance page making site visitors aware of the state of the site.](../../.gitbook/assets/maintenancePage.png)
 
+{% hint style="info" %}
+Two different pages are shown during an upgrade, depending on how the upgrade runs:
+
+* The **maintenance page** is shown while an upgrade is pending and waiting for an administrator to run it.
+* The **upgrading page** is shown while an [unattended upgrade](../../get-started/upgrading-and-migrating/upgrade-unattended.md) runs in the background.
+
+Customizing one does not change the other. This article covers the maintenance page. To customize the upgrading page, use the `UpgradingViewPath` setting instead.
+{% endhint %}
+
 ## Customize the maintenance page
 
 The following guide will take you through the steps to customize and brand the default maintenance page.
 
+There are two ways to do this. Configuring a view path is recommended. The view then lives alongside the rest of your views, and a mistake in the path is reported instead of being ignored.
+
+{% hint style="info" %}
+Both approaches require Umbraco 17.8 or later. In earlier versions, the default maintenance page could not be replaced.
+{% endhint %}
+
+### Configure your own view
+
+1. Add a new file to your project, for example `Views/Maintenance.cshtml`.
+2. Add your custom markup to the file.
+3. Open the project `appSettings.json` file.
+4. Add the following configuration, pointing at your file:
+
+{% code title="appSettings.json" %}
+```json
+{
+    "Umbraco": {
+        "CMS": {
+            "Global": {
+                "MaintenanceViewPath": "~/Views/Maintenance.cshtml"
+            }
+        }
+    }
+}
+```
+{% endcode %}
+
+### Replace the default view
+
+Alternatively, add a file at the location the default view uses. Umbraco then renders your file instead of the one built into the CMS.
+
 1. Go to the root of your Umbraco project files.
-2. Create a new folder called `UmbracoWebsite`, and open it.
-3. Add a new file called `maintenance.cshtml`.
+2. Open the `umbraco` folder, and create a new folder called `UmbracoWebsite` if it does not already exist.
+3. Add a new file called `Maintenance.cshtml`.
 4. Add your custom markup to the file.
+
+{% hint style="warning" %}
+The folder and file names must match exactly, including the casing. If the path does not match, Umbraco renders its default page and no error is shown.
+{% endhint %}
 
 {% hint style="warning" %}
 Keeping the Umbraco project in Upgrade mode for a longer time is not recommended. Most migrations can be executed while the website continues to work.

--- a/18/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
@@ -32,6 +32,8 @@ The following snippet contains all the available options, with default values, a
       "Id": "184a8175-bc0b-43dd-8267-d99871eaec3d",
       "NoNodesViewPath": "~/umbraco/UmbracoWebsite/NoNodes.cshtml",
       "UpgradingViewPath": "~/umbraco/UmbracoWebsite/Upgrading.cshtml",
+      "MaintenanceViewPath": "~/umbraco/UmbracoWebsite/Maintenance.cshtml",
+      "NotFoundViewPath": "~/umbraco/UmbracoWebsite/NotFound.cshtml",
       "Smtp": {
         "From": "person@umbraco.dk",
         "Host": "localhost",
@@ -235,6 +237,22 @@ Key: `UpgradingViewPath` Type: `string` (default: `~/umbraco/UmbracoWebsite/Upgr
 This setting specifies the view to render when an unattended upgrade is running in the background. Frontend and surface controller requests receive an HTTP 503 response with this view during the upgrade. See [Upgrade Unattended](../../get-started/upgrading-and-migrating/upgrade-unattended.md) for details on the upgrade process.
 
 To customize this view, create your own `.cshtml` file at a location of your choosing. Set this key to that file's path. For example `~/Views/CustomUpgrading.cshtml`.
+
+### Maintenance view path
+
+Key: `MaintenanceViewPath` Type: `string` (default: `~/umbraco/UmbracoWebsite/Maintenance.cshtml`)
+
+This setting specifies the view to render when an upgrade is pending and waiting for an administrator to run it. This is a different view from the one used for unattended upgrades, which is configured with `UpgradingViewPath`. See [Create a custom maintenance page](../../run-in-production/tutorials/create-a-custom-maintenance-page.md) for a full guide.
+
+To customize this view, create your own `.cshtml` file at a location of your choosing. Set this key to that file's path. For example `~/Views/CustomMaintenance.cshtml`.
+
+### Not found view path
+
+Key: `NotFoundViewPath` Type: `string` (default: `~/umbraco/UmbracoWebsite/NotFound.cshtml`)
+
+This setting specifies the view to render when Umbraco cannot render a page. That happens when no document matches the URL, or when the matched document has no template. This is the fallback shown when no custom error page has been configured. See [Implement Custom Error Pages](../tutorials/custom-error-page.md) for how to serve a 404 page from content instead.
+
+To customize this view, create your own `.cshtml` file at a location of your choosing. Set this key to that file's path. For example `~/Views/CustomNotFound.cshtml`.
 
 ## SMTP settings
 

--- a/18/umbraco-cms/run-in-production/tutorials/create-a-custom-maintenance-page.md
+++ b/18/umbraco-cms/run-in-production/tutorials/create-a-custom-maintenance-page.md
@@ -10,14 +10,58 @@ A maintenance page will be shown when an Umbraco project is running an upgrade. 
 
 ![The default maintenance page making site visitors aware of the state of the site.](../../.gitbook/assets/maintenancePage.png)
 
+{% hint style="info" %}
+Two different pages are shown during an upgrade, depending on how the upgrade runs:
+
+* The **maintenance page** is shown while an upgrade is pending and waiting for an administrator to run it.
+* The **upgrading page** is shown while an [unattended upgrade](../../get-started/upgrading-and-migrating/upgrade-unattended.md) runs in the background.
+
+Customizing one does not change the other. This article covers the maintenance page. To customize the upgrading page, use the `UpgradingViewPath` setting instead.
+{% endhint %}
+
 ## Customize the maintenance page
 
 The following guide will take you through the steps to customize and brand the default maintenance page.
 
+There are two ways to do this. Configuring a view path is recommended. The view then lives alongside the rest of your views, and a mistake in the path is reported instead of being ignored.
+
+{% hint style="info" %}
+Both approaches require Umbraco 18.3 or later. In earlier versions, the default maintenance page could not be replaced.
+{% endhint %}
+
+### Configure your own view
+
+1. Add a new file to your project, for example `Views/Maintenance.cshtml`.
+2. Add your custom markup to the file.
+3. Open the project `appSettings.json` file.
+4. Add the following configuration, pointing at your file:
+
+{% code title="appSettings.json" %}
+```json
+{
+    "Umbraco": {
+        "CMS": {
+            "Global": {
+                "MaintenanceViewPath": "~/Views/Maintenance.cshtml"
+            }
+        }
+    }
+}
+```
+{% endcode %}
+
+### Replace the default view
+
+Alternatively, add a file at the location the default view uses. Umbraco then renders your file instead of the one built into the CMS.
+
 1. Go to the root of your Umbraco project files.
-2. Create a new folder called `UmbracoWebsite`, and open it.
-3. Add a new file called `maintenance.cshtml`.
+2. Open the `umbraco` folder, and create a new folder called `UmbracoWebsite` if it does not already exist.
+3. Add a new file called `Maintenance.cshtml`.
 4. Add your custom markup to the file.
+
+{% hint style="warning" %}
+The folder and file names must match exactly, including the casing. If the path does not match, Umbraco renders its default page and no error is shown.
+{% endhint %}
 
 {% hint style="warning" %}
 Keeping the Umbraco project in Upgrade mode for a longer time is not recommended. Most migrations can be executed while the website continues to work.


### PR DESCRIPTION
## 📋 Description

Update documentation on configuring custom maintenance page, adding some fixes, improvements and clarifications.

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/issues/23749
https://github.com/umbraco/Umbraco-CMS/pull/23763

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17.8 and 18.3

## Deadline (if relevant)

Could wait until release of 17.8 and 18.3 release candidates (due on 15th October), but could also go in now.  For the feature to work, the PR linked above needs to be reviewed and merged.  But I've added a version flag to the documentation, so it would be OK to go in sooner.