### PR TITLE
Add Umbraco UI Builder 18.0.4, 18.0.5, and 18.0.6 release notes

### DIFF
--- a/18/umbraco-ui-builder/release-notes.md
+++ b/18/umbraco-ui-builder/release-notes.md
@@ -28,7 +28,7 @@ Below are the release notes for Umbraco UI Builder, detailing all changes in thi
 
 ### [**18.0.4**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.4) **(July 29th 2026)**
 
-* Fixed custom repository save errors not showing a notification in the back office [#230](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/230)
+* Fixed custom repository save errors not showing a notification in the backoffice [#230](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/230)
 
 ### [**18.0.3**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.3) **(July 27th 2026)**
 

--- a/18/umbraco-ui-builder/release-notes.md
+++ b/18/umbraco-ui-builder/release-notes.md
@@ -18,6 +18,18 @@ If you are upgrading to a new major version, check the breaking changes in the [
 
 Below are the release notes for Umbraco UI Builder, detailing all changes in this version.
 
+### [**18.0.6**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.6) **(September 7th 2026)**
+
+* Fixed action notifications failing with an error when they contained non-ASCII characters such as å, æ, or ø [#232](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/232)
+
+### [**18.0.5**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.5) **(August 17th 2026)**
+
+* Fixed a collection configured with `MakeReadOnly()` still being selectable [#231](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/231)
+
+### [**18.0.4**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.4) **(July 29th 2026)**
+
+* Fixed custom repository save errors not showing a notification in the back office [#230](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/230)
+
 ### [**18.0.3**](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.3) **(July 27th 2026)**
 
 * Fixed the collection workspace heading showing the internal collection alias instead of the configured collection name [#229](https://github.com/umbraco/Umbraco.UIBuilder.Issues/issues/229)


### PR DESCRIPTION
## 📋 Description

Adds the missing release notes entries for UI Builder v18.0.4, v18.0.5, and v18.0.6, sourced from issues closed and labeled `release/{version}` in `umbraco/Umbraco.UIBuilder.Issues`.

## 📎 Related Issues (if applicable)

- umbraco/Umbraco.UIBuilder.Issues#230
- umbraco/Umbraco.UIBuilder.Issues#231
- umbraco/Umbraco.UIBuilder.Issues#232

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language ("we", "I") are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco UI Builder 18.0.4, 18.0.5, 18.0.6

🤖 Generated with Claude Code