### PR TITLE
Add kind property to entity action manifest

### DIFF
--- a/17/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-types/entity-actions.md
+++ b/17/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-types/entity-actions.md
@@ -54,6 +54,7 @@ import { extensionRegistry } from '@umbraco-cms/extension-registry';
 
 const manifest = {
     type: 'entityAction',
+    kind: 'default',
     alias: 'My.EntityAction',
     name: 'My Entity Action',
     weight: 10,

--- a/18/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-types/entity-actions.md
+++ b/18/umbraco-cms/extend-your-project/backoffice-extensions/extending-overview/extension-types/entity-actions.md
@@ -54,6 +54,7 @@ import { extensionRegistry } from '@umbraco-cms/extension-registry';
 
 const manifest = {
     type: 'entityAction',
+    kind: 'default',
     alias: 'My.EntityAction',
     name: 'My Entity Action',
     weight: 10,


### PR DESCRIPTION
## 📋 Description

<!-- A clear and concise description of what this PR changes or adds. Include context if necessary. -->
Spend way to long figuring out why entity action didn't show up and after looking at code examples in source code, I noticed `kind: 'default'`:
https://github.com/umbraco/Umbraco-CMS/blob/7f0b6d882a969f59f76f0f342de93c6bc5b8384f/src/Umbraco.Web.UI.Client/examples/collection/entity-actions/manifests.ts

Without kind, it need a custom element (an example of this would be great).

Besides that I think a condition to limit entity action based on content type would be useful. @nielslyngsoe mentioned a custom condition here, but hopefully it can be available out of  the box as it was simple to handle via `MenuRenderingNotification` in v13:
https://forum.umbraco.com/t/limit-entity-action-to-specific-document-types/7218

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

<!-- Mention the product and all applicable versions for which the PR is being created. -->

## Deadline (if relevant)

<!-- When should the content be published? -->

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
