### PR TITLE
RTE config dead link

### DIFF
--- a/17/umbraco-cms/get-started/backoffice-essentials/working-with-rich-text-editors.md
+++ b/17/umbraco-cms/get-started/backoffice-essentials/working-with-rich-text-editors.md
@@ -325,4 +325,4 @@ There are other options available for modifying cells, rows, and columns such as
 
 The Rich Text Editor in Umbraco can be configured in many different ways.
 
-For more information, see the [Rich Text Editor Configuration](../../../model-your-content/property-editors/built-in-umbraco-property-editors/rich-text-editor/configuration.md) article.
+For more information, see the [Rich Text Editor Configuration](../../model-your-content/property-editors/built-in-umbraco-property-editors/rich-text-editor/configuration.md) article.

--- a/18/umbraco-cms/get-started/backoffice-essentials/working-with-rich-text-editors.md
+++ b/18/umbraco-cms/get-started/backoffice-essentials/working-with-rich-text-editors.md
@@ -326,4 +326,4 @@ There are other options available for modifying cells, rows, and columns such as
 
 The Rich Text Editor in Umbraco can be configured in many different ways.
 
-For more information, see the [Rich Text Editor Configuration](../../../model-your-content/property-editors/built-in-umbraco-property-editors/rich-text-editor/configuration.md) article.
+For more information, see the [Rich Text Editor Configuration](../../model-your-content/property-editors/built-in-umbraco-property-editors/rich-text-editor/configuration.md) article.


### PR DESCRIPTION
## 📋 Description

There's a dead link on the https://docs.umbraco.com/umbraco-cms/17.latest/get-started/backoffice-essentials/working-with-rich-text-editors page, in the Configuring a Rich Text Editor section for both 17 + 18.

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [x] Screenshots or diagrams are included if useful.
* [x] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

17 and 18

## Deadline (if relevant)

Yesterday

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
