### PR TITLE
Documented settings and resolution for database timeouts (CMS 17.8, 18.3)

### DIFF
--- a/17/umbraco-cms/develop-with-umbraco/configuration/connectionstringssettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/connectionstringssettings.md
@@ -32,6 +32,65 @@ Umbraco currently supports using either a Microsoft SQL Server or a SQLite datab
 If you're using Umbraco 9 [SQL Server Compact database](https://www.connectionstrings.com/sql-server-compact/) is supported instead of SQLite.
 {% endhint %}
 
+## Database timeouts
+
+Two separate timeouts apply to the database connection:
+
+* The **command timeout** is the maximum time a single database command can run before it is canceled.
+* The **connect timeout** is the maximum time to wait when opening a connection to the database.
+
+You can set both in the connection string, or with the [Database command timeout](globalsettings.md#database-command-timeout) and [Database connect timeout](globalsettings.md#database-connect-timeout) global settings.
+
+The keywords used in the connection string depend on the database provider:
+
+| Provider | Command timeout | Connect timeout |
+| --- | --- | --- |
+| SQL Server | `Command Timeout` | `Connect Timeout` or `Connection Timeout` |
+| SQLite | `Default Timeout` | Not supported |
+
+The following connection string gives commands five minutes to complete, while a connection attempt is abandoned after 30 seconds:
+
+```json
+{
+  "ConnectionStrings": {
+    "umbracoDbDSN": "Server=.;Database=Umbraco;Integrated Security=true;TrustServerCertificate=true;Connect Timeout=30;Command Timeout=300",
+    "umbracoDbDSN_ProviderName": "Microsoft.Data.SqlClient"
+  }
+}
+```
+
+### How the command timeout is resolved
+
+Umbraco uses the first of the following that applies:
+
+1. A timeout set in code for a single command.
+2. A timeout set in code on the database instance, for example by a package.
+3. The `Umbraco:CMS:Global:DatabaseCommandTimeout` setting.
+4. The command timeout in the connection string.
+5. The connect timeout in the connection string. This step is deprecated. See [Deprecated: connect timeout used as the command timeout](#deprecated-connect-timeout-used-as-the-command-timeout).
+6. The database provider's default, which is 30 seconds for both SQL Server and SQLite.
+
+The connect timeout is resolved the same way, without the deprecated step: the `DatabaseConnectTimeout` setting first, then the connection string, then the provider default.
+
+{% hint style="info" %}
+The global settings are applied by rewriting the connection string. Every consumer of the connection string sees the configured values, not only Umbraco's own data access.
+{% endhint %}
+
+### Deprecated: connect timeout used as the command timeout
+
+In Umbraco 17.7 and earlier, the connect timeout in the connection string was also used as the command timeout. A `Command Timeout` keyword in the connection string had no effect.
+
+From Umbraco 17.8, `Command Timeout` is honored. The old behavior is kept as a fallback that applies only when no command timeout is configured, so existing sites are unaffected. Where the fallback applies, Umbraco logs a warning once at startup.
+
+{% hint style="warning" %}
+The fallback is removed in Umbraco 19. A site that relies on it gets the provider default of 30 seconds instead.
+{% endhint %}
+
+To stop relying on the fallback, do one of the following:
+
+* Add `Command Timeout` to the connection string.
+* Configure the `Umbraco:CMS:Global:DatabaseCommandTimeout` setting.
+
 ## Provider name
 Because Umbraco cannot determine the provider name from the connection string in all cases. Umbraco follows [Microsoft's convention](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-8.0#connection-string-prefixes-1) for provider names, which involves specifying it as a postfix in the connection string name.
 

--- a/17/umbraco-cms/develop-with-umbraco/configuration/connectionstringssettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/connectionstringssettings.md
@@ -78,15 +78,13 @@ The global settings are applied by rewriting the connection string. Every consum
 
 ### Deprecated: connect timeout used as the command timeout
 
-In Umbraco 17.7 and earlier, the connect timeout in the connection string was also used as the command timeout. A `Command Timeout` keyword in the connection string had no effect.
-
-From Umbraco 17.8, `Command Timeout` is honored. The old behavior is kept as a fallback that applies only when no command timeout is configured, so existing sites are unaffected. Where the fallback applies, Umbraco logs a warning once at startup.
+Where the connection string sets a connect timeout and no command timeout, Umbraco also uses the connect timeout as the command timeout. This behavior is deprecated. Where it applies, Umbraco logs a warning once at startup.
 
 {% hint style="warning" %}
-The fallback is removed in Umbraco 19. A site that relies on it gets the provider default of 30 seconds instead.
+This fallback is removed in Umbraco 19. A site that relies on it then gets the provider default of 30 seconds instead.
 {% endhint %}
 
-To stop relying on the fallback, do one of the following:
+To prepare, do one of the following:
 
 * Add `Command Timeout` to the connection string.
 * Configure the `Umbraco:CMS:Global:DatabaseCommandTimeout` setting.

--- a/17/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
@@ -184,10 +184,6 @@ When set, this value takes precedence over a command timeout in the connection s
 
 For the full order in which the command timeout is resolved, see [Database timeouts](connectionstringssettings.md#database-timeouts).
 
-{% hint style="info" %}
-The `DatabaseCommandTimeout` setting is available from Umbraco 17.8.
-{% endhint %}
-
 ### Database connect timeout
 
 Key: `DatabaseConnectTimeout` Type: `string` (default: not set)
@@ -197,10 +193,6 @@ Sets the maximum time to wait when opening a connection to the database. The for
 When set, this value takes precedence over a connect timeout in the connection string. When it is not set, the connection string value applies, or the database provider's default.
 
 SQLite has no connect timeout. If you configure this setting on a site running SQLite, Umbraco logs an information message at startup and the setting has no effect.
-
-{% hint style="info" %}
-The `DatabaseConnectTimeout` setting is available from Umbraco 17.8.
-{% endhint %}
 
 ### Main dom lock
 

--- a/17/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
+++ b/17/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
@@ -27,6 +27,8 @@ The following snippet contains all the available options, with default values, a
       "InstallMissingDatabase": false,
       "DisableElectionForSingleServer": false,
       "DatabaseFactoryServerVersion": "SqlServer.V2019",
+      "DatabaseCommandTimeout": "00:05:00",
+      "DatabaseConnectTimeout": "00:00:30",
       "MainDomLock": "FileSystemMainDomLock",
       "MainDomKeyDiscriminator": "",
       "Id": "184a8175-bc0b-43dd-8267-d99871eaec3d",
@@ -171,6 +173,34 @@ Key: `DatabaseFactoryServerVersion` Type: `bool` (default: `false`)
 This is not a setting that commonly needs to be configured.
 
 This setting is used to specify which sql server version that the database is running, this setting is only required if you use SqlServer 2008, if this is the case set the setting to `"SqlServer.V2008"`.
+
+### Database command timeout
+
+Key: `DatabaseCommandTimeout` Type: `string` (default: not set)
+
+Sets the maximum time a single database command can run before it is canceled. The format is `HH:MM:SS`. Use `00:00:00` for no limit.
+
+When set, this value takes precedence over a command timeout in the connection string. When it is not set, the connection string value applies, or the database provider's default of 30 seconds.
+
+For the full order in which the command timeout is resolved, see [Database timeouts](connectionstringssettings.md#database-timeouts).
+
+{% hint style="info" %}
+The `DatabaseCommandTimeout` setting is available from Umbraco 17.8.
+{% endhint %}
+
+### Database connect timeout
+
+Key: `DatabaseConnectTimeout` Type: `string` (default: not set)
+
+Sets the maximum time to wait when opening a connection to the database. The format is `HH:MM:SS`.
+
+When set, this value takes precedence over a connect timeout in the connection string. When it is not set, the connection string value applies, or the database provider's default.
+
+SQLite has no connect timeout. If you configure this setting on a site running SQLite, Umbraco logs an information message at startup and the setting has no effect.
+
+{% hint style="info" %}
+The `DatabaseConnectTimeout` setting is available from Umbraco 17.8.
+{% endhint %}
 
 ### Main dom lock
 

--- a/18/umbraco-cms/develop-with-umbraco/configuration/connectionstringssettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/connectionstringssettings.md
@@ -32,6 +32,65 @@ Umbraco currently supports using either a Microsoft SQL Server or a SQLite datab
 If you're using Umbraco 9 [SQL Server Compact database](https://www.connectionstrings.com/sql-server-compact/) is supported instead of SQLite.
 {% endhint %}
 
+## Database timeouts
+
+Two separate timeouts apply to the database connection:
+
+* The **command timeout** is the maximum time a single database command can run before it is canceled.
+* The **connect timeout** is the maximum time to wait when opening a connection to the database.
+
+You can set both in the connection string, or with the [Database command timeout](globalsettings.md#database-command-timeout) and [Database connect timeout](globalsettings.md#database-connect-timeout) global settings.
+
+The keywords used in the connection string depend on the database provider:
+
+| Provider | Command timeout | Connect timeout |
+| --- | --- | --- |
+| SQL Server | `Command Timeout` | `Connect Timeout` or `Connection Timeout` |
+| SQLite | `Default Timeout` | Not supported |
+
+The following connection string gives commands five minutes to complete, while a connection attempt is abandoned after 30 seconds:
+
+```json
+{
+  "ConnectionStrings": {
+    "umbracoDbDSN": "Server=.;Database=Umbraco;Integrated Security=true;TrustServerCertificate=true;Connect Timeout=30;Command Timeout=300",
+    "umbracoDbDSN_ProviderName": "Microsoft.Data.SqlClient"
+  }
+}
+```
+
+### How the command timeout is resolved
+
+Umbraco uses the first of the following that applies:
+
+1. A timeout set in code for a single command.
+2. A timeout set in code on the database instance, for example by a package.
+3. The `Umbraco:CMS:Global:DatabaseCommandTimeout` setting.
+4. The command timeout in the connection string.
+5. The connect timeout in the connection string. This step is deprecated. See [Deprecated: connect timeout used as the command timeout](#deprecated-connect-timeout-used-as-the-command-timeout).
+6. The database provider's default, which is 30 seconds for both SQL Server and SQLite.
+
+The connect timeout is resolved the same way, without the deprecated step: the `DatabaseConnectTimeout` setting first, then the connection string, then the provider default.
+
+{% hint style="info" %}
+The global settings are applied by rewriting the connection string. Every consumer of the connection string sees the configured values, not only Umbraco's own data access.
+{% endhint %}
+
+### Deprecated: connect timeout used as the command timeout
+
+In Umbraco 18.2 and earlier, the connect timeout in the connection string was also used as the command timeout. A `Command Timeout` keyword in the connection string had no effect.
+
+From Umbraco 18.3, `Command Timeout` is honored. The old behavior is kept as a fallback that applies only when no command timeout is configured, so existing sites are unaffected. Where the fallback applies, Umbraco logs a warning once at startup.
+
+{% hint style="warning" %}
+The fallback is removed in Umbraco 19. A site that relies on it gets the provider default of 30 seconds instead.
+{% endhint %}
+
+To stop relying on the fallback, do one of the following:
+
+* Add `Command Timeout` to the connection string.
+* Configure the `Umbraco:CMS:Global:DatabaseCommandTimeout` setting.
+
 ## Provider name
 Because Umbraco cannot determine the provider name from the connection string in all cases. Umbraco follows [Microsoft's convention](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-8.0#connection-string-prefixes-1) for provider names, which involves specifying it as a postfix in the connection string name.
 

--- a/18/umbraco-cms/develop-with-umbraco/configuration/connectionstringssettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/connectionstringssettings.md
@@ -78,15 +78,13 @@ The global settings are applied by rewriting the connection string. Every consum
 
 ### Deprecated: connect timeout used as the command timeout
 
-In Umbraco 18.2 and earlier, the connect timeout in the connection string was also used as the command timeout. A `Command Timeout` keyword in the connection string had no effect.
-
-From Umbraco 18.3, `Command Timeout` is honored. The old behavior is kept as a fallback that applies only when no command timeout is configured, so existing sites are unaffected. Where the fallback applies, Umbraco logs a warning once at startup.
+Where the connection string sets a connect timeout and no command timeout, Umbraco also uses the connect timeout as the command timeout. This behavior is deprecated. Where it applies, Umbraco logs a warning once at startup.
 
 {% hint style="warning" %}
-The fallback is removed in Umbraco 19. A site that relies on it gets the provider default of 30 seconds instead.
+This fallback is removed in Umbraco 19. A site that relies on it then gets the provider default of 30 seconds instead.
 {% endhint %}
 
-To stop relying on the fallback, do one of the following:
+To prepare, do one of the following:
 
 * Add `Command Timeout` to the connection string.
 * Configure the `Umbraco:CMS:Global:DatabaseCommandTimeout` setting.

--- a/18/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
@@ -27,6 +27,8 @@ The following snippet contains all the available options, with default values, a
       "InstallMissingDatabase": false,
       "DisableElectionForSingleServer": false,
       "DatabaseFactoryServerVersion": "SqlServer.V2019",
+      "DatabaseCommandTimeout": "00:05:00",
+      "DatabaseConnectTimeout": "00:00:30",
       "MainDomLock": "FileSystemMainDomLock",
       "MainDomKeyDiscriminator": "",
       "Id": "184a8175-bc0b-43dd-8267-d99871eaec3d",
@@ -171,6 +173,34 @@ Key: `DatabaseFactoryServerVersion` Type: `bool` (default: `false`)
 This is not a setting that commonly needs to be configured.
 
 This setting is used to specify which sql server version that the database is running, this setting is only required if you use SqlServer 2008, if this is the case set the setting to `"SqlServer.V2008"`.
+
+### Database command timeout
+
+Key: `DatabaseCommandTimeout` Type: `string` (default: not set)
+
+Sets the maximum time a single database command can run before it is canceled. The format is `HH:MM:SS`. Use `00:00:00` for no limit.
+
+When set, this value takes precedence over a command timeout in the connection string. When it is not set, the connection string value applies, or the database provider's default of 30 seconds.
+
+For the full order in which the command timeout is resolved, see [Database timeouts](connectionstringssettings.md#database-timeouts).
+
+{% hint style="info" %}
+The `DatabaseCommandTimeout` setting is available from Umbraco 18.3.
+{% endhint %}
+
+### Database connect timeout
+
+Key: `DatabaseConnectTimeout` Type: `string` (default: not set)
+
+Sets the maximum time to wait when opening a connection to the database. The format is `HH:MM:SS`.
+
+When set, this value takes precedence over a connect timeout in the connection string. When it is not set, the connection string value applies, or the database provider's default.
+
+SQLite has no connect timeout. If you configure this setting on a site running SQLite, Umbraco logs an information message at startup and the setting has no effect.
+
+{% hint style="info" %}
+The `DatabaseConnectTimeout` setting is available from Umbraco 18.3.
+{% endhint %}
 
 ### Main dom lock
 

--- a/18/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
+++ b/18/umbraco-cms/develop-with-umbraco/configuration/globalsettings.md
@@ -184,10 +184,6 @@ When set, this value takes precedence over a command timeout in the connection s
 
 For the full order in which the command timeout is resolved, see [Database timeouts](connectionstringssettings.md#database-timeouts).
 
-{% hint style="info" %}
-The `DatabaseCommandTimeout` setting is available from Umbraco 18.3.
-{% endhint %}
-
 ### Database connect timeout
 
 Key: `DatabaseConnectTimeout` Type: `string` (default: not set)
@@ -197,10 +193,6 @@ Sets the maximum time to wait when opening a connection to the database. The for
 When set, this value takes precedence over a connect timeout in the connection string. When it is not set, the connection string value applies, or the database provider's default.
 
 SQLite has no connect timeout. If you configure this setting on a site running SQLite, Umbraco logs an information message at startup and the setting has no effect.
-
-{% hint style="info" %}
-The `DatabaseConnectTimeout` setting is available from Umbraco 18.3.
-{% endhint %}
 
 ### Main dom lock
 


### PR DESCRIPTION
## 📋 Description

Documented settings and resolution for database timeouts.

## 📎 Related Issues (if applicable)

https://github.com/umbraco/Umbraco-CMS/pull/23817
https://github.com/umbraco/Umbraco-CMS/issues/23705

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [X] Sentences are short and clear (preferably under 25 words).
* [X] Passive voice and first-person language (“we”, “I”) are avoided.
* [X] Relevant pages are linked.
* [X] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [X] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS 17.8 and 18.3.

## Deadline (if relevant)

With the release candidates for CMS 17.8 and 18.3, on 15th October.