### PR TITLE
Added redirects for Installation article

### DIFF
--- a/17/umbraco-cms/.gitbook.yaml
+++ b/17/umbraco-cms/.gitbook.yaml
@@ -726,3 +726,4 @@ redirects:
     extend-your-project/backoffice-extensions/utilities/modals: extend-your-project/backoffice-extensions/extending-overview/extension-types/modals/README.md
     model-your-content/content-types-and-structure/data/defining-content/default-document-types: model-your-content/content-types-and-structure/data/defining-content/document-type-options.md
     get-started/backoffice-essentials/working-with-content: get-started/backoffice-essentials/working-with-rich-text-editors.md
+    get-started/installation/install-umbraco-with-templates: get-started/installation/README.md

--- a/17/umbraco-cms/.gitbook.yaml
+++ b/17/umbraco-cms/.gitbook.yaml
@@ -171,6 +171,7 @@ redirects:
     fundamentals/setup: get-started/installation/README.md
     fundamentals/setup/requirements: get-started/installation/requirements.md
     fundamentals/setup/install: get-started/installation/README.md
+    fundamentals/setup/install/install-umbraco-with-templates: get-started/installation/README.md
     fundamentals/setup/install/visual-studio: get-started/installation/visual-studio.md
     fundamentals/setup/install/install-umbraco-with-vs-code: get-started/installation/install-umbraco-with-vs-code.md
     fundamentals/setup/install/running-umbraco-on-linux-macos: get-started/installation/running-umbraco-on-linux-macos.md

--- a/17/umbraco-cms/.gitbook.yaml
+++ b/17/umbraco-cms/.gitbook.yaml
@@ -171,7 +171,6 @@ redirects:
     fundamentals/setup: get-started/installation/README.md
     fundamentals/setup/requirements: get-started/installation/requirements.md
     fundamentals/setup/install: get-started/installation/README.md
-    fundamentals/setup/install/install-umbraco-with-templates: get-started/installation/install-umbraco-with-templates.md
     fundamentals/setup/install/visual-studio: get-started/installation/visual-studio.md
     fundamentals/setup/install/install-umbraco-with-vs-code: get-started/installation/install-umbraco-with-vs-code.md
     fundamentals/setup/install/running-umbraco-on-linux-macos: get-started/installation/running-umbraco-on-linux-macos.md

--- a/18/umbraco-cms/.gitbook.yaml
+++ b/18/umbraco-cms/.gitbook.yaml
@@ -213,3 +213,4 @@ redirects:
     extend-your-project/backoffice-extensions/utilities/modals: extend-your-project/backoffice-extensions/extending-overview/extension-types/modals/README.md
     model-your-content/content-types-and-structure/data/defining-content/default-document-types: model-your-content/content-types-and-structure/data/defining-content/document-type-options.md
     get-started/backoffice-essentials/working-with-content: get-started/backoffice-essentials/working-with-rich-text-editors.md
+    get-started/installation/install-umbraco-with-templates: get-started/installation/README.md


### PR DESCRIPTION
## 📋 Description

Added redirects for `install-umbraco-with-templates.md`. v17 has 2 entries for the same filename. Should I leave the previous one as well? Asking cz I can never be sure how these redirects work 😀

## 📎 Related Issues (if applicable)

<!-- List any related issues, e.g. "Fixes #1234" -->

## ✅ Contributor Checklist

I've followed the [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide) and can confirm that:

* [ ] Code blocks are correctly formatted.
* [ ] Sentences are short and clear (preferably under 25 words).
* [ ] Passive voice and first-person language (“we”, “I”) are avoided.
* [ ] Relevant pages are linked.
* [ ] All links work and point to the correct resources.
* [ ] Screenshots or diagrams are included if useful.
* [ ] Any code examples or instructions have been tested.
* [ ] Typos, broken links, and broken images are fixed.

## Product & Version (if relevant)

CMS v17 and v18

## Deadline (if relevant)

Anytime

## 📚 Helpful Resources

* 🧾 [Umbraco Contribution Guidelines](https://docs.umbraco.com/contributing)
* ✍️ [Umbraco Documentation Style Guide](https://docs.umbraco.com/contributing/documentation/style-guide)
