### PR TITLE
Add Umbraco UI Builder 17.2.6, 17.2.7, and 17.2.8 release notes

### DIFF
--- a/17/umbraco-ui-builder/release-notes.md
+++ b/17/umbraco-ui-builder/release-notes.md
@@ -18,6 +18,18 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 Below are the release notes for Umbraco UI Builder, detailing all changes in this version.
 
+### [**17.2.8**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.8) **(September 7th 2026)**
+
+* Fixed action notifications failing with an error when they contained non-ASCII characters such as å, æ, or ø [#232](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/232)
+
+### [**17.2.7**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.7) **(August 17th 2026)**
+
+* Fixed a collection configured with `MakeReadOnly()` still being selectable [#231](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/231)
+
+### [**17.2.6**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.6) **(July 29th 2026)**
+
+* Fixed custom repository save errors not showing a notification in the back office [#230](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/230)
+
 ### [**17.2.5**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.5) **(July 27th 2026)**
 
 * Fixed collection names returning the singular name in place of the plural, affecting the section dashboard cards, grouped collection tabs, and Entity Picker configuration [#229](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/229)

--- a/17/umbraco-ui-builder/release-notes.md
+++ b/17/umbraco-ui-builder/release-notes.md
@@ -28,7 +28,7 @@ Below are the release notes for Umbraco UI Builder, detailing all changes in thi
 
 ### [**17.2.6**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.6) **(July 29th 2026)**
 
-* Fixed custom repository save errors not showing a notification in the back office [#230](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/230)
+* Fixed custom repository save errors not showing a notification in the backoffice [#230](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/230)
 
 ### [**17.2.5**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.5) **(July 27th 2026)**
 


### PR DESCRIPTION
## 📋 Description

Adds the missing release notes entries for UI Builder v17.2.6, v17.2.7, and v17.2.8, sourced from issues closed and labeled `release/{version}` in `umbraco/Umbraco.UIBuilder.Issues`.

## 📎 Related Issues (if applicable)

- umbraco/Umbraco.UIBuilder.Issues#230
- umbraco/Umbraco.UIBuilder.Issues#231
- umbraco/Umbraco.UIBuilder.Issues#232

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco UI Builder 17.2.6, 17.2.7, 17.2.8

🤖 Generated with Claude Code