### PR TITLE
Add Umbraco Commerce 17.2.4 release notes

### DIFF
--- a/17/umbraco-commerce/release-notes/README.md
+++ b/17/umbraco-commerce/release-notes/README.md
@@ -1,3 +1,4 @@
+---
 description: >-
   Get an overview of the things changed and fixed in each version of Umbraco
   Commerce.

--- a/17/umbraco-commerce/release-notes/README.md
+++ b/17/umbraco-commerce/release-notes/README.md
@@ -1,4 +1,3 @@
----
 description: >-
   Get an overview of the things changed and fixed in each version of Umbraco
   Commerce.
@@ -17,6 +16,15 @@ If you are upgrading to a new major version, check the breaking changes in the [
 ## Release History
 
 This section contains the release notes for Umbraco Commerce 17 including all changes for this version.
+
+#### 17.2.4 (7th Sep 2026)
+* Fix analytics dashboard widgets overlapping when the browser window is resized [#884](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/884)
+* Fix custom cart filters registered via `WithCartAdvancedFilters()` being silently ignored [#885](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/885)
+* Fix order cleanup failing on SQL Server with a "too many parameters" error on large stores [#887](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/887)
+* Fix a crash on the first request after an unattended upgrade [#888](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/888)
+* Fix a SQLite migration failure when upgrading a store with existing customer data [#889](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/889)
+* Fix discount rule and reward provider setting descriptions not showing in the backoffice [#890](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/890)
+* Fix the Variants tab not appearing when the Variants Editor property is inherited through a Content Type Composition [#891](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/891)
 
 #### 17.2.3 (21st Aug 2026)
 * Fix a startup crash on large stores during the customer data migration [#883](https://github.com/umbraco/Umbraco.Commerce.Issues/issues/883)


### PR DESCRIPTION
## Summary
- Adds the 17.2.4 entry to the Umbraco Commerce v17 release notes, covering the 7 bugs fixed in this hotfix release (#884, #885, #887, #888, #889, #890, #891).

## Test plan
- [x] Matches the established style of the neighboring entries in this file (plain heading, no trailing period, inline issue links).

🤖 Generated with Claude Code