### PR TITLE
Recommend local file workflow over backoffice for templates, partial views, and static assets

### DIFF
--- a/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/partial-views.md
+++ b/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/partial-views.md
@@ -6,9 +6,25 @@ description: Information on working with partial views in Umbraco
 
 A Partial View (`.cshtml` file) is a regular view that can be used multiple times throughout your site. A Partial View is used to break up large markup files into smaller components such as header, footer, navigation menu, and so on. It helps to reduce the duplication of code. A partial view renders a view within the parent view.
 
+{% hint style="warning" %}
+Creating a partial view from a snippet in the backoffice is a good way to scaffold a starting point. Managing partial views through the backoffice beyond that isn't the recommended approach for most projects.
+
+The backoffice editor doesn't integrate with source control or local build tooling. The editor also gives you no IntelliSense or type checking against your models. Mistakes surface when the page renders instead of while you work.
+
+Creating, editing, renaming, and deleting partial views in the backoffice is blocked entirely when the site runs in `Production` runtime mode. For more information, see [Runtime Modes](../../../run-in-production/runtime-modes.md).
+
+In other runtime modes, changes take effect immediately only with the Razor runtime compilation package installed. Without the package, you must rebuild and restart the site. For details, see ["InMemoryAuto models builder and Razor runtime compilation have moved into their own package"](../../../get-started/upgrading-and-migrating/version-specific/README.md#umbraco-17) in the Version-specific upgrades guide.
+
+Maintain partial views locally as `.cshtml` files in the `Views/Partials` folder using your own IDE. For more information, see [Source Control](../../application-code/backend-and-custom-logic/source-control.md).
+{% endhint %}
+
+## Creating a Partial View Locally
+
+Add a `.cshtml` file to the `Views/Partials` folder of your project using your own IDE. The file name becomes the partial view name.
+
 ## Partial Views in the Backoffice
 
-You can create and edit partial views from the **Partial Views** folder in the **Settings** section of the Backoffice.
+You can create and edit partial views from the **Partial Views** folder in the **Settings** section of the Backoffice. Use this to scaffold a file, then move ongoing edits to your project.
 
 ![Creating a new partial view](../../../.gitbook/assets/create-partial.png)
 
@@ -18,7 +34,7 @@ In the **Create** menu, there are three options available:
 * Partial view from snippet
 * Folder... (for keeping the partial views organized)
 
-## Creating a Partial View
+### Creating an Empty Partial View
 
 To create a partial view:
 
@@ -35,7 +51,7 @@ By default, the partial views are saved in the `Views/Partials` folder in the so
 
 ![Partial View folder in the project directory](../../../.gitbook/assets/partial-views-in-directory.png)
 
-## Creating a Partial View from Snippet
+### Creating a Partial View from Snippet
 
 To create a partial view from the snippet:
 
@@ -66,7 +82,7 @@ Umbraco provides the following partial view snippets:
 * Register Member - Displays a Member registration form. It will only display the properties marked as **Member can edit** on the **Info** tab of the Member Type.
 * Site Map - Displays a list of links of all the visible pages of the site using the `Traverse()` method to select and display the markup and links as nested unordered HTML lists.
 
-## Creating a Folder
+### Creating a Folder
 
 To create a folder:
 

--- a/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/partial-views.md
+++ b/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/partial-views.md
@@ -24,7 +24,7 @@ Add a `.cshtml` file to the `Views/Partials` folder of your project using your o
 
 ## Partial Views in the Backoffice
 
-You can create and edit partial views from the **Partial Views** folder in the **Settings** section of the Backoffice. Use this to scaffold a file, then move ongoing edits to your project.
+You can create and edit partial views from the **Partial Views** folder in the **Settings** section of the Backoffice. The file is created in your project's `Views/Partials` folder, so you can continue editing it in your own IDE.
 
 ![Creating a new partial view](../../../.gitbook/assets/create-partial.png)
 

--- a/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/stylesheets-javascript.md
+++ b/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/stylesheets-javascript.md
@@ -11,9 +11,11 @@ This article explains how to work with stylesheets and JavaScript and clarifies 
 {% hint style="warning" %}
 Managing stylesheets and JavaScript through the backoffice is not the recommended approach for most projects. The backoffice editor doesn't integrate with source control, build tooling, or local testing.
 
-Maintain these files locally in the `wwwroot/css` and `wwwroot/scripts` folders using your own IDE. Deploy them through your regular build and deployment process. For more information, see [Source Control](../../application-code/backend-and-custom-logic/source-control.md).
+Maintain these files in your project using your own IDE, and deploy them through your regular build and deployment process. For more information, see [Source Control](../../application-code/backend-and-custom-logic/source-control.md).
 
-Files you add or edit locally still appear in the backoffice. Click **...** next to the **Stylesheets** or **Scripts** folder and select **Reload children** to see the changes.
+Your site can serve stylesheets and JavaScript from anywhere under `wwwroot`, so these files don't have to sit in the folders shown below. The backoffice only lists the folders set by the `UmbracoCssPath` and `UmbracoScriptsPath` settings, which default to `wwwroot/css` and `wwwroot/scripts`. For more information, see [Global Settings](../../configuration/globalsettings.md).
+
+Files you add or edit in those folders still appear in the backoffice. Click **...** next to the **Stylesheets** or **Scripts** folder and select **Reload children** to see the changes.
 {% endhint %}
 
 ## Stylesheets in the Backoffice
@@ -38,7 +40,7 @@ To create a stylesheet:
 
 7. Click **Save**.
 
-The stylesheet is saved in the `wwwroot/css` folder of your project.
+The stylesheet is saved in the `wwwroot/css` folder of your project by default.
 
 ### Using stylesheets
 
@@ -78,7 +80,7 @@ To create JavaScript files:
 
 7. Click **Save**.
 
-The JavaScript is saved in the `wwwroot/scripts` folder of your project.
+The JavaScript is saved in the `wwwroot/scripts` folder of your project by default.
 
 ### Using JavaScript files
 

--- a/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/stylesheets-javascript.md
+++ b/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/stylesheets-javascript.md
@@ -4,9 +4,17 @@ description: Information on working with stylesheets and JavaScript in Umbraco.
 
 # Stylesheets And JavaScript
 
-In Umbraco, you can manage stylesheets and JavaScript files directly from the backoffice. These files are used to control the appearance and behavior of your website.
+Stylesheets and JavaScript files control the appearance and behavior of your website. In Umbraco, these files live in the `wwwroot` folder of your project. You can also manage them from the backoffice.
 
 This article explains how to work with stylesheets and JavaScript and clarifies how styling works with the Rich Text Editor (RTE) Data Type.
+
+{% hint style="warning" %}
+Managing stylesheets and JavaScript through the backoffice is not the recommended approach for most projects. The backoffice editor doesn't integrate with source control, build tooling, or local testing.
+
+Maintain these files locally in the `wwwroot/css` and `wwwroot/scripts` folders using your own IDE. Deploy them through your regular build and deployment process. For more information, see [Source Control](../../application-code/backend-and-custom-logic/source-control.md).
+
+Files you add or edit locally still appear in the backoffice. Click **...** next to the **Stylesheets** or **Scripts** folder and select **Reload children** to see the changes.
+{% endhint %}
 
 ## Stylesheets in the Backoffice
 
@@ -66,7 +74,7 @@ To create JavaScript files:
 5. Select **JavaScript file**.
 6. Give the file a name and add your JavaScript code.
 
-![Sample Javascript](../../../.gitbook/assets/sample-Javacsript.png)
+![Sample JavaScript](../../../.gitbook/assets/sample-Javacsript.png)
 
 7. Click **Save**.
 
@@ -81,10 +89,6 @@ Navigate to the template where you would like to reference your scripts:
 ```
 
 ![Reference the script in template](../../../.gitbook/assets/script-reference.png)
-
-{% hint style="info" %}
-If you are working locally, you can create CSS and JS files outside of the Backoffice. Place files in the `css` or `scripts` folders. In the Backoffice, click **...** next to the **Stylesheets** or **Scripts** folder and select **Reload children**.
-{% endhint %}
 
 ## Rich Text Editor styling
 

--- a/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/templates.md
+++ b/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/templates.md
@@ -6,7 +6,19 @@ description: Templating in Umbraco builds on the concept of Razor Views from ASP
 
 Templates are the files that control the look and feel of the frontend of your Umbraco websites. Building on the concept of MVC Razor Views, template files enable you to structure your websites using HTML, CSS, and JavaScript. When tied to a Document Type, templates are used to render your Umbraco content on the frontend.
 
-You can manage and work with your templates directly from the Settings section in the Umbraco backoffice. Each Template can also be found as a `cshtml` file in the `Views` folder in your project directory.
+Each Template is a `cshtml` file in the `Views` folder of your project directory. You can also manage Templates from the Settings section in the Umbraco backoffice.
+
+{% hint style="warning" %}
+Generating a Template alongside a new Document Type is a good way to scaffold a starting point. Managing Templates through the backoffice beyond that isn't the recommended approach for most projects.
+
+The backoffice editor doesn't integrate with source control or local build tooling. The editor also gives you no IntelliSense or type checking against your models. Mistakes surface when the page renders instead of while you work.
+
+Editing Templates in the backoffice is blocked entirely when the site runs in `Production` runtime mode. For more information, see [Runtime Modes](../../run-in-production/runtime-modes.md).
+
+In other runtime modes, changes take effect immediately only with the Razor runtime compilation package installed. Without the package, you must rebuild and restart the site. For details, see ["InMemoryAuto models builder and Razor runtime compilation have moved into their own package"](../../get-started/upgrading-and-migrating/version-specific/README.md#umbraco-17) in the Version-specific upgrades guide.
+
+Maintain Templates locally as `.cshtml` files in the `Views` folder using your own IDE. For more information, see [Source Control](../application-code/backend-and-custom-logic/source-control.md).
+{% endhint %}
 
 ## Creating Templates
 
@@ -25,6 +37,12 @@ In some cases, you might want to create independent Templates that don't have a 
 You will now see the default template markup in the backoffice template editor.
 
 ![Created template](../../.gitbook/assets/create-template.png)
+
+{% hint style="info" %}
+Templates are registered in the Umbraco database, so adding a `.cshtml` file to the `Views` folder does not create one on its own.
+
+If the file already exists, create the Template using the file name as the alias. Umbraco picks up the existing file content instead of overwriting it.
+{% endhint %}
 
 ## Allowing a Template on a Document Type
 
@@ -74,7 +92,7 @@ Alternatively, you can manually change the value of the `Layout` variable in the
 The updated markup will look something like the snippet below and the Template is now referred to as a _Child Template_:
 
 ```csharp
-@inherits Umbraco.Web.Mvc.UmbracoViewPage
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @{
     Layout = "MainView.cshtml";
 }
@@ -86,7 +104,7 @@ When a page that uses a Template with a Master Template defined is rendered, the
 The code from the Template replaces the `@RenderBody()` tag in the Master Template. Following the examples above, the final HTML will look like the code in the snippet below:
 
 ```csharp
-@inherits Umbraco.Web.Mvc.UmbracoViewPage
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @{
     Layout = null;
 }
@@ -105,16 +123,9 @@ Template Sections give you added flexibility when building your templates. Use t
 
 If a Child Template needs to add code to the `<head>` tag a Section must be defined and then used in the Master Template. This is made possible by [Named Sections](https://www.youtube.com/watch?v=lrnJwglbGUA).
 
-The following steps will guide you through defining and using a Named Section:
+### Using code
 
-1. Open your Template.
-2. Select the **Sections** option.
-3. Choose **Define a named section**.
-4. Give the section a name and click **Submit**.
-
-![Define a named section by giving it a name](../../.gitbook/assets/defined-named-section.png)
-
-The following code will be added to your Template:
+Define a named section in your Template:
 
 ```csharp
 @section SectionName {
@@ -122,19 +133,16 @@ The following code will be added to your Template:
 }
 ```
 
-5. Add your code between the curly brackets.
-6. Save the changes.
-7. Open the Master Template.
-8. Choose a spot for the section and set the cursor there.
-9. Select the **Sections** option.
-10. Choose **Render a named section**.
-11. Enter the name of the section you want to add.
-12. Click **Submit**.
+Add your code between the curly brackets, then render the section in your Master Template:
+
+```csharp
+@RenderSection("SectionName", false)
+```
 
 For instance, if you want to be able to add HTML to your `<head>` tags, you would add the tag there:
 
 ```csharp
-@inherits Umbraco.Web.Mvc.UmbracoViewPage
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @{
     Layout = null;
 }
@@ -150,7 +158,29 @@ For instance, if you want to be able to add HTML to your `<head>` tags, you woul
 </html>
 ```
 
-You can decide whether a section should be mandatory or not. Making a section mandatory means that any template using the Master Template is required to have the section defined.
+### Using the backoffice
+
+The **Sections** dialog writes the same `@section` and `@RenderSection()` code for you:
+
+1. Open your Template.
+2. Select the **Sections** option.
+3. Choose **Define a named section**.
+4. Give the section a name and click **Submit**.
+
+![Define a named section by giving it a name](../../.gitbook/assets/defined-named-section.png)
+
+5. Add your code between the curly brackets.
+6. Save the changes.
+7. Open the Master Template.
+8. Choose a spot for the section and set the cursor there.
+9. Select the **Sections** option.
+10. Choose **Render a named section**.
+11. Enter the name of the section you want to add.
+12. Click **Submit**.
+
+### Making a section mandatory
+
+Making a section mandatory means that any template using the Master Template is required to have the section defined.
 
 {% hint style="info" %}
 Keep in mind that whenever a mandatory named section is missing, it will result in errors on your website.
@@ -158,7 +188,7 @@ Keep in mind that whenever a mandatory named section is missing, it will result 
 
 To make the section mandatory, you have two options:
 
-* Add `true` to the code tag: `@RenderSection("SectionName", true)`.
+* Pass `true` as the second argument: `@RenderSection("SectionName", true)`.
 * Check the **Section is mandatory** field when using the **Sections** dialog in the backoffice.
 
 ![Create partial](../../.gitbook/assets/render-named-section-mandatory.png)
@@ -167,26 +197,27 @@ To make the section mandatory, you have two options:
 
 Another way to reuse HTML is to use partial views - which are small reusable views that can be injected into another view.
 
-Like templates, you can create a partial view, by clicking **...** next to the **Partial Views** folder and selecting **Create**. You can then either create an empty partial view or a partial view from a snippet.
+Like Templates, a partial view is a `.cshtml` file in your project, stored in the `Views/Partials` folder. You can also create one from the **Partial Views** folder in the backoffice. For more information, see [Partial Views](design/partial-views.md).
 
 ![Create partial](../../.gitbook/assets/create-partial.png)
 
-The created partial view can now be injected into any template by using the `@Html.Partial()` method like so:
+The partial view can be injected into any template using the `<partial>` tag helper, like so:
 
 ```csharp
-@inherits Umbraco.Web.Mvc.UmbracoViewPage
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @{
     Layout = "MasterView.cshtml";
 }
 
 <h1>My new page</h1>
-@Html.Partial("a-new-view")
+<partial name="~/Views/Partials/a-new-view.cshtml" />
 ```
 
 ### Related Articles
 
 * [Working with MVC](templating/mvc/README.md)
 * [Rendering content](design/rendering-content.md)
+* [Partial Views](design/partial-views.md)
 
 ### Tutorials
 

--- a/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/partial-views.md
+++ b/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/partial-views.md
@@ -24,7 +24,7 @@ Add a `.cshtml` file to the `Views/Partials` folder of your project using your o
 
 ## Partial Views in the Backoffice
 
-You can create and edit partial views from the **Partial Views** folder in the **Settings** section of the Backoffice. Use this to scaffold a file, then move ongoing edits to your project.
+You can create and edit partial views from the **Partial Views** folder in the **Settings** section of the Backoffice. The file is created in your project's `Views/Partials` folder, so you can continue editing it in your own IDE.
 
 ![Creating a new partial view](../../../.gitbook/assets/create-partial.png)
 

--- a/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/partial-views.md
+++ b/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/partial-views.md
@@ -6,9 +6,25 @@ description: Information on working with partial views in Umbraco
 
 A Partial View (`.cshtml` file) is a regular view that can be used multiple times throughout your site. A Partial View is used to break up large markup files into smaller components such as header, footer, navigation menu, and so on. It helps to reduce the duplication of code. A partial view renders a view within the parent view.
 
+{% hint style="warning" %}
+Creating a partial view from a snippet in the backoffice is a good way to scaffold a starting point. Managing partial views through the backoffice beyond that isn't the recommended approach for most projects.
+
+The backoffice editor doesn't integrate with source control or local build tooling. The editor also gives you no IntelliSense or type checking against your models. Mistakes surface when the page renders instead of while you work.
+
+Creating, editing, renaming, and deleting partial views in the backoffice is blocked entirely when the site runs in `Production` runtime mode. For more information, see [Runtime Modes](../../../run-in-production/runtime-modes.md).
+
+In other runtime modes, changes take effect immediately only with the Razor runtime compilation package installed. Without the package, you must rebuild and restart the site. For details, see ["InMemoryAuto models builder and Razor runtime compilation have moved into their own package"](../../../get-started/upgrading-and-migrating/version-specific/README.md#umbraco-17) in the Version-specific upgrades guide.
+
+Maintain partial views locally as `.cshtml` files in the `Views/Partials` folder using your own IDE. For more information, see [Source Control](../../application-code/backend-and-custom-logic/source-control.md).
+{% endhint %}
+
+## Creating a Partial View Locally
+
+Add a `.cshtml` file to the `Views/Partials` folder of your project using your own IDE. The file name becomes the partial view name.
+
 ## Partial Views in the Backoffice
 
-You can create and edit partial views from the **Partial Views** folder in the **Settings** section of the Backoffice.
+You can create and edit partial views from the **Partial Views** folder in the **Settings** section of the Backoffice. Use this to scaffold a file, then move ongoing edits to your project.
 
 ![Creating a new partial view](../../../.gitbook/assets/create-partial.png)
 
@@ -18,7 +34,7 @@ In the **Create** menu, there are three options available:
 * Partial view from snippet
 * Folder... (for keeping the partial views organized)
 
-## Creating a Partial View
+### Creating an Empty Partial View
 
 To create a partial view:
 
@@ -33,7 +49,7 @@ To create a partial view:
 
 By default, the partial views are saved in the `Views/Partials` folder in the solution.
 
-## Creating a Partial View from Snippet
+### Creating a Partial View from Snippet
 
 To create a partial view from the snippet:
 
@@ -64,7 +80,7 @@ Umbraco provides the following partial view snippets:
 * Register Member - Displays a Member registration form. It will only display the properties marked as **Member can edit** on the **Info** tab of the Member Type.
 * Site Map - Displays a list of links of all the visible pages of the site using the `Traverse()` method to select and display the markup and links as nested unordered HTML lists.
 
-## Creating a Folder
+### Creating a Folder
 
 To create a folder:
 

--- a/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/stylesheets-javascript.md
+++ b/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/stylesheets-javascript.md
@@ -11,9 +11,11 @@ This article explains how to work with stylesheets and JavaScript and clarifies 
 {% hint style="warning" %}
 Managing stylesheets and JavaScript through the backoffice is not the recommended approach for most projects. The backoffice editor doesn't integrate with source control, build tooling, or local testing.
 
-Maintain these files locally in the `wwwroot/css` and `wwwroot/scripts` folders using your own IDE. Deploy them through your regular build and deployment process. For more information, see [Source Control](../../application-code/backend-and-custom-logic/source-control.md).
+Maintain these files in your project using your own IDE, and deploy them through your regular build and deployment process. For more information, see [Source Control](../../application-code/backend-and-custom-logic/source-control.md).
 
-Files you add or edit locally still appear in the backoffice. Click **...** next to the **Stylesheets** or **Scripts** folder and select **Reload children** to see the changes.
+Your site can serve stylesheets and JavaScript from anywhere under `wwwroot`, so these files don't have to sit in the folders shown below. The backoffice only lists the folders set by the `UmbracoCssPath` and `UmbracoScriptsPath` settings, which default to `wwwroot/css` and `wwwroot/scripts`. For more information, see [Global Settings](../../configuration/globalsettings.md).
+
+Files you add or edit in those folders still appear in the backoffice. Click **...** next to the **Stylesheets** or **Scripts** folder and select **Reload children** to see the changes.
 {% endhint %}
 
 ## Stylesheets in the Backoffice
@@ -38,7 +40,7 @@ To create a stylesheet:
 
 7. Click **Save**.
 
-The stylesheet is saved in the `wwwroot/css` folder of your project.
+The stylesheet is saved in the `wwwroot/css` folder of your project by default.
 
 ### Using stylesheets
 
@@ -78,7 +80,7 @@ To create JavaScript files:
 
 7. Click **Save**.
 
-The JavaScript is saved in the `wwwroot/scripts` folder of your project.
+The JavaScript is saved in the `wwwroot/scripts` folder of your project by default.
 
 ### Using JavaScript files
 

--- a/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/stylesheets-javascript.md
+++ b/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/design/stylesheets-javascript.md
@@ -4,9 +4,17 @@ description: Information on working with stylesheets and JavaScript in Umbraco.
 
 # Stylesheets And JavaScript
 
-In Umbraco, you can manage stylesheets and JavaScript files directly from the backoffice. These files are used to control the appearance and behavior of your website.
+Stylesheets and JavaScript files control the appearance and behavior of your website. In Umbraco, these files live in the `wwwroot` folder of your project. You can also manage them from the backoffice.
 
 This article explains how to work with stylesheets and JavaScript and clarifies how styling works with the Rich Text Editor (RTE) Data Type.
+
+{% hint style="warning" %}
+Managing stylesheets and JavaScript through the backoffice is not the recommended approach for most projects. The backoffice editor doesn't integrate with source control, build tooling, or local testing.
+
+Maintain these files locally in the `wwwroot/css` and `wwwroot/scripts` folders using your own IDE. Deploy them through your regular build and deployment process. For more information, see [Source Control](../../application-code/backend-and-custom-logic/source-control.md).
+
+Files you add or edit locally still appear in the backoffice. Click **...** next to the **Stylesheets** or **Scripts** folder and select **Reload children** to see the changes.
+{% endhint %}
 
 ## Stylesheets in the Backoffice
 
@@ -66,7 +74,7 @@ To create JavaScript files:
 5. Select **JavaScript file**.
 6. Give the file a name and add your JavaScript code.
 
-![Sample Javascript](../../../.gitbook/assets/sample-Javacsript.png)
+![Sample JavaScript](../../../.gitbook/assets/sample-Javacsript.png)
 
 7. Click **Save**.
 
@@ -81,10 +89,6 @@ Navigate to the template where you would like to reference your scripts:
 ```
 
 ![Reference the script in template](../../../.gitbook/assets/script-reference.png)
-
-{% hint style="info" %}
-If you are working locally, you can create CSS and JS files outside of the Backoffice. Place files in the `css` or `scripts` folders. In the Backoffice, click **...** next to the **Stylesheets** or **Scripts** folder and select **Reload children**.
-{% endhint %}
 
 ## Rich Text Editor styling
 

--- a/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/templates.md
+++ b/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/templates.md
@@ -6,7 +6,19 @@ description: Templating in Umbraco builds on the concept of Razor Views from ASP
 
 Templates are the files that control the look and feel of the frontend of your Umbraco websites. Building on the concept of MVC Razor Views, template files enable you to structure your websites using HTML, CSS, and JavaScript. When tied to a Document Type, templates are used to render your Umbraco content on the frontend.
 
-You can manage and work with your templates directly from the Settings section in the Umbraco backoffice. Each Template can also be found as a `cshtml` file in the `Views` folder in your project directory.
+Each Template is a `cshtml` file in the `Views` folder of your project directory. You can also manage Templates from the Settings section in the Umbraco backoffice.
+
+{% hint style="warning" %}
+Generating a Template alongside a new Document Type is a good way to scaffold a starting point. Managing Templates through the backoffice beyond that isn't the recommended approach for most projects.
+
+The backoffice editor doesn't integrate with source control or local build tooling. The editor also gives you no IntelliSense or type checking against your models. Mistakes surface when the page renders instead of while you work.
+
+Editing Templates in the backoffice is blocked entirely when the site runs in `Production` runtime mode. For more information, see [Runtime Modes](../../run-in-production/runtime-modes.md).
+
+In other runtime modes, changes take effect immediately only with the Razor runtime compilation package installed. Without the package, you must rebuild and restart the site. For details, see ["InMemoryAuto models builder and Razor runtime compilation have moved into their own package"](../../get-started/upgrading-and-migrating/version-specific/README.md#umbraco-17) in the Version-specific upgrades guide.
+
+Maintain Templates locally as `.cshtml` files in the `Views` folder using your own IDE. For more information, see [Source Control](../application-code/backend-and-custom-logic/source-control.md).
+{% endhint %}
 
 ## Creating Templates
 
@@ -25,6 +37,12 @@ In some cases, you might want to create independent Templates that don't have a 
 You will now see the default template markup in the backoffice template editor.
 
 ![Created template](../../.gitbook/assets/create-template.png)
+
+{% hint style="info" %}
+Templates are registered in the Umbraco database, so adding a `.cshtml` file to the `Views` folder does not create one on its own.
+
+If the file already exists, create the Template using the file name as the alias. Umbraco picks up the existing file content instead of overwriting it.
+{% endhint %}
 
 ## Allowing a Template on a Document Type
 
@@ -75,7 +93,7 @@ Alternatively, you can manually change the value of the `Layout` variable in the
 The updated markup will look something like the snippet below and the Template is now referred to as a _Child Template_:
 
 ```csharp
-@inherits Umbraco.Web.Mvc.UmbracoViewPage
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @{
     Layout = "MainView.cshtml";
 }
@@ -87,7 +105,7 @@ When a page that uses a Template with a Layout Template defined is rendered, the
 The code from the Template replaces the `@RenderBody()` tag in the Layout Template. Following the examples above, the final HTML will look like the code in the snippet below:
 
 ```csharp
-@inherits Umbraco.Web.Mvc.UmbracoViewPage
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @{
     Layout = null;
 }
@@ -106,16 +124,9 @@ Template Sections give you added flexibility when building your templates. Use t
 
 If a Child Template needs to add code to the `<head>` tag a Section must be defined and then used in the Layout Template. This is made possible by [Named Sections](https://www.youtube.com/watch?v=lrnJwglbGUA).
 
-The following steps will guide you through defining and using a Named Section:
+### Using code
 
-1. Open your Template.
-2. Select the **Sections** option.
-3. Choose **Define a named section**.
-4. Give the section a name and click **Submit**.
-
-![Define a named section by giving it a name](../../.gitbook/assets/defined-named-section.png)
-
-The following code will be added to your Template:
+Define a named section in your Template:
 
 ```csharp
 @section SectionName {
@@ -123,19 +134,16 @@ The following code will be added to your Template:
 }
 ```
 
-5. Add your code between the curly brackets.
-6. Save the changes.
-7. Open the Layout Template.
-8. Choose a spot for the section and set the cursor there.
-9. Select the **Sections** option.
-10. Choose **Render a named section**.
-11. Enter the name of the section you want to add.
-12. Click **Submit**.
+Add your code between the curly brackets, then render the section in your Layout Template:
+
+```csharp
+@RenderSection("SectionName", false)
+```
 
 For instance, if you want to be able to add HTML to your `<head>` tags, you would add the tag there:
 
 ```csharp
-@inherits Umbraco.Web.Mvc.UmbracoViewPage
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @{
     Layout = null;
 }
@@ -151,7 +159,29 @@ For instance, if you want to be able to add HTML to your `<head>` tags, you woul
 </html>
 ```
 
-You can decide whether a section should be mandatory or not. Making a section mandatory means that any template using the Layout Template is required to have the section defined.
+### Using the backoffice
+
+The **Sections** dialog writes the same `@section` and `@RenderSection()` code for you:
+
+1. Open your Template.
+2. Select the **Sections** option.
+3. Choose **Define a named section**.
+4. Give the section a name and click **Submit**.
+
+![Define a named section by giving it a name](../../.gitbook/assets/defined-named-section.png)
+
+5. Add your code between the curly brackets.
+6. Save the changes.
+7. Open the Layout Template.
+8. Choose a spot for the section and set the cursor there.
+9. Select the **Sections** option.
+10. Choose **Render a named section**.
+11. Enter the name of the section you want to add.
+12. Click **Submit**.
+
+### Making a section mandatory
+
+Making a section mandatory means that any template using the Layout Template is required to have the section defined.
 
 {% hint style="info" %}
 Keep in mind that whenever a mandatory named section is missing, it will result in errors on your website.
@@ -159,7 +189,7 @@ Keep in mind that whenever a mandatory named section is missing, it will result 
 
 To make the section mandatory, you have two options:
 
-* Add `true` to the code tag: `@RenderSection("SectionName", true)`.
+* Pass `true` as the second argument: `@RenderSection("SectionName", true)`.
 * Check the **Section is mandatory** field when using the **Sections** dialog in the backoffice.
 
 ![Create partial](../../.gitbook/assets/render-named-section-mandatory.png)
@@ -168,26 +198,27 @@ To make the section mandatory, you have two options:
 
 Another way to reuse HTML is to use partial views - which are small reusable views that can be injected into another view.
 
-Like templates, you can create a partial view, by clicking **...** next to the **Partial Views** folder and selecting **Create**. You can then either create an empty partial view or a partial view from a snippet.
+Like Templates, a partial view is a `.cshtml` file in your project, stored in the `Views/Partials` folder. You can also create one from the **Partial Views** folder in the backoffice. For more information, see [Partial Views](design/partial-views.md).
 
 ![Create partial](../../.gitbook/assets/create-partial.png)
 
-The created partial view can now be injected into any template by using the `@Html.Partial()` method like so:
+The partial view can be injected into any template using the `<partial>` tag helper, like so:
 
 ```csharp
-@inherits Umbraco.Web.Mvc.UmbracoViewPage
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @{
     Layout = "MainView.cshtml";
 }
 
 <h1>My new page</h1>
-@Html.Partial("a-new-view")
+<partial name="~/Views/Partials/a-new-view.cshtml" />
 ```
 
 ### Related Articles
 
 * [Working with MVC](templating/mvc/README.md)
 * [Rendering content](design/rendering-content.md)
+* [Partial Views](design/partial-views.md)
 
 ### Tutorials
 


### PR DESCRIPTION
## 📋 Description

The **Stylesheets And JavaScript**, **Partial Views**, and **Working with Templates** articles presented the backoffice as the primary place to manage site assets. Nothing indicated that this is unsuitable for most real projects, and each article opened by actively promoting the backoffice workflow.

Each article now leads with the file-based reality and carries a warning covering source control, build tooling, and the lack of IntelliSense or type checking in the backoffice editor.

For Templates and Partial Views, the runtime behaviour is now documented:

* Backoffice editing is blocked when the site runs in `Production` runtime mode.
* In other runtime modes, changes take effect immediately only with the Razor runtime compilation package installed. Without it, a rebuild and restart is needed.

The Templates article also notes that adding a `.cshtml` file to `Views` does not register a Template on its own. If the file already exists, creating a Template with a matching alias adopts the existing file content instead of overwriting it.

Stylesheets and Scripts deliberately make no production-mode claim, as those services have no runtime-mode restriction.

Other fixes made while in these files:

* Replaced `@Html.Partial()` with the `<partial>` tag helper, which the Partial Views article already recommended.
* Corrected the pre-v9 `Umbraco.Web.Mvc.UmbracoViewPage` namespace, which contradicted the correct namespace used elsewhere in the same article.
* Nested the backoffice create steps under their parent sections, since they were top-level headings describing options of one section.
* Split **Named Sections** into code and backoffice paths, with the mandatory-section guidance covering both.

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco CMS, versions 17 and 18.

## Deadline (if relevant)

None.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
