### PR TITLE
Updates Deploy Installation article with correct JSON

### DIFF
--- a/17/umbraco-forms/installation/the-licensing-model.md
+++ b/17/umbraco-forms/installation/the-licensing-model.md
@@ -86,4 +86,5 @@ Apply the following configuration with the appropriate algorithm - `DES` (the de
     "Licensing": {
       "LicenseEncodeAndDecodeAlgorithm": "DES|TripleDES|AES"
     },
+  }
 ```

--- a/18/umbraco-deploy/installation/install-configure.md
+++ b/18/umbraco-deploy/installation/install-configure.md
@@ -288,7 +288,9 @@ For example, in `appsettings.json`:
       ...
     },
     "Licenses": {
-      "Umbraco.Deploy.OnPrem": "<your license key>"
+      "Products": {
+         "Umbraco.Deploy.OnPrem": "<your license key>"
+      },
     },
     "Deploy": {
        ...

--- a/18/umbraco-forms/installation/the-licensing-model.md
+++ b/18/umbraco-forms/installation/the-licensing-model.md
@@ -86,4 +86,5 @@ Apply the following configuration with the appropriate algorithm - `DES` (the de
     "Licensing": {
       "LicenseEncodeAndDecodeAlgorithm": "DES|TripleDES|AES"
     },
+  }
 ```


### PR DESCRIPTION
## 📋 Description

Ensured that all DXP installation guides used the wrong JSON path for the license keys.
