### PR TITLE
Automate: Document `ISupportsManualRun` for custom trigger authors

### DIFF
--- a/17/umbraco-automate/concepts/triggers.md
+++ b/17/umbraco-automate/concepts/triggers.md
@@ -69,7 +69,7 @@ Open the automation's context menu (the three dots next to it in the tree) and s
 * **Manual Trigger** and **Scheduled Trigger** always support **Run now**.
 * **Webhook** also supports it, using the trigger's saved **Test request body** and **Test request headers** instead of a real HTTP request. See [Finding the Webhook URL](#finding-the-webhook-url) below. Authentication and the allowed-method check are skipped for on-demand runs, since nothing is calling the webhook endpoint.
 * Content, Media, Member, and User triggers don't support **Run now**. Trigger their automations by performing the underlying action (publish a content item, save a media item, and so on).
-* Add-on and custom triggers can opt in to **Run now** individually. If the option isn't in the context menu, the automation's trigger doesn't support it.
+* Add-on and custom triggers can opt in to **Run now** individually. If the option isn't in the context menu, the automation's trigger doesn't support it. See [Supporting Run Now](../extending/custom-trigger.md#supporting-run-now) to add it to your own trigger.
 
 ## Finding the Webhook URL
 

--- a/17/umbraco-automate/extending/custom-trigger.md
+++ b/17/umbraco-automate/extending/custom-trigger.md
@@ -133,11 +133,11 @@ public interface ISupportsManualRun
 
 `CreateManualRunOutput` returns one of three things:
 
-* `ManualRunOutput.None` — the trigger needs no payload, so the automation just starts.
+* `ManualRunOutput.None` — the trigger needs no payload, so the automation starts.
 * `ManualRunOutput.From(data)` — stand-in output built from the trigger's own saved settings, used in place of the payload the real event would carry.
 * `ManualRunOutput.Invalid(reason)` — the saved settings can't produce a payload. Automate refuses the run and shows `reason` to the author, instead of starting it with data they didn't mean.
 
-`MyCustomTrigger` above is a case for **not** implementing this interface. Its output carries a real content node from `ContentSavedNotification`, and a fake node would mislead any step that reads it. Implement `ISupportsManualRun` only when the trigger's own settings can convincingly stand in for the real event, such as a webhook trigger with a saved test payload. See [Trigger from a Webhook](schedule-and-webhook-triggers.md#supporting-run-now) for a worked example.
+`MyCustomTrigger` above is a case for **not** implementing this interface. Its output carries a real content node from `ContentSavedNotification`, and a fake node would mislead any step that reads it. Implement `ISupportsManualRun` only when the trigger's own settings can stand in for the real event, like a webhook trigger with a saved test payload. See [Trigger from a Webhook](schedule-and-webhook-triggers.md#supporting-run-now) for a worked example.
 
 Automate reports which triggers support this on their catalogue entry, which is what makes **Run now** appear in the backoffice for the trigger. See [Running a Trigger On Demand](../concepts/triggers.md#running-a-trigger-on-demand) for the editor-facing behavior.
 

--- a/17/umbraco-automate/extending/custom-trigger.md
+++ b/17/umbraco-automate/extending/custom-trigger.md
@@ -120,6 +120,27 @@ The check is all-of: the service account must have every listed section. Omit th
 
 See [Service-Account Permissions](../concepts/workspaces.md#service-account-permissions) for the runtime effects.
 
+## Supporting Run Now
+
+Editors can start an automation on demand from the backoffice, without waiting for its trigger to fire naturally, using **Run now**. A trigger opts into this by implementing `ISupportsManualRun`:
+
+```csharp
+public interface ISupportsManualRun
+{
+    ManualRunOutput CreateManualRunOutput(object? settings);
+}
+```
+
+`CreateManualRunOutput` returns one of three things:
+
+* `ManualRunOutput.None` — the trigger needs no payload, so the automation just starts.
+* `ManualRunOutput.From(data)` — stand-in output built from the trigger's own saved settings, used in place of the payload the real event would carry.
+* `ManualRunOutput.Invalid(reason)` — the saved settings can't produce a payload. Automate refuses the run and shows `reason` to the author, instead of starting it with data they didn't mean.
+
+`MyCustomTrigger` above is a case for **not** implementing this interface. Its output carries a real content node from `ContentSavedNotification`, and a fake node would mislead any step that reads it. Implement `ISupportsManualRun` only when the trigger's own settings can convincingly stand in for the real event, such as a webhook trigger with a saved test payload. See [Trigger from a Webhook](schedule-and-webhook-triggers.md#supporting-run-now) for a worked example.
+
+Automate reports which triggers support this on their catalogue entry, which is what makes **Run now** appear in the backoffice for the trigger. See [Running a Trigger On Demand](../concepts/triggers.md#running-a-trigger-on-demand) for the editor-facing behavior.
+
 ## Registration
 
 No manual registration is required. The trigger is discovered at startup by its `[Trigger]` attribute and the base class.

--- a/17/umbraco-automate/extending/schedule-and-webhook-triggers.md
+++ b/17/umbraco-automate/extending/schedule-and-webhook-triggers.md
@@ -123,6 +123,62 @@ public sealed class OrderPaidTrigger
 
 A webhook trigger receives its payload through Automate's webhook endpoint. Map the posted body to trigger output the same way a notification-based trigger maps a notification — see [Create a Custom Trigger](custom-trigger.md) for the `MapEvent` and `CanHandle` pattern.
 
+### Supporting Run Now
+
+A webhook is a natural fit for [Run now](custom-trigger.md#supporting-run-now), since a saved test payload can stand in for the real HTTP request. Add settings to hold that test payload, and implement `ISupportsManualRun` to build output from them:
+
+{% code title="OrderPaidTriggerSettings.cs" %}
+```csharp
+namespace MyProject.Automate;
+
+public sealed class OrderPaidTriggerSettings
+{
+    [Field(Label = "Test Order Reference", Description = "Used by Run now instead of a real webhook call.")]
+    public string? TestOrderReference { get; set; }
+
+    [Field(Label = "Test Amount Paid")]
+    public decimal TestAmountPaid { get; set; }
+}
+```
+{% endcode %}
+
+{% code title="OrderPaidTrigger.cs" %}
+```csharp
+using Umbraco.Automate.Core.Triggers;
+
+namespace MyProject.Automate;
+
+[Trigger("myProject.orderPaid", "Order Paid",
+    Description = "Fires when the payment provider posts a paid webhook.",
+    Group = "My Project",
+    Icon = "icon-coins")]
+public sealed class OrderPaidTrigger
+    : WebhookTriggerBase<OrderPaidTriggerSettings, OrderPaidTriggerOutput>, ISupportsManualRun
+{
+    public OrderPaidTrigger(TriggerInfrastructure infrastructure)
+        : base(infrastructure)
+    {
+    }
+
+    public ManualRunOutput CreateManualRunOutput(object? settings)
+    {
+        var typedSettings = settings as OrderPaidTriggerSettings;
+
+        if (string.IsNullOrWhiteSpace(typedSettings?.TestOrderReference))
+        {
+            return ManualRunOutput.Invalid("Set a test order reference in the trigger's settings first.");
+        }
+
+        return ManualRunOutput.From(new Dictionary<string, object?>
+        {
+            ["orderReference"] = typedSettings.TestOrderReference,
+            ["amountPaid"] = typedSettings.TestAmountPaid,
+        });
+    }
+}
+```
+{% endcode %}
+
 ### Verifying the Request Came From Your Vendor
 
 An inbound webhook URL is public. Verify the request before trusting its payload by implementing `IWebhookAuthenticator`, or by inheriting the convenience base class `WebhookAuthenticatorBase<TSettings>`. It reads discovery metadata from a `[WebhookAuthenticator]` attribute and derives the settings schema from `TSettings` automatically.

--- a/18/umbraco-automate/concepts/triggers.md
+++ b/18/umbraco-automate/concepts/triggers.md
@@ -69,7 +69,7 @@ Open the automation's context menu (the three dots next to it in the tree) and s
 * **Manual Trigger** and **Scheduled Trigger** always support **Run now**.
 * **Webhook** also supports it, using the trigger's saved **Test request body** and **Test request headers** instead of a real HTTP request. See [Finding the Webhook URL](#finding-the-webhook-url) below. Authentication and the allowed-method check are skipped for on-demand runs, since nothing is calling the webhook endpoint.
 * Content, Media, Member, and User triggers don't support **Run now**. Trigger their automations by performing the underlying action (publish a content item, save a media item, and so on).
-* Add-on and custom triggers can opt in to **Run now** individually. If the option isn't in the context menu, the automation's trigger doesn't support it.
+* Add-on and custom triggers can opt in to **Run now** individually. If the option isn't in the context menu, the automation's trigger doesn't support it. See [Supporting Run Now](../extending/custom-trigger.md#supporting-run-now) to add it to your own trigger.
 
 ## Finding the Webhook URL
 

--- a/18/umbraco-automate/extending/custom-trigger.md
+++ b/18/umbraco-automate/extending/custom-trigger.md
@@ -133,11 +133,11 @@ public interface ISupportsManualRun
 
 `CreateManualRunOutput` returns one of three things:
 
-* `ManualRunOutput.None` — the trigger needs no payload, so the automation just starts.
+* `ManualRunOutput.None` — the trigger needs no payload, so the automation starts.
 * `ManualRunOutput.From(data)` — stand-in output built from the trigger's own saved settings, used in place of the payload the real event would carry.
 * `ManualRunOutput.Invalid(reason)` — the saved settings can't produce a payload. Automate refuses the run and shows `reason` to the author, instead of starting it with data they didn't mean.
 
-`MyCustomTrigger` above is a case for **not** implementing this interface. Its output carries a real content node from `ContentSavedNotification`, and a fake node would mislead any step that reads it. Implement `ISupportsManualRun` only when the trigger's own settings can convincingly stand in for the real event, such as a webhook trigger with a saved test payload. See [Trigger from a Webhook](schedule-and-webhook-triggers.md#supporting-run-now) for a worked example.
+`MyCustomTrigger` above is a case for **not** implementing this interface. Its output carries a real content node from `ContentSavedNotification`, and a fake node would mislead any step that reads it. Implement `ISupportsManualRun` only when the trigger's own settings can stand in for the real event, like a webhook trigger with a saved test payload. See [Trigger from a Webhook](schedule-and-webhook-triggers.md#supporting-run-now) for a worked example.
 
 Automate reports which triggers support this on their catalogue entry, which is what makes **Run now** appear in the backoffice for the trigger. See [Running a Trigger On Demand](../concepts/triggers.md#running-a-trigger-on-demand) for the editor-facing behavior.
 

--- a/18/umbraco-automate/extending/custom-trigger.md
+++ b/18/umbraco-automate/extending/custom-trigger.md
@@ -120,6 +120,27 @@ The check is all-of: the service account must have every listed section. Omit th
 
 See [Service-Account Permissions](../concepts/workspaces.md#service-account-permissions) for the runtime effects.
 
+## Supporting Run Now
+
+Editors can start an automation on demand from the backoffice, without waiting for its trigger to fire naturally, using **Run now**. A trigger opts into this by implementing `ISupportsManualRun`:
+
+```csharp
+public interface ISupportsManualRun
+{
+    ManualRunOutput CreateManualRunOutput(object? settings);
+}
+```
+
+`CreateManualRunOutput` returns one of three things:
+
+* `ManualRunOutput.None` — the trigger needs no payload, so the automation just starts.
+* `ManualRunOutput.From(data)` — stand-in output built from the trigger's own saved settings, used in place of the payload the real event would carry.
+* `ManualRunOutput.Invalid(reason)` — the saved settings can't produce a payload. Automate refuses the run and shows `reason` to the author, instead of starting it with data they didn't mean.
+
+`MyCustomTrigger` above is a case for **not** implementing this interface. Its output carries a real content node from `ContentSavedNotification`, and a fake node would mislead any step that reads it. Implement `ISupportsManualRun` only when the trigger's own settings can convincingly stand in for the real event, such as a webhook trigger with a saved test payload. See [Trigger from a Webhook](schedule-and-webhook-triggers.md#supporting-run-now) for a worked example.
+
+Automate reports which triggers support this on their catalogue entry, which is what makes **Run now** appear in the backoffice for the trigger. See [Running a Trigger On Demand](../concepts/triggers.md#running-a-trigger-on-demand) for the editor-facing behavior.
+
 ## Registration
 
 No manual registration is required. The trigger is discovered at startup by its `[Trigger]` attribute and the base class.

--- a/18/umbraco-automate/extending/schedule-and-webhook-triggers.md
+++ b/18/umbraco-automate/extending/schedule-and-webhook-triggers.md
@@ -123,6 +123,62 @@ public sealed class OrderPaidTrigger
 
 A webhook trigger receives its payload through Automate's webhook endpoint. Map the posted body to trigger output the same way a notification-based trigger maps a notification — see [Create a Custom Trigger](custom-trigger.md) for the `MapEvent` and `CanHandle` pattern.
 
+### Supporting Run Now
+
+A webhook is a natural fit for [Run now](custom-trigger.md#supporting-run-now), since a saved test payload can stand in for the real HTTP request. Add settings to hold that test payload, and implement `ISupportsManualRun` to build output from them:
+
+{% code title="OrderPaidTriggerSettings.cs" %}
+```csharp
+namespace MyProject.Automate;
+
+public sealed class OrderPaidTriggerSettings
+{
+    [Field(Label = "Test Order Reference", Description = "Used by Run now instead of a real webhook call.")]
+    public string? TestOrderReference { get; set; }
+
+    [Field(Label = "Test Amount Paid")]
+    public decimal TestAmountPaid { get; set; }
+}
+```
+{% endcode %}
+
+{% code title="OrderPaidTrigger.cs" %}
+```csharp
+using Umbraco.Automate.Core.Triggers;
+
+namespace MyProject.Automate;
+
+[Trigger("myProject.orderPaid", "Order Paid",
+    Description = "Fires when the payment provider posts a paid webhook.",
+    Group = "My Project",
+    Icon = "icon-coins")]
+public sealed class OrderPaidTrigger
+    : WebhookTriggerBase<OrderPaidTriggerSettings, OrderPaidTriggerOutput>, ISupportsManualRun
+{
+    public OrderPaidTrigger(TriggerInfrastructure infrastructure)
+        : base(infrastructure)
+    {
+    }
+
+    public ManualRunOutput CreateManualRunOutput(object? settings)
+    {
+        var typedSettings = settings as OrderPaidTriggerSettings;
+
+        if (string.IsNullOrWhiteSpace(typedSettings?.TestOrderReference))
+        {
+            return ManualRunOutput.Invalid("Set a test order reference in the trigger's settings first.");
+        }
+
+        return ManualRunOutput.From(new Dictionary<string, object?>
+        {
+            ["orderReference"] = typedSettings.TestOrderReference,
+            ["amountPaid"] = typedSettings.TestAmountPaid,
+        });
+    }
+}
+```
+{% endcode %}
+
 ### Verifying the Request Came From Your Vendor
 
 An inbound webhook URL is public. Verify the request before trusting its payload by implementing `IWebhookAuthenticator`, or by inheriting the convenience base class `WebhookAuthenticatorBase<TSettings>`. It reads discovery metadata from a `[WebhookAuthenticator]` attribute and derives the settings schema from `TSettings` automatically.


### PR DESCRIPTION
## 📋 Description

Adds developer-facing documentation for the `ISupportsManualRun` interface, which lets a custom or add-on trigger opt into the backoffice **Run now** action.

The last release's doc pass (webhook trigger UX, Run Script, Media actions, step name/alias, disconnected-step warning, content culture deltas) covered **Run now** for editors in `concepts/triggers.md` and `backoffice/building-an-automation.md`, but never documented how a trigger author implements the interface itself. This PR closes that gap:

* New "Supporting Run Now" section in `extending/custom-trigger.md`: explains `ISupportsManualRun`, the three `ManualRunOutput` cases (`None`, `From`, `Invalid`), and when *not* to implement it (triggers whose output carries real entity data, e.g. content events).
* New worked example in `extending/schedule-and-webhook-triggers.md`: extends the existing `OrderPaidTrigger` webhook example with test-payload settings and the interface implementation.
* Cross-links added both ways, and from `concepts/triggers.md`'s existing "Add-on and custom triggers can opt in..." bullet.

Applied identically to both `17/umbraco-automate` and `18/umbraco-automate`, since the feature ships on both version lines and the affected pages were byte-identical beforehand.

## 📎 Related Issues (if applicable)

None.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful. — not applicable, this is developer-facing C# reference content, no UI change.
* [ ] Any code examples or instructions have been tested. — code samples mirror the real `Umbraco.Automate` source (`ISupportsManualRun`, `ManualRunOutput`, `WebhookTrigger`) but were not independently compiled.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Automate 17 and 18.

## Deadline (if relevant)

When approved