### PR TITLE
Adding version 18 to Cloud Major Upgrade guide

### DIFF
--- a/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
+++ b/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
@@ -236,7 +236,7 @@ Update all projects and packages in your solution to support the latest .NET.
 
 ## Step 4: Finishing the Upgrade
 
-1. Enable the [Unattended Upgrades](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/upgrading/upgrade-unattended) feature.
+1. Ensure that [Unattended Upgrades](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/upgrading/upgrade-unattended) are enabled.
 2. Run the **project locally**.
 3. Log in to the Umbraco backoffice to **verify the upgrade** has happened.
    * If you cannot login locally via Umbraco ID and URL shows `/umbraco/authorizeupgrade?redir=` then this is because of the Unattended Upgrades setting. It must be set to `true` and deployed to the environment before the upgrade.

--- a/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
+++ b/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
@@ -125,7 +125,7 @@ Delete the `<PackageReference>` entries for these packages.
 7. Ensure all projects and packages in your solution is compatible with the latest .NET.
 {% endtab %}
 
-{% tab title="Umbraco 17" %}
+{% tab title="Umbraco 17 (LTS)" %}
 6. Update the all `Umbraco.*` packages to the latest version 17.
   * `Umbraco.Community.*` packages may also need updating, though we cannot guarantee their compatibility.
   * Ensure the following default Cloud packages are upgraded:
@@ -198,7 +198,7 @@ If the folder is empty after deleting the files, you can safely remove the entir
 From Umbraco 13, the `Umbraco.Deploy.Forms` package has been replaced with the `Umbraco.Forms.Deploy` package.
 
 6. Remove the `Umbraco.Deploy.Forms` package.
-7. Update the all `Umbraco.*` packages to the latest version 14.
+7. Update the all `Umbraco.*` packages to the latest version 13.
   * `Umbraco.Community.*` packages may also need updating, though we cannot guarantee their compatibility.
   * Ensure the following default Cloud packages are upgraded:
     * `Umbraco.Cms`
@@ -214,7 +214,7 @@ From Umbraco 13, the `Umbraco.Deploy.Forms` package has been replaced with the `
 {% endtab %}
 
 {% tab title="Umbraco 10" %}
-6. Update the all `Umbraco.*` packages to the latest version 14.
+6. Update the all `Umbraco.*` packages to the latest version 10.
   * `Umbraco.Community.*` packages may also need updating, though we cannot guarantee their compatibility.
   * Ensure the following default Cloud packages are upgraded:
     * `Umbraco.Deploy.Forms`

--- a/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
+++ b/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
@@ -112,30 +112,36 @@ Delete the `<PackageReference>` entries for these packages.
 
 {% tabs %}
 {% tab title="Umbraco 18" %}
-* Update the following packages:
-  * `Umbraco.Forms.Deploy`
-  * `Umbraco.Cms`
-  * `Umbraco.Deploy.Cloud`
-  * `Umbraco.Deploy.Contrib`
-  * `Umbraco.Forms`
-  * `Umbraco.Cloud.Cms`
-  * `Umbraco.Cloud.StorageProviders.AzureBlob`
+6. Update the all `Umbraco.` packages to the latest version 18.
+  * This **does not** include `Umbraco.Community.` packages, as we cannot guarantee their compatibility.
+  * Ensure the following default Cloud packages are upgraded:
+    * `Umbraco.Forms.Deploy`
+    * `Umbraco.Cms`
+    * `Umbraco.Deploy.Cloud`
+    * `Umbraco.Deploy.Contrib`
+    * `Umbraco.Forms`
+    * `Umbraco.Cloud.Cms`
+    * `Umbraco.Cloud.StorageProviders.AzureBlob`
+7. Ensure all projects and packages in your solution is compatible with the latest .NET.
+{% endtab %}
 {% endtab %}
 {% tab title="Umbraco 17" %}
-* Update the following packages:
-  * `Umbraco.Forms.Deploy`
-  * `Umbraco.Cms`
-  * `Umbraco.Deploy.Cloud`
-  * `Umbraco.Deploy.Contrib`
-  * `Umbraco.Forms`
-  * `Umbraco.Cloud.Cms`
-  * `Umbraco.Cloud.StorageProviders.AzureBlob`
-* Open the `Licenses` folder and delete all Umbraco-related `.lic` files.
-* Keep any `.lic` files needed for your third-party tools.
+6. Update the all `Umbraco.` packages to the latest version 17.
+  * This **does not** include `Umbraco.Community.` packages, as we cannot guarantee their compatibility.
+  * Ensure the following default Cloud packages are upgraded:
+    * `Umbraco.Forms.Deploy`
+    * `Umbraco.Cms`
+    * `Umbraco.Deploy.Cloud`
+    * `Umbraco.Deploy.Contrib`
+    * `Umbraco.Forms`
+    * `Umbraco.Cloud.Cms`
+    * `Umbraco.Cloud.StorageProviders.AzureBlob`
+7. Open the `Licenses` folder and delete all Umbraco-related `.lic` files.
+8. Keep any `.lic` files needed for your third-party tools.
 
 If the folder is empty after deleting the files, you can safely remove the entire `Licenses` folder as well.
 
-*  _[Optional]_ If using Deploy and Forms on Umbraco Cloud:
+9. _[Optional]_ If using Deploy and Forms on Umbraco Cloud:
 
     1. Locate and open the `appsettings.json` file (and any environment-specific variants).
     2. Add the following section to `Umbraco:Licenses:Products:<ProductName>`:
@@ -154,66 +160,73 @@ If the folder is empty after deleting the files, you can safely remove the entir
     ```
 
     This ensures the built-in Umbraco Cloud licenses are recognized after upgrading. Without these values, you may encounter license validation errors even though your project is on Umbraco Cloud.
-* _\[Optional]_ If you use `InMemoryAuto` models builder, or rely on Razor runtime compilation for editing templates via the backoffice, reference the `Umbraco.Cms.DevelopmentMode.Backoffice` package. For more information, see the [Breaking Changes](https://docs.umbraco.com/umbraco-cms/17.latest/fundamentals/setup/upgrading/version-specific#umbraco-17) article.
+10. _\[Optional]_ If you use `InMemoryAuto` models builder, or rely on Razor runtime compilation for editing templates via the backoffice, reference the `Umbraco.Cms.DevelopmentMode.Backoffice` package. For more information, see the [Breaking Changes](https://docs.umbraco.com/umbraco-cms/17.latest/fundamentals/setup/upgrading/version-specific#umbraco-17) article.
+11. Ensure all projects and packages in your solution is compatible with the latest .NET.
 {% endtab %}
 
 {% tab title="Umbraco 15 and 16" %}
-Update the following packages:
-
-* `Umbraco.Forms.Deploy`
-* `Umbraco.Cms`
-* `Umbraco.Deploy.Cloud`
-* `Umbraco.Deploy.Contrib`
-* `Umbraco.Forms`
-* `Umbraco.Cloud.Cms`
-* `Umbraco.Cloud.StorageProviders.AzureBlob`
+6. Update the all `Umbraco.` packages to the latest version 15/16.
+  * This **does not** include `Umbraco.Community.` packages, as we cannot guarantee their compatibility.
+  * Ensure the following default Cloud packages are upgraded:
+    * `Umbraco.Forms.Deploy`
+    * `Umbraco.Cms`
+    * `Umbraco.Deploy.Cloud`
+    * `Umbraco.Deploy.Contrib`
+    * `Umbraco.Forms`
+    * `Umbraco.Cloud.Cms`
+    * `Umbraco.Cloud.StorageProviders.AzureBlob`
+7. Ensure all projects and packages in your solution is compatible with the latest .NET.
 {% endtab %}
 
 {% tab title="Umbraco 14" %}
-Update the following packages:
-
-* `Umbraco.Forms.Deploy`
-* `Umbraco.Cms`
-* `Umbraco.Deploy.Cloud`
-* `Umbraco.Deploy.Contrib`
-* `Umbraco.Forms`
-* `Umbraco.Cloud.Cms`
-* `Umbraco.Cloud.Identity.Cms`
-* `Umbraco.Cloud.Cms.PublicAccess`
-* `Umbraco.Cloud.StorageProviders.AzureBlob`
-* `Microsoft.Extensions.DependencyInjection.Abstractions`
+6. Update the all `Umbraco.` packages to the latest version 14.
+  * This **does not** include `Umbraco.Community.` packages, as we cannot guarantee their compatibility.
+  * Ensure the following default Cloud packages are upgraded:
+    * `Umbraco.Forms.Deploy`
+    * `Umbraco.Cms`
+    * `Umbraco.Deploy.Cloud`
+    * `Umbraco.Deploy.Contrib`
+    * `Umbraco.Forms`
+    * `Umbraco.Cloud.Cms`
+    * `Umbraco.Cloud.Identity.Cms`
+    * `Umbraco.Cloud.Cms.PublicAccess`
+    * `Umbraco.Cloud.StorageProviders.AzureBlob`
+    * `Microsoft.Extensions.DependencyInjection.Abstractions`
 {% endtab %}
 
 {% tab title="Umbraco 13" %}
 From Umbraco 13, the `Umbraco.Deploy.Forms` package has been replaced with the `Umbraco.Forms.Deploy` package.
 
-* Remove the `Umbraco.Deploy.Forms` package.
-* Update the following packages:
-  * `Umbraco.Cms`
-  * `Umbraco.Deploy.Cloud`
-  * `Umbraco.Deploy.Contrib`
-  * `Umbraco.Forms`
-  * `Umbraco.Cloud.Cms`
-  * `Umbraco.Cloud.Identity.Cms`
-  * `Umbraco.Cloud.Cms.PublicAccess`
-  * `Umbraco.Cloud.StorageProviders.AzureBlob`
-  * `Microsoft.Extensions.DependencyInjection.Abstractions`
-* Install the `Umbraco.Forms.Deploy` package.
+6. Remove the `Umbraco.Deploy.Forms` package.
+7. Update the all `Umbraco.` packages to the latest version 14.
+  * This **does not** include `Umbraco.Community.` packages, as we cannot guarantee their compatibility.
+  * Ensure the following default Cloud packages are upgraded:
+    * `Umbraco.Cms`
+    * `Umbraco.Deploy.Cloud`
+    * `Umbraco.Deploy.Contrib`
+    * `Umbraco.Forms`
+    * `Umbraco.Cloud.Cms`
+    * `Umbraco.Cloud.Identity.Cms`
+    * `Umbraco.Cloud.Cms.PublicAccess`
+    * `Umbraco.Cloud.StorageProviders.AzureBlob`
+    * `Microsoft.Extensions.DependencyInjection.Abstractions`
+8. Install the `Umbraco.Forms.Deploy` package.
 {% endtab %}
 
 {% tab title="Umbraco 10" %}
-Update the following packages:
-
-* `Umbraco.Deploy.Forms`
-* `Umbraco.Cms`
-* `Umbraco.Deploy.Cloud`
-* `Umbraco.Deploy.Contrib`
-* `Umbraco.Forms`
-* `Umbraco.Cloud.Cms`
-* `Umbraco.Cloud.Identity.Cms`
-* `Umbraco.Cloud.Cms.PublicAccess`
-* `Umbraco.Cloud.StorageProviders.AzureBlob`
-* `Microsoft.Extensions.DependencyInjection.Abstractions`
+6. Update the all `Umbraco.` packages to the latest version 14.
+  * This **does not** include `Umbraco.Community.` packages, as we cannot guarantee their compatibility.
+  * Ensure the following default Cloud packages are upgraded:
+    * `Umbraco.Deploy.Forms`
+    * `Umbraco.Cms`
+    * `Umbraco.Deploy.Cloud`
+    * `Umbraco.Deploy.Contrib`
+    * `Umbraco.Forms`
+    * `Umbraco.Cloud.Cms`
+    * `Umbraco.Cloud.Identity.Cms`
+    * `Umbraco.Cloud.Cms.PublicAccess`
+    * `Umbraco.Cloud.StorageProviders.AzureBlob`
+    * `Microsoft.Extensions.DependencyInjection.Abstractions`
 {% endtab %}
 {% endtabs %}
 

--- a/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
+++ b/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
@@ -112,8 +112,8 @@ Delete the `<PackageReference>` entries for these packages.
 
 {% tabs %}
 {% tab title="Umbraco 18" %}
-6. Update the all `Umbraco.` packages to the latest version 18.
-  * This **does not** include `Umbraco.Community.` packages, as we cannot guarantee their compatibility.
+6. Update the all `Umbraco.*` packages to the latest version 18.
+  * `Umbraco.Community.*` packages may also need updating, though we cannot guarantee their compatibility.
   * Ensure the following default Cloud packages are upgraded:
     * `Umbraco.Forms.Deploy`
     * `Umbraco.Cms`
@@ -127,7 +127,7 @@ Delete the `<PackageReference>` entries for these packages.
 {% endtab %}
 {% tab title="Umbraco 17" %}
 6. Update the all `Umbraco.` packages to the latest version 17.
-  * This **does not** include `Umbraco.Community.` packages, as we cannot guarantee their compatibility.
+  * `Umbraco.Community.*` packages may also need updating, though we cannot guarantee their compatibility.
   * Ensure the following default Cloud packages are upgraded:
     * `Umbraco.Forms.Deploy`
     * `Umbraco.Cms`
@@ -166,7 +166,7 @@ If the folder is empty after deleting the files, you can safely remove the entir
 
 {% tab title="Umbraco 15 and 16" %}
 6. Update the all `Umbraco.` packages to the latest version 15/16.
-  * This **does not** include `Umbraco.Community.` packages, as we cannot guarantee their compatibility.
+  * `Umbraco.Community.*` packages may also need updating, though we cannot guarantee their compatibility.
   * Ensure the following default Cloud packages are upgraded:
     * `Umbraco.Forms.Deploy`
     * `Umbraco.Cms`
@@ -180,7 +180,7 @@ If the folder is empty after deleting the files, you can safely remove the entir
 
 {% tab title="Umbraco 14" %}
 6. Update the all `Umbraco.` packages to the latest version 14.
-  * This **does not** include `Umbraco.Community.` packages, as we cannot guarantee their compatibility.
+  * `Umbraco.Community.*` packages may also need updating, though we cannot guarantee their compatibility.
   * Ensure the following default Cloud packages are upgraded:
     * `Umbraco.Forms.Deploy`
     * `Umbraco.Cms`
@@ -199,7 +199,7 @@ From Umbraco 13, the `Umbraco.Deploy.Forms` package has been replaced with the `
 
 6. Remove the `Umbraco.Deploy.Forms` package.
 7. Update the all `Umbraco.` packages to the latest version 14.
-  * This **does not** include `Umbraco.Community.` packages, as we cannot guarantee their compatibility.
+  * `Umbraco.Community.*` packages may also need updating, though we cannot guarantee their compatibility.
   * Ensure the following default Cloud packages are upgraded:
     * `Umbraco.Cms`
     * `Umbraco.Deploy.Cloud`
@@ -215,7 +215,7 @@ From Umbraco 13, the `Umbraco.Deploy.Forms` package has been replaced with the `
 
 {% tab title="Umbraco 10" %}
 6. Update the all `Umbraco.` packages to the latest version 14.
-  * This **does not** include `Umbraco.Community.` packages, as we cannot guarantee their compatibility.
+  * `Umbraco.Community.*` packages may also need updating, though we cannot guarantee their compatibility.
   * Ensure the following default Cloud packages are upgraded:
     * `Umbraco.Deploy.Forms`
     * `Umbraco.Cms`

--- a/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
+++ b/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
@@ -126,7 +126,7 @@ Delete the `<PackageReference>` entries for these packages.
 {% endtab %}
 {% endtab %}
 {% tab title="Umbraco 17" %}
-6. Update the all `Umbraco.` packages to the latest version 17.
+6. Update the all `Umbraco.*` packages to the latest version 17.
   * `Umbraco.Community.*` packages may also need updating, though we cannot guarantee their compatibility.
   * Ensure the following default Cloud packages are upgraded:
     * `Umbraco.Forms.Deploy`
@@ -165,7 +165,7 @@ If the folder is empty after deleting the files, you can safely remove the entir
 {% endtab %}
 
 {% tab title="Umbraco 15 and 16" %}
-6. Update the all `Umbraco.` packages to the latest version 15/16.
+6. Update the all `Umbraco.*` packages to the latest version 15/16.
   * `Umbraco.Community.*` packages may also need updating, though we cannot guarantee their compatibility.
   * Ensure the following default Cloud packages are upgraded:
     * `Umbraco.Forms.Deploy`
@@ -179,7 +179,7 @@ If the folder is empty after deleting the files, you can safely remove the entir
 {% endtab %}
 
 {% tab title="Umbraco 14" %}
-6. Update the all `Umbraco.` packages to the latest version 14.
+6. Update the all `Umbraco.*` packages to the latest version 14.
   * `Umbraco.Community.*` packages may also need updating, though we cannot guarantee their compatibility.
   * Ensure the following default Cloud packages are upgraded:
     * `Umbraco.Forms.Deploy`
@@ -198,7 +198,7 @@ If the folder is empty after deleting the files, you can safely remove the entir
 From Umbraco 13, the `Umbraco.Deploy.Forms` package has been replaced with the `Umbraco.Forms.Deploy` package.
 
 6. Remove the `Umbraco.Deploy.Forms` package.
-7. Update the all `Umbraco.` packages to the latest version 14.
+7. Update the all `Umbraco.*` packages to the latest version 14.
   * `Umbraco.Community.*` packages may also need updating, though we cannot guarantee their compatibility.
   * Ensure the following default Cloud packages are upgraded:
     * `Umbraco.Cms`
@@ -214,7 +214,7 @@ From Umbraco 13, the `Umbraco.Deploy.Forms` package has been replaced with the `
 {% endtab %}
 
 {% tab title="Umbraco 10" %}
-6. Update the all `Umbraco.` packages to the latest version 14.
+6. Update the all `Umbraco.*` packages to the latest version 14.
   * `Umbraco.Community.*` packages may also need updating, though we cannot guarantee their compatibility.
   * Ensure the following default Cloud packages are upgraded:
     * `Umbraco.Deploy.Forms`

--- a/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
+++ b/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
@@ -194,7 +194,7 @@ If the folder is empty after deleting the files, you can safely remove the entir
     * `Microsoft.Extensions.DependencyInjection.Abstractions`
 {% endtab %}
 
-{% tab title="Umbraco 13" %}
+{% tab title="Umbraco 13 (LTS)" %}
 From Umbraco 13, the `Umbraco.Deploy.Forms` package has been replaced with the `Umbraco.Forms.Deploy` package.
 
 6. Remove the `Umbraco.Deploy.Forms` package.

--- a/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
+++ b/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
@@ -111,6 +111,16 @@ Delete the `<PackageReference>` entries for these packages.
 5. Select the version you are updating to and follow the instructions:
 
 {% tabs %}
+{% tab title="Umbraco 18" %}
+* Update the following packages:
+  * `Umbraco.Forms.Deploy`
+  * `Umbraco.Cms`
+  * `Umbraco.Deploy.Cloud`
+  * `Umbraco.Deploy.Contrib`
+  * `Umbraco.Forms`
+  * `Umbraco.Cloud.Cms`
+  * `Umbraco.Cloud.StorageProviders.AzureBlob`
+{% endtab %}
 {% tab title="Umbraco 17" %}
 * Update the following packages:
   * `Umbraco.Forms.Deploy`

--- a/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
+++ b/umbraco-cloud/optimize-and-maintain-your-site/manage-product-upgrades/product-upgrades/major-upgrades.md
@@ -124,7 +124,7 @@ Delete the `<PackageReference>` entries for these packages.
     * `Umbraco.Cloud.StorageProviders.AzureBlob`
 7. Ensure all projects and packages in your solution is compatible with the latest .NET.
 {% endtab %}
-{% endtab %}
+
 {% tab title="Umbraco 17" %}
 6. Update the all `Umbraco.*` packages to the latest version 17.
   * `Umbraco.Community.*` packages may also need updating, though we cannot guarantee their compatibility.


### PR DESCRIPTION
## 📋 Description

Updated Major Upgrade guide to include Umbraco 18.
Made some minor tweaks to the version tables, making it a little clearer which packages to keep an eye out for when upgrading.

## Product & Version (if relevant)

Cloud, CMS+Forms+Deploy 18

## Deadline (if relevant)

As soon as it's been reviewed