### PR TITLE
Forms: Add missing 18.1.0 migration ID to migration IDs table

### DIFF
--- a/18/umbraco-forms/upgrading/migration-ids.md
+++ b/18/umbraco-forms/upgrading/migration-ids.md
@@ -56,3 +56,4 @@ A unique **migration ID** is generated for each Umbraco Forms upgrade that requi
 | bedc287a-42ae-4be0-8d11-6939ff61b7c1 | 18.1.0                | Migrates the Save as Umbraco node workflow root node setting to dynamic root.      |
 | 29a8d464-40e3-4fca-bf5f-85b3a5bc63d0 | 18.1.0                | Adds indexes on the Records table for member entry counts and analytics.           |
 | 0f7a3c97-5367-4da7-aa13-44290ecd3bce | 18.1.0                | Adds hour-level breakdowns to the analytics daily summary table for local time zones.|
+| 0c07728b-48a6-460b-bd56-3ad32fd4a2b5 | 18.1.0                | Rebuilds the records index.                                                         |


### PR DESCRIPTION
## 📋 Description

The v18 migration IDs table (`18/umbraco-forms/upgrading/migration-ids.md`) was missing a row for `0c07728b-48a6-460b-bd56-3ad32fd4a2b5`. This is the final records-index rebuild step shipped in Forms 18.1.0/18.1.1 (the last step in `FormsMigrationPlan` on `v18/main`).

Found while cross-checking the v17 and v18 migration ID docs against the actual `FormsMigrationPlan` on `v17/main`/`v18/main` in the Forms repo. Every other ID matched.

## 📎 Related Issues (if applicable)

N/A

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Forms 17 and 18

## Deadline (if relevant)

When approved!