### PR TITLE
Add Umbraco Deploy 17.3.0-rc1 and 18.1.0-rc1 release notes

### DIFF
--- a/17/umbraco-deploy/release-notes.md
+++ b/17/umbraco-deploy/release-notes.md
@@ -16,6 +16,17 @@ If you are upgrading to a new major version, you can find the details about the 
 
 This section contains the release notes for Umbraco Deploy 17, including all changes for this version.
 
+### [17.3.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.3.0-rc1) (September 4th 2026)
+
+* Register dependencies for rich text local links in the `{localLink:<guid>}` format, so linked documents and media are transferred with the content [#348](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/348).
+* Start the operations on the Deploy dashboard from the Management API, fixing operations that could remain pending indefinitely and reporting the progress of every operation.
+* Report the cause of unexplained 403 errors returned by the environment API. Redirects are no longer followed when calling a remote environment, because a redirect strips the authorization header.
+* Reduce the memory used while setting cached signatures, using the new `ExpandRangePageSize` and `SetSignaturesBatchSize` settings.
+* Apply Deploy configuration changes without restarting the site. Invalid configuration no longer prevents the site from starting.
+* Run start-up operations while the license validation result is still unknown, so triggers like `deploy-on-start` are no longer skipped on newly created environments.
+* Load the Deploy backoffice code on demand, reducing the amount loaded on every backoffice page.
+* Remove the Umbraco Cloud project **Trial expires in...** message from the Deploy dashboard, because it does not reflect the state of your Deploy license. The trial status of a Cloud project is available in the Umbraco Cloud portal.
+
 ### [17.2.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.2.1) (July 21st 2026)
 
 * Update public access role rules when a member group is renamed during a deploy.

--- a/17/umbraco-deploy/release-notes.md
+++ b/17/umbraco-deploy/release-notes.md
@@ -16,7 +16,7 @@ If you are upgrading to a new major version, you can find the details about the 
 
 This section contains the release notes for Umbraco Deploy 17, including all changes for this version.
 
-### [17.3.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.3.0-rc1) (September 4th 2026)
+### [17.3.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F17.3.0) (September 4th 2026)
 
 * Register dependencies for rich text local links in the `{localLink:<guid>}` format, so linked documents and media are transferred with the content [#348](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/348).
 * Start the operations on the Deploy dashboard from the Management API, fixing operations that could remain pending indefinitely and reporting the progress of every operation.

--- a/18/umbraco-deploy/release-notes.md
+++ b/18/umbraco-deploy/release-notes.md
@@ -18,6 +18,17 @@ If you are upgrading to a new major version, you can find the details about the 
 
 This section contains the release notes for Umbraco Deploy 18, including all changes for this version.
 
+### [18.1.0-rc1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.1.0) (September 4th 2026)
+
+* Register dependencies for rich text local links in the `{localLink:<guid>}` format, so linked documents and media are transferred with the content [#348](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/348).
+* Start the operations on the Deploy dashboard from the Management API, fixing operations that could remain pending indefinitely and reporting the progress of every operation.
+* Add granular user permissions for the **Queue for Transfer**, **Partial Restore**, and **Export** actions on elements and element folders.
+* Report the cause of unexplained 403 errors returned by the environment API. Redirects are no longer followed when calling a remote environment, because a redirect strips the authorization header.
+* Reduce the memory used while setting cached signatures, using the new `ExpandRangePageSize` and `SetSignaturesBatchSize` settings.
+* Apply Deploy configuration changes without restarting the site. Invalid configuration no longer prevents the site from starting.
+* Run start-up operations while the license validation result is still unknown, so triggers like `deploy-on-start` are no longer skipped on newly created environments.
+* Load the Deploy backoffice code on demand, reducing the amount loaded on every backoffice page.
+
 ### [18.0.1](https://github.com/umbraco/Umbraco.Deploy.Issues/issues?q=is%3Aissue+is%3Aclosed+label%3Arelease%2F18.0.1) (July 21st 2026)
 
 * Update public access role rules when a member group is renamed during a deploy.


### PR DESCRIPTION
## 📋 Description

Adds the release notes for Umbraco Deploy 17.3.0-rc1 and 18.1.0-rc1, released on September 4th 2026.

Both versions contain the same changes, apart from two version-specific items. Version 18.1.0-rc1 adds granular user permissions for the Deploy actions on elements and element folders, which are not available in version 17. Version 17.3.0-rc1 removes the Umbraco Cloud project trial message from the Deploy dashboard, which version 18 does not display.

## 🤖 AI Disclosure

This content is AI-assisted, following the [AI contribution guidelines](https://docs.umbraco.com/contributing/documentation/ai-guidelines) and using the `umbraco-docs-content` skill. The release notes were drafted from the 17.3.0-rc1 and 18.1.0-rc1 releases and the pull requests they contain, then reviewed and edited for accuracy and scope.

## 📎 Related Issues (if applicable)

Both release notes reference umbraco/Umbraco.Deploy.Issues#348.

Following the existing convention for release candidates, the version headings link to the `release/17.3.0` and `release/18.1.0` labels. Both labels are created in the issue tracker, so the links resolve once the labels are applied.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Deploy 17.3.0-rc1 and 18.1.0-rc1.

## Deadline (if relevant)

Publish together with the 17.3.0-rc1 and 18.1.0-rc1 releases.
