### PR TITLE
Workflow release notes: 17.5.0 and 18.2.0 release candidates

### DIFF
--- a/17/umbraco-workflow/getting-started/configuration.md
+++ b/17/umbraco-workflow/getting-started/configuration.md
@@ -249,7 +249,7 @@ When true, Workflow will send email notifications to approval groups, with a dig
 
 #### PublishIsReview (bool)
 
-When true, publishing a node is treated as a review, and will generate a new review date. When false, content must be explicitly reviewed via the review banner rendered at the top of the editor.
+When true, publishing a node is treated as a review, and will generate a new review date. When false, content must be explicitly reviewed.
 
 For example: To set the site URL, hide it in the backoffice, and set the content review period but keep the property read-only. The configuration would look like this:
 

--- a/17/umbraco-workflow/getting-started/content-review-settings.md
+++ b/17/umbraco-workflow/getting-started/content-review-settings.md
@@ -10,7 +10,7 @@ You can configure the **General** Settings from the **Content reviews** tab in t
 
 * **Enable content reviews** - Enable this setting if you wish to remind users to review their content. By default, this option is disabled.
 * **Send notifications** - Enable this setting to send email notifications to approval groups when content requires review.
-* **Treat saving as a review?** - Enable this setting to reset the review date when content is saved. Saving a content node recalculates the review date, using the review period assigned to the content node, its Document Type, or the default Review period value. If disabled, content must be explicitly reviewed via the review banner displayed on the content item.
+* **Treat saving as a review?** - Enable this setting to reset the review date when content is saved. Saving a content node recalculates the review date, using the review period assigned to the content node, its Document Type, or the default Review period value. If disabled, content must be explicitly reviewed via the review dialog displayed on the content item.
 * **Review period (days)** - The default number of days between content reviews.
 * **Reminder threshold (days)** - Determines how many days before the review date the Workflow should notify editors of required reviews. By default, the number of days is set to 1.
 

--- a/17/umbraco-workflow/release-notes.md
+++ b/17/umbraco-workflow/release-notes.md
@@ -16,6 +16,21 @@ Check the [Version Specific Upgrade Notes](upgrading/version-specific.md) articl
 
 This section contains the release notes for Umbraco Workflow 17, including all changes for this version.
 
+### [17.5.0-rc1](https://github.com/umbraco/Umbraco.Workflow.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.5.0-rc1) (September 7 2026)
+
+* Fixes "View differences" on a workflow task returning an unhelpful error instead of a licensing message when Workflow is unlicensed [#176](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/176)
+* Restructures the backoffice frontend build into per-feature packages:
+  * Fixes asset caching not invalidating after an upgrade [#172](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/172) 
+  * Fixes Workflow tab intermittently failing to render [#175](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/175)
+* Fixes group approval emails missing content when the group has no language set [#173](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/173)
+* Fixes several Advanced Search issues [#168](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/168): 
+  * Empty value inputs for config-driven property editors
+  * Invariant properties incorrectly treated as empty when cultures are selected
+  * ContentPicker/MultiNodeTreePicker searches returning unrelated results
+* Adds a "Clear selection" action and a loading indicator to the Advanced Search dashboard [#168](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/168)
+* Fixes due-date save and permission gaps in document-editor content reviews
+* Enforces mandatory workflow comments server-side on approve/reject, closing a gap in the external approval and email reply channels
+
 ### 17.4.2 (August 31 2026)
 
 * Fixes culture resolution for external approval using an invariant workflow on a culture-variant document.

--- a/17/umbraco-workflow/workflow-section/content-reviews.md
+++ b/17/umbraco-workflow/workflow-section/content-reviews.md
@@ -22,7 +22,7 @@ The Content Reviews Dashboard provides an overview of the expired content. The d
 
 ![Content Reviews Dashboard](../.gitbook/assets/Content-review-dashboard-v14.png)
 
-Selecting a content node takes you to the content node in the **Content** section, where you can see the Content review banner. The Content review banner is displayed only when the node has passed its review date. Also, the review banner is displayed only to users assigned as reviewers for the node. For more information, see the [Content Reviews Permissions](../getting-started/content-review-settings.md#content-review-permissions) section
+Selecting a content node takes you to the content node in the **Content** section, where you can see the Content review dialog. The Content review dialog is displayed only when the node has passed its review date. Also, the review dialog is displayed only to users assigned as reviewers for the node. For more information, see the [Content Reviews Permissions](../getting-started/content-review-settings.md#content-review-permissions) section
 
 ![Content Review Message Banner](../.gitbook/assets/content-review-message-banner-v14.png)
 

--- a/18/umbraco-workflow/getting-started/configuration.md
+++ b/18/umbraco-workflow/getting-started/configuration.md
@@ -249,7 +249,7 @@ When true, Workflow will send email notifications to approval groups, with a dig
 
 #### PublishIsReview (bool)
 
-When true, publishing a node is treated as a review, and will generate a new review date. When false, content must be explicitly reviewed via the review banner rendered at the top of the editor.
+When true, publishing a node is treated as a review, and will generate a new review date. When false, content must be explicitly reviewed..
 
 For example: To set the site URL, hide it in the backoffice, and set the content review period but keep the property read-only. The configuration would look like this:
 

--- a/18/umbraco-workflow/getting-started/content-review-settings.md
+++ b/18/umbraco-workflow/getting-started/content-review-settings.md
@@ -10,7 +10,7 @@ You can configure the **General** Settings from the **Content reviews** tab in t
 
 * **Enable content reviews** - Enable this setting if you wish to remind users to review their content. By default, this option is disabled.
 * **Send notifications** - Enable this setting to send email notifications to approval groups when content requires review.
-* **Treat saving as a review?** - Enable this setting to reset the review date when content is saved. Saving a content node recalculates the review date, using the review period assigned to the content node, its Document Type, or the default Review period value. If disabled, content must be explicitly reviewed via the review banner displayed on the content item.
+* **Treat saving as a review?** - Enable this setting to reset the review date when content is saved. Saving a content node recalculates the review date, using the review period assigned to the content node, its Document Type, or the default Review period value. If disabled, content must be explicitly reviewed via the review dialog displayed on the content item.
 * **Review period (days)** - The default number of days between content reviews.
 * **Reminder threshold (days)** - Determines how many days before the review date the Workflow should notify editors of required reviews. By default, the number of days is set to 1.
 

--- a/18/umbraco-workflow/release-notes.md
+++ b/18/umbraco-workflow/release-notes.md
@@ -16,6 +16,21 @@ Check the [Version Specific Upgrade Notes](upgrading/version-specific.md) articl
 
 This section contains the release notes for Umbraco Workflow 18, including all changes for this version.
 
+### [18.2.0-rc1](https://github.com/umbraco/Umbraco.Workflow.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.2.0-rc1) (September 7 2026)
+
+* Fixes "View differences" on a workflow task returning an unhelpful error instead of a licensing message when Workflow is unlicensed [#176](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/176)
+* Restructures the backoffice frontend build into per-feature packages:
+  * Fixes asset caching not invalidating after an upgrade [#172](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/172) 
+  * Fixes Workflow tab intermittently failing to render [#175](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/175)
+* Fixes group approval emails missing content when the group has no language set [#173](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/173)
+* Fixes several Advanced Search issues [#168](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/168): 
+  * Empty value inputs for config-driven property editors
+  * Invariant properties incorrectly treated as empty when cultures are selected
+  * ContentPicker/MultiNodeTreePicker searches returning unrelated results
+* Adds a "Clear selection" action and a loading indicator to the Advanced Search dashboard [#168](https://github.com/umbraco/Umbraco.Workflow.Issues/issues/168)
+* Fixes due-date save and permission gaps in document-editor content reviews
+* Enforces mandatory workflow comments server-side on approve/reject, closing a gap in the external approval and email reply channels
+
 ### 18.1.2 (August 31 2026)
 
 * Fixes culture resolution for external approval using an invariant workflow on a culture-variant document.

--- a/18/umbraco-workflow/workflow-section/content-reviews.md
+++ b/18/umbraco-workflow/workflow-section/content-reviews.md
@@ -22,7 +22,7 @@ The Content Reviews Dashboard provides an overview of the expired content. The d
 
 ![Content Reviews Dashboard](../.gitbook/assets/Content-review-dashboard-v14.png)
 
-Selecting a content node takes you to the content node in the **Content** section, where you can see the Content review banner. The Content review banner is displayed only when the node has passed its review date. Also, the review banner is displayed only to users assigned as reviewers for the node. For more information, see the [Content Reviews Permissions](../getting-started/content-review-settings.md#content-review-permissions) section
+Selecting a content node takes you to the content node in the **Content** section, where you can see the Content review dialog. The Content review dialog is displayed only when the node has passed its review date. Also, the review dialog is displayed only to users assigned as reviewers for the node. For more information, see the [Content Reviews Permissions](../getting-started/content-review-settings.md#content-review-permissions) section
 
 ![Content Review Message Banner](../.gitbook/assets/content-review-message-banner-v14.png)
 


### PR DESCRIPTION
Adds release notes for 17.5.0 and 18.2.0 RCs, and tidies a few references to the content review banner, which is a dialog in 17/18.

RCs are out now.