### PR TITLE
Document cleaning schema on the deploying deletions articles

### DIFF
--- a/13/umbraco-deploy/deployment-workflow/deploy-dashboard.md
+++ b/13/umbraco-deploy/deployment-workflow/deploy-dashboard.md
@@ -26,6 +26,10 @@ Below you can read what each operation will do when run through the dashboard.
 
 Running this operation will update the Umbraco Schema based on the information in the `.uda` files on disk.
 
+### Verify and Clean Schema
+
+This operation deletes schema from your current environment if it does not have a matching UDA file. It manually deletes each item in the Schema Comparison overview with an exclamation mark in the 'File Exists' column.
+
 ### Export Schema To Data Files
 
 Running this operation will extract the schema from Umbraco and output it to the `.uda` files on disk.

--- a/13/umbraco-deploy/deployment-workflow/deploying-deletions.md
+++ b/13/umbraco-deploy/deployment-workflow/deploying-deletions.md
@@ -14,6 +14,8 @@ The databases are environment specific. When you deploy from one environment to 
 
 The workflow described above does not pick up deletions of content and schema from the database, which is why you'll need to delete the content and/or schema on all your environments, in order to fully complete the deletion.
 
+For schema, Umbraco Deploy can remove the database entries that no longer have a corresponding UDA file. Cleaning is an explicit operation or an opt-in setting, so nothing is deleted without a decision on each environment. See [Cleaning schema](#cleaning-schema) for details.
+
 The main reason Umbraco Deploy does not delete schema and content on deployments, is because it could lead to unrecoverable loss of data. Imagine that you delete a Document Type on your Development environment, and push this deletion to your production environment where you have a lot of content nodes based on the deleted Document Type. When the deployments goes through, all of those content nodes would be instantly removed with no option to roll back as the Document Type they are based on no longer exists. To avoid anyone ending up in this unfortunate situation, deletes are not automatically handled and will require an active decision from you on each environment in order to take place.
 
 ## Example scenario
@@ -33,6 +35,8 @@ Once the deployment is complete, you will notice the following:
 You might wonder why the Document Type that you have deleted, is still there. The reason is, that deploy only deletes the associated UDA file, and not the actual Document Type in the database.
 
 In order to completely delete the Document Type from your entire project, you need to delete it from the backoffice of any of the other environments you have as well. When the Document Type has been deleted from the backoffice of all environments and no UDA file exists, you can consider it completely gone.
+
+Instead of deleting the Document Type in the backoffice, you can [clean the schema](#cleaning-schema) on the production environment. Deploy then deletes the Document Type, because its UDA file no longer exists.
 
 You should however keep in mind that if you at any point during the process, save your Document Type again, a UDA file will be regenerated and when you start deploying changes between environments, this will likely end up recreating your deleted Document Type.
 
@@ -73,6 +77,8 @@ As these are **only** files, everything will be deleted on the next environment 
 
 Content and media deletions will not be picked up by deployments and will have to be deleted on each environment you wish to delete the content or media on.
 
+To reduce the risk of accidental deletions, restrict the delete permission for the relevant user groups using [granular Document permissions](https://docs.umbraco.com/umbraco-cms/manage-and-publish-content/users-and-members/users#granular-permissions).
+
 ### Deleting backoffice languages
 
 Deleted:
@@ -85,3 +91,18 @@ Not deleted:
 * The language will still be visible in the backoffice/content dashboard (for multilingual content)
 
 Deleting the language in the backoffice on the target environment will ensure the environments are in sync.
+
+## Cleaning schema
+
+Schema deletions leave database entries behind, as described above. Umbraco Deploy 13.4 and later can remove these entries for you. Deploy compares the schema in the database with the UDA files on disk and deletes the items without a matching file. Cleaning applies to all schema types managed by Deploy, including Templates and Languages.
+
+You can clean the schema in two ways:
+
+* **Manually**: Run the **Verify and Clean Schema** operation from the [Deploy Dashboard](deploy-dashboard.md#verify-and-clean-schema) on the environment you want to clean. The Schema Comparison table on the same dashboard shows which items are missing a file.
+* **Automatically**: Set the [`PostDeploySchemaOperation`](../getting-started/deploy-settings.md#post-deploy-schema-operation) setting to `CleanSchema`. Deploy then cleans the schema after every schema deployment to that environment.
+
+{% hint style="warning" %}
+Cleaning the schema deletes items. Deleting a Document Type also deletes all content using that type, with no option to roll back. Only configure `CleanSchema` on environments where this is acceptable, such as local or development environments. On production, run the operation manually after checking the Schema Comparison table.
+{% endhint %}
+
+Cleaning the schema does not affect content and media. Those deletions must still be made manually on each environment.

--- a/17/umbraco-deploy/deployment-workflow/deploying-deletions.md
+++ b/17/umbraco-deploy/deployment-workflow/deploying-deletions.md
@@ -14,6 +14,8 @@ Databases are environment-specific. When deploying between environments, Umbraco
 
 The workflow described above does not pick up deletions of content and schema from the database, which is why you'll need to delete the content and/or schema on all your environments, in order to fully complete the deletion.
 
+For schema, Umbraco Deploy can remove the database entries that no longer have a corresponding UDA file. Cleaning is an explicit operation or an opt-in setting, so nothing is deleted without a decision on each environment. See [Cleaning schema](#cleaning-schema) for details.
+
 The main reason Umbraco Deploy does not delete schema and content on deployments, is because it could lead to unrecoverable loss of data. Imagine that you delete a Document Type on your Development environment, and push this deletion to your production environment where you have a lot of content nodes based on the deleted Document Type. When the deployments goes through, all of those content nodes would be instantly removed with no option to roll back as the Document Type they are based on no longer exists. To avoid anyone ending up in this unfortunate situation, deletes are not automatically handled and will require an active decision from you on each environment in order to take place.
 
 ## Example scenario
@@ -33,6 +35,8 @@ Once the deployment is complete, you will notice the following:
 You might wonder why the Document Type that you have deleted, is still there. The reason is, that deploy only deletes the associated UDA file, and not the actual Document Type in the database.
 
 To fully delete a Document Type from the project, delete it from the backoffice of every environment in use. A Document Type is fully deleted once it has been removed from all environments and no UDA file remains.
+
+Instead of deleting the Document Type in the backoffice, you can [clean the schema](#cleaning-schema) on the production environment. Deploy then deletes the Document Type, because its UDA file no longer exists.
 
 You should however keep in mind that if you at any point during the process, save your Document Type again, a UDA file will be regenerated and when you start deploying changes between environments, this will likely end up recreating your deleted Document Type.
 
@@ -73,6 +77,8 @@ As these are **only** files, everything will be deleted on the next environment 
 
 Content and media deletions will not be picked up by deployments and will have to be deleted on each environment you wish to delete the content or media on.
 
+To reduce the risk of accidental deletions, restrict the delete permission for the relevant user groups using [granular Document permissions](https://docs.umbraco.com/umbraco-cms/manage-and-publish-content/users-and-members/users#granular-permissions).
+
 ### Deleting backoffice languages
 
 Deleted:
@@ -85,3 +91,18 @@ Not deleted:
 * The language will still be visible in the backoffice/content dashboard (for multilingual content)
 
 Deleting the language in the backoffice on the target environment will ensure the environments are in sync.
+
+## Cleaning schema
+
+Schema deletions leave database entries behind, as described above. Umbraco Deploy 13.4 and later can remove these entries for you. Deploy compares the schema in the database with the UDA files on disk and deletes the items without a matching file. Cleaning applies to all schema types managed by Deploy, including Templates and Languages.
+
+You can clean the schema in two ways:
+
+* **Manually**: Run the **Verify and Clean Schema** operation from the [Deploy Dashboard](deploy-dashboard.md#verify-and-clean-schema) on the environment you want to clean. The Schema Comparison table on the same dashboard shows which items are missing a file.
+* **Automatically**: Set the [`PostDeploySchemaOperation`](../getting-started/deploy-settings.md#post-deploy-schema-operation) setting to `CleanSchema`. Deploy then cleans the schema after every schema deployment to that environment.
+
+{% hint style="warning" %}
+Cleaning the schema deletes items. Deleting a Document Type also deletes all content using that type, with no option to roll back. Only configure `CleanSchema` on environments where this is acceptable, such as local or development environments. On production, run the operation manually after checking the Schema Comparison table.
+{% endhint %}
+
+Cleaning the schema does not affect content and media. Those deletions must still be made manually on each environment.

--- a/18/umbraco-deploy/deployment-workflow/deploying-deletions.md
+++ b/18/umbraco-deploy/deployment-workflow/deploying-deletions.md
@@ -14,6 +14,8 @@ Databases are environment-specific. When deploying between environments, Umbraco
 
 The workflow described above does not pick up deletions of content and schema from the database, which is why you'll need to delete the content and/or schema on all your environments, in order to fully complete the deletion.
 
+For schema, Umbraco Deploy can remove the database entries that no longer have a corresponding UDA file. Cleaning is an explicit operation or an opt-in setting, so nothing is deleted without a decision on each environment. See [Cleaning schema](#cleaning-schema) for details.
+
 The main reason Umbraco Deploy does not delete schema and content on deployments, is because it could lead to unrecoverable loss of data. Imagine that you delete a Document Type on your Development environment, and push this deletion to your production environment where you have a lot of content nodes based on the deleted Document Type. When the deployments goes through, all of those content nodes would be instantly removed with no option to roll back as the Document Type they are based on no longer exists. To avoid anyone ending up in this unfortunate situation, deletes are not automatically handled and will require an active decision from you on each environment in order to take place.
 
 ## Example scenario
@@ -33,6 +35,8 @@ Once the deployment is complete, you will notice the following:
 You might wonder why the Document Type that you have deleted, is still there. The reason is, that deploy only deletes the associated UDA file, and not the actual Document Type in the database.
 
 To fully delete a Document Type from the project, delete it from the backoffice of every environment in use. A Document Type is fully deleted once it has been removed from all environments and no UDA file remains.
+
+Instead of deleting the Document Type in the backoffice, you can [clean the schema](#cleaning-schema) on the production environment. Deploy then deletes the Document Type, because its UDA file no longer exists.
 
 You should however keep in mind that if you at any point during the process, save your Document Type again, a UDA file will be regenerated and when you start deploying changes between environments, this will likely end up recreating your deleted Document Type.
 
@@ -73,6 +77,8 @@ As these are **only** files, everything will be deleted on the next environment 
 
 Content and media deletions will not be picked up by deployments and will have to be deleted on each environment you wish to delete the content or media on.
 
+To reduce the risk of accidental deletions, restrict the delete permission for the relevant user groups using [granular Document permissions](https://docs.umbraco.com/umbraco-cms/manage-and-publish-content/users-and-members/users#granular-permissions).
+
 ### Deleting backoffice languages
 
 Deleted:
@@ -85,3 +91,18 @@ Not deleted:
 * The language will still be visible in the backoffice/content dashboard (for multilingual content)
 
 Deleting the language in the backoffice on the target environment will ensure the environments are in sync.
+
+## Cleaning schema
+
+Schema deletions leave database entries behind, as described above. Umbraco Deploy 13.4 and later can remove these entries for you. Deploy compares the schema in the database with the UDA files on disk and deletes the items without a matching file. Cleaning applies to all schema types managed by Deploy, including Templates and Languages.
+
+You can clean the schema in two ways:
+
+* **Manually**: Run the **Verify schema** operation from the **Status** page in the [Deploy Settings](deploy-dashboard.md#verify-schema) on the environment you want to clean. The **Schema** page shows which items are missing a file.
+* **Automatically**: Set the [`PostDeploySchemaOperation`](../getting-started/deploy-settings.md#post-deploy-schema-operation) setting to `CleanSchema`. Deploy then cleans the schema after every schema deployment to that environment.
+
+{% hint style="warning" %}
+Cleaning the schema deletes items. Deleting a Document Type also deletes all content using that type, with no option to roll back. Only configure `CleanSchema` on environments where this is acceptable, such as local or development environments. On production, run the operation manually after checking the **Schema** page.
+{% endhint %}
+
+Cleaning the schema does not affect content and media. Those deletions must still be made manually on each environment.

--- a/umbraco-cloud/build-and-customize-your-solution/handle-deployments-and-environments/deployment/deploying-deletions.md
+++ b/umbraco-cloud/build-and-customize-your-solution/handle-deployments-and-environments/deployment/deploying-deletions.md
@@ -10,6 +10,8 @@ The databases are environment specific. During deployment across environments, U
 
 The workflow described above does not recognize deletions of content and schema from the database. You'll need to delete the content and/or schema on all your environments to fully complete the deletion.
 
+For schema, Umbraco Deploy can remove the database entries that no longer have a corresponding `.uda` file. Cleaning is an explicit operation or an opt-in setting, so nothing is deleted without a decision on each environment. See [Cleaning schema](#cleaning-schema) for details.
+
 The main reason not to delete schema and content on deployments is that it could lead to an unrecoverable loss of data.
 
 Here's an example of what can happen when a Document Type is deleted and deployed:
@@ -38,6 +40,8 @@ Once the deployment is completed, the following changes has taken place:
 The reason for the Document Type to still be there is, that the associated `.uda` file is deleted. The Document Type still exists in the database.
 
 To delete the Document Type from your entire project, you need to delete it from the backoffice of the other environments. When the Document Type has been deleted from the backoffice of all the environments and no `.uda` file exist, it is fully removed.
+
+Instead of deleting the Document Type in the backoffice, you can [clean the schema](#cleaning-schema) on the Live environment. Deploy then deletes the Document Type, because its `.uda` file no longer exists.
 
 If you save your Document Type during the process, a new `.uda` file is generated. This can recreate your deleted Document Type when deploying changes between environments.
 
@@ -69,6 +73,8 @@ All files are deleted in the next environment upon deployment.
 
 Deletions of content and media won't be detected during deployments. You must manually delete them on each environment where removal is desired.
 
+To reduce the risk of accidental deletions, restrict the delete permission for the relevant user groups using [granular Document permissions](https://docs.umbraco.com/umbraco-cms/manage-and-publish-content/users-and-members/users#granular-permissions).
+
 ### Deleting Backoffice Languages
 
 | Deleted                     | Not Deleted                                                                                        |
@@ -77,3 +83,18 @@ Deletions of content and media won't be detected during deployments. You must ma
 |                             | The language will still be visible in the Backoffice/Content dashboard (for multilingual content). |
 
 Deleting the language in the backoffice on the target environment will ensure the environments are in sync.
+
+## Cleaning schema
+
+Schema deletions leave database entries behind, as described above. Umbraco Deploy 13.4 and later can remove these entries for you. Deploy compares the schema in the database with the `.uda` files on disk and deletes the items without a matching file. Cleaning applies to all schema types managed by Deploy, including Templates and Languages.
+
+You can clean the schema in two ways:
+
+* **Manually**: Run the **Verify schema** operation from the [Deploy Settings](deploy-dashboard.md#verify-schema) on the environment you want to clean. With Umbraco Deploy 18 and later, the operation is on the **Status** page and the **Schema** page shows which items are missing a file. In earlier versions, both are on the Deploy dashboard.
+* **Automatically**: Set the [`PostDeploySchemaOperation`](https://docs.umbraco.com/umbraco-deploy/getting-started/deploy-settings#post-deploy-schema-operation) setting to `CleanSchema`. Deploy then cleans the schema after every schema deployment to that environment.
+
+{% hint style="warning" %}
+Cleaning the schema deletes items. Deleting a Document Type also deletes all content using that type, with no option to roll back. Only configure `CleanSchema` on environments where this is acceptable, such as local or Development environments. On Live, run the operation manually after checking the schema comparison.
+{% endhint %}
+
+Cleaning the schema does not affect content and media. Those deletions must still be made manually on each environment.


### PR DESCRIPTION
## 📋 Description

The Deploying Deletions articles (Umbraco Cloud and Umbraco Deploy 13, 17 and 18) explain that schema deletions only remove the UDA file and leave the database entry behind, requiring manual deletion in the backoffice of every environment. They didn't mention that Umbraco Deploy 13.4 and later can clean the schema: either manually via the Verify (and Clean) Schema operation (on the Deploy dashboard, or the Status page in Deploy 18+), or automatically by setting `PostDeploySchemaOperation` to `CleanSchema`.

This adds a "Cleaning schema" section to all four articles, with a warning about using `CleanSchema` on production environments (deleting a Document Type also deletes its content). It also references the new section from the intro and the example scenario, and adds a tip under content/media deletions to restrict the delete permission using granular Document permissions, since content deletions are by design not deployed.

The Deploy 13 dashboard article was missing the "Verify and Clean Schema" operation (available since 13.4.0), so that was added as well to give the new section a link target.

## 📎 Related Issues (if applicable)

Prompted by https://github.com/umbraco/Umbraco.Cloud.Issues/discussions/893.

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [x] Code blocks are correctly formatted.
* [x] Sentences are short and clear (preferably under 25 words).
* [x] Passive voice and first-person language (“we”, “I”) are avoided.
* [x] Relevant pages are linked.
* [x] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [x] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

Umbraco Deploy 13, 17 and 18; Umbraco Cloud.

## Deadline (if relevant)

None.
