### PR TITLE
Rewrite UDI Identifiers article

### DIFF
--- a/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/README.md
+++ b/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/README.md
@@ -2,9 +2,9 @@
 
 _Overview of multiple ways of querying, filtering, and searching published content for use on your website._
 
-## [UDI identifiers](udi-identifiers.md)
+## [UDI Identifiers](udi-identifiers.md)
 
-Umbraco stores identifiers in UDI format for most Umbraco object types. This identifier stores all of the metadata required to retrieve an Umbraco object and is parseable within text. Example: `umb://document/4fed18d8c5e34d5e88cfff3a5b457bf2`. UDI's can be used in many of the querying APIs.
+A UDI is a string that identifies an Umbraco entity, such as `umb://document/4fed18d8c5e34d5e88cfff3a5b457bf2`. Some of the querying APIs accept UDIs directly.
 
 ## [IPublishedContent](ipublishedcontent/)
 

--- a/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/querying.md
+++ b/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/querying.md
@@ -27,7 +27,7 @@ You can also retrieve content using the `Guid` Id. In the example "ca4249ed-2b23
 @Umbraco.Content(Guid.Parse("ca4249ed-2b23-4337-b522-63cabe5587d1"))
 ```
 
-You can also pass a [Udi](udi-identifiers.md) to retrieve the content.
+You can also pass a UDI to retrieve the content. For more information, see the [UDI Identifiers](udi-identifiers.md) article.
 
 ```csharp
 // to return the Umbraco.Core.Models.IPublishedContent

--- a/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/udi-identifiers.md
+++ b/17/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/udi-identifiers.md
@@ -1,80 +1,86 @@
+---
+description: >-
+  UDIs are an identifier format in Umbraco. Learn how they are structured, how to
+  query content with them, and how to convert between UDIs and GUIDs.
+---
+
 # UDI Identifiers
 
-Umbraco uses Unique Document Identifiers (UDIs) to reference most object types, such as content, media, and members. A UDI contains all the metadata needed to retrieve an Umbraco object and is readable within text.
+A Unique Document Identifier (UDI) is a string that identifies an Umbraco entity. An example of a UDI is `umb://document/4fed18d8c5e34d5e88cfff3a5b457bf2`.
 
-Example:
-
-```text
-umb://document/4fed18d8c5e34d5e88cfff3a5b457bf2. 
-```
-
-UDIs are commonly used in Umbraco’s querying and management APIs.
+Most Umbraco APIs identify entities by their GUID key. The backoffice and the Management API both work with plain GUIDs. UDIs are more commonly used as a storage and integration format.
 
 ## Format
 
 A UDI consists of three parts:
 
-1. Scheme: `umb://` – Identifies as an Umbraco UDI.
-2. Type: `document`– Specifies the object type (for example, media, member, Data Type, and so on).
-3. GUID Identifier: `4fed18d8c5e34d5e88cfff3a5b457bf2` – A unique identifier for the object (a GUID without dashes).
+| Part | Example | Description |
+| --- | --- | --- |
+| Scheme | `umb://` | Marks the value as an Umbraco identifier. |
+| Entity type | `document` | The type of entity the identifier points to. Other examples are `media`, `member`, and `data-type`. |
+| Identifier | `4fed18d8c5e34d5e88cfff3a5b457bf2` | The unique identifier of the entity. |
 
-## Usage
+### GUID and string UDIs
 
-UDIs are useful for retrieving content, media, or other Umbraco objects through the API. Below are examples of how to use a UDI in C# to get content or media.
+The identifier part is either a GUID or a string. Which one is used depends on the entity type.
 
-### Retrieving Content by UDI
+A [`GuidUdi`](https://apidocs.umbraco.com/v17/csharp/api/Umbraco.Cms.Core.GuidUdi.html) has a GUID as its identifier. The GUID is written without dashes. Most entity types use this format, such as `document`, `media`, and `member`.
 
-You can retrieve a content item using `IContentService`:
+```none
+umb://document/4fed18d8c5e34d5e88cfff3a5b457bf2
+```
 
-```cs
-using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Models
+A [`StringUdi`](https://apidocs.umbraco.com/v17/csharp/api/Umbraco.Cms.Core.StringUdi.html) has a string as its identifier, such as a file path or a culture code. A few entity types use this format, such as `stylesheet`, `script`, and `language`.
 
-@inject IContentService contentService
+```none
+umb://stylesheet/style.css
+umb://language/en-US
+```
+
+## Query content with a UDI
+
+`IPublishedContentQuery` accepts UDIs directly through the `Content(Udi)` and `Media(Udi)` overloads. You do not need to convert a UDI to a GUID first.
+
+The following example resolves a UDI in a view:
+
+{% code title="MyView.cshtml" %}
+
+```csharp
+@using Umbraco.Cms.Core
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
+@inject IPublishedContentQuery PublishedContentQuery
 
 @{
-   // Define the UDI string here
-    var udiString = "umb://document/334cadfa62dd49049aad86b6e4c02aac"; // Example UDI string
-
-   if (udiString.StartsWith("umb://document/"))
+    const string storedValue = "umb://document/4fed18d8c5e34d5e88cfff3a5b457bf2";
+    if (UdiParser.TryParse(storedValue, out Udi? udi))
     {
-        // Extract the GUID from the UDI string
-        var guidString = udiString.Replace("umb://document/", "");
-        if (Guid.TryParse(guidString, out var guid))
-        {
-            // Retrieve the content by GUID
-            var content = contentService.GetById(guid);
-            if (content != null)
-            {
-                // Access the body text field
-                var bodyText = content.GetValue<string>("bodyText"); // Replace 'bodyText' with the alias of your body text field
-                <p>@bodyText</p>  // Output the body text
-            }
-        else
-            {
-                <p>Content not found.</p>
-            }
-        }
-        else
-        {
-            <p>Invalid GUID in the UDI string.</p>
-        }
+        // Pass the UDI straight to the query. No conversion needed.
+        IPublishedContent? content = PublishedContentQuery.Content(udi);
+        <p>@content?.Name</p>
     }
 }
 ```
 
-## UDI Types
+{% endcode %}
 
-There are two types of UDIs in Umbraco:
+`UmbracoHelper` exposes the same overloads. In a view that inherits `UmbracoViewPage`, you can call `Umbraco.Content(udi)` instead.
 
-### GUID UDI
+## Convert between UDIs and GUIDs
 
-Used for objects that have a GUID identifier, such as content and media.
+Use `UdiParser.TryParse()` to read a UDI. Parsing is safer than manipulating the string, as it validates both the entity type and the identifier. The `Guid` property gives you the key used by the GUID-first APIs:
 
-* [API Reference: GuidUdi](https://apidocs.umbraco.com/v17/csharp/api/Umbraco.Cms.Core.GuidUdi.html)
+```csharp
+if (UdiParser.TryParse("umb://document/4fed18d8c5e34d5e88cfff3a5b457bf2", out GuidUdi? udi))
+{
+    Guid contentKey = udi.Guid;
+}
+```
 
-### String UDI
+To build a UDI from an entity type and a GUID key, use `Udi.Create()`:
 
-Used for objects that are not GUID-based, such as dictionary items.
+```csharp
+Guid contentKey = Guid.Parse("4fed18d8-c5e3-4d5e-88cf-ff3a5b457bf2");
+Udi udi = Udi.Create(Constants.UdiEntityType.Document, contentKey);
+```
 
-* [API Reference: StringUdi](https://apidocs.umbraco.com/v17/csharp/api/Umbraco.Cms.Core.StringUdi.html)
+These types are all in the `Umbraco.Cms.Core` namespace.

--- a/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/README.md
+++ b/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/README.md
@@ -2,9 +2,9 @@
 
 _Overview of multiple ways of querying, filtering, and searching published content for use on your website._
 
-## [UDI identifiers](udi-identifiers.md)
+## [UDI Identifiers](udi-identifiers.md)
 
-Umbraco stores identifiers in UDI format for most Umbraco object types. This identifier stores all of the metadata required to retrieve an Umbraco object and is parseable within text. Example: `umb://document/4fed18d8c5e34d5e88cfff3a5b457bf2`. UDI's can be used in many of the querying APIs.
+A UDI is a string that identifies an Umbraco entity, such as `umb://document/4fed18d8c5e34d5e88cfff3a5b457bf2`. Some of the querying APIs accept UDIs directly.
 
 ## [IPublishedContent](ipublishedcontent/)
 

--- a/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/querying.md
+++ b/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/querying.md
@@ -27,7 +27,7 @@ You can also retrieve content using the `Guid` Id. In the example "ca4249ed-2b23
 @Umbraco.Content(Guid.Parse("ca4249ed-2b23-4337-b522-63cabe5587d1"))
 ```
 
-You can also pass a [Udi](udi-identifiers.md) to retrieve the content.
+You can also pass a UDI to retrieve the content. For more information, see the [UDI Identifiers](udi-identifiers.md) article.
 
 ```csharp
 // to return the Umbraco.Core.Models.IPublishedContent

--- a/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/udi-identifiers.md
+++ b/18/umbraco-cms/develop-with-umbraco/templating-and-rendering/querying/udi-identifiers.md
@@ -1,80 +1,86 @@
+---
+description: >-
+  UDIs are an identifier format in Umbraco. Learn how they are structured, how to
+  query content with them, and how to convert between UDIs and GUIDs.
+---
+
 # UDI Identifiers
 
-Umbraco uses Unique Document Identifiers (UDIs) to reference most object types, such as content, media, and members. A UDI contains all the metadata needed to retrieve an Umbraco object and is readable within text.
+A Unique Document Identifier (UDI) is a string that identifies an Umbraco entity. An example of a UDI is `umb://document/4fed18d8c5e34d5e88cfff3a5b457bf2`.
 
-Example:
-
-```text
-umb://document/4fed18d8c5e34d5e88cfff3a5b457bf2. 
-```
-
-UDIs are commonly used in Umbraco’s querying and management APIs.
+Most Umbraco APIs identify entities by their GUID key. The backoffice and the Management API both work with plain GUIDs. UDIs are more commonly used as a storage and integration format.
 
 ## Format
 
 A UDI consists of three parts:
 
-1. Scheme: `umb://` – Identifies as an Umbraco UDI.
-2. Type: `document`– Specifies the object type (for example, media, member, Data Type, and so on).
-3. GUID Identifier: `4fed18d8c5e34d5e88cfff3a5b457bf2` – A unique identifier for the object (a GUID without dashes).
+| Part | Example | Description |
+| --- | --- | --- |
+| Scheme | `umb://` | Marks the value as an Umbraco identifier. |
+| Entity type | `document` | The type of entity the identifier points to. Other examples are `media`, `member`, and `data-type`. |
+| Identifier | `4fed18d8c5e34d5e88cfff3a5b457bf2` | The unique identifier of the entity. |
 
-## Usage
+### GUID and string UDIs
 
-UDIs are useful for retrieving content, media, or other Umbraco objects through the API. Below are examples of how to use a UDI in C# to get content or media.
+The identifier part is either a GUID or a string. Which one is used depends on the entity type.
 
-### Retrieving Content by UDI
+A [`GuidUdi`](https://apidocs.umbraco.com/v18/csharp/api/Umbraco.Cms.Core.GuidUdi.html) has a GUID as its identifier. The GUID is written without dashes. Most entity types use this format, such as `document`, `media`, and `member`.
 
-You can retrieve a content item using `IContentService`:
+```none
+umb://document/4fed18d8c5e34d5e88cfff3a5b457bf2
+```
 
-```cs
-using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Models
+A [`StringUdi`](https://apidocs.umbraco.com/v18/csharp/api/Umbraco.Cms.Core.StringUdi.html) has a string as its identifier, such as a file path or a culture code. A few entity types use this format, such as `stylesheet`, `script`, and `language`.
 
-@inject IContentService contentService
+```none
+umb://stylesheet/style.css
+umb://language/en-US
+```
+
+## Query content with a UDI
+
+`IPublishedContentQuery` accepts UDIs directly through the `Content(Udi)` and `Media(Udi)` overloads. You do not need to convert a UDI to a GUID first.
+
+The following example resolves a UDI in a view:
+
+{% code title="MyView.cshtml" %}
+
+```csharp
+@using Umbraco.Cms.Core
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
+@inject IPublishedContentQuery PublishedContentQuery
 
 @{
-   // Define the UDI string here
-    var udiString = "umb://document/334cadfa62dd49049aad86b6e4c02aac"; // Example UDI string
-
-   if (udiString.StartsWith("umb://document/"))
+    const string storedValue = "umb://document/4fed18d8c5e34d5e88cfff3a5b457bf2";
+    if (UdiParser.TryParse(storedValue, out Udi? udi))
     {
-        // Extract the GUID from the UDI string
-        var guidString = udiString.Replace("umb://document/", "");
-        if (Guid.TryParse(guidString, out var guid))
-        {
-            // Retrieve the content by GUID
-            var content = contentService.GetById(guid);
-            if (content != null)
-            {
-                // Access the body text field
-                var bodyText = content.GetValue<string>("bodyText"); // Replace 'bodyText' with the alias of your body text field
-                <p>@bodyText</p>  // Output the body text
-            }
-        else
-            {
-                <p>Content not found.</p>
-            }
-        }
-        else
-        {
-            <p>Invalid GUID in the UDI string.</p>
-        }
+        // Pass the UDI straight to the query. No conversion needed.
+        IPublishedContent? content = PublishedContentQuery.Content(udi);
+        <p>@content?.Name</p>
     }
 }
 ```
 
-## UDI Types
+{% endcode %}
 
-There are two types of UDIs in Umbraco:
+`UmbracoHelper` exposes the same overloads. In a view that inherits `UmbracoViewPage`, you can call `Umbraco.Content(udi)` instead.
 
-### GUID UDI
+## Convert between UDIs and GUIDs
 
-Used for objects that have a GUID identifier, such as content and media.
+Use `UdiParser.TryParse()` to read a UDI. Parsing is safer than manipulating the string, as it validates both the entity type and the identifier. The `Guid` property gives you the key used by the GUID-first APIs:
 
-* [API Reference: GuidUdi](https://apidocs.umbraco.com/v18/csharp/api/Umbraco.Cms.Core.GuidUdi.html)
+```csharp
+if (UdiParser.TryParse("umb://document/4fed18d8c5e34d5e88cfff3a5b457bf2", out GuidUdi? udi))
+{
+    Guid contentKey = udi.Guid;
+}
+```
 
-### String UDI
+To build a UDI from an entity type and a GUID key, use `Udi.Create()`:
 
-Used for objects that are not GUID-based, such as dictionary items.
+```csharp
+Guid contentKey = Guid.Parse("4fed18d8-c5e3-4d5e-88cf-ff3a5b457bf2");
+Udi udi = Udi.Create(Constants.UdiEntityType.Document, contentKey);
+```
 
-* [API Reference: StringUdi](https://apidocs.umbraco.com/v18/csharp/api/Umbraco.Cms.Core.StringUdi.html)
+These types are all in the `Umbraco.Cms.Core` namespace.


### PR DESCRIPTION
## 📋 Description

Rewrites the UDI Identifiers article for versions 17 and 18. The article was inaccurate in places and its only code sample did not compile.

What changed:

* **Corrected the String UDI description.** The article stated that String UDIs are used for dictionary items. Dictionary items use a GUID UDI. String UDIs are used for entity types such as `stylesheet`, `script`, and `language`.
* **Replaced the code sample.** The previous sample was fenced as C# but contained Razor, was missing a semicolon, had a misaligned `else`, and rendered a `//` comment as page text. It also extracted the GUID by calling `Replace()` on the UDI string, and used `IContentService` to retrieve content for rendering. The article now uses `UdiParser.TryParse()` and `IPublishedContentQuery`.
* **Documented querying with a UDI.** `IPublishedContentQuery` exposes `Content(Udi)` and `Media(Udi)` overloads, so a UDI does not need converting to a GUID before looking up published content. This was not mentioned anywhere.
* **Clarified how UDIs relate to GUID keys.** The article claimed UDIs are commonly used in the querying and management APIs. The backoffice and the Management API work with plain GUID keys. The intro now describes UDIs as a storage and integration format.
* **Described the two UDI types by the shape of their identifier** rather than by where the entity is stored, which is what actually distinguishes `GuidUdi` from `StringUdi`.
* **Added frontmatter, a code block caption, and API reference links** on the `GuidUdi` and `StringUdi` type names.

Two supporting files are updated alongside the article. The `Querying & Models` landing page carried a stale summary claiming UDIs store "all of the metadata required to retrieve an Umbraco object" and are used "for most Umbraco object types". The inline link in `Traversal` was reworded so the link text matches the article title.

The article stays in its existing location, so no redirects or `SUMMARY.md` changes are needed.

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

The code samples were verified against the Umbraco CMS source, but have not been compiled or run in a site.

## Product & Version (if relevant)

Umbraco CMS, versions 17 and 18.

## Deadline (if relevant)

None.

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
